### PR TITLE
feat(security): harden /auth/login with rate limiting + brute-force lock

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ PORT=3001
 NODE_ENV=development
 JWT_SECRET=troque-isto
 JWT_EXPIRES_IN=24h
+TRUST_PROXY=1
 # Exemplo local:
 # DATABASE_URL=postgresql://postgres:postgres@localhost:5432/control_finance
 # Exemplo cloud:
@@ -22,3 +23,9 @@ DB_SSL=false
 # Aceita lista separada por virgula (ex.: local + Vercel):
 # CORS_ORIGIN=http://localhost:5173,https://control-finance-react-tail-wind.vercel.app
 CORS_ORIGIN=http://localhost:5173
+# Login hardening
+AUTH_RATE_LIMIT_WINDOW_MS=900000
+AUTH_RATE_LIMIT_MAX_REQUESTS=20
+AUTH_BRUTE_FORCE_WINDOW_MS=900000
+AUTH_BRUTE_FORCE_MAX_ATTEMPTS=5
+AUTH_BRUTE_FORCE_LOCK_MS=900000

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Detalhes tecnicos:
 - Auth: `docs/architecture/v1.3.0-auth.md`
 - Transactions API: `docs/architecture/v1.3.1-transactions.md`
 - Postgres Persistence: `docs/architecture/v1.4.0-postgres.md`
+- Auth Hardening: `docs/architecture/v1.4.2-auth-hardening.md`
 
 ## Funcionalidades atuais (web)
 
@@ -43,12 +44,14 @@ Detalhes tecnicos:
 - Login e criacao de conta com JWT
 - Sessao JWT com token em `localStorage` (chave namespaced)
 - Logout e rota protegida para `/app`
+- Protecao de login com rate limiting e bloqueio temporario por `IP+email`
 
 ## API (apps/api)
 
 - `GET /health` retorna `{ ok: true, version }` com a versao atual do `apps/api/package.json`
 - `POST /auth/register` cria usuario no Postgres
 - `POST /auth/login` retorna `{ token, user }`
+- `/auth/login` aplica rate limit por IP e bloqueio temporario por brute force
 - `GET /transactions` lista transacoes do usuario autenticado
 - `POST /transactions` cria transacao para o usuario autenticado
 - `DELETE /transactions/:id` remove transacao do usuario autenticado
@@ -81,7 +84,9 @@ npm run dev
 - API: `apps/api/.env.example`
 - Em deploy (Vercel), `VITE_API_URL` e obrigatoria e deve apontar para a URL publica da API
 - Para Postgres gerenciado com SSL, configure `DB_SSL=true` na API
+- Em deploy com proxy (Render), use `TRUST_PROXY=1` na API
 - `CORS_ORIGIN` da API pode receber lista separada por virgula (local + dominios de deploy)
+- Hardening de login: `AUTH_RATE_LIMIT_*` e `AUTH_BRUTE_FORCE_*`
 
 ## Scripts (root)
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -2,6 +2,7 @@ PORT=3001
 NODE_ENV=development
 JWT_SECRET=troque-isto
 JWT_EXPIRES_IN=24h
+TRUST_PROXY=1
 # Exemplo local:
 # DATABASE_URL=postgresql://postgres:postgres@localhost:5432/control_finance
 # Exemplo cloud:
@@ -13,3 +14,9 @@ DB_SSL=false
 # Aceita lista separada por virgula (ex.: local + Vercel)
 # CORS_ORIGIN=http://localhost:5173,https://control-finance-react-tail-wind.vercel.app
 CORS_ORIGIN=http://localhost:5173
+# Login hardening
+AUTH_RATE_LIMIT_WINDOW_MS=900000
+AUTH_RATE_LIMIT_MAX_REQUESTS=20
+AUTH_BRUTE_FORCE_WINDOW_MS=900000
+AUTH_BRUTE_FORCE_MAX_ATTEMPTS=5
+AUTH_BRUTE_FORCE_LOCK_MS=900000

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,6 +20,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.21.2",
+    "express-rate-limit": "^8.2.1",
     "jsonwebtoken": "^9.0.2",
     "pg": "^8.16.3"
   },

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -10,6 +10,32 @@ dotenv.config();
 
 const app = express();
 
+const resolveTrustProxyValue = () => {
+  const rawValue = (process.env.TRUST_PROXY || "").trim().toLowerCase();
+
+  if (!rawValue) {
+    return process.env.NODE_ENV === "production" ? 1 : false;
+  }
+
+  if (rawValue === "true") {
+    return true;
+  }
+
+  if (rawValue === "false") {
+    return false;
+  }
+
+  const parsedValue = Number(rawValue);
+
+  if (Number.isInteger(parsedValue) && parsedValue >= 0) {
+    return parsedValue;
+  }
+
+  return rawValue;
+};
+
+app.set("trust proxy", resolveTrustProxyValue());
+
 const allowedOrigins = (process.env.CORS_ORIGIN || "http://localhost:5173")
   .split(",")
   .map((origin) => origin.trim())

--- a/apps/api/src/middlewares/login-protection.middleware.js
+++ b/apps/api/src/middlewares/login-protection.middleware.js
@@ -1,0 +1,176 @@
+import rateLimit from "express-rate-limit";
+
+const DEFAULT_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+const DEFAULT_RATE_LIMIT_MAX_REQUESTS = 20;
+const DEFAULT_BRUTE_FORCE_WINDOW_MS = 15 * 60 * 1000;
+const DEFAULT_BRUTE_FORCE_MAX_ATTEMPTS = 5;
+const DEFAULT_BRUTE_FORCE_LOCK_MS = 15 * 60 * 1000;
+
+export const LOGIN_THROTTLE_MESSAGE =
+  "Muitas tentativas de login. Tente novamente em alguns minutos.";
+
+const loginAttemptStore = new Map();
+
+const parsePositiveInteger = (value, fallbackValue) => {
+  const parsedValue = Number(value);
+  return Number.isInteger(parsedValue) && parsedValue > 0
+    ? parsedValue
+    : fallbackValue;
+};
+
+const getRateLimitWindowMs = () =>
+  parsePositiveInteger(
+    process.env.AUTH_RATE_LIMIT_WINDOW_MS,
+    DEFAULT_RATE_LIMIT_WINDOW_MS,
+  );
+
+const getRateLimitMaxRequests = () =>
+  parsePositiveInteger(
+    process.env.AUTH_RATE_LIMIT_MAX_REQUESTS,
+    DEFAULT_RATE_LIMIT_MAX_REQUESTS,
+  );
+
+const getBruteForceWindowMs = () =>
+  parsePositiveInteger(
+    process.env.AUTH_BRUTE_FORCE_WINDOW_MS,
+    DEFAULT_BRUTE_FORCE_WINDOW_MS,
+  );
+
+const getBruteForceMaxAttempts = () =>
+  parsePositiveInteger(
+    process.env.AUTH_BRUTE_FORCE_MAX_ATTEMPTS,
+    DEFAULT_BRUTE_FORCE_MAX_ATTEMPTS,
+  );
+
+const getBruteForceLockMs = () =>
+  parsePositiveInteger(
+    process.env.AUTH_BRUTE_FORCE_LOCK_MS,
+    DEFAULT_BRUTE_FORCE_LOCK_MS,
+  );
+
+const createError = (status, message) => {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+};
+
+const getRequestIp = (request) =>
+  request.ip || request.socket?.remoteAddress || "unknown";
+
+const normalizeEmail = (email) =>
+  typeof email === "string" ? email.trim().toLowerCase() : "";
+
+const getLoginAttemptKey = (request) => {
+  const email = normalizeEmail(request.body?.email);
+
+  if (!email) {
+    return null;
+  }
+
+  return `${getRequestIp(request)}:${email}`;
+};
+
+const shouldResetAttemptState = (entry, now) => {
+  if (!entry) {
+    return true;
+  }
+
+  if (entry.lockUntil && entry.lockUntil <= now) {
+    return true;
+  }
+
+  return now - entry.firstFailedAt >= getBruteForceWindowMs();
+};
+
+export const loginRateLimiter = rateLimit({
+  windowMs: getRateLimitWindowMs(),
+  max: getRateLimitMaxRequests(),
+  standardHeaders: true,
+  legacyHeaders: false,
+  skipSuccessfulRequests: true,
+  keyGenerator: (request) => getRequestIp(request),
+  handler: (_request, _response, next) => {
+    next(createError(429, LOGIN_THROTTLE_MESSAGE));
+  },
+});
+
+export const bruteForceLoginGuard = (request, _response, next) => {
+  const attemptKey = getLoginAttemptKey(request);
+  request.loginAttemptKey = attemptKey;
+
+  if (!attemptKey) {
+    next();
+    return;
+  }
+
+  const entry = loginAttemptStore.get(attemptKey);
+  const now = Date.now();
+
+  if (!entry) {
+    next();
+    return;
+  }
+
+  if (shouldResetAttemptState(entry, now)) {
+    loginAttemptStore.delete(attemptKey);
+    next();
+    return;
+  }
+
+  if (entry.lockUntil && entry.lockUntil > now) {
+    next(createError(429, LOGIN_THROTTLE_MESSAGE));
+    return;
+  }
+
+  next();
+};
+
+export const registerLoginFailure = (request) => {
+  const attemptKey = request.loginAttemptKey || getLoginAttemptKey(request);
+
+  if (!attemptKey) {
+    return;
+  }
+
+  const now = Date.now();
+  const maxAttempts = getBruteForceMaxAttempts();
+  const lockMs = getBruteForceLockMs();
+  const currentEntry = loginAttemptStore.get(attemptKey);
+
+  if (shouldResetAttemptState(currentEntry, now)) {
+    const shouldLockImmediately = maxAttempts <= 1;
+    loginAttemptStore.set(attemptKey, {
+      failedCount: 1,
+      firstFailedAt: now,
+      lockUntil: shouldLockImmediately ? now + lockMs : 0,
+    });
+    return;
+  }
+
+  const failedCount = currentEntry.failedCount + 1;
+  const lockUntil = failedCount >= maxAttempts ? now + lockMs : 0;
+
+  loginAttemptStore.set(attemptKey, {
+    failedCount,
+    firstFailedAt: currentEntry.firstFailedAt,
+    lockUntil,
+  });
+};
+
+export const clearLoginFailures = (request) => {
+  const attemptKey = request.loginAttemptKey || getLoginAttemptKey(request);
+
+  if (!attemptKey) {
+    return;
+  }
+
+  loginAttemptStore.delete(attemptKey);
+};
+
+export const resetLoginProtectionState = () => {
+  loginAttemptStore.clear();
+
+  if (loginRateLimiter?.store?.resetAll) {
+    loginRateLimiter.store.resetAll();
+  }
+};

--- a/apps/api/src/routes/auth.routes.js
+++ b/apps/api/src/routes/auth.routes.js
@@ -1,5 +1,11 @@
 import { Router } from "express";
 import { loginUser, registerUser } from "../services/auth.service.js";
+import {
+  bruteForceLoginGuard,
+  clearLoginFailures,
+  loginRateLimiter,
+  registerLoginFailure,
+} from "../middlewares/login-protection.middleware.js";
 
 const router = Router();
 
@@ -13,12 +19,17 @@ router.post("/register", async (req, res, next) => {
   }
 });
 
-router.post("/login", async (req, res, next) => {
+router.post("/login", loginRateLimiter, bruteForceLoginGuard, async (req, res, next) => {
   try {
     const authResult = await loginUser(req.body || {});
+    clearLoginFailures(req);
 
     res.status(200).json(authResult);
   } catch (error) {
+    if (error.status === 401) {
+      registerLoginFailure(req);
+    }
+
     next(error);
   }
 });

--- a/docs/architecture/v1.4.2-auth-hardening.md
+++ b/docs/architecture/v1.4.2-auth-hardening.md
@@ -1,0 +1,36 @@
+# Arquitetura v1.4.2 (Auth Hardening)
+
+## Objetivo
+Reduzir risco de brute-force no login sem impactar fluxo funcional existente.
+
+## Estrategia
+
+- Rate limit por IP em `POST /auth/login` com `express-rate-limit`.
+- Bloqueio temporario por combinacao `IP+email` apos falhas consecutivas.
+- Mensagem generica de bloqueio para evitar leak de informacao.
+
+## Implementacao
+
+- Middleware: `src/middlewares/login-protection.middleware.js`
+  - `loginRateLimiter`
+  - `bruteForceLoginGuard`
+  - `registerLoginFailure`
+  - `clearLoginFailures`
+- Integracao em `src/routes/auth.routes.js`
+  - pipeline: `loginRateLimiter -> bruteForceLoginGuard -> login handler`
+  - falha `401` registra tentativa
+  - sucesso limpa tentativas acumuladas
+
+## Configuracoes por ambiente
+
+- `AUTH_RATE_LIMIT_WINDOW_MS`
+- `AUTH_RATE_LIMIT_MAX_REQUESTS`
+- `AUTH_BRUTE_FORCE_WINDOW_MS`
+- `AUTH_BRUTE_FORCE_MAX_ATTEMPTS`
+- `AUTH_BRUTE_FORCE_LOCK_MS`
+- `TRUST_PROXY` (recomendado `1` em deploy com proxy)
+
+## Testes
+
+- Bloqueio por brute force e desbloqueio apos janela.
+- Isolamento por `IP+email` (bloqueio de um usuario nao afeta outro).

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.21.2",
+        "express-rate-limit": "^8.2.1",
         "jsonwebtoken": "^9.0.2",
         "pg": "^8.16.3"
       },
@@ -3998,6 +3999,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -4759,6 +4778,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {


### PR DESCRIPTION
### Context

This PR reduces brute-force risk on `POST /auth/login` while keeping the current auth contract unchanged (`{ token, user }` on success; errors stay consistent).

### What changed

* Added **rate limiting by IP** on `/auth/login` via `express-rate-limit`
* Added **temporary lockout by IP+email** after consecutive failed logins
* Clears accumulated failures on successful login
* Added `TRUST_PROXY` support for correct IP detection behind proxies (Render)

### Configuration

Environment variables (defaults are safe):

* `AUTH_RATE_LIMIT_WINDOW_MS` (default 15m)
* `AUTH_RATE_LIMIT_MAX_REQUESTS` (default 20)
* `AUTH_BRUTE_FORCE_WINDOW_MS` (default 15m)
* `AUTH_BRUTE_FORCE_MAX_ATTEMPTS` (default 5)
* `AUTH_BRUTE_FORCE_LOCK_MS` (default 15m)
* `TRUST_PROXY` (recommended `1` on Render)

Blocked responses return:

* `429` with message: **"Muitas tentativas de login. Tente novamente em alguns minutos."**

### Tests

Integration tests added to cover:

* lockout after repeated failures + automatic unlock after window
* isolation by `IP+email` (locking one user doesn’t block another)

### Notes / Follow-ups

* Current brute-force store is in-memory (resets on deploy). If we scale horizontally, we should move it to Redis (future v1.4.x).
* Consider adding generic auth responses to reduce user enumeration (optional hardening).
