### PR TITLE
chore(release): v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,67 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.11.0] - 2026-02-19
+
+### Highlights
+
+- Monthly budgets by category for budget vs actual tracking in the selected month.
+- Budget status signals (`ok`, `near_limit`, `exceeded`) with progress visualization.
+- Full Web management flow for monthly budgets (create, edit, delete).
+
+### API
+
+- Added monthly budgets domain:
+  - `POST /budgets` for upsert by `user_id + category_id + month`
+  - `GET /budgets?month=YYYY-MM` for consolidated budget view per category
+  - `DELETE /budgets/:id` for user-scoped delete with ownership enforcement
+- Added persistence:
+  - New `monthly_budgets` table
+  - Unique index on `(user_id, category_id, month)`
+  - Index on `(user_id, month)`
+- `GET /budgets` consolidation includes:
+  - `actual` from `transactions` with `type = 'Saida'`, monthly range, `deleted_at IS NULL`
+  - computed `remaining`, `percentage`, and `status`
+- Status rules:
+  - `ok` when usage is `< 80%`
+  - `near_limit` when usage is `>= 80%` and `<= 100%`
+  - `exceeded` when usage is `> 100%`
+
+### Web
+
+- Added "Metas do mes" block to dashboard:
+  - fetches budgets by selected summary month
+  - loading, empty, error, and retry states
+  - per-category card with budget, actual, remaining, usage percentage, status badge, and progress bar
+- Added budgets CRUD UX:
+  - `+ Nova meta` action
+  - edit and delete actions per budget card
+  - inline modal for create/edit with validation and success feedback
+- Added UX and accessibility improvements:
+  - applied filter chips summary and removable chips
+  - icon-only remove control with preserved aria-label and 32x32 hit area
+  - search `Escape` behavior for draft clear and applied query removal
+  - polish for empty state CTA and edit mode clarity
+
+### Quality
+
+- Expanded API contract tests for budgets:
+  - upsert
+  - aggregation and status calculation
+  - ownership-safe delete
+- Expanded Web tests for:
+  - budgets block rendering and error retry
+  - budgets create and delete flows
+  - applied filters summary and chip removal
+  - search `Escape` behavior
+  - budgets polish flows (empty state CTA and edit-mode messaging)
+- CI green across `lint`, `test`, and `build`.
+
+### Release Integrity
+
+- Main aligned at `86f97054c8f48862d5cd9dbf2736f70dcf5d6900`.
+- Release train delivered with additive endpoints and no breaking API changes.
+
 ## [1.10.4] - 2026-02-19
 
 ### Highlights

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/api",
   "private": true,
-  "version": "1.10.4",
+  "version": "1.11.0",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/web",
   "private": true,
-  "version": "1.10.4",
+  "version": "1.11.0",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "control-finance-monorepo",
   "private": true,
-  "version": "1.10.4",
+  "version": "1.11.0",
   "engines": {
     "node": "24.x"
   },


### PR DESCRIPTION
Release prep for v1.11.0: version bumps (root/api/web) + CHANGELOG entry. Validation: lint/test/build ✅