### PR TITLE
feat(api): add monthly transactions summary endpoint

### DIFF
--- a/apps/api/src/routes/transactions.routes.js
+++ b/apps/api/src/routes/transactions.routes.js
@@ -4,6 +4,7 @@ import {
   createTransactionForUser,
   deleteTransactionForUser,
   exportTransactionsCsvByUser,
+  getMonthlySummaryForUser,
   listTransactionsByUser,
   restoreTransactionForUser,
   updateTransactionForUser,
@@ -46,6 +47,15 @@ router.get("/export.csv", async (req, res, next) => {
     );
 
     res.status(200).send(csvExport.content);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get("/summary", async (req, res, next) => {
+  try {
+    const summary = await getMonthlySummaryForUser(req.user.id, req.query.month);
+    res.status(200).json(summary);
   } catch (error) {
     next(error);
   }


### PR DESCRIPTION
﻿## Overview
Adds `GET /transactions/summary?month=YYYY-MM` to return monthly totals and expense breakdown by category.

## Response
- `month`
- `income`
- `expense`
- `balance`
- `byCategory` (`categoryId`, `categoryName`, `expense`)

## Rules
- requires auth
- considers only authenticated user transactions
- ignores soft-deleted transactions (`deleted_at IS NULL`)
- uses month range `[YYYY-MM-01, next-month-01)`
- includes `Sem categoria` for `category_id = null`

## Errors
- missing month -> `400 { message: "Mes e obrigatorio. Use YYYY-MM." }`
- invalid month -> `400 { message: "Mes invalido. Use YYYY-MM." }`

## Tests
- unauthorized access blocked
- missing/invalid month validation
- zero totals for empty month
- mixed dataset (income + categorized expense + uncategorized expense)

## Validation
- `npm -w apps/api run lint` ✅
- `npm -w apps/api run test` ✅
- `npm run lint` ✅
- `npm run test` ✅
- `npm run build` ✅
