### PR TITLE
chore(release): bump versions to 1.10.3

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/api",
   "private": true,
-  "version": "1.10.2",
+  "version": "1.10.3",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/web",
   "private": true,
-  "version": "1.10.2",
+  "version": "1.10.3",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "control-finance-monorepo",
   "private": true,
-  "version": "1.10.2",
+  "version": "1.10.3",
   "engines": {
     "node": "24.x"
   },


### PR DESCRIPTION
## What
- bump versions from `1.10.2` -> `1.10.3` in:
  - `package.json`
  - `apps/api/package.json`
  - `apps/web/package.json`

## Why
- create a patch release tag after post-`v1.10.2` improvements (observability, pagination hardening, indexes, test stabilization)
- keep main history clean with an explicit release marker

## Validation
- `npm run lint`
- `npm run test`
- `npm run build`

## Scope
- bump-only (no runtime/code changes)