### PR TITLE
feat(v1.6.2): add paginated transactions UI and remove legacy response support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Detalhes tecnicos:
 - Auth Hardening: `docs/architecture/v1.4.2-auth-hardening.md`
 - Transactions CRUD+: `docs/architecture/v1.4.3-transactions-crud-plus.md`
 - Export CSV: `docs/architecture/v1.5.0-export-csv.md`
+- Web Pagination: `docs/architecture/v1.6.2-web-pagination.md`
 
 ## Funcionalidades atuais (web)
 
@@ -54,6 +55,7 @@ Detalhes tecnicos:
 - Edicao de transacao com descricao e observacoes
 - Exclusao com confirmacao e desfazer (undo real)
 - Exportacao CSV com filtros ativos (categoria + periodo) e totais consolidados
+- Listagem paginada com `Anterior/Proxima` e indicador de pagina
 
 ## API (apps/api)
 

--- a/apps/web/src/services/transactions.service.js
+++ b/apps/web/src/services/transactions.service.js
@@ -23,6 +23,14 @@ const buildTransactionParams = (options = {}) => {
     params.q = options.q.trim();
   }
 
+  if (Number.isInteger(options.page) && options.page > 0) {
+    params.page = String(options.page);
+  }
+
+  if (Number.isInteger(options.limit) && options.limit > 0) {
+    params.limit = String(options.limit);
+  }
+
   return params;
 };
 
@@ -49,19 +57,23 @@ const resolveCsvFilename = (contentDispositionHeader) => {
 };
 
 export const transactionsService = {
-  list: async (options = {}) => {
+  listPage: async (options = {}) => {
     const params = buildTransactionParams(options);
     const { data } = await api.get("/transactions", { params });
+    const page = Number(data?.meta?.page);
+    const limit = Number(data?.meta?.limit);
+    const total = Number(data?.meta?.total);
+    const totalPages = Number(data?.meta?.totalPages);
 
-    if (Array.isArray(data)) {
-      return data;
-    }
-
-    if (Array.isArray(data?.data)) {
-      return data.data;
-    }
-
-    return [];
+    return {
+      data: Array.isArray(data?.data) ? data.data : [],
+      meta: {
+        page: Number.isInteger(page) && page > 0 ? page : 1,
+        limit: Number.isInteger(limit) && limit > 0 ? limit : 20,
+        total: Number.isInteger(total) && total >= 0 ? total : 0,
+        totalPages: Number.isInteger(totalPages) && totalPages > 0 ? totalPages : 1,
+      },
+    };
   },
   create: async (payload) => {
     const { data } = await api.post("/transactions", payload);

--- a/docs/architecture/v1.6.2-web-pagination.md
+++ b/docs/architecture/v1.6.2-web-pagination.md
@@ -1,0 +1,43 @@
+# Arquitetura v1.6.2 (Web Pagination)
+
+## Objetivo
+Migrar o dashboard web para consumir definitivamente o contrato paginado da API em `/transactions` e remover o suporte legado de resposta em array.
+
+## Escopo
+- Service `transactionsService.listPage` com contrato `{ data, meta }`
+- Remocao do compat layer legado no web
+- Controles de paginacao na UI (`Anterior` / `Proxima`)
+- Reset de pagina para `1` ao alterar filtros (categoria e periodo)
+- Testes de paginação e fluxos principais atualizados
+
+## Mudancas no Web
+
+### services/transactions.service.js
+- Novo metodo `listPage(options)`
+- Inclusao de `page` e `limit` nos query params
+- Fallback defensivo para `meta` quando API retorna payload incompleto
+
+### pages/App.jsx
+- Estado de paginacao:
+  - `currentPage`
+  - `paginationMeta { page, limit, total, totalPages }`
+- Carregamento API-first com filtros + pagina:
+  - `type`
+  - `from`
+  - `to`
+  - `page`
+  - `limit`
+- Navegacao por pagina com botoes `Anterior` e `Proxima`
+- Indicador de pagina e total de registros
+- Reset para pagina 1 quando filtros mudam
+
+### pages/App.test.jsx
+Cenarios cobertos:
+- carregamento inicial com `meta`
+- navegacao para proxima pagina
+- reset para pagina 1 ao trocar filtro
+- fluxos de create/edit/delete/restore com recarga paginada
+- export CSV com filtros ativos
+
+## Resultado
+A listagem web passa a operar com paginacao real da API e remove suporte legado, reduzindo acoplamento e preparando a base para evolucao de UX paginada (v1.6.x).


### PR DESCRIPTION
### Overview

This PR updates the web dashboard to consume the paginated `/transactions` API response introduced in v1.6.0 and removes the legacy array-response compatibility layer.

### Changes

* Added `transactionsService.listPage(options)` returning `{ data, meta }`
* Dashboard now loads transactions API-first with pagination:

  * `page`, `limit`, and `meta` support
  * Next/Previous controls and `Page X of Y` indicator
  * Displays total records from `meta.total`
* Page resets to `1` whenever filters change (category/period/custom dates)
* Removed support for legacy array-shaped responses in the web service
* Updated web tests to cover:

  * initial paginated load + meta rendering
  * page navigation
  * filter change resets page to 1
  * create/edit/delete/restore flows with paginated reload
  * CSV export using active filters
* Added architecture note: `docs/architecture/v1.6.2-web-pagination.md`
* README updated to reference v1.6.2 changes

### Validation

* `npm run lint` ✅
* `npm run test` ✅
* `npm run build` ✅