### PR TITLE
feat(ui): render active-filter chips as horizontal scroll row

### DIFF
--- a/apps/web/src/pages/App.jsx
+++ b/apps/web/src/pages/App.jsx
@@ -1390,11 +1390,11 @@ const App = ({ onLogout = undefined }) => {
                       Limpar tudo
                     </button>
                   </div>
-                  <div className="flex flex-wrap items-center gap-2">
+                  <div className="-mx-1 flex flex-nowrap items-center gap-2 overflow-x-auto px-1 pb-1">
                     {appliedChips.map((chip) => (
                       <span
                         key={chip.id}
-                        className="inline-flex items-center gap-1 rounded-full border border-gray-300 bg-white py-1 pl-2.5 pr-1.5 text-xs font-medium text-gray-700"
+                        className="inline-flex whitespace-nowrap items-center gap-1 rounded-full border border-gray-300 bg-white py-1 pl-2.5 pr-1.5 text-xs font-medium text-gray-700"
                       >
                         {chip.text}
                         {chip.removable ? (


### PR DESCRIPTION
## What
- render active-filter chips in a single horizontal row with overflow scrolling when needed
- keep chip text in one line to avoid vertical layout growth
- keep 'Limpar tudo' outside the scroll area (header actions unchanged)

## Why
- avoid chip wrapping into multiple lines when many filters are active
- keep the filters summary compact and predictable on mobile/desktop

## Validation
- npm -w apps/web run test:run -- src/pages/App.test.jsx
- npm -w apps/web run lint
- npm -w apps/web run build