### PR TITLE
fix(ui): prevent transaction card action overflow on small screens

### DIFF
--- a/apps/web/src/components/TransactionList.jsx
+++ b/apps/web/src/components/TransactionList.jsx
@@ -18,27 +18,27 @@ const TransactionList = ({ transactions, onDelete, onEdit }) => {
       {transactions.map((transaction) => (
         <div
           key={transaction.id}
-          className="my-2 flex items-center justify-between rounded border border-brand-1 bg-gray-mode p-3.5"
+          className="my-2 flex w-full min-w-0 flex-col items-start gap-2 rounded border border-brand-1 bg-gray-mode p-3.5 sm:flex-row sm:items-center sm:justify-between"
         >
-          <div className="flex flex-col">
-            <span className="text-sm font-medium text-gray-100">
+          <div className="flex min-w-0 flex-1 flex-col">
+            <span className="break-words text-sm font-medium text-gray-100">
               {transaction.description || "Sem descricao"}
             </span>
             <span className="text-base font-medium text-gray-100">
               {formatValue(transaction.value)}
             </span>
             <span className="text-xs text-gray-200">{formatDate(transaction.date)}</span>
-            <span className="text-xs text-gray-200">
+            <span className="break-words text-xs text-gray-200">
               Categoria: {transaction.categoryName || "Sem categoria"}
             </span>
             {transaction.notes ? (
-              <span className="text-xs text-gray-200">{transaction.notes}</span>
+              <span className="break-words text-xs text-gray-200">{transaction.notes}</span>
             ) : null}
           </div>
 
-          <div className="flex items-center gap-2">
+          <div className="mt-1 flex w-full flex-wrap items-center gap-2 sm:mt-0 sm:w-auto sm:flex-nowrap sm:justify-end">
             <span
-              className={`rounded px-3 py-1 text-sm font-medium ${
+              className={`whitespace-nowrap rounded px-3 py-1 text-sm font-medium ${
                 transaction.type === CATEGORY_ENTRY
                   ? "bg-brand-3 text-brand-1"
                   : "bg-gray-400 text-gray-100"
@@ -49,7 +49,7 @@ const TransactionList = ({ transactions, onDelete, onEdit }) => {
             <button
               type="button"
               onClick={() => onEdit(transaction)}
-              className="rounded border border-gray-300 px-2 py-1 text-xs font-semibold text-gray-200 transition-colors hover:border-gray-200 hover:text-gray-100"
+              className="whitespace-nowrap rounded border border-gray-300 px-2 py-1 text-xs font-semibold text-gray-200 transition-colors hover:border-gray-200 hover:text-gray-100"
               aria-label={`Editar transacao ${transaction.id}`}
             >
               Editar
@@ -57,7 +57,7 @@ const TransactionList = ({ transactions, onDelete, onEdit }) => {
             <button
               type="button"
               onClick={() => onDelete(transaction.id)}
-              className="rounded border border-gray-300 px-2 py-1 text-xs font-semibold text-gray-200 transition-colors hover:border-gray-200 hover:text-gray-100"
+              className="whitespace-nowrap rounded border border-gray-300 px-2 py-1 text-xs font-semibold text-gray-200 transition-colors hover:border-gray-200 hover:text-gray-100"
               aria-label={`Excluir transacao ${transaction.id}`}
             >
               Excluir


### PR DESCRIPTION
## What
- make transaction card layout responsive on small screens
- allow action area (tipo/editar/excluir) to wrap in mobile
- keep desktop layout unchanged with inline actions
- add width/overflow-safe utility classes (w-full, min-w-0, reak-words)

## Why
- fix horizontal overflow in transaction cards on narrow devices (<420px)
- preserve hierarchy/readability without changing business logic

## Validation
- npm -w apps/web run test:run -- src/pages/App.test.jsx
- npm -w apps/web run lint
- npm -w apps/web run build