### PR TITLE
docs: add evidences block to production release runbook

### DIFF
--- a/docs/runbooks/release-production-checklist.md
+++ b/docs/runbooks/release-production-checklist.md
@@ -78,7 +78,31 @@ Rollback required: yes/no
 Notes:
 ```
 
-## 6. Suggested Operational Sequence
+## 6. Evidences (Per Release)
+
+> Copy this block for each new release and keep history at the end of this file.
+
+```md
+Release: vX.Y.Z
+Date:
+Owner:
+
+PR release:
+Tag:
+GitHub Release:
+Commit main:
+Commit runtime (`/health.commit`):
+
+Render deploy (link):
+Vercel deploy (link):
+Output `/health` (json):
+Smoke executed: yes/no
+Monitoring 15-30 min: ok/not ok
+Rollback needed: yes/no
+Observations:
+```
+
+## 7. Suggested Operational Sequence
 
 For each release:
 1. Open and merge PR.


### PR DESCRIPTION
## What
- add an Evidences section to the production release runbook
- include a reusable per-release block for links, health output, smoke, monitoring, and rollback outcome
- add guidance to copy the block for each new release and keep history in the same document

## Why
- improve release traceability and auditability

## Scope
- docs-only (docs/runbooks/release-production-checklist.md)