### PR TITLE
feat(ui): hide presets when filters are active

### DIFF
--- a/apps/web/src/pages/App.jsx
+++ b/apps/web/src/pages/App.jsx
@@ -1148,6 +1148,7 @@ const App = ({ onLogout = undefined }) => {
     return count;
   }, [selectedCategory, selectedPeriod, selectedQuery, selectedTransactionCategoryId]);
   const hasActiveFilters = activeFiltersCount > 0;
+  const shouldShowPresets = !hasActiveFilters;
   const hasMonthlySummaryData =
     monthlySummary.income > 0 ||
     monthlySummary.expense > 0 ||
@@ -1423,23 +1424,35 @@ const App = ({ onLogout = undefined }) => {
                 </div>
               ) : null}
             </div>
-            <div className="flex flex-wrap gap-2">
-              {visibleFilterPresets.map((preset) => (
+            {shouldShowPresets ? (
+              <div className="flex flex-wrap gap-2">
+                {visibleFilterPresets.map((preset) => (
+                  <button
+                    key={preset.id}
+                    type="button"
+                    aria-pressed={isPresetActive(preset.id)}
+                    onClick={() => applyFilterPreset(preset.id)}
+                    className={`flex items-center justify-center gap-2.5 rounded border px-4 py-2 text-sm font-semibold transition-colors ${
+                      isPresetActive(preset.id)
+                        ? "border-brand-1 bg-brand-3 text-brand-1"
+                        : "border-gray-300 bg-white text-gray-900 hover:bg-gray-100"
+                    }`}
+                  >
+                    {preset.label}
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <div className="flex items-center gap-2">
                 <button
-                  key={preset.id}
                   type="button"
-                  aria-pressed={isPresetActive(preset.id)}
-                  onClick={() => applyFilterPreset(preset.id)}
-                  className={`flex items-center justify-center gap-2.5 rounded border px-4 py-2 text-sm font-semibold transition-colors ${
-                    isPresetActive(preset.id)
-                      ? "border-brand-1 bg-brand-3 text-brand-1"
-                      : "border-gray-300 bg-white text-gray-900 hover:bg-gray-100"
-                  }`}
+                  onClick={() => searchInputRef.current?.focus()}
+                  className="rounded border border-gray-300 bg-white px-2 py-1 text-xs font-semibold text-gray-700 hover:bg-gray-100"
                 >
-                  {preset.label}
+                  Editar filtros
                 </button>
-              ))}
-            </div>
+              </div>
+            )}
             <div className="flex flex-col gap-2">
               <span className="text-xs font-semibold uppercase tracking-wide text-gray-200">
                 Filtrar lista

--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -743,7 +743,10 @@ describe("App", () => {
     await user.click(screen.getByRole("button", { name: "Este mes" }));
 
     expect(await screen.findByText("Depois do preset")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Este mes" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.queryByRole("button", { name: "Este mes" })).not.toBeInTheDocument();
+    expect(screen.getByText("Filtros ativos (1)")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Editar filtros" })).toBeInTheDocument();
+    expect(screen.getByText(`Periodo: ${startDate} -> ${endDate}`)).toBeInTheDocument();
     expect(transactionsService.listPage).toHaveBeenLastCalledWith({
       limit: 20,
       offset: 0,
@@ -890,6 +893,9 @@ describe("App", () => {
     render(<App />);
 
     expect(await screen.findByText("Sem filtros ativos")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Este mes" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Entradas" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Saidas" })).toBeInTheDocument();
     expect(screen.queryByText(/Filtros ativos \(\d+\)/)).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Limpar tudo" })).not.toBeInTheDocument();
 
@@ -899,6 +905,10 @@ describe("App", () => {
     expect(await screen.findByText("Com filtros ativos")).toBeInTheDocument();
     expect(screen.getByText("Filtros ativos (1)")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Limpar tudo" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Este mes" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Entradas" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Saidas" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Editar filtros" })).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Filtrar entradas" }));
     expect(await screen.findByText("Com dois filtros ativos")).toBeInTheDocument();


### PR DESCRIPTION
## What
- Hide preset shortcuts (Este mes, Entradas, Saidas) when active filters are present
- Keep active-filter chips as the single applied-state representation
- Keep Limpar tudo in the active-filters block
- Add Editar filtros shortcut (focuses search input) when active filters are present
- Add/adjust tests for preset visibility with and without active filters

## Why
- Remove duplicated controls and reduce visual noise in the filters area
- Keep filters UX aligned with SaaS pattern (actions vs state)

## Validation
- npm -w apps/web run test:run -- src/pages/App.test.jsx
- npm -w apps/web run lint
- npm -w apps/web run build
- npm run lint
- npm run test
- npm run build