### PR TITLE
chore(api): use package version as primary source for /health

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Aplicacao web para controle financeiro pessoal com entradas/saidas, filtros por 
 
 - Deploy trigger: merge na `main` (Render Auto Deploy) ou manual via **Deploy latest commit**.
 - Health endpoint: `/health` retorna `{ ok, version, commit }`.
-  - `version`: usa `APP_VERSION` quando setado (produção), senão fallback `sha-<short>`.
-  - `commit`: resolvido via `RENDER_GIT_COMMIT` (ou fallback) e representa exatamente o código em runtime.
+  - `version`: usa a versao de `apps/api/package.json`; fallback para `APP_VERSION` e depois `sha-<short>`.
+  - `commit`: resolvido via `RENDER_GIT_COMMIT` (ou fallback) e representa exatamente o codigo em runtime.
 - CI gates (web): `lint`, `typecheck`, `typecheck:auth`, `test`, `build`.
 - Git tag/release: `vX.Y.Z`.
-- Render `APP_VERSION`: `X.Y.Z` (sem `v`).
+- Render `APP_VERSION`: opcional (`X.Y.Z`, sem `v`) para override/fallback.
 - Runbook: `docs/runbooks/release-production-checklist.md`.
 
 ## Preview
@@ -80,7 +80,7 @@ Detalhes tecnicos:
 ## API (apps/api)
 
 - `GET /health` retorna `{ ok: true, version, commit }`
-  - `version`: `APP_VERSION` (opcional) ou fallback automatico `sha-<commit-curto>`
+  - `version`: `apps/api/package.json` por padrao, com fallback opcional `APP_VERSION` e depois `sha-<commit-curto>`
   - `commit`: prioriza `RENDER_GIT_COMMIT`, com fallback para `APP_COMMIT`/`COMMIT_SHA`
 - `POST /auth/register` cria usuario no Postgres
 - `POST /auth/login` retorna `{ token, user }`
@@ -124,7 +124,7 @@ npm run dev
 - Em deploy com proxy (Render), use `TRUST_PROXY=1` na API
 - `CORS_ORIGIN` da API pode receber lista separada por virgula (local + dominios de deploy)
 - Hardening de login: `AUTH_RATE_LIMIT_*` e `AUTH_BRUTE_FORCE_*`
-- Build identity da API no healthcheck: `APP_VERSION` (opcional) e commit automatico via `RENDER_GIT_COMMIT`
+- Build identity da API no healthcheck: versao do `apps/api/package.json` e commit automatico via `RENDER_GIT_COMMIT`
 
 ## Scripts (root)
 

--- a/apps/api/src/config/version.js
+++ b/apps/api/src/config/version.js
@@ -1,3 +1,7 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
 const normalizeEnvValue = (value) => {
   if (typeof value !== "string") {
     return "";
@@ -5,6 +9,22 @@ const normalizeEnvValue = (value) => {
 
   return value.trim();
 };
+
+const resolvePackageVersion = () => {
+  try {
+    const currentFilePath = fileURLToPath(import.meta.url);
+    const currentDirectory = path.dirname(currentFilePath);
+    const packageJsonPath = path.resolve(currentDirectory, "..", "..", "package.json");
+    const packageJsonContent = fs.readFileSync(packageJsonPath, "utf-8");
+    const packageJson = JSON.parse(packageJsonContent);
+
+    return normalizeEnvValue(packageJson?.version);
+  } catch {
+    return "";
+  }
+};
+
+const API_PACKAGE_VERSION = resolvePackageVersion();
 
 export const resolveApiCommit = (env = process.env) => {
   const commitFromRenderEnv = normalizeEnvValue(env.RENDER_GIT_COMMIT);
@@ -28,7 +48,16 @@ export const resolveApiCommit = (env = process.env) => {
   return "unknown";
 };
 
-export const resolveApiVersion = (env = process.env) => {
+export const resolveApiVersion = (
+  env = process.env,
+  options = {},
+) => {
+  const packageVersion = normalizeEnvValue(options.packageVersion ?? API_PACKAGE_VERSION);
+
+  if (packageVersion) {
+    return packageVersion;
+  }
+
   const appVersionFromEnv = normalizeEnvValue(env.APP_VERSION);
 
   if (appVersionFromEnv) {
@@ -43,4 +72,3 @@ export const resolveApiVersion = (env = process.env) => {
 
   return "unknown";
 };
-

--- a/apps/api/src/config/version.test.js
+++ b/apps/api/src/config/version.test.js
@@ -35,27 +35,44 @@ describe("version config", () => {
     expect(commit).toBe("unknown");
   });
 
-  it("prioriza APP_VERSION para versao", () => {
+  it("prioriza versao do package quando disponivel", () => {
     const version = resolveApiVersion({
-      APP_VERSION: "1.6.10",
+      APP_VERSION: "9.9.9",
       RENDER_GIT_COMMIT: "render-commit",
+    }, {
+      packageVersion: "1.7.0",
     });
 
-    expect(version).toBe("1.6.10");
+    expect(version).toBe("1.7.0");
   });
 
-  it("usa fallback sha curto quando APP_VERSION nao existe", () => {
+  it("usa APP_VERSION quando package version nao pode ser resolvida", () => {
+    const version = resolveApiVersion(
+      {
+        APP_VERSION: "1.7.0",
+        RENDER_GIT_COMMIT: "render-commit",
+      },
+      {
+        packageVersion: "",
+      },
+    );
+
+    expect(version).toBe("1.7.0");
+  });
+
+  it("usa fallback sha curto quando package version e APP_VERSION nao existem", () => {
     const version = resolveApiVersion({
       RENDER_GIT_COMMIT: "2e0ec31e19777924f4c5dfd59dcd240456d28c5e",
+    }, {
+      packageVersion: "",
     });
 
     expect(version).toBe("sha-2e0ec31");
   });
 
-  it("retorna unknown quando versao e commit nao existem", () => {
-    const version = resolveApiVersion({});
+  it("retorna unknown quando nenhuma fonte de versao e commit existem", () => {
+    const version = resolveApiVersion({}, { packageVersion: "" });
 
     expect(version).toBe("unknown");
   });
 });
-

--- a/docs/deployment/monorepo-render-vercel.md
+++ b/docs/deployment/monorepo-render-vercel.md
@@ -42,7 +42,7 @@ Se o service estiver com Root Directory no root do monorepo:
 - `JWT_EXPIRES_IN` (ex.: `24h`)
 - `CORS_ORIGIN` (ex.: `http://localhost:5173,https://<seu-vercel>.vercel.app`)
 - `TRUST_PROXY=1`
-- `APP_VERSION` (opcional, ex.: `1.6.10`; sem configurar, `/health.version` usa `sha-<commit-curto>`)
+- `APP_VERSION` (opcional para override; por padrao, `/health.version` usa `apps/api/package.json`)
 - `APP_COMMIT` (opcional; `RENDER_GIT_COMMIT` continua prioridade no `/health.commit`)
 
 ### Checklist pos-deploy (Render)

--- a/docs/runbooks/release-production-checklist.md
+++ b/docs/runbooks/release-production-checklist.md
@@ -12,8 +12,8 @@ Keep release, deploy, and runtime (`/health`) consistent.
 - Publish GitHub Release for the same tag.
 
 3. Render (API service)
-- Set `APP_VERSION=X.Y.Z`.
 - Click **Deploy latest commit** (optionally: clear cache if needed).
+- Optional: set `APP_VERSION=X.Y.Z` only if you want an explicit runtime override.
 
 4. Verify runtime
 Run:
@@ -26,4 +26,3 @@ Invoke-RestMethod -Uri $api -Method Get | ConvertTo-Json -Compress
 Expected:
 - `version` matches the release (`X.Y.Z`).
 - `commit` matches `origin/main` at the release tag.
-


### PR DESCRIPTION
## What
- changed `/health.version` source to prioritize `apps/api/package.json` version
- kept `APP_VERSION` only as optional fallback/override
- kept `sha-<short>` fallback when neither package version nor env version is available
- updated docs to reflect the new source of truth

## Why
- prevents runtime version drift caused by stale `APP_VERSION` in Render
- keeps release/tag and runtime health version aligned by default

## Tests
- updated `apps/api/src/config/version.test.js` for new precedence rules
- validated with `npm -w apps/api run test` ✅
- validated lint with `npm run lint` ✅

## Scope
- no auth/transactions behavior changes
- no API contract change besides version source behavior in `/health`