### PR TITLE
chore(deploy): monorepo render + vercel safe config

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Aplicacao web para controle financeiro pessoal com entradas/saidas, filtros por 
 - CI: [GitHub Actions - CI](https://github.com/JrValerio/Control-Finance-React-TailWind/actions/workflows/ci.yml)
 - Releases: [GitHub Releases](https://github.com/JrValerio/Control-Finance-React-TailWind/releases)
 
+## Deploy (Render + Vercel)
+
+- Guia monorepo: `docs/deployment/monorepo-render-vercel.md`
+
 ## Preview
 
 ![Tela principal](docs/images/home.png)

--- a/docs/deployment/monorepo-render-vercel.md
+++ b/docs/deployment/monorepo-render-vercel.md
@@ -66,3 +66,9 @@ Settings -> General:
 - Build finaliza sem erros
 - Web carrega normalmente
 - Login/register chamando API via `VITE_API_URL` (sem fallback para localhost)
+
+---
+
+## Observacao importante (monorepo)
+
+Evite rodar `npm ci --omit=dev` no root se o pipeline tambem buildar o web junto. O web pode depender de devDependencies na etapa de build.


### PR DESCRIPTION
### Context

This PR standardizes deployment configuration for the monorepo:

* API → Render (`apps/api`)
* Web → Vercel (`apps/web`)

The goal is to avoid installing unnecessary tooling in production and prevent workspace/root misconfiguration issues.

---

### What changed

#### Render (API)

* Documented recommended setup:

  * `Root Directory = apps/api`
  * `npm ci --omit=dev && npm run build`
  * `npm start`
* Added safe alternative when Root Directory is the repository root.
* Clarified required environment variables:

  * `DATABASE_URL`
  * `DB_SSL`
  * `JWT_SECRET`
  * `CORS_ORIGIN`
  * `TRUST_PROXY`

#### Vercel (Web)

* Documented:

  * `Root Directory = apps/web`
  * `Framework = Vite`
  * `VITE_API_URL` requirement
* Added post-deploy validation checklist.

#### Docs

* Added: `docs/deployment/monorepo-render-vercel.md`
* Linked deployment guide in `README.md`

---

### Why

* Prevents installing devDependencies in API production runtime.
* Avoids monorepo root misconfiguration.
* Makes deployment reproducible and explicit.
* Reduces future deploy incidents related to workspace resolution.

---

### Validation checklist

* [ ] Render API builds with `npm ci --omit=dev`
* [ ] `/health` returns 200
* [ ] `/auth/register` works
* [ ] `/auth/login` works
* [ ] Vercel build succeeds with `apps/web`
* [ ] Web uses `VITE_API_URL` (no localhost fallback)