### PR TITLE
feat(api): add import history endpoint with pagination

### DIFF
--- a/apps/api/src/routes/transactions.routes.js
+++ b/apps/api/src/routes/transactions.routes.js
@@ -15,6 +15,7 @@ import {
 import {
   commitTransactionsImportForUser,
   dryRunTransactionsImportForUser,
+  listTransactionsImportSessionsByUser,
 } from "../services/transactions-import.service.js";
 
 const router = Router();
@@ -97,6 +98,15 @@ router.get("/summary", async (req, res, next) => {
   try {
     const summary = await getMonthlySummaryForUser(req.user.id, req.query.month);
     res.status(200).json(summary);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get("/imports", async (req, res, next) => {
+  try {
+    const imports = await listTransactionsImportSessionsByUser(req.user.id, req.query || {});
+    res.status(200).json(imports);
   } catch (error) {
     next(error);
   }


### PR DESCRIPTION
## Scope
- Add import history endpoint for authenticated users
- API-only PR (no web changes)

## Endpoint
- `GET /transactions/imports?limit=20&offset=0`
- Returns `items[]` with `id`, `createdAt`, `expiresAt`, `committedAt`, and `summary`
- Returns `pagination` with `limit` and `offset`

## Rules
- `limit`: default `20`, min `1`, max `100`
- `offset`: default `0`, min `0`
- Invalid pagination returns `400 { message: "Paginacao invalida." }`
- `imported` is derived as `committedAt ? validRows : 0`
- Ordered by `created_at DESC`
- User scope enforced by `user_id`

## Tests
- 401 without token
- 400 on invalid pagination
- User isolation
- Response shape + ordering + limit/offset behavior

## Validation
- `npm -w apps/api run lint`
- `npm -w apps/api run test`
- `npm run lint`
- `npm run test`
- `npm run build`
