### PR TITLE
chore(release): prepare v1.10.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ Quando uma linha e invalida, a resposta traz erros por campo:
 - `POST /transactions/import/dry-run` valida CSV por linha e cria sessao de importacao com TTL
 - `POST /transactions/import/commit` confirma sessao de importacao e persiste apenas linhas validas
 - `GET /transactions/imports` lista historico de sessoes de importacao por usuario com `limit`/`offset`
+- `GET /transactions/imports/metrics` retorna metricas por usuario (`total`, `last30Days`, `lastImportAt`)
+- Correlacao de request: aceita `x-request-id` (ou `x-correlation-id`) e ecoa `x-request-id` na resposta
 - Migrations SQL automaticas no startup (`src/db/migrations`)
 - Middleware global de erro e fallback `404`
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/api",
   "private": true,
-  "version": "1.10.1",
+  "version": "1.10.2",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/web",
   "private": true,
-  "version": "1.10.1",
+  "version": "1.10.2",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "control-finance-monorepo",
   "private": true,
-  "version": "1.10.1",
+  "version": "1.10.2",
   "engines": {
     "node": "24.x"
   },


### PR DESCRIPTION
## What\n- bump root/api/web versions from 1.10.1 to 1.10.2\n- update README API section with:\n  - GET /transactions/imports/metrics\n  - request correlation headers (x-request-id / x-correlation-id)\n\n## Why\n- close v1.10.2 after request-id correlation and import metrics endpoint delivery\n\n## Validation\n- npm run lint\n- npm run test\n- npm run build\n