### PR TITLE
chore(db): add active transactions list indexes

### DIFF
--- a/apps/api/src/db/migrations/007_add_transactions_active_indexes.sql
+++ b/apps/api/src/db/migrations/007_add_transactions_active_indexes.sql
@@ -1,0 +1,7 @@
+CREATE INDEX IF NOT EXISTS idx_transactions_user_date_id_active
+  ON transactions (user_id, date ASC, id ASC)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_transactions_user_type_date_id_active
+  ON transactions (user_id, type, date ASC, id ASC)
+  WHERE deleted_at IS NULL;


### PR DESCRIPTION
## What
- add migration `007_add_transactions_active_indexes.sql`
- create partial indexes for active transactions (`deleted_at IS NULL`):
  - `idx_transactions_user_date_id_active` on `(user_id, date ASC, id ASC)`
  - `idx_transactions_user_type_date_id_active` on `(user_id, type, date ASC, id ASC)`

## Why
- optimize hot paths for transactions list/export queries:
  - `WHERE user_id = ? AND deleted_at IS NULL`
  - optional `type` filter
  - `ORDER BY date ASC, id ASC`
- keep existing non-partial indexes from migration 003 to preserve `includeDeleted=true` performance

## Validation
- `npm -w apps/api run test`
- `npm run lint`
- `npm run build`