### PR TITLE
docs: add release ops section to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,3 +10,8 @@
 - [ ] Sem erros no console
 - [ ] README atualizado (se necessario)
 - [ ] Mudancas de UX revisadas em desktop e mobile
+
+## Release / Ops (quando aplicavel)
+- [ ] Executei `docs/runbooks/release-production-checklist.md` apos deploy
+- [ ] `/health` validado (version + commit esperados)
+- [ ] Smoke de auth e endpoint(s) afetados executado


### PR DESCRIPTION
## What
- Add optional Release / Ops checklist linking to production runbook

## Why
- Make release verification repeatable and auditable

## Scope
- docs-only