### PR TITLE
fix(api): include requestId in auth middleware errors

### DIFF
--- a/apps/api/src/app.test.js
+++ b/apps/api/src/app.test.js
@@ -490,10 +490,17 @@ describe("API auth and transactions", () => {
     expect(response.status).toBe(401);
   });
 
-  it("GET /transactions/imports/metrics bloqueia sem token", async () => {
-    const response = await request(app).get("/transactions/imports/metrics");
+  it("GET /transactions/imports/metrics bloqueia sem token e retorna requestId", async () => {
+    const response = await request(app)
+      .get("/transactions/imports/metrics")
+      .set("x-request-id", "rid-123");
 
     expect(response.status).toBe(401);
+    expect(response.body).toEqual({
+      message: "Token de autenticacao ausente ou invalido.",
+      requestId: "rid-123",
+    });
+    expect(response.headers["x-request-id"]).toBe("rid-123");
   });
 
   it("GET /transactions/imports/metrics retorna zeros quando usuario nao possui sessoes", async () => {

--- a/apps/api/src/middlewares/auth.middleware.js
+++ b/apps/api/src/middlewares/auth.middleware.js
@@ -1,20 +1,25 @@
 import { verifyAuthToken } from "../services/auth.service.js";
 
+const createUnauthorizedResponse = (req, message) => ({
+  message,
+  requestId: req.requestId || null,
+});
+
 export const authMiddleware = (req, res, next) => {
   const authorizationHeader = req.headers.authorization;
 
   if (!authorizationHeader || !authorizationHeader.startsWith("Bearer ")) {
-    return res.status(401).json({
-      message: "Token de autenticacao ausente ou invalido.",
-    });
+    return res
+      .status(401)
+      .json(createUnauthorizedResponse(req, "Token de autenticacao ausente ou invalido."));
   }
 
   const token = authorizationHeader.slice("Bearer ".length).trim();
 
   if (!token) {
-    return res.status(401).json({
-      message: "Token de autenticacao ausente ou invalido.",
-    });
+    return res
+      .status(401)
+      .json(createUnauthorizedResponse(req, "Token de autenticacao ausente ou invalido."));
   }
 
   try {
@@ -27,8 +32,6 @@ export const authMiddleware = (req, res, next) => {
 
     return next();
   } catch {
-    return res.status(401).json({
-      message: "Token invalido ou expirado.",
-    });
+    return res.status(401).json(createUnauthorizedResponse(req, "Token invalido ou expirado."));
   }
 };


### PR DESCRIPTION
## What
- add `requestId` to auth middleware 401 responses
- keep existing auth error messages unchanged
- update protected-route unauthorized test to assert `{ message, requestId }` and header echo

## Why
- make error payload contract consistent across direct middleware responses and global error handler responses
- improve support/debug flow by always correlating errors with `requestId`

## Validation
- `npm -w apps/api run lint`
- `npm -w apps/api run test -- -t "metrics bloqueia sem token e retorna requestId"`
- `npm -w apps/api run test`
- `npm run lint`