### PR TITLE
feat(api): add requestId middleware and correlate import logs

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -6,6 +6,7 @@ import authRoutes from "./routes/auth.routes.js";
 import categoriesRoutes from "./routes/categories.routes.js";
 import transactionsRoutes from "./routes/transactions.routes.js";
 import { notFoundHandler, errorHandler } from "./middlewares/error.middleware.js";
+import { requestIdMiddleware } from "./middlewares/request-id.middleware.js";
 
 dotenv.config();
 
@@ -36,6 +37,7 @@ const resolveTrustProxyValue = () => {
 };
 
 app.set("trust proxy", resolveTrustProxyValue());
+app.use(requestIdMiddleware);
 
 const allowedOrigins = (process.env.CORS_ORIGIN || "http://localhost:5173")
   .split(",")

--- a/apps/api/src/app.test.js
+++ b/apps/api/src/app.test.js
@@ -106,6 +106,25 @@ describe("API auth and transactions", () => {
     expect(response.body.commit.length).toBeGreaterThan(0);
   });
 
+  it("echoa x-request-id quando informado no header", async () => {
+    const response = await request(app)
+      .get("/health")
+      .set("x-request-id", "request-id-test-123");
+
+    expect(response.status).toBe(200);
+    expect(response.headers["x-request-id"]).toBe("request-id-test-123");
+  });
+
+  it("gera x-request-id quando nao informado no header", async () => {
+    const response = await request(app).get("/health");
+    const requestId = response.headers["x-request-id"];
+
+    expect(response.status).toBe(200);
+    expect(typeof requestId).toBe("string");
+    expect(requestId.length).toBeGreaterThan(0);
+    expect(requestId.length).toBeLessThanOrEqual(128);
+  });
+
   it("POST /auth/register cria usuario", async () => {
     const response = await request(app).post("/auth/register").send({
       name: "Junior",

--- a/apps/api/src/middlewares/request-id.middleware.js
+++ b/apps/api/src/middlewares/request-id.middleware.js
@@ -1,0 +1,34 @@
+import { randomUUID } from "node:crypto";
+
+const MAX_REQUEST_ID_LENGTH = 128;
+
+const normalizeRequestIdValue = (value) => {
+  if (Array.isArray(value)) {
+    const firstValue = value.find((item) => typeof item === "string" && item.trim());
+    return normalizeRequestIdValue(firstValue || "");
+  }
+
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  const normalizedValue = value.trim();
+
+  if (!normalizedValue) {
+    return "";
+  }
+
+  return normalizedValue.slice(0, MAX_REQUEST_ID_LENGTH);
+};
+
+export const requestIdMiddleware = (req, res, next) => {
+  const requestIdFromHeader = normalizeRequestIdValue(req.headers["x-request-id"]);
+  const requestIdFromCorrelation = normalizeRequestIdValue(req.headers["x-correlation-id"]);
+  const requestId = requestIdFromHeader || requestIdFromCorrelation || randomUUID();
+
+  req.requestId = requestId;
+  res.setHeader("x-request-id", requestId);
+
+  next();
+};
+


### PR DESCRIPTION
## What\n- add equestIdMiddleware to resolve request correlation id from headers with UUID fallback\n- echo resolved request id in response header x-request-id\n- attach equestId to import observability events on:\n  - GET /transactions/imports\n  - POST /transactions/import/dry-run\n  - POST /transactions/import/commit\n- add API tests for request-id header behavior\n\n## Request ID resolution\n1. x-request-id\n2. x-correlation-id\n3. generated crypto.randomUUID()\n\n## Validation\n- npm -w apps/api run lint\n- npm -w apps/api run test\n- npm run lint\n- npm run test\n- npm run build\n