### PR TITLE
chore(release): bump versions to 1.9.0

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/api",
   "private": true,
-  "version": "1.8.1",
+  "version": "1.9.0",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/web",
   "private": true,
-  "version": "1.8.1",
+  "version": "1.9.0",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "control-finance-monorepo",
   "private": true,
-  "version": "1.8.1",
+  "version": "1.9.0",
   "engines": {
     "node": "24.x"
   },


### PR DESCRIPTION
## Scope
- Bump package versions from `1.8.1` to `1.9.0`.
- Keep root/api/web versions aligned for release + `/health` consistency.

## Files changed
- `package.json`
- `apps/api/package.json`
- `apps/web/package.json`

## Validation
- `npm run lint` ?
- `npm run test` ?
- `npm run build` ?

## Notes
- No runtime behavior change beyond version metadata.