### PR TITLE
feat(api): add csv import dry-run with row validation

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,11 +17,13 @@
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",
+    "csv-parse": "^5.6.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.21.2",
     "express-rate-limit": "^8.2.1",
     "jsonwebtoken": "^9.0.2",
+    "multer": "^2.0.2",
     "pg": "^8.16.3"
   },
   "devDependencies": {

--- a/apps/api/src/db/migrations/005_add_transaction_import_sessions.sql
+++ b/apps/api/src/db/migrations/005_add_transaction_import_sessions.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS transaction_import_sessions (
+  id TEXT PRIMARY KEY,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  payload_json JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at TIMESTAMPTZ NOT NULL,
+  committed_at TIMESTAMPTZ NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_transaction_import_sessions_user_expires
+  ON transaction_import_sessions (user_id, expires_at);

--- a/apps/api/src/routes/transactions.routes.js
+++ b/apps/api/src/routes/transactions.routes.js
@@ -1,4 +1,6 @@
 import { Router } from "express";
+import path from "node:path";
+import multer from "multer";
 import { authMiddleware } from "../middlewares/auth.middleware.js";
 import {
   createTransactionForUser,
@@ -9,10 +11,45 @@ import {
   restoreTransactionForUser,
   updateTransactionForUser,
 } from "../services/transactions.service.js";
+import { dryRunTransactionsImportForUser } from "../services/transactions-import.service.js";
 
 const router = Router();
+const CSV_MAX_FILE_SIZE_BYTES = Number(process.env.IMPORT_CSV_MAX_FILE_SIZE_BYTES || 2 * 1024 * 1024);
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize:
+      Number.isInteger(CSV_MAX_FILE_SIZE_BYTES) && CSV_MAX_FILE_SIZE_BYTES > 0
+        ? CSV_MAX_FILE_SIZE_BYTES
+        : 2 * 1024 * 1024,
+  },
+});
 
 router.use(authMiddleware);
+
+const createError = (status, message) => {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+};
+
+const ensureValidCsvFile = (file) => {
+  if (!file) {
+    throw createError(400, "Arquivo CSV (file) e obrigatorio.");
+  }
+
+  const originalName = String(file.originalname || "");
+  const extension = path.extname(originalName).toLowerCase();
+  const mimeType = String(file.mimetype || "").toLowerCase();
+  const hasCsvExtension = extension === ".csv";
+  const hasCsvMimeType = ["text/csv", "application/csv", "application/vnd.ms-excel"].includes(
+    mimeType,
+  );
+
+  if ((!hasCsvExtension && !hasCsvMimeType) || !file.buffer || file.buffer.length === 0) {
+    throw createError(400, "Arquivo invalido. Envie um CSV.");
+  }
+};
 
 const getListFiltersFromQuery = (query = {}, options = {}) => {
   const includePagination = options.includePagination !== false;
@@ -114,6 +151,26 @@ router.post("/:id/restore", async (req, res, next) => {
   } catch (error) {
     next(error);
   }
+});
+
+router.post("/import/dry-run", (req, res, next) => {
+  upload.single("file")(req, res, async (error) => {
+    if (error) {
+      if (error instanceof multer.MulterError && error.code === "LIMIT_FILE_SIZE") {
+        return next(createError(413, "Arquivo muito grande."));
+      }
+
+      return next(error);
+    }
+
+    try {
+      ensureValidCsvFile(req.file);
+      const dryRunResult = await dryRunTransactionsImportForUser(req.user.id, req.file.buffer);
+      return res.status(200).json(dryRunResult);
+    } catch (serviceError) {
+      return next(serviceError);
+    }
+  });
 });
 
 export default router;

--- a/apps/api/src/services/transactions-import.service.js
+++ b/apps/api/src/services/transactions-import.service.js
@@ -1,0 +1,352 @@
+import { randomUUID } from "node:crypto";
+import { parse as parseCsv } from "csv-parse/sync";
+import { dbQuery } from "../db/index.js";
+
+const CATEGORY_ENTRY = "Entrada";
+const CATEGORY_EXIT = "Saida";
+const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+const IMPORT_TTL_MINUTES = 30;
+const REQUIRED_HEADERS = ["date", "type", "value", "description"];
+const OPTIONAL_HEADERS = ["notes", "category"];
+const ALLOWED_HEADERS = new Set([...REQUIRED_HEADERS, ...OPTIONAL_HEADERS]);
+const HEADER_ERROR_MESSAGE =
+  "CSV invalido. Cabecalho esperado: date,type,value,description,notes,category";
+
+const createError = (status, message) => {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+};
+
+const normalizeHeader = (value) => String(value || "").trim().toLowerCase();
+
+const normalizeRawCell = (value) =>
+  typeof value === "undefined" || value === null ? "" : String(value);
+
+const ensureValidCsvHeaders = (headerRow) => {
+  const normalizedHeaders = headerRow.map(normalizeHeader);
+  const uniqueHeaders = new Set(normalizedHeaders);
+
+  if (
+    normalizedHeaders.length === 0 ||
+    uniqueHeaders.size !== normalizedHeaders.length ||
+    normalizedHeaders.some((header) => !header || !ALLOWED_HEADERS.has(header))
+  ) {
+    throw createError(400, HEADER_ERROR_MESSAGE);
+  }
+
+  const missingRequiredHeader = REQUIRED_HEADERS.some(
+    (requiredHeader) => !uniqueHeaders.has(requiredHeader),
+  );
+
+  if (missingRequiredHeader) {
+    throw createError(400, HEADER_ERROR_MESSAGE);
+  }
+
+  return normalizedHeaders;
+};
+
+const buildRawRow = (sourceRow = {}) => ({
+  date: normalizeRawCell(sourceRow.date),
+  type: normalizeRawCell(sourceRow.type),
+  value: normalizeRawCell(sourceRow.value),
+  description: normalizeRawCell(sourceRow.description),
+  notes: normalizeRawCell(sourceRow.notes),
+  category: normalizeRawCell(sourceRow.category),
+});
+
+const parseCsvFileRows = (fileBuffer) => {
+  const csvContent = fileBuffer.toString("utf8");
+
+  let parsedRows;
+
+  try {
+    parsedRows = parseCsv(csvContent, {
+      bom: true,
+      skip_empty_lines: true,
+      relax_column_count: true,
+    });
+  } catch {
+    throw createError(400, "CSV invalido. Nao foi possivel processar o arquivo.");
+  }
+
+  if (!Array.isArray(parsedRows) || parsedRows.length === 0) {
+    throw createError(400, HEADER_ERROR_MESSAGE);
+  }
+
+  const [headerRow, ...dataRows] = parsedRows;
+
+  if (!Array.isArray(headerRow) || headerRow.length === 0) {
+    throw createError(400, HEADER_ERROR_MESSAGE);
+  }
+
+  const normalizedHeaders = ensureValidCsvHeaders(headerRow);
+
+  return dataRows.map((rowValues, rowIndex) => {
+    const sourceValues = Array.isArray(rowValues) ? rowValues : [rowValues];
+    const rowObject = {};
+
+    normalizedHeaders.forEach((header, headerIndex) => {
+      rowObject[header] = normalizeRawCell(sourceValues[headerIndex]);
+    });
+
+    return {
+      line: rowIndex + 2,
+      raw: buildRawRow(rowObject),
+    };
+  });
+};
+
+const normalizeDate = (value) => {
+  const normalizedValue = String(value || "").trim();
+
+  if (!ISO_DATE_REGEX.test(normalizedValue)) {
+    throw new Error("Data invalida. Use YYYY-MM-DD.");
+  }
+
+  const parsedDate = new Date(`${normalizedValue}T00:00:00`);
+
+  if (
+    Number.isNaN(parsedDate.getTime()) ||
+    parsedDate.toISOString().slice(0, 10) !== normalizedValue
+  ) {
+    throw new Error("Data invalida. Use YYYY-MM-DD.");
+  }
+
+  return normalizedValue;
+};
+
+const normalizeType = (value) => {
+  const normalizedValue = String(value || "")
+    .trim()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+
+  if (normalizedValue === "entrada") {
+    return CATEGORY_ENTRY;
+  }
+
+  if (normalizedValue === "saida") {
+    return CATEGORY_EXIT;
+  }
+
+  throw new Error("Tipo invalido. Use Entrada ou Saida.");
+};
+
+const normalizeValue = (value) => {
+  const compactValue = String(value || "").trim().replace(/\s+/g, "");
+
+  if (!compactValue) {
+    throw new Error("Valor invalido. Informe um numero maior que zero.");
+  }
+
+  const hasComma = compactValue.includes(",");
+  const hasDot = compactValue.includes(".");
+  let normalizedNumericValue = compactValue;
+
+  if (hasComma && hasDot) {
+    const decimalSeparator =
+      compactValue.lastIndexOf(",") > compactValue.lastIndexOf(".") ? "," : ".";
+
+    normalizedNumericValue =
+      decimalSeparator === ","
+        ? compactValue.replace(/\./g, "").replace(",", ".")
+        : compactValue.replace(/,/g, "");
+  } else if (hasComma) {
+    normalizedNumericValue = compactValue.replace(",", ".");
+  }
+
+  const parsedValue = Number(normalizedNumericValue);
+
+  if (!Number.isFinite(parsedValue) || parsedValue <= 0) {
+    throw new Error("Valor invalido. Informe um numero maior que zero.");
+  }
+
+  return Number(parsedValue.toFixed(2));
+};
+
+const normalizeDescription = (value) => {
+  const normalizedValue = String(value || "").trim();
+
+  if (!normalizedValue) {
+    throw new Error("Descricao e obrigatoria.");
+  }
+
+  return normalizedValue;
+};
+
+const normalizeNotes = (value) => String(value || "").trim();
+
+const resolveCategoryId = (value, categoryMap) => {
+  const normalizedCategoryName = String(value || "").trim();
+
+  if (!normalizedCategoryName) {
+    return null;
+  }
+
+  const categoryId = categoryMap.get(normalizedCategoryName.toLowerCase());
+
+  if (!categoryId) {
+    throw new Error("Categoria nao encontrada.");
+  }
+
+  return categoryId;
+};
+
+const loadCategoryMapForUser = async (userId) => {
+  const result = await dbQuery(
+    `
+      SELECT id, name
+      FROM categories
+      WHERE user_id = $1
+    `,
+    [userId],
+  );
+
+  return result.rows.reduce((categoryMap, row) => {
+    categoryMap.set(String(row.name).trim().toLowerCase(), Number(row.id));
+    return categoryMap;
+  }, new Map());
+};
+
+const normalizeCsvRow = (rawRow, categoryMap) => {
+  const errors = [];
+  let normalizedDate;
+  let normalizedType;
+  let normalizedValue;
+  let normalizedDescription;
+  let normalizedCategoryId;
+
+  try {
+    normalizedDate = normalizeDate(rawRow.date);
+  } catch (error) {
+    errors.push({ field: "date", message: error.message });
+  }
+
+  try {
+    normalizedType = normalizeType(rawRow.type);
+  } catch (error) {
+    errors.push({ field: "type", message: error.message });
+  }
+
+  try {
+    normalizedValue = normalizeValue(rawRow.value);
+  } catch (error) {
+    errors.push({ field: "value", message: error.message });
+  }
+
+  try {
+    normalizedDescription = normalizeDescription(rawRow.description);
+  } catch (error) {
+    errors.push({ field: "description", message: error.message });
+  }
+
+  try {
+    normalizedCategoryId = resolveCategoryId(rawRow.category, categoryMap);
+  } catch (error) {
+    errors.push({ field: "category", message: error.message });
+  }
+
+  if (errors.length > 0) {
+    return {
+      status: "invalid",
+      normalized: null,
+      errors,
+    };
+  }
+
+  return {
+    status: "valid",
+    normalized: {
+      date: normalizedDate,
+      type: normalizedType,
+      value: normalizedValue,
+      description: normalizedDescription,
+      notes: normalizeNotes(rawRow.notes),
+      categoryId: normalizedCategoryId,
+    },
+    errors: [],
+  };
+};
+
+const createSummary = (rows = []) => {
+  return rows.reduce(
+    (summary, row) => {
+      if (row.status === "valid") {
+        summary.validRows += 1;
+
+        if (row.normalized.type === CATEGORY_ENTRY) {
+          summary.income += row.normalized.value;
+        } else if (row.normalized.type === CATEGORY_EXIT) {
+          summary.expense += row.normalized.value;
+        }
+      } else {
+        summary.invalidRows += 1;
+      }
+
+      return summary;
+    },
+    {
+      totalRows: rows.length,
+      validRows: 0,
+      invalidRows: 0,
+      income: 0,
+      expense: 0,
+    },
+  );
+};
+
+const persistImportSession = async (userId, payload) => {
+  const importId = randomUUID();
+  const expiresAtDate = new Date(Date.now() + IMPORT_TTL_MINUTES * 60 * 1000);
+  const result = await dbQuery(
+    `
+      INSERT INTO transaction_import_sessions (id, user_id, payload_json, expires_at)
+      VALUES ($1, $2, $3::jsonb, $4)
+      RETURNING expires_at
+    `,
+    [importId, userId, JSON.stringify(payload), expiresAtDate.toISOString()],
+  );
+
+  return {
+    importId,
+    expiresAt:
+      typeof result.rows[0]?.expires_at === "string"
+        ? result.rows[0].expires_at
+        : new Date(result.rows[0]?.expires_at || expiresAtDate).toISOString(),
+  };
+};
+
+export const dryRunTransactionsImportForUser = async (userId, csvFileBuffer) => {
+  const parsedRows = parseCsvFileRows(csvFileBuffer);
+  const categoryMap = await loadCategoryMapForUser(userId);
+  const rows = parsedRows.map((row) => {
+    const normalizedRow = normalizeCsvRow(row.raw, categoryMap);
+
+    return {
+      line: row.line,
+      status: normalizedRow.status,
+      raw: row.raw,
+      normalized: normalizedRow.normalized,
+      errors: normalizedRow.errors,
+    };
+  });
+  const summary = createSummary(rows);
+
+  const normalizedRows = rows
+    .filter((row) => row.status === "valid" && row.normalized)
+    .map((row) => row.normalized);
+
+  const persistedSession = await persistImportSession(userId, {
+    normalizedRows,
+    summary,
+  });
+
+  return {
+    importId: persistedSession.importId,
+    expiresAt: persistedSession.expiresAt,
+    summary,
+    rows,
+  };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "control-finance-monorepo",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "control-finance-monorepo",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "workspaces": [
         "apps/web",
         "apps/api"
@@ -20,14 +20,16 @@
     },
     "apps/api": {
       "name": "@control-finance/api",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
+        "csv-parse": "^5.6.0",
         "dotenv": "^16.4.5",
         "express": "^4.21.2",
         "express-rate-limit": "^8.2.1",
         "jsonwebtoken": "^9.0.2",
+        "multer": "^2.0.2",
         "pg": "^8.16.3"
       },
       "devDependencies": {
@@ -42,7 +44,7 @@
     },
     "apps/web": {
       "name": "@control-finance/web",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "dependencies": {
         "autoprefixer": "^10.4.24",
         "axios": "^1.8.4",
@@ -2402,6 +2404,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -2807,6 +2815,23 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -3154,6 +3179,21 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
     "node_modules/concurrently": {
       "version": "9.2.1",
       "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
@@ -3297,6 +3337,12 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/csv-parse": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
+      "integrity": "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==",
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -6043,6 +6089,15 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -6050,6 +6105,18 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/moment": {
@@ -6074,6 +6141,24 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
+      "integrity": "sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "mkdirp": "^0.5.6",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.18",
+        "xtend": "^4.0.2"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      }
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -7198,6 +7283,20 @@
         "pify": "^2.3.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -7850,6 +7949,23 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -8635,6 +8751,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",


### PR DESCRIPTION
﻿## Overview
PR1 for v1.9.0 import flow: adds CSV dry-run endpoint with per-row validation and import session persistence.

## Changes
- Added migration `005_add_transaction_import_sessions.sql`.
- Added `POST /transactions/import/dry-run` (multipart, `file`) in transactions routes.
- Added dry-run service with:
  - CSV header validation
  - row normalization/validation (`date`, `type`, `value`, `description`, `notes`, `category`)
  - category lookup by user (case-insensitive name)
  - summary (`totalRows`, `validRows`, `invalidRows`, `income`, `expense`)
  - persisted import session (`importId`, `expiresAt`, payload JSON)
- Added API tests for:
  - auth protection
  - missing file
  - invalid file format
  - oversized file (413)
  - invalid header
  - mixed valid/invalid rows with session persistence
  - invalid date/type rows

## Contract
`POST /transactions/import/dry-run`
- request: multipart/form-data, field `file`
- response: `{ importId, expiresAt, summary, rows[] }`
- request-level errors: `{ message }`
- row-level errors: `errors[]` with `{ field, message }`

## Validation
- npm run lint ✅
- npm run test ✅
- npm run build ✅

## Scope
- API only
- No auth changes
- No web changes
- Commit endpoint intentionally out of scope (PR2)
