### PR TITLE
chore(release): bump versions to 1.8.1

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/api",
   "private": true,
-  "version": "1.8.0",
+  "version": "1.8.1",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/web",
   "private": true,
-  "version": "1.8.0",
+  "version": "1.8.1",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "control-finance-monorepo",
   "private": true,
-  "version": "1.8.0",
+  "version": "1.8.1",
   "engines": {
     "node": "24.x"
   },


### PR DESCRIPTION
﻿## Overview
Bumps package versions to 1.8.1 to align release tag, runtime `/health.version`, and monorepo metadata.

## Changes
- root `package.json`: 1.8.0 -> 1.8.1
- `apps/api/package.json`: 1.8.0 -> 1.8.1
- `apps/web/package.json`: 1.8.0 -> 1.8.1

## Validation
- npm run lint ✅
- npm run test ✅
- npm run build ✅
