### PR TITLE
feat(v1.5.0): CSV export with server-side filters + totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/JrValerio/Control-Finance-React-TailWind/actions/workflows/ci.yml/badge.svg)](https://github.com/JrValerio/Control-Finance-React-TailWind/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
-Aplicacao web para controle financeiro pessoal com entradas/saidas, filtros por categoria e periodo, grafico de receita x despesa e autenticacao JWT.
+Aplicacao web para controle financeiro pessoal com entradas/saidas, filtros por categoria e periodo, grafico de receita x despesa, exportacao CSV e autenticacao JWT.
 
 ## Links
 
@@ -35,6 +35,7 @@ Detalhes tecnicos:
 - Postgres Persistence: `docs/architecture/v1.4.0-postgres.md`
 - Auth Hardening: `docs/architecture/v1.4.2-auth-hardening.md`
 - Transactions CRUD+: `docs/architecture/v1.4.3-transactions-crud-plus.md`
+- Export CSV: `docs/architecture/v1.5.0-export-csv.md`
 
 ## Funcionalidades atuais (web)
 
@@ -52,6 +53,7 @@ Detalhes tecnicos:
 - Protecao de login com rate limiting e bloqueio temporario por `IP+email`
 - Edicao de transacao com descricao e observacoes
 - Exclusao com confirmacao e desfazer (undo real)
+- Exportacao CSV com filtros ativos (categoria + periodo) e totais consolidados
 
 ## API (apps/api)
 
@@ -59,11 +61,12 @@ Detalhes tecnicos:
 - `POST /auth/register` cria usuario no Postgres
 - `POST /auth/login` retorna `{ token, user }`
 - `/auth/login` aplica rate limit por IP e bloqueio temporario por brute force
-- `GET /transactions` lista transacoes do usuario autenticado
+- `GET /transactions` lista transacoes do usuario autenticado com filtros opcionais (`type`, `from`, `to`, `q`, `includeDeleted`)
 - `POST /transactions` cria transacao para o usuario autenticado
 - `PATCH /transactions/:id` atualiza transacao do usuario autenticado
 - `DELETE /transactions/:id` aplica soft delete para o usuario autenticado
 - `POST /transactions/:id/restore` restaura transacao removida
+- `GET /transactions/export.csv` exporta CSV filtrado com totais de entradas, saidas e saldo
 - Migrations SQL automaticas no startup (`src/db/migrations`)
 - Middleware global de erro e fallback `404`
 
@@ -121,7 +124,8 @@ npm run dev
 - [x] PR 2 (v1.3.0): autenticacao JWT + rotas protegidas
 - [x] PR 3 (v1.3.0): transacoes por usuario no backend + frontend API-first
 - [x] Persistencia em banco remoto (Postgres) para ambiente de producao
-- [ ] Exportacao/importacao CSV e JSON
+- [x] Exportacao CSV com filtros e totais
+- [ ] Importacao CSV/JSON
 
 ## Licenca
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/api",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.5.0",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/web",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.5.0",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/apps/web/src/components/DatabaseUtils.test.jsx
+++ b/apps/web/src/components/DatabaseUtils.test.jsx
@@ -12,6 +12,7 @@ import {
   getTodayISODate,
   normalizeTransactionDate,
   parseCurrencyInput,
+  resolvePeriodRange,
 } from "./DatabaseUtils";
 
 describe("DatabaseUtils", () => {
@@ -57,6 +58,26 @@ describe("DatabaseUtils", () => {
         referenceDate,
       ),
     ).toEqual([{ id: 2, value: 50, type: CATEGORY_ENTRY, date: "2026-02-10" }]);
+  });
+
+  it("resolve intervalo por periodo e ordena datas personalizadas", () => {
+    const referenceDate = new Date("2026-02-13T12:00:00");
+
+    expect(resolvePeriodRange(PERIOD_TODAY, {}, referenceDate)).toEqual({
+      startDate: "2026-02-13",
+      endDate: "2026-02-13",
+    });
+
+    expect(
+      resolvePeriodRange(
+        PERIOD_CUSTOM,
+        { startDate: "2026-02-20", endDate: "2026-02-10" },
+        referenceDate,
+      ),
+    ).toEqual({
+      startDate: "2026-02-10",
+      endDate: "2026-02-20",
+    });
   });
 
   it("calcula saldo com entradas e saidas", () => {

--- a/apps/web/src/services/api.test.js
+++ b/apps/web/src/services/api.test.js
@@ -47,13 +47,13 @@ describe("api service", () => {
 
   it("consulta o healthcheck da API", async () => {
     api.get.mockResolvedValueOnce({
-      data: { ok: true, version: "1.4.0" },
+      data: { ok: true, version: "1.5.0" },
     });
 
     const result = await getApiHealth();
 
     expect(api.get).toHaveBeenCalledWith("/health");
-    expect(result).toEqual({ ok: true, version: "1.4.0" });
+    expect(result).toEqual({ ok: true, version: "1.5.0" });
   });
 
   it("resolve URL configurada para producao", () => {

--- a/apps/web/src/services/transactions.service.js
+++ b/apps/web/src/services/transactions.service.js
@@ -1,13 +1,56 @@
 import { api } from "./api";
 
+const buildTransactionParams = (options = {}) => {
+  const params = {};
+
+  if (options.includeDeleted === true) {
+    params.includeDeleted = "true";
+  }
+
+  if (options.type) {
+    params.type = options.type;
+  }
+
+  if (options.from) {
+    params.from = options.from;
+  }
+
+  if (options.to) {
+    params.to = options.to;
+  }
+
+  if (typeof options.q === "string" && options.q.trim()) {
+    params.q = options.q.trim();
+  }
+
+  return params;
+};
+
+const resolveCsvFilename = (contentDispositionHeader) => {
+  if (typeof contentDispositionHeader !== "string") {
+    return "";
+  }
+
+  const fileNameMatch = contentDispositionHeader.match(
+    /filename\*=UTF-8''([^;]+)|filename="?([^"]+)"?/i,
+  );
+
+  if (!fileNameMatch) {
+    return "";
+  }
+
+  const fileName = fileNameMatch[1] || fileNameMatch[2] || "";
+
+  try {
+    return decodeURIComponent(fileName);
+  } catch {
+    return fileName;
+  }
+};
+
 export const transactionsService = {
   list: async (options = {}) => {
-    const params = {};
-
-    if (options.includeDeleted === true) {
-      params.includeDeleted = "true";
-    }
-
+    const params = buildTransactionParams(options);
     const { data } = await api.get("/transactions", { params });
     return data;
   },
@@ -26,5 +69,17 @@ export const transactionsService = {
   restore: async (id) => {
     const { data } = await api.post(`/transactions/${id}/restore`);
     return data;
+  },
+  exportCsv: async (options = {}) => {
+    const params = buildTransactionParams(options);
+    const response = await api.get("/transactions/export.csv", {
+      params,
+      responseType: "blob",
+    });
+
+    return {
+      blob: response.data,
+      fileName: resolveCsvFilename(response.headers?.["content-disposition"]),
+    };
   },
 };

--- a/docs/architecture/v1.5.0-export-csv.md
+++ b/docs/architecture/v1.5.0-export-csv.md
@@ -1,0 +1,84 @@
+# Arquitetura v1.5.0 (Export CSV + filtros API)
+
+## Objetivo
+
+Adicionar exportacao CSV de transacoes com filtros server-side e totais consolidados no proprio arquivo.
+
+## Escopo
+
+- API:
+  - `GET /transactions` com filtros opcionais por `type`, `from`, `to`, `q` e `includeDeleted`
+  - `GET /transactions/export.csv` para download de CSV com os mesmos filtros
+- Web:
+  - Botao `Exportar CSV` no dashboard
+  - Exportacao com filtros ativos (categoria + periodo)
+  - Download de arquivo com nome retornado pela API
+
+## Backend (apps/api)
+
+### Filtros unificados
+
+`transactions.service.js` passou a normalizar filtros em um unico fluxo:
+
+- `type`: `Entrada` ou `Saida`
+- `from` / `to`: formato `YYYY-MM-DD` (com swap automatico quando invertido)
+- `q`: busca textual por `description` e `notes` (case-insensitive via `ILIKE`)
+- `includeDeleted`: inclui removidos por soft delete quando `true`
+
+### Export CSV
+
+Novo metodo `exportTransactionsCsvByUser`:
+
+- reaproveita os filtros da listagem
+- gera CSV UTF-8 com BOM
+- escapa campos com virgula, aspas e quebra de linha
+- adiciona bloco final de resumo:
+  - `total_entradas`
+  - `total_saidas`
+  - `saldo`
+
+### Rota
+
+`apps/api/src/routes/transactions.routes.js`:
+
+- `GET /transactions/export.csv` (autenticada)
+- headers de download:
+  - `Content-Type: text/csv; charset=utf-8`
+  - `Content-Disposition: attachment; filename="..."`
+
+## Frontend (apps/web)
+
+### Service layer
+
+`transactions.service.js` recebeu `exportCsv(options)`:
+
+- envia filtros por query string
+- recebe blob (`responseType: "blob"`)
+- extrai nome de arquivo de `content-disposition`
+
+### Dashboard
+
+`App.jsx`:
+
+- novo botao `Exportar CSV`
+- bloqueio de clique durante exportacao (`isExportingCsv`)
+- reutiliza filtro ativo para montar payload de export:
+  - categoria (`type`)
+  - periodo (`from`/`to` via `resolvePeriodRange`)
+
+## Testes
+
+### API
+
+- filtro combinado (`type + from/to + q`) em `GET /transactions`
+- validacao de export CSV (headers, dados filtrados, escape e totais)
+
+### Web
+
+- validacao do clique em `Exportar CSV`
+- garante chamada do service com filtros ativos
+- valida ciclo de download (`createObjectURL`, `click`, `revokeObjectURL`)
+
+## Resultado
+
+v1.5.0 adiciona exportacao orientada a uso real sem alterar contratos existentes de criacao/edicao/exclusao de transacoes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "control-finance-monorepo",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "control-finance-monorepo",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "workspaces": [
         "apps/web",
         "apps/api"
@@ -20,7 +20,7 @@
     },
     "apps/api": {
       "name": "@control-finance/api",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
@@ -42,7 +42,7 @@
     },
     "apps/web": {
       "name": "@control-finance/web",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "dependencies": {
         "autoprefixer": "^10.4.24",
         "axios": "^1.8.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "control-finance-monorepo",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.5.0",
   "engines": {
     "node": "24.x"
   },


### PR DESCRIPTION
### What changed

* Added server-side filtering to `GET /transactions` (optional: `type`, `from`, `to`, `q`, `includeDeleted`)
* Added `GET /transactions/export.csv` to download a CSV using the same filters
* CSV output includes proper escaping (commas/quotes/newlines), UTF-8 BOM for Excel, and a totals summary (income/expense/balance)
* Web dashboard now has an **Export CSV** button that uses the currently active filters (category + period)
* Added tests for API filters + CSV export and Web export flow (blob download cycle)

### Why

Make the app more “real-world” by allowing users to export exactly what they’re seeing on the dashboard, with totals included—useful for reporting, bookkeeping, and sharing.

### How to test

#### API

* `GET /health` -> `200`
* `GET /transactions?type=Saida&from=YYYY-MM-DD&to=YYYY-MM-DD&q=...` -> `200` and filtered results
* `GET /transactions/export.csv` (same query params) -> `200`

  * `Content-Type` includes `text/csv`
  * `Content-Disposition` includes `attachment; filename="..."`
  * CSV contains headers + filtered rows + summary totals

#### Web

* Open dashboard
* Apply **Period** (including Custom range) and **Category** filters
* Click **Export CSV**

  * Download starts
  * Filename comes from API header (fallback used if missing)

### Checklist

* [ ] Render API deploy passes (`/health` returns 200)
* [ ] Register/Login works
* [ ] `GET /transactions` filters work in prod
* [ ] `GET /transactions/export.csv` downloads correctly (rows + totals)
* [ ] Vercel Web build succeeds and Export CSV works with `VITE_API_URL`

### Notes

* Version bumped to `1.5.0` (root + workspaces)
* Docs added: `docs/architecture/v1.5.0-export-csv.md`
