### PR TITLE
feat(v1.6.10): health version fallback to deploy commit sha

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Detalhes tecnicos:
 - Web Pagination: `docs/architecture/v1.6.2-web-pagination.md`
 - Pagination UI Polish: `docs/architecture/v1.6.3-pagination-polish.md`
 - Health Build Identity: `docs/architecture/v1.6.4-health-build-identity.md`
+- Health Version Fallback: `docs/architecture/v1.6.10-health-version-fallback.md`
 - Web TypeScript Thin Slice: `docs/architecture/v1.6.5-web-typescript-thin-slice.md`
 - Web TypeScript Services + Routes: `docs/architecture/v1.6.6-web-typescript-services-and-routes.md`
 
@@ -66,7 +67,9 @@ Detalhes tecnicos:
 
 ## API (apps/api)
 
-- `GET /health` retorna `{ ok: true, version, commit }` (build identity via `APP_VERSION`/`APP_COMMIT` com fallback seguro)
+- `GET /health` retorna `{ ok: true, version, commit }`
+  - `version`: `APP_VERSION` (opcional) ou fallback automatico `sha-<commit-curto>`
+  - `commit`: prioriza `RENDER_GIT_COMMIT`, com fallback para `APP_COMMIT`/`COMMIT_SHA`
 - `POST /auth/register` cria usuario no Postgres
 - `POST /auth/login` retorna `{ token, user }`
 - `/auth/login` aplica rate limit por IP e bloqueio temporario por brute force
@@ -109,7 +112,7 @@ npm run dev
 - Em deploy com proxy (Render), use `TRUST_PROXY=1` na API
 - `CORS_ORIGIN` da API pode receber lista separada por virgula (local + dominios de deploy)
 - Hardening de login: `AUTH_RATE_LIMIT_*` e `AUTH_BRUTE_FORCE_*`
-- Build identity da API no healthcheck: `APP_VERSION`, `APP_COMMIT` (Render usa `RENDER_GIT_COMMIT` automaticamente)
+- Build identity da API no healthcheck: `APP_VERSION` (opcional) e commit automatico via `RENDER_GIT_COMMIT`
 
 ## Scripts (root)
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -3,7 +3,7 @@ NODE_ENV=development
 # Build identity for /health (optional)
 # APP_VERSION=1.6.3
 # APP_COMMIT=2eb3f64
-# Render auto-populates RENDER_GIT_COMMIT
+# Render auto-populates RENDER_GIT_COMMIT (version fallback: sha-<commit-curto>)
 JWT_SECRET=troque-isto
 JWT_EXPIRES_IN=24h
 TRUST_PROXY=1

--- a/apps/api/src/config/version.js
+++ b/apps/api/src/config/version.js
@@ -1,11 +1,3 @@
-import fs from "node:fs";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const apiPackageJsonPath = path.resolve(__dirname, "../../package.json");
-
 const normalizeEnvValue = (value) => {
   if (typeof value !== "string") {
     return "";
@@ -14,46 +6,41 @@ const normalizeEnvValue = (value) => {
   return value.trim();
 };
 
-const loadApiVersion = () => {
-  try {
-    const packageJsonRaw = fs.readFileSync(apiPackageJsonPath, "utf8");
-    const packageJson = JSON.parse(packageJsonRaw);
-
-    if (typeof packageJson.version === "string" && packageJson.version.trim()) {
-      return packageJson.version;
-    }
-  } catch {
-    return "unknown";
-  }
-
-  return "unknown";
-};
-
-const resolveApiVersion = () => {
-  const appVersionFromEnv = normalizeEnvValue(process.env.APP_VERSION);
-
-  if (appVersionFromEnv) {
-    return appVersionFromEnv;
-  }
-
-  return loadApiVersion();
-};
-
-const resolveApiCommit = () => {
-  const commitFromAppEnv = normalizeEnvValue(process.env.APP_COMMIT);
-
-  if (commitFromAppEnv) {
-    return commitFromAppEnv;
-  }
-
-  const commitFromRenderEnv = normalizeEnvValue(process.env.RENDER_GIT_COMMIT);
+export const resolveApiCommit = (env = process.env) => {
+  const commitFromRenderEnv = normalizeEnvValue(env.RENDER_GIT_COMMIT);
 
   if (commitFromRenderEnv) {
     return commitFromRenderEnv;
   }
 
+  const commitFromAppEnv = normalizeEnvValue(env.APP_COMMIT);
+
+  if (commitFromAppEnv) {
+    return commitFromAppEnv;
+  }
+
+  const commitFromGenericEnv = normalizeEnvValue(env.COMMIT_SHA);
+
+  if (commitFromGenericEnv) {
+    return commitFromGenericEnv;
+  }
+
   return "unknown";
 };
 
-export const API_VERSION = resolveApiVersion();
-export const API_COMMIT = resolveApiCommit();
+export const resolveApiVersion = (env = process.env) => {
+  const appVersionFromEnv = normalizeEnvValue(env.APP_VERSION);
+
+  if (appVersionFromEnv) {
+    return appVersionFromEnv;
+  }
+
+  const commit = resolveApiCommit(env);
+
+  if (commit !== "unknown") {
+    return `sha-${commit.slice(0, 7)}`;
+  }
+
+  return "unknown";
+};
+

--- a/apps/api/src/config/version.test.js
+++ b/apps/api/src/config/version.test.js
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { resolveApiCommit, resolveApiVersion } from "./version.js";
+
+describe("version config", () => {
+  it("prioriza RENDER_GIT_COMMIT para commit", () => {
+    const commit = resolveApiCommit({
+      RENDER_GIT_COMMIT: "render-commit",
+      APP_COMMIT: "app-commit",
+      COMMIT_SHA: "generic-commit",
+    });
+
+    expect(commit).toBe("render-commit");
+  });
+
+  it("usa APP_COMMIT quando RENDER_GIT_COMMIT nao existe", () => {
+    const commit = resolveApiCommit({
+      APP_COMMIT: "app-commit",
+      COMMIT_SHA: "generic-commit",
+    });
+
+    expect(commit).toBe("app-commit");
+  });
+
+  it("usa COMMIT_SHA quando nenhum commit especifico existe", () => {
+    const commit = resolveApiCommit({
+      COMMIT_SHA: "generic-commit",
+    });
+
+    expect(commit).toBe("generic-commit");
+  });
+
+  it("retorna unknown quando nenhum commit esta disponivel", () => {
+    const commit = resolveApiCommit({});
+
+    expect(commit).toBe("unknown");
+  });
+
+  it("prioriza APP_VERSION para versao", () => {
+    const version = resolveApiVersion({
+      APP_VERSION: "1.6.10",
+      RENDER_GIT_COMMIT: "render-commit",
+    });
+
+    expect(version).toBe("1.6.10");
+  });
+
+  it("usa fallback sha curto quando APP_VERSION nao existe", () => {
+    const version = resolveApiVersion({
+      RENDER_GIT_COMMIT: "2e0ec31e19777924f4c5dfd59dcd240456d28c5e",
+    });
+
+    expect(version).toBe("sha-2e0ec31");
+  });
+
+  it("retorna unknown quando versao e commit nao existem", () => {
+    const version = resolveApiVersion({});
+
+    expect(version).toBe("unknown");
+  });
+});
+

--- a/apps/api/src/routes/health.routes.js
+++ b/apps/api/src/routes/health.routes.js
@@ -1,13 +1,13 @@
 import { Router } from "express";
-import { API_COMMIT, API_VERSION } from "../config/version.js";
+import { resolveApiCommit, resolveApiVersion } from "../config/version.js";
 
 const router = Router();
 
 router.get("/", (_req, res) => {
   res.status(200).json({
     ok: true,
-    version: API_VERSION,
-    commit: API_COMMIT,
+    version: resolveApiVersion(),
+    commit: resolveApiCommit(),
   });
 });
 

--- a/docs/architecture/v1.6.10-health-version-fallback.md
+++ b/docs/architecture/v1.6.10-health-version-fallback.md
@@ -1,0 +1,22 @@
+# Arquitetura v1.6.10 (Health Version Fallback)
+
+## Objetivo
+Reduzir dependencia manual de `APP_VERSION` no Render e manter `/health` coerente com o deploy.
+
+## Mudancas
+- `commit` no `/health` agora prioriza:
+  1. `RENDER_GIT_COMMIT`
+  2. `APP_COMMIT`
+  3. `COMMIT_SHA`
+  4. `unknown`
+- `version` no `/health` agora prioriza:
+  1. `APP_VERSION` (opcional)
+  2. fallback automatico `sha-<commit-curto>`
+  3. `unknown`
+- Rota `/health` passou a resolver `version` e `commit` dinamicamente via funcoes.
+
+## Resultado
+- Deploy na `main` fica observavel sem ajuste manual de versao.
+- `APP_VERSION` continua disponivel quando quiser semver humano no runtime.
+- Menos risco de mismatch entre release e `/health`.
+

--- a/docs/deployment/monorepo-render-vercel.md
+++ b/docs/deployment/monorepo-render-vercel.md
@@ -42,8 +42,8 @@ Se o service estiver com Root Directory no root do monorepo:
 - `JWT_EXPIRES_IN` (ex.: `24h`)
 - `CORS_ORIGIN` (ex.: `http://localhost:5173,https://<seu-vercel>.vercel.app`)
 - `TRUST_PROXY=1`
-- `APP_VERSION` (opcional, ex.: `1.6.3`, exposto no `/health`)
-- `APP_COMMIT` (opcional, fallback automatico para `RENDER_GIT_COMMIT`)
+- `APP_VERSION` (opcional, ex.: `1.6.10`; sem configurar, `/health.version` usa `sha-<commit-curto>`)
+- `APP_COMMIT` (opcional; `RENDER_GIT_COMMIT` continua prioridade no `/health.commit`)
 
 ### Checklist pos-deploy (Render)
 


### PR DESCRIPTION
﻿## Scope
API health build-identity hardening (runtime only) + docs.

## Changes
- Updated `apps/api/src/config/version.js`:
  - `resolveApiCommit()` now prioritizes `RENDER_GIT_COMMIT`, then `APP_COMMIT`, then `COMMIT_SHA`
  - `resolveApiVersion()` now prioritizes `APP_VERSION` and falls back to `sha-<short-commit>`
- Updated `GET /health` to resolve `version`/`commit` dynamically via resolver functions
- Added unit tests for version/commit resolution precedence and fallbacks (`apps/api/src/config/version.test.js`)
- Updated docs and env guidance:
  - `README.md`
  - `apps/api/.env.example`
  - `docs/deployment/monorepo-render-vercel.md`
  - `docs/architecture/v1.6.10-health-version-fallback.md`

## Why
Removes manual `APP_VERSION` dependency for coherent `/health` after deploys. `APP_VERSION` remains optional for human semver when desired.

## Validation
- `npm run lint` ✅
- `npm run test` ✅
- `npm run build` ✅
