### PR TITLE
fix(docs): normalize markdown encoding and enforce LF for GitHub Pages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+﻿* text=auto
+
+*.md   text eol=lf
+*.yml  text eol=lf
+*.yaml text eol=lf
+*.json text eol=lf
+*.js   text eol=lf
+*.jsx  text eol=lf
+*.css  text eol=lf
+*.html text eol=lf
+*.sql  text eol=lf

--- a/docs/architecture/v1.6.2-web-pagination.md
+++ b/docs/architecture/v1.6.2-web-pagination.md
@@ -8,7 +8,7 @@ Migrar o dashboard web para consumir definitivamente o contrato paginado da API 
 - Remocao do compat layer legado no web
 - Controles de paginacao na UI (`Anterior` / `Proxima`)
 - Reset de pagina para `1` ao alterar filtros (categoria e periodo)
-- Testes de paginação e fluxos principais atualizados
+- Testes de paginacao e fluxos principais atualizados
 
 ## Mudancas no Web
 


### PR DESCRIPTION
## Overview

This hotfix unblocks the GitHub Pages (Jekyll) workflow that was failing due to invalid UTF-8 bytes in a documentation file.

## Changes

* Re-encoded `docs/architecture/v1.6.2-web-pagination.md` to valid UTF-8 (no BOM)
* Added `.gitattributes` to normalize text files and enforce LF line endings (docs + common code extensions)

## Why

The Pages build was failing with:

* `Invalid byte sequence in UTF-8`
* `The source text contains invalid characters for the used encoding UTF-8`

## Scope

* Documentation / repository hygiene only
* No runtime behavior changes
* No API/UI changes

## Validation

* Strict UTF-8 validation passed for `docs/**/*.md`

## After merge

Re-run **Actions → pages build and deployment** to confirm the workflow is green.