### PR TITLE
feat(ui): compact active filters and mobile header actions

### DIFF
--- a/apps/web/src/pages/App.jsx
+++ b/apps/web/src/pages/App.jsx
@@ -57,7 +57,7 @@ const SORT_OPTION_VALUES = new Set(SORT_OPTIONS.map((option) => option.value));
 const DEFAULT_SORT = "date:asc";
 const DEFAULT_OFFSET = 0;
 const DEFAULT_LIMIT = 20;
-const MOBILE_HEADER_ACTIONS_BREAKPOINT = 400;
+const MOBILE_HEADER_ACTIONS_BREAKPOINT = 420;
 const MOBILE_ACTIONS_MENU_ID = "mobile-header-actions-menu";
 const PAGE_SIZE_OPTIONS = [10, 20, 50];
 const PAGE_SIZE_STORAGE_KEY = "control_finance.page_size";
@@ -1264,14 +1264,6 @@ const App = ({ onLogout = undefined }) => {
           <div className="flex flex-wrap items-center justify-end gap-2">
             {useMobileActionsMenu ? (
               <div className="relative flex items-center gap-2">
-                {onLogout ? (
-                  <button
-                    onClick={handleLogoutFromActionsMenu}
-                    className="whitespace-nowrap rounded border border-gray-300 bg-white px-2.5 py-1.5 text-xs font-semibold text-gray-100 hover:bg-gray-400"
-                  >
-                    Sair
-                  </button>
-                ) : null}
                 <button
                   type="button"
                   aria-haspopup="menu"
@@ -1317,6 +1309,19 @@ const App = ({ onLogout = undefined }) => {
                     >
                       Historico de imports
                     </button>
+                    {onLogout ? (
+                      <>
+                        <div className="my-1 h-px bg-gray-200" role="separator" />
+                        <button
+                          type="button"
+                          role="menuitem"
+                          onClick={handleLogoutFromActionsMenu}
+                          className="rounded px-2 py-2 text-left text-xs font-semibold text-red-700 hover:bg-red-50"
+                        >
+                          Sair
+                        </button>
+                      </>
+                    ) : null}
                   </div>
                 ) : null}
               </div>

--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import App from "./App";
 import { CATEGORY_ENTRY, CATEGORY_EXIT } from "../components/DatabaseUtils";
@@ -1248,13 +1248,17 @@ describe("App", () => {
       writable: true,
       value: 360,
     });
-    fireEvent(window, new Event("resize"));
+    act(() => {
+      fireEvent(window, new Event("resize"));
+    });
 
     try {
       render(<App onLogout={onLogout} />);
 
+      expect(screen.queryByRole("button", { name: "Sair" })).not.toBeInTheDocument();
       await user.click(screen.getByRole("button", { name: "Acoes" }));
       expect(await screen.findByRole("menu", { name: "Acoes rapidas" })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: "Sair" })).toBeInTheDocument();
 
       await waitFor(() => {
         expect(screen.getByRole("menuitem", { name: "Exportar CSV" })).toHaveFocus();
@@ -1273,7 +1277,9 @@ describe("App", () => {
         writable: true,
         value: originalInnerWidth,
       });
-      fireEvent(window, new Event("resize"));
+      act(() => {
+        fireEvent(window, new Event("resize"));
+      });
     }
   });
 


### PR DESCRIPTION
## What
- Render active filter state as compact chips with removable actions
- Add inline clear-all action in the active filters block
- Keep filter action buttons in Filtrar lista and remove duplicated clear preset button
- Replace sub-400px header action overflow with an Acoes menu (Exportar, Importar, Historico)
- Keep desktop header actions compact and unchanged in behavior
- Update tests for the renamed clear action and filter accessibility labels

## Why
- Reduce visual duplication between filter controls and filter state
- Avoid horizontal action overflow on very small mobile widths
- Preserve deterministic accessibility selectors in tests

## Validation
- npm -w apps/web run test:run -- src/pages/App.test.jsx
- npm -w apps/web run lint
- npm -w apps/web run build
- npm run lint
- npm run test
- npm run build