### PR TITLE
chore(release): bump versions to 1.9.1

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/api",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.9.1",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/web",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.9.1",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "control-finance-monorepo",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.9.1",
   "engines": {
     "node": "24.x"
   },


### PR DESCRIPTION
## Scope
- Bump monorepo package versions to `1.9.1` (root + api + web)

## Validation
- `npm run lint`
- `npm run test`
- `npm run build`

## Notes
- Release metadata only (no runtime behavior change in this PR)
