### PR TITLE
chore(release): bump versions to 1.8.0

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/api",
   "private": true,
-  "version": "1.7.0",
+  "version": "1.8.0",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/web",
   "private": true,
-  "version": "1.7.0",
+  "version": "1.8.0",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "control-finance-monorepo",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "control-finance-monorepo",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "workspaces": [
         "apps/web",
         "apps/api"
@@ -20,7 +20,7 @@
     },
     "apps/api": {
       "name": "@control-finance/api",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
@@ -42,7 +42,7 @@
     },
     "apps/web": {
       "name": "@control-finance/web",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "dependencies": {
         "autoprefixer": "^10.4.24",
         "axios": "^1.8.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "control-finance-monorepo",
   "private": true,
-  "version": "1.7.0",
+  "version": "1.8.0",
   "engines": {
     "node": "24.x"
   },


### PR DESCRIPTION
Bumps root/api/web package versions to 1.8.0 so /health.version aligns with release tags for v1.8.0.