### PR TITLE
feat(v1.6.0): add paginated transactions listing with meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ Detalhes tecnicos:
 - `POST /auth/register` cria usuario no Postgres
 - `POST /auth/login` retorna `{ token, user }`
 - `/auth/login` aplica rate limit por IP e bloqueio temporario por brute force
-- `GET /transactions` lista transacoes do usuario autenticado com filtros opcionais (`type`, `from`, `to`, `q`, `includeDeleted`)
+- `GET /transactions` lista transacoes do usuario autenticado com filtros opcionais (`type`, `from`, `to`, `q`, `includeDeleted`, `page`, `limit`)
+  - resposta paginada: `{ data, meta: { page, limit, total, totalPages } }`
 - `POST /transactions` cria transacao para o usuario autenticado
 - `PATCH /transactions/:id` atualiza transacao do usuario autenticado
 - `DELETE /transactions/:id` aplica soft delete para o usuario autenticado

--- a/apps/api/src/routes/transactions.routes.js
+++ b/apps/api/src/routes/transactions.routes.js
@@ -13,21 +13,29 @@ const router = Router();
 
 router.use(authMiddleware);
 
-const getListFiltersFromQuery = (query = {}) => {
-  return {
+const getListFiltersFromQuery = (query = {}, options = {}) => {
+  const includePagination = options.includePagination !== false;
+  const filters = {
     includeDeleted: String(query.includeDeleted || "").toLowerCase() === "true",
     type: query.type,
     from: query.from,
     to: query.to,
     q: query.q,
   };
+
+  if (includePagination) {
+    filters.page = query.page;
+    filters.limit = query.limit;
+  }
+
+  return filters;
 };
 
 router.get("/export.csv", async (req, res, next) => {
   try {
     const csvExport = await exportTransactionsCsvByUser(
       req.user.id,
-      getListFiltersFromQuery(req.query),
+      getListFiltersFromQuery(req.query, { includePagination: false }),
     );
 
     res.setHeader("Content-Type", "text/csv; charset=utf-8");

--- a/apps/web/src/services/transactions.service.js
+++ b/apps/web/src/services/transactions.service.js
@@ -52,7 +52,16 @@ export const transactionsService = {
   list: async (options = {}) => {
     const params = buildTransactionParams(options);
     const { data } = await api.get("/transactions", { params });
-    return data;
+
+    if (Array.isArray(data)) {
+      return data;
+    }
+
+    if (Array.isArray(data?.data)) {
+      return data.data;
+    }
+
+    return [];
   },
   create: async (payload) => {
     const { data } = await api.post("/transactions", payload);


### PR DESCRIPTION
### Overview

This PR introduces pagination support to the `GET /transactions` endpoint as part of the v1.6 architecture upgrade.

The endpoint now returns a paginated response with metadata while preserving existing filtering capabilities.

---

### Changes

* `GET /transactions` now returns:

```json
{
  "data": [...],
  "meta": {
    "page": number,
    "limit": number,
    "total": number,
    "totalPages": number
  }
}
```

* Added support for `page` and `limit` query parameters

  * Default: `page=1`, `limit=20`
  * Maximum `limit=100`
* Existing filters preserved:

  * `type`
  * `from`
  * `to`
  * `q`
  * `includeDeleted`
* CSV export (`GET /transactions/export.csv`) remains **non-paginated**
* API tests updated to reflect new contract
* Added dedicated pagination test case
* Temporary compatibility layer in web service to support both old and new response shapes

---

### Non-Goals

* No UI pagination implemented yet
* No changes to CSV export behavior
* No database index changes (handled in upcoming PR)

---

### Validation

* `npm run lint` ✅
* `npm run test` ✅
* `npm run build` ✅
