### PR TITLE
chore(v1.6.9): enforce auth strict typecheck in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Lint (web)
         run: npm -w apps/web run lint
 
+      - name: Typecheck auth (web)
+        run: npm -w apps/web run typecheck:auth
+
       - name: Test (web)
         run: npm -w apps/web run test:run
 


### PR DESCRIPTION
﻿## Scope
CI hardening only (v1.6.9 step 1).

## Change
- Added `Typecheck auth (web)` step to `.github/workflows/ci.yml` in the `web` job.
- Command executed in CI:
  - `npm -w apps/web run typecheck:auth`

## Why
Ensures auth strict-nullability checks are enforced in CI, not only locally.

## Validation
- `npm -w apps/web run typecheck:auth` ✅

## Notes
- No frontend runtime changes
- No backend/API changes
