### PR TITLE
feat(web): improve applied chips remove button accessibility

### DIFF
--- a/apps/web/src/pages/App.jsx
+++ b/apps/web/src/pages/App.jsx
@@ -997,10 +997,21 @@ const App = ({ onLogout = undefined }) => {
                         <button
                           type="button"
                           aria-label={`Remover filtro: ${chip.removeLabel}`}
-                          className="ml-1 rounded px-1 text-xs font-bold text-gray-700 hover:bg-gray-100"
+                          className="ml-1 inline-flex h-8 w-8 items-center justify-center rounded-full text-gray-700 transition-colors hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-brand-1 focus:ring-offset-1"
                           onClick={() => handleRemoveAppliedChip(chip.id)}
                         >
-                          x
+                          <svg
+                            aria-hidden="true"
+                            viewBox="0 0 16 16"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            className="h-3.5 w-3.5"
+                          >
+                            <path d="M4 4L12 12" />
+                            <path d="M12 4L4 12" />
+                          </svg>
                         </button>
                       ) : null}
                     </span>


### PR DESCRIPTION
## What
- replace plain x text with an inline close icon in applied filter chips
- keep existing aria-label contract: Remover filtro: ...
- increase remove-button hit area to 32x32 (h-8 w-8) with visible keyboard focus ring

## Why
- improve mobile tap usability and accessibility without changing behavior

## Validation
- npm -w apps/web run test:run -- src/pages/App.test.jsx
- npm -w apps/web run lint
- npm -w apps/web run build
- npm run lint
- npm run test
- npm run build
