### PR TITLE
feat(web): offset-based sort querystring sync

### DIFF
--- a/apps/web/src/services/transactions.service.ts
+++ b/apps/web/src/services/transactions.service.ts
@@ -22,6 +22,7 @@ export interface TransactionListOptions {
   from?: string;
   to?: string;
   q?: string;
+  sort?: string;
   page?: number;
   limit?: number;
   offset?: number;
@@ -283,6 +284,10 @@ const buildTransactionParams = (options: TransactionListOptions = {}): Record<st
 
   if (typeof options.q === "string" && options.q.trim()) {
     params.q = options.q.trim();
+  }
+
+  if (typeof options.sort === "string" && options.sort.trim()) {
+    params.sort = options.sort.trim();
   }
 
   if (Number.isInteger(options.page) && options.page > 0) {


### PR DESCRIPTION
## What
- adds `sort` support to transactions list params in web service
- migrates dashboard sort state to URL-driven querystring (`sort=<field>:<direction>`)
- applies sort in API list calls together with existing filters/pagination
- resets `offset` to `0` when sort changes
- keeps pagination URL-driven (`limit/offset`) and compatible with backend precedence (`offset` over `page`)

## Why
- make sorting shareable and refresh-safe through URL state
- keep transactions list behavior deterministic with offset-based pagination
- prepare UX foundations for future presets/search/sort refinements

## Validation
- `npm -w apps/web run test:run -- src/pages/App.test.jsx`
- `npm -w apps/web run lint`
- `npm -w apps/web run build`
- `npm run lint`
- `npm run test`
- `npm run build`
