### PR TITLE
feat(v1.3.2): user-scoped transactions API + web API-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ apps/
 Detalhes tecnicos:
 - Foundation: `docs/architecture/v1.3.0.md`
 - Auth: `docs/architecture/v1.3.0-auth.md`
+- Transactions API: `docs/architecture/v1.3.1-transactions.md`
 
 ## Funcionalidades atuais (web)
 
@@ -35,7 +36,7 @@ Detalhes tecnicos:
 - Filtro por periodo: `Todo periodo`, `Hoje`, `Ultimos 7 dias`, `Ultimos 30 dias`, `Personalizado`
 - Saldo e totais por tipo em tempo real
 - Grafico de receita x despesa (Recharts, lazy-loaded)
-- Persistencia local de transacoes (temporaria nesta fase)
+- Transacoes carregadas e persistidas pela API (por usuario autenticado)
 - Modal com fechamento por `ESC` e clique no backdrop
 - Remocao de transacoes
 - Login e criacao de conta com JWT
@@ -47,7 +48,9 @@ Detalhes tecnicos:
 - `GET /health` retorna `{ ok: true, version: "1.3.0" }`
 - `POST /auth/register` cria usuario (store em memoria)
 - `POST /auth/login` retorna `{ token, user }`
-- `/transactions` protegido por middleware JWT
+- `GET /transactions` lista transacoes do usuario autenticado
+- `POST /transactions` cria transacao para o usuario autenticado
+- `DELETE /transactions/:id` remove transacao do usuario autenticado
 - Middleware global de erro e fallback `404`
 
 ## Como rodar localmente
@@ -92,7 +95,7 @@ npm run dev
 ## Roadmap
 
 - [x] PR 2 (v1.3.0): autenticacao JWT + rotas protegidas
-- [ ] PR 3 (v1.3.0): transacoes por usuario no backend + migracao localStorage -> API
+- [x] PR 3 (v1.3.0): transacoes por usuario no backend + frontend API-first
 - [ ] Persistencia em banco remoto (Postgres) para ambiente de producao
 - [ ] Exportacao/importacao CSV e JSON
 

--- a/apps/api/src/routes/transactions.routes.js
+++ b/apps/api/src/routes/transactions.routes.js
@@ -1,29 +1,39 @@
 import { Router } from "express";
 import { authMiddleware } from "../middlewares/auth.middleware.js";
+import {
+  createTransactionForUser,
+  deleteTransactionForUser,
+  listTransactionsByUser,
+} from "../services/transactions.service.js";
 
 const router = Router();
 
 router.use(authMiddleware);
 
 router.get("/", (req, res) => {
-  res.status(501).json({
-    message: "Transactions list not implemented yet. Planned for PR 3.",
-    userId: req.user.id,
-  });
+  const transactions = listTransactionsByUser(req.user.id);
+  res.status(200).json(transactions);
 });
 
-router.post("/", (req, res) => {
-  res.status(501).json({
-    message: "Transactions create not implemented yet. Planned for PR 3.",
-    userId: req.user.id,
-  });
+router.post("/", (req, res, next) => {
+  try {
+    const transaction = createTransactionForUser(req.user.id, req.body || {});
+    res.status(201).json(transaction);
+  } catch (error) {
+    next(error);
+  }
 });
 
-router.delete("/:id", (req, res) => {
-  res.status(501).json({
-    message: "Transactions delete not implemented yet. Planned for PR 3.",
-    userId: req.user.id,
-  });
+router.delete("/:id", (req, res, next) => {
+  try {
+    const removedTransaction = deleteTransactionForUser(req.user.id, req.params.id);
+    res.status(200).json({
+      id: removedTransaction.id,
+      success: true,
+    });
+  } catch (error) {
+    next(error);
+  }
 });
 
 export default router;

--- a/apps/api/src/services/transactions.service.js
+++ b/apps/api/src/services/transactions.service.js
@@ -1,11 +1,120 @@
-export const transactionsServicePlaceholder = {
-  list: async () => {
-    throw new Error("Not implemented");
-  },
-  create: async () => {
-    throw new Error("Not implemented");
-  },
-  remove: async () => {
-    throw new Error("Not implemented");
-  },
+const CATEGORY_ENTRY = "Entrada";
+const CATEGORY_EXIT = "Saida";
+const VALID_TYPES = new Set([CATEGORY_ENTRY, CATEGORY_EXIT]);
+
+const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+const transactionsByUser = new Map();
+let nextTransactionId = 1;
+
+const createError = (status, message) => {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+};
+
+const toISODate = (value = new Date()) => {
+  const date = new Date(value);
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+
+  return `${year}-${month}-${day}`;
+};
+
+const isValidISODate = (value) => {
+  if (typeof value !== "string" || !ISO_DATE_REGEX.test(value)) {
+    return false;
+  }
+
+  const parsedDate = new Date(`${value}T00:00:00`);
+  if (Number.isNaN(parsedDate.getTime())) {
+    return false;
+  }
+
+  return toISODate(parsedDate) === value;
+};
+
+const getUserTransactions = (userId) => {
+  if (!transactionsByUser.has(userId)) {
+    transactionsByUser.set(userId, []);
+  }
+
+  return transactionsByUser.get(userId);
+};
+
+const normalizeValue = (value) => {
+  const parsedValue = Number(value);
+
+  if (!Number.isFinite(parsedValue) || parsedValue <= 0) {
+    throw createError(400, "Valor invalido. Informe um numero maior que zero.");
+  }
+
+  return Number(parsedValue.toFixed(2));
+};
+
+const normalizeType = (type) => {
+  if (!VALID_TYPES.has(type)) {
+    throw createError(400, "Tipo invalido. Use Entrada ou Saida.");
+  }
+
+  return type;
+};
+
+const normalizeDate = (date) => {
+  if (typeof date === "undefined" || date === null || date === "") {
+    return toISODate();
+  }
+
+  if (!isValidISODate(date)) {
+    throw createError(400, "Data invalida. Use o formato YYYY-MM-DD.");
+  }
+
+  return date;
+};
+
+export const listTransactionsByUser = (userId) => {
+  const transactions = getUserTransactions(userId);
+  return [...transactions];
+};
+
+export const createTransactionForUser = (userId, payload = {}) => {
+  const transaction = {
+    id: nextTransactionId,
+    userId,
+    value: normalizeValue(payload.value),
+    type: normalizeType(payload.type),
+    date: normalizeDate(payload.date),
+    createdAt: new Date().toISOString(),
+  };
+
+  const transactions = getUserTransactions(userId);
+  transactions.push(transaction);
+  nextTransactionId += 1;
+
+  return transaction;
+};
+
+export const deleteTransactionForUser = (userId, transactionId) => {
+  const id = Number(transactionId);
+
+  if (!Number.isInteger(id) || id <= 0) {
+    throw createError(400, "ID de transacao invalido.");
+  }
+
+  const transactions = getUserTransactions(userId);
+  const index = transactions.findIndex((transaction) => transaction.id === id);
+
+  if (index === -1) {
+    throw createError(404, "Transacao nao encontrada.");
+  }
+
+  const [removedTransaction] = transactions.splice(index, 1);
+  return removedTransaction;
+};
+
+export const __resetTransactionsStoreForTests = () => {
+  transactionsByUser.clear();
+  nextTransactionId = 1;
 };

--- a/docs/architecture/v1.3.1-transactions.md
+++ b/docs/architecture/v1.3.1-transactions.md
@@ -1,0 +1,34 @@
+# Arquitetura v1.3.1 (Transactions by User)
+
+## Objetivo
+Concluir o PR3 com transacoes reais por usuario autenticado e frontend usando API como fonte unica de verdade.
+
+## Backend (`apps/api`)
+
+- `transactions.service` com store em memoria separada por `userId`.
+- `listTransactionsByUser(userId)` retorna apenas dados do usuario autenticado.
+- `createTransactionForUser(userId, payload)` valida:
+  - `type`: `Entrada` ou `Saida`
+  - `value`: numero > 0
+  - `date`: `YYYY-MM-DD` (ou data atual por padrao)
+- `deleteTransactionForUser(userId, id)` remove apenas transacao do proprio usuario.
+- Rotas protegidas por `authMiddleware`:
+  - `GET /transactions`
+  - `POST /transactions`
+  - `DELETE /transactions/:id`
+
+## Frontend (`apps/web`)
+
+- `App` tornou-se API-first:
+  - carrega transacoes via `transactionsService.list()`
+  - cria via `transactionsService.create(payload)`
+  - remove via `transactionsService.remove(id)`
+- `localStorage` de transacoes removido.
+- Erros de request exibidos no dashboard com opcao de retry.
+- Sessao continua JWT-based via `AuthProvider` + interceptor Axios.
+
+## Integracao e seguranca
+
+- `userId` e inferido exclusivamente do token JWT no backend.
+- Usuario autenticado nao acessa/transfere dados de outro usuario.
+- `401` em qualquer request autenticada encerra sessao no frontend.


### PR DESCRIPTION

Este PR conclui o PR3: transações reais por usuário autenticado (userId via JWT) e frontend consumindo a API como fonte única de verdade (sem localStorage de transações).

## O que mudou

### Backend (apps/api)
- Implementa store em memória **separada por userId** (`Map<userId, transactions[]>`)
- `GET /transactions` lista somente transações do usuário autenticado
- `POST /transactions` cria transação com validações:
  - `type`: Entrada | Saida
  - `value`: número > 0
  - `date`: YYYY-MM-DD (ou data atual por padrão)
- `DELETE /transactions/:id` remove somente transação do próprio usuário
- Testes cobrindo:
  - criação + listagem
  - isolamento por usuário (A não vê B)
  - não permite remover transação de outro usuário (404)
  - remove transação do próprio usuário

### Frontend (apps/web)
- Dashboard (`App`) virou **API-first**:
  - carrega via `transactionsService.list()`
  - cria via `transactionsService.create(payload)`
  - remove via `transactionsService.remove(id)`
- **Remove persistência local de transações**
- Exibe erro de request com opção de retry
- Testes atualizados para o fluxo API-first (mock do transactionsService)

## Como testar (local)

```bash
npm ci
npm run dev
````

* Web: [http://localhost:5173](http://localhost:5173)
* API: [http://localhost:3001/health](http://localhost:3001/health)

### Fluxo

1. Crie conta / faça login
2. Acesse `/app`
3. Crie uma transação (Entrada ou Saida)
4. Recarregue a página e confirme que os dados vêm da API
5. Delete uma transação e confirme atualização na lista
6. (Opcional) Faça login com outro usuário e confirme isolamento

## Notas / decisões

* Persistência ainda é em memória (reiniciar a API apaga dados). Banco entra na próxima etapa.
* `userId` é inferido exclusivamente via JWT no backend (sem aceitar userId no payload).

## Docs

* `docs/architecture/v1.3.1-transactions.md`
