### PR TITLE
feat(api): add transactions sort query with safe whitelist

### DIFF
--- a/apps/api/src/routes/transactions.routes.js
+++ b/apps/api/src/routes/transactions.routes.js
@@ -74,6 +74,7 @@ const getListFiltersFromQuery = (query = {}, options = {}) => {
     to: query.to,
     q: query.q,
     categoryId: query.categoryId,
+    sort: query.sort,
   };
 
   if (includePagination) {


### PR DESCRIPTION
## What
- add `sort` support to `GET /transactions` query parsing
- implement server-side sort with strict whitelist mapping (no direct SQL interpolation)
- keep current default ordering when sort is missing or invalid (fallback, no 400)
- enforce deterministic ordering with `id` tie-breaker aligned to sort direction
- add API contract tests for valid sort, direction case-insensitive, and invalid sort fallback

## Contract
- `sort=<field>:<direction>`
- fields: `date`, `amount` (alias for `value`), `value`, `description`, `createdAt`
- directions: `asc` | `desc` (case-insensitive)
- invalid sort -> fallback to default ordering (`date ASC, id ASC`)

## Validation
- npm -w apps/api run lint
- npm -w apps/api run test
- npm run lint
- npm run test
- npm run build