### PR TITLE
docs: polish API pagination notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,8 +219,8 @@ Notes:
 - `GET /transactions` lista transacoes do usuario autenticado com filtros opcionais (`type`, `from`, `to`, `q`, `includeDeleted`, `page`, `limit`, `offset`)
   - defaults: `limit=20`, `offset=0`
   - validacao: `limit` inteiro entre `1` e `100`; `offset` inteiro `>= 0`
-  - regra de precedencia: quando `offset` e enviado, ele tem precedencia sobre `page`
-  - resposta paginada: `{ data, meta: { page, limit, offset, total, totalPages } }`
+  - Pagination precedence: when `offset` is provided, it takes precedence over `page`.
+  - Paginated response shape: `{ data, meta: { page, limit, offset, total, totalPages } }`
 - `POST /transactions` cria transacao para o usuario autenticado
 - `PATCH /transactions/:id` atualiza transacao do usuario autenticado
 - `DELETE /transactions/:id` aplica soft delete para o usuario autenticado


### PR DESCRIPTION
Removes duplicated pagination response bullet and standardizes API pagination notes.