### PR TITLE
feat(v1.6.3): polish paginated transactions UI (range, page size, navigation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Detalhes tecnicos:
 - Transactions CRUD+: `docs/architecture/v1.4.3-transactions-crud-plus.md`
 - Export CSV: `docs/architecture/v1.5.0-export-csv.md`
 - Web Pagination: `docs/architecture/v1.6.2-web-pagination.md`
+- Pagination UI Polish: `docs/architecture/v1.6.3-pagination-polish.md`
 
 ## Funcionalidades atuais (web)
 
@@ -56,6 +57,7 @@ Detalhes tecnicos:
 - Exclusao com confirmacao e desfazer (undo real)
 - Exportacao CSV com filtros ativos (categoria + periodo) e totais consolidados
 - Listagem paginada com `Anterior/Proxima` e indicador de pagina
+- Faixa de pagina (`Mostrando X-Y de N`) e seletor de itens por pagina
 
 ## API (apps/api)
 

--- a/docs/architecture/v1.6.3-pagination-polish.md
+++ b/docs/architecture/v1.6.3-pagination-polish.md
@@ -1,0 +1,30 @@
+# Arquitetura v1.6.3 (Pagination UI Polish)
+
+## Objetivo
+Melhorar a experiencia de uso da paginacao no dashboard web sem alterar contrato de API ou regras de negocio.
+
+## Escopo
+- Indicador de faixa: `Mostrando X-Y de N`
+- Seletor de itens por pagina (`10`, `20`, `50`)
+- Persistencia de page size em `localStorage`
+- Navegacao de pagina com `Primeira`, `Anterior`, `Proxima` e `Ultima`
+- Scroll para o topo da lista ao trocar pagina
+- Loading com skeleton para transacoes
+
+## Mudancas no Web
+
+### pages/App.jsx
+- Novo estado `pageSize` com chave `control_finance.page_size`
+- Requisicoes de listagem agora usam `limit` dinamico
+- Reset para `page=1` ao alterar `pageSize`
+- Exibicao de contexto de pagina atual com faixa e total
+- Melhorias de navegacao e feedback visual
+
+### pages/App.test.jsx
+Novos cenarios cobertos:
+- alteracao de itens por pagina com reset para pagina 1
+- navegacao para ultima pagina
+- renderizacao da faixa `Mostrando X-Y de N`
+
+## Resultado
+A paginacao web fica mais clara e previsivel para o usuario, com menos friccao em navegacao e melhor leitura do volume de dados exibidos.


### PR DESCRIPTION
## Overview
This PR improves pagination UX in the web dashboard without API contract changes.

## Changes
- Added pagination range display: `Mostrando X-Y de N`
- Added page-size selector (`10`, `20`, `50`) with page reset to `1` on change
- Added `First` / `Previous` / `Next` / `Last` navigation controls
- Added smooth scroll-to-list behavior when changing page/limit
- Added loading skeletons for transaction list fetch
- Kept filters integrated with pagination and reset behavior

## Tests
- Updated web tests for paginated loading and navigation
- Added coverage for:
  - page-size change resetting to page 1
  - last-page navigation
  - pagination range rendering with API meta

## Docs
- Added architecture note: `docs/architecture/v1.6.3-pagination-polish.md`
- Updated README architecture/features references

## Validation
- `npm run lint` ✅
- `npm run test` ✅
- `npm run build` ✅
