### PR TITLE
docs(runbook): clarify health.version reflects package version, not Git tag

### DIFF
--- a/docs/runbooks/release-production-checklist.md
+++ b/docs/runbooks/release-production-checklist.md
@@ -24,5 +24,10 @@ Invoke-RestMethod -Uri $api -Method Get | ConvertTo-Json -Compress
 ```
 
 Expected:
-- `version` matches the release (`X.Y.Z`).
+- `version` matches the API package version (`apps/api/package.json`).
 - `commit` matches `origin/main` at the release tag.
+
+Note:
+`/health.version` reflects the API package version (`apps/api/package.json`),
+not the Git tag. Release tags may differ when a release is observability-only
+(e.g. no package version bump).


### PR DESCRIPTION
## What
- clarified that `/health.version` reflects API package version (`apps/api/package.json`), not Git tag
- updated post-deploy validation expectation in the production release runbook
- documented observability-only release scenario (no package bump)

## Scope
- docs-only
- no runtime or contract changes