### PR TITLE
fix(config): fail fast without VITE_API_URL in prod + multi-origin CORS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@
 # Copy values to each app-specific .env file.
 
 # apps/web/.env
+# Em producao (Vercel), use a URL publica da API:
+# VITE_API_URL=https://sua-api.exemplo.com
 VITE_API_URL=http://localhost:3001
 
 # apps/api/.env
@@ -10,4 +12,6 @@ NODE_ENV=development
 JWT_SECRET=troque-isto
 JWT_EXPIRES_IN=24h
 DATABASE_URL=file:./dev.db
+# Aceita lista separada por virgula (ex.: local + Vercel):
+# CORS_ORIGIN=http://localhost:5173,https://control-finance-react-tail-wind.vercel.app
 CORS_ORIGIN=http://localhost:5173

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ npm run dev
 - Referencia geral: `.env.example`
 - Web: `apps/web/.env.example`
 - API: `apps/api/.env.example`
+- Em deploy (Vercel), `VITE_API_URL` e obrigatoria e deve apontar para a URL publica da API
+- `CORS_ORIGIN` da API pode receber lista separada por virgula (local + dominios de deploy)
 
 ## Scripts (root)
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -3,4 +3,6 @@ NODE_ENV=development
 JWT_SECRET=troque-isto
 JWT_EXPIRES_IN=24h
 DATABASE_URL=file:./dev.db
+# Aceita lista separada por virgula (ex.: local + Vercel)
+# CORS_ORIGIN=http://localhost:5173,https://control-finance-react-tail-wind.vercel.app
 CORS_ORIGIN=http://localhost:5173

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -10,11 +10,26 @@ dotenv.config();
 
 const app = express();
 
-const allowedOrigin = process.env.CORS_ORIGIN || "http://localhost:5173";
+const allowedOrigins = (process.env.CORS_ORIGIN || "http://localhost:5173")
+  .split(",")
+  .map((origin) => origin.trim())
+  .filter(Boolean);
 
 app.use(
   cors({
-    origin: allowedOrigin,
+    origin: (origin, callback) => {
+      if (!origin) {
+        return callback(null, true);
+      }
+
+      if (allowedOrigins.includes(origin)) {
+        return callback(null, true);
+      }
+
+      const corsError = new Error("CORS origin not allowed.");
+      corsError.status = 403;
+      return callback(corsError);
+    },
     credentials: true,
   }),
 );

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,1 +1,2 @@
+# Em producao (Vercel), substitua por URL publica da API.
 VITE_API_URL=http://localhost:3001

--- a/apps/web/src/context/AuthContext.jsx
+++ b/apps/web/src/context/AuthContext.jsx
@@ -10,7 +10,7 @@ import {
 import { AuthContext } from "./auth-context";
 
 const getApiErrorMessage = (error, fallbackMessage) => {
-  return error?.response?.data?.message || fallbackMessage;
+  return error?.response?.data?.message || error?.message || fallbackMessage;
 };
 
 export const AuthProvider = ({ children }) => {

--- a/apps/web/src/pages/App.jsx
+++ b/apps/web/src/pages/App.jsx
@@ -31,7 +31,7 @@ const PERIOD_OPTIONS = [
 ];
 
 const getApiErrorMessage = (error, fallbackMessage) => {
-  return error?.response?.data?.message || fallbackMessage;
+  return error?.response?.data?.message || error?.message || fallbackMessage;
 };
 
 const normalizeTransactions = (transactions) => {

--- a/apps/web/src/services/api.js
+++ b/apps/web/src/services/api.js
@@ -1,8 +1,33 @@
 import axios from "axios";
 
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3001";
+const API_URL_LOCAL_DEV = "http://localhost:3001";
+const API_CONFIGURATION_ERROR_MESSAGE =
+  "VITE_API_URL nao configurada para este ambiente. Defina a variavel no deploy.";
+
+export const resolveApiUrl = (env = import.meta.env) => {
+  const configuredApiUrl = env?.VITE_API_URL?.trim();
+
+  if (configuredApiUrl) {
+    return configuredApiUrl;
+  }
+
+  if (env?.DEV) {
+    return API_URL_LOCAL_DEV;
+  }
+
+  return "";
+};
+
+const API_URL = resolveApiUrl();
 export const AUTH_TOKEN_STORAGE_KEY = "control_finance.auth_token";
+const isApiConfigured = Boolean(API_URL);
 let unauthorizedHandler = undefined;
+
+const createApiConfigurationError = () => {
+  const error = new Error(API_CONFIGURATION_ERROR_MESSAGE);
+  error.code = "API_URL_NOT_CONFIGURED";
+  return error;
+};
 
 export const getStoredToken = () => {
   if (typeof window === "undefined") {
@@ -33,11 +58,15 @@ export const setUnauthorizedHandler = (handler) => {
 };
 
 export const api = axios.create({
-  baseURL: API_URL,
+  baseURL: API_URL || undefined,
   timeout: 8000,
 });
 
 api.interceptors.request.use((config) => {
+  if (!isApiConfigured) {
+    return Promise.reject(createApiConfigurationError());
+  }
+
   const token = getStoredToken();
 
   if (!token) {

--- a/apps/web/src/services/api.test.js
+++ b/apps/web/src/services/api.test.js
@@ -5,6 +5,7 @@ import {
   clearStoredToken,
   getApiHealth,
   getStoredToken,
+  resolveApiUrl,
   setStoredToken,
   setUnauthorizedHandler,
 } from "./api";
@@ -53,6 +54,24 @@ describe("api service", () => {
 
     expect(api.get).toHaveBeenCalledWith("/health");
     expect(result).toEqual({ ok: true, version: "1.3.0" });
+  });
+
+  it("resolve URL configurada para producao", () => {
+    const url = resolveApiUrl({
+      DEV: false,
+      VITE_API_URL: "https://control-finance-api.example.com",
+    });
+
+    expect(url).toBe("https://control-finance-api.example.com");
+  });
+
+  it("nao usa localhost em producao sem VITE_API_URL", () => {
+    const url = resolveApiUrl({
+      DEV: false,
+      VITE_API_URL: "",
+    });
+
+    expect(url).toBe("");
   });
 
   it("persiste token de autenticacao no localStorage", () => {


### PR DESCRIPTION
## O que mudou

- Web: impede fallback para `localhost` em produção; requests falham com erro explícito quando `VITE_API_URL` não está configurada
- Web: mensagens de erro agora exibem `error.message` quando não há resposta HTTP
- API: `CORS_ORIGIN` agora suporta lista separada por vírgula (local + deploy)
- Docs: `.env.example` e README atualizados com setup de deploy

## Como testar

- [ ] `npm run lint`
- [ ] `npm run test`
- [ ] `npm run build`

## Validação manual (deploy)

- [ ] Definir `VITE_API_URL` no Vercel (Production + Preview)
- [ ] Definir `CORS_ORIGIN` na API com domínio local + domínio Vercel
- [ ] Redeploy do web e validação de `POST /auth/register` sem `localhost:3001`
