### PR TITLE
feat(api): add csv import commit with transactional persistence

### DIFF
--- a/apps/api/src/routes/transactions.routes.js
+++ b/apps/api/src/routes/transactions.routes.js
@@ -11,7 +11,10 @@ import {
   restoreTransactionForUser,
   updateTransactionForUser,
 } from "../services/transactions.service.js";
-import { dryRunTransactionsImportForUser } from "../services/transactions-import.service.js";
+import {
+  commitTransactionsImportForUser,
+  dryRunTransactionsImportForUser,
+} from "../services/transactions-import.service.js";
 
 const router = Router();
 const CSV_MAX_FILE_SIZE_BYTES = Number(process.env.IMPORT_CSV_MAX_FILE_SIZE_BYTES || 2 * 1024 * 1024);
@@ -171,6 +174,18 @@ router.post("/import/dry-run", (req, res, next) => {
       return next(serviceError);
     }
   });
+});
+
+router.post("/import/commit", async (req, res, next) => {
+  try {
+    const commitResult = await commitTransactionsImportForUser(
+      req.user.id,
+      req.body?.importId,
+    );
+    res.status(200).json(commitResult);
+  } catch (error) {
+    next(error);
+  }
 });
 
 export default router;


### PR DESCRIPTION
## Scope
- Add POST /transactions/import/commit to persist dry-run normalized rows.
- Keep response/error contract with { message } and status rules.

## Contract
- 400 for missing/invalid importId
- 404 when session does not exist (or does not belong to user)
- 410 when session is expired
- 409 when session is already committed
- 200 success: { imported, summary: { income, expense, balance } }

## Implementation
- Added withDbTransaction helper in pps/api/src/db/index.js.
- Commit flow updates session and inserts transactions inside one DB transaction.
- Preserves user ownership and idempotency rules.

## Tests
- Added coverage in pps/api/src/app.test.js for:
  - no token
  - missing importId
  - invalid importId
  - successful commit
  - cross-user commit (404)
  - repeated commit (409)
  - expired session (410)

## Validation
- 
pm -w apps/api run lint ✅
- 
pm -w apps/api run test ✅
- 
pm -w apps/api run build ✅
- 
pm run lint ✅
- 
pm run test ✅
- 
pm run build ✅