### PR TITLE
docs: document offset-based pagination and prepare v1.10.4 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [1.10.4] - 2026-02-19
+
+### Highlights
+
+#### Web
+
+- Pagination migrated to an offset-first model
+- Pagination state persisted in querystring:
+  - `limit`
+  - `offset`
+  - `type`
+  - `categoryId`
+  - `period`
+  - `from`
+  - `to`
+- Predictable navigation controls:
+  - First
+  - Previous
+  - Next
+  - Last
+- Shareable and refresh-safe dashboard URLs
+
+#### API
+
+- `GET /transactions` exposes `meta.offset`
+- `offset` takes precedence over `page` when both are provided
+- Backward-compatible response shape:
+
+```json
+{
+  "data": [],
+  "meta": {
+    "page": 1,
+    "limit": 20,
+    "offset": 0,
+    "total": 45,
+    "totalPages": 3
+  }
+}
+```
+
+#### UX improvements
+
+- Range display based on `meta.offset`
+- Automatic clamp of extreme offsets
+- Pagination reset when filters or page size change
+
+#### Quality
+
+- Updated unit tests (API + Web)
+- Full CI green (`lint`, `test`, `build`)
+- No breaking changes

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Aplicacao web para controle financeiro pessoal com entradas/saidas, filtros por 
 - [Monthly Summary](#monthly-summary)
 - [CSV Import (Dry-run + Commit)](#csv-import-dry-run--commit)
 - [Import History](#import-history)
+- [Pagination](#pagination)
 - [Export CSV (Architecture Doc)](docs/architecture/v1.5.0-export-csv.md)
 - [API (apps/api)](#api-appsapi)
 - [Auth (Architecture Doc)](docs/architecture/v1.3.0-auth.md)
@@ -178,6 +179,35 @@ Quando uma linha e invalida, a resposta traz erros por campo:
 - `Expired`: nao possui `committedAt` e `Date.now() > Date.parse(expiresAt)`
 - `Pending`: nao possui `committedAt` e nao expirou
 
+## Pagination
+
+The transactions list supports server-side pagination using `limit` and `offset`.
+
+Example:
+
+```http
+GET /transactions?limit=20&offset=40
+```
+
+Notes:
+
+- `offset` takes precedence over `page`
+- The dashboard persists pagination and filters in the querystring
+- URLs are shareable and refresh-safe
+- Pagination metadata is returned in `meta`:
+
+```json
+{
+  "meta": {
+    "page": 3,
+    "limit": 20,
+    "offset": 40,
+    "total": 95,
+    "totalPages": 5
+  }
+}
+```
+
 ## API (apps/api)
 
 - `GET /health` retorna `{ ok: true, version, commit }`
@@ -190,7 +220,7 @@ Quando uma linha e invalida, a resposta traz erros por campo:
   - defaults: `limit=20`, `offset=0`
   - validacao: `limit` inteiro entre `1` e `100`; `offset` inteiro `>= 0`
   - regra de precedencia: quando `offset` e enviado, ele tem precedencia sobre `page`
-  - resposta paginada: `{ data, meta: { page, limit, total, totalPages } }`
+  - resposta paginada: `{ data, meta: { page, limit, offset, total, totalPages } }`
 - `POST /transactions` cria transacao para o usuario autenticado
 - `PATCH /transactions/:id` atualiza transacao do usuario autenticado
 - `DELETE /transactions/:id` aplica soft delete para o usuario autenticado


### PR DESCRIPTION
## What
- add a new README section for transactions pagination with `limit`/`offset`
- document precedence rule (`offset` over `page`) and metadata shape including `meta.offset`
- add `CHANGELOG.md` entry for `v1.10.4` highlights

## Why
- keep docs aligned with current runtime behavior
- make pagination behavior explicit for API consumers and dashboard usage
- provide release-ready notes for `v1.10.4`

## Validation
- docs-only change (no runtime impact)