### PR TITLE
chore(api): add sanitized database connection diagnostics on startup failure

### DIFF
--- a/apps/api/src/server.js
+++ b/apps/api/src/server.js
@@ -1,4 +1,5 @@
 import app from "./app.js";
+import { getDatabaseConnectionDiagnostics } from "./db/index.js";
 import { runMigrations } from "./db/migrate.js";
 
 const port = Number(process.env.PORT) || 3001;
@@ -13,5 +14,6 @@ const startServer = async () => {
 
 startServer().catch((error) => {
   console.error("Failed to start API server.", error);
+  console.error("Database connection diagnostics:", getDatabaseConnectionDiagnostics());
   process.exit(1);
 });


### PR DESCRIPTION
## Context

API was failing on startup due to Postgres authentication issues (`28P01`).
The logs did not provide enough visibility to quickly identify whether the problem was:

- wrong DATABASE_URL
- wrong user/database
- SSL mismatch
- malformed URL
- environment override

This PR adds sanitized database diagnostics to make future incidents trivial to debug.

---

## What changed

- Added `parseConnectionStringDiagnostics()` in `db/index.js`
- Added `getDatabaseConnectionDiagnostics()` export
- Logs sanitized connection details on startup failure in `server.js`

No password or secret is ever logged.

---

## Diagnostics now include

- `hasDatabaseUrl`
- `protocol`
- `host`
- `port`
- `database`
- `user`
- `sslModeInUrl`
- `nodeEnv`
- `dbSsl`
- `parseError` (if URL malformed)

This runs **only when startup fails**.

---

## How to test

1. Deploy normally → no new logs.
2. Break DATABASE_URL intentionally.
3. Observe sanitized diagnostics block in logs.

---

## Risk

Low.  
No runtime logic changed.  
No impact on request handling.

---

## Follow-up

Once DB credentials are rotated and updated in Render:

- `/health` should return 200
- `POST /auth/login` should succeed
