### PR TITLE
v1.7.0 - Auth contract hardening (register auto-login + normalized errors)

### DIFF
--- a/apps/api/src/app.test.js
+++ b/apps/api/src/app.test.js
@@ -93,12 +93,15 @@ describe("API auth and transactions", () => {
     });
 
     expect(response.status).toBe(201);
+    expect(typeof response.body.token).toBe("string");
+    expect(response.body.token.length).toBeGreaterThan(10);
     expect(response.body.user).toMatchObject({
       name: "Junior",
       email: "jr@controlfinance.dev",
     });
     expect(Number.isInteger(response.body.user.id)).toBe(true);
     expect(response.body.user.id).toBeGreaterThan(0);
+    expect(response.body.user.password_hash).toBeUndefined();
   });
 
   it("POST /auth/register bloqueia email duplicado", async () => {
@@ -113,6 +116,27 @@ describe("API auth and transactions", () => {
     });
 
     expect(response.status).toBe(409);
+    expect(response.body).toEqual({ message: "Usuario ja cadastrado." });
+  });
+
+  it("POST /auth/register retorna erro quando email esta vazio", async () => {
+    const response = await request(app).post("/auth/register").send({
+      email: "",
+      password: "Senha123",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ message: "Email e senha sao obrigatorios." });
+  });
+
+  it("POST /auth/register retorna erro quando senha esta vazia", async () => {
+    const response = await request(app).post("/auth/register").send({
+      email: "vazio-register@controlfinance.dev",
+      password: "",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ message: "Email e senha sao obrigatorios." });
   });
 
   it("POST /auth/login retorna token", async () => {
@@ -130,6 +154,27 @@ describe("API auth and transactions", () => {
     expect(response.body.user.email).toBe("login@controlfinance.dev");
     expect(typeof response.body.token).toBe("string");
     expect(response.body.token.length).toBeGreaterThan(10);
+    expect(response.body.user.password_hash).toBeUndefined();
+  });
+
+  it("POST /auth/login retorna erro quando email esta vazio", async () => {
+    const response = await request(app).post("/auth/login").send({
+      email: "",
+      password: "Senha123",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ message: "Email e senha sao obrigatorios." });
+  });
+
+  it("POST /auth/login retorna erro quando senha esta vazia", async () => {
+    const response = await request(app).post("/auth/login").send({
+      email: "vazio-login@controlfinance.dev",
+      password: "",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ message: "Email e senha sao obrigatorios." });
   });
 
   it("aplica bloqueio por brute force e desbloqueia apos janela", async () => {

--- a/apps/api/src/middlewares/error.middleware.js
+++ b/apps/api/src/middlewares/error.middleware.js
@@ -7,8 +7,14 @@ export const errorHandler = (error, _req, res, next) => {
     return next(error);
   }
 
-  const status = error.status || 500;
-  const message = error.message || "Internal server error";
+  const status =
+    Number.isInteger(error?.status) && error.status >= 400 && error.status < 600
+      ? error.status
+      : 500;
+  const message =
+    typeof error?.message === "string" && error.message.trim()
+      ? error.message
+      : "Internal server error";
 
   return res.status(status).json({ message });
 };

--- a/apps/api/src/routes/auth.routes.js
+++ b/apps/api/src/routes/auth.routes.js
@@ -11,9 +11,9 @@ const router = Router();
 
 router.post("/register", async (req, res, next) => {
   try {
-    const user = await registerUser(req.body || {});
+    const authResult = await registerUser(req.body || {});
 
-    res.status(201).json({ user });
+    res.status(201).json(authResult);
   } catch (error) {
     next(error);
   }


### PR DESCRIPTION
## What
- POST /auth/register now returns 201 with { token, user } (auto-login)
- POST /auth/login keeps 200 with { token, user }
- errors are normalized as { message } via the global error middleware

## Why
- explicit, stable auth contract for frontend consumption
- predictable and safe error payloads
- no leakage of sensitive fields like password_hash

## Tests
- updated register shape assertion (	oken + user)
- added empty-field tests for register/login
- added duplicate-email error shape assertion (409)
- added explicit non-leak checks for password_hash
- full validation green: lint, 	est, uild

## Checklist
- [x] Minimal diff in /auth
- [x] Consistent { token, user } contract
- [x] Error payload shape { message }
- [x] Invalid-input and response-shape tests
- [ ] Version bump to 1.7.0 (follow-up before release tag)