### PR TITLE
feat(api): add import observability logs and counters

### DIFF
--- a/apps/api/src/observability/import-observability.js
+++ b/apps/api/src/observability/import-observability.js
@@ -1,0 +1,111 @@
+const METRIC_NAMES = {
+  dryRunTotal: "import_dry_run_total",
+  commitTotal: "import_commit_total",
+  commitSuccessTotal: "import_commit_success_total",
+  commitFailTotal: "import_commit_fail_total",
+  rowsTotal: "import_rows_total",
+  rowsSamples: "import_rows_samples",
+};
+
+const importMetricsState = {
+  [METRIC_NAMES.dryRunTotal]: 0,
+  [METRIC_NAMES.commitTotal]: 0,
+  [METRIC_NAMES.commitSuccessTotal]: 0,
+  [METRIC_NAMES.commitFailTotal]: 0,
+  [METRIC_NAMES.rowsTotal]: 0,
+  [METRIC_NAMES.rowsSamples]: 0,
+};
+
+const toNonNegativeInteger = (value, fallbackValue = 0) => {
+  const parsedValue = Number(value);
+
+  if (!Number.isInteger(parsedValue) || parsedValue < 0) {
+    return fallbackValue;
+  }
+
+  return parsedValue;
+};
+
+const incrementMetric = (metricName, incrementValue = 1) => {
+  importMetricsState[metricName] += toNonNegativeInteger(incrementValue, 0);
+};
+
+const observeRows = (rowsCount) => {
+  const normalizedRowsCount = toNonNegativeInteger(rowsCount, 0);
+
+  incrementMetric(METRIC_NAMES.rowsTotal, normalizedRowsCount);
+  incrementMetric(METRIC_NAMES.rowsSamples, 1);
+};
+
+const shouldEmitImportLogs = () => {
+  if (process.env.NODE_ENV !== "test") {
+    return true;
+  }
+
+  return String(process.env.LOG_IMPORT_EVENTS_IN_TEST || "").trim().toLowerCase() === "true";
+};
+
+export const getImportMetricsSnapshot = () => {
+  const rowsSamples = importMetricsState[METRIC_NAMES.rowsSamples];
+  const rowsAverage =
+    rowsSamples > 0
+      ? Number((importMetricsState[METRIC_NAMES.rowsTotal] / rowsSamples).toFixed(2))
+      : 0;
+
+  return {
+    import_dry_run_total: importMetricsState[METRIC_NAMES.dryRunTotal],
+    import_commit_total: importMetricsState[METRIC_NAMES.commitTotal],
+    import_commit_success_total: importMetricsState[METRIC_NAMES.commitSuccessTotal],
+    import_commit_fail_total: importMetricsState[METRIC_NAMES.commitFailTotal],
+    import_rows_avg: rowsAverage,
+  };
+};
+
+export const createElapsedTimer = () => {
+  const startedAt = Date.now();
+
+  return () => {
+    return Date.now() - startedAt;
+  };
+};
+
+export const trackDryRunMetrics = ({ rowsTotal = 0 } = {}) => {
+  incrementMetric(METRIC_NAMES.dryRunTotal);
+  observeRows(rowsTotal);
+};
+
+export const trackCommitAttemptMetrics = () => {
+  incrementMetric(METRIC_NAMES.commitTotal);
+};
+
+export const trackCommitSuccessMetrics = ({ rowsImported = 0 } = {}) => {
+  incrementMetric(METRIC_NAMES.commitSuccessTotal);
+  observeRows(rowsImported);
+};
+
+export const trackCommitFailMetrics = () => {
+  incrementMetric(METRIC_NAMES.commitFailTotal);
+};
+
+export const logImportEvent = (eventName, payload = {}) => {
+  if (!shouldEmitImportLogs()) {
+    return;
+  }
+
+  const structuredLogPayload = {
+    scope: "import",
+    event: String(eventName || "unknown"),
+    timestamp: new Date().toISOString(),
+    ...payload,
+    metrics: getImportMetricsSnapshot(),
+  };
+
+  console.log(JSON.stringify(structuredLogPayload));
+};
+
+export const resetImportObservabilityForTests = () => {
+  Object.keys(importMetricsState).forEach((metricName) => {
+    importMetricsState[metricName] = 0;
+  });
+};
+

--- a/apps/api/src/services/transactions-import.service.js
+++ b/apps/api/src/services/transactions-import.service.js
@@ -575,6 +575,12 @@ export const commitTransactionsImportForUser = async (userId, importId) => {
   const normalizedRows = Array.isArray(payload.normalizedRows)
     ? payload.normalizedRows
     : [];
+  const payloadSummary = payload.summary || {};
+  const observabilitySummary = {
+    totalRows: normalizeSummaryInteger(payloadSummary.totalRows, normalizedRows.length),
+    validRows: normalizeSummaryInteger(payloadSummary.validRows, normalizedRows.length),
+    invalidRows: normalizeSummaryInteger(payloadSummary.invalidRows, 0),
+  };
 
   const commitOutcome = await withDbTransaction(async (transactionClient) => {
     const sessionUpdateResult = await transactionClient.query(
@@ -664,6 +670,12 @@ export const commitTransactionsImportForUser = async (userId, importId) => {
       income: commitOutcome.income,
       expense: commitOutcome.expense,
       balance: commitOutcome.income - commitOutcome.expense,
+    },
+    observability: {
+      importId: normalizedImportId,
+      totalRows: observabilitySummary.totalRows,
+      validRows: observabilitySummary.validRows,
+      invalidRows: observabilitySummary.invalidRows,
     },
   };
 };


### PR DESCRIPTION
## What\n- add structured import observability module with in-memory counters\n- instrument POST /transactions/import/dry-run with success/error events\n- instrument POST /transactions/import/commit with success/error events (including 409/410 specific events)\n- instrument GET /transactions/imports list endpoint with success/error events\n- include elapsed time (elapsedMs), status code, userId, importId, row totals in events\n- preserve public API response shapes\n\n## Metrics\n- import_dry_run_total\n- import_commit_total\n- import_commit_success_total\n- import_commit_fail_total\n- import_rows_avg\n\n## Validation\n- npm -w apps/api run lint\n- npm -w apps/api run test\n- npm run lint\n- npm run test\n- npm run build\n