### PR TITLE
feat(ui): polish filters panel visual hierarchy

### DIFF
--- a/apps/web/src/pages/App.jsx
+++ b/apps/web/src/pages/App.jsx
@@ -1450,18 +1450,25 @@ const App = ({ onLogout = undefined }) => {
       <main className="mx-auto mt-8 w-full max-w-6xl space-y-6 px-4 sm:mt-10 sm:px-6">
         <section ref={filtersPanelRef}>
           <div className="space-y-4 rounded border border-gray-300 bg-white p-4">
-            <div className="flex items-start justify-between gap-3">
-              <h2 className="text-lg font-medium text-gray-100">Resumo financeiro</h2>
-              {isMobileFiltersPanel ? (
-                <button
-                  type="button"
-                  onClick={() => setIsFiltersPanelOpen((currentValue) => !currentValue)}
-                  aria-expanded={isFiltersPanelOpen}
-                  className="whitespace-nowrap rounded border border-gray-300 bg-white px-2 py-1 text-xs font-semibold text-gray-700 hover:bg-gray-100"
-                >
-                  {isFiltersPanelOpen ? "Ocultar" : "Filtros"}
-                </button>
-              ) : null}
+            <div className="flex items-start justify-between gap-3 rounded border border-gray-200 bg-gray-50 px-3 py-2">
+              <h2 className="text-base font-semibold text-gray-100">Resumo financeiro</h2>
+              <div className="flex items-center gap-2">
+                {!hasActiveFilters && !isMobileFiltersPanel ? (
+                  <span className="rounded-full border border-gray-300 bg-white px-2 py-1 text-xs font-semibold text-gray-600">
+                    Sem filtros ativos
+                  </span>
+                ) : null}
+                {isMobileFiltersPanel ? (
+                  <button
+                    type="button"
+                    onClick={() => setIsFiltersPanelOpen((currentValue) => !currentValue)}
+                    aria-expanded={isFiltersPanelOpen}
+                    className="whitespace-nowrap rounded border border-gray-300 bg-white px-2.5 py-1 text-xs font-semibold text-gray-700 hover:bg-gray-100"
+                  >
+                    {isFiltersPanelOpen ? "Ocultar" : "Filtros"}
+                  </button>
+                ) : null}
+              </div>
             </div>
 
             {hasActiveFilters && appliedChips.length > 0 ? (
@@ -1525,16 +1532,16 @@ const App = ({ onLogout = undefined }) => {
 
             {isFiltersContentVisible ? (
               <div className="space-y-4">
-                <div className="space-y-3 rounded border border-gray-300 bg-gray-50 p-2">
+                <div className="space-y-3 rounded border border-gray-200 bg-gray-50 p-3">
                   {shouldShowPresets ? (
-                    <div className="flex flex-wrap gap-2">
+                    <div className="flex flex-wrap items-center gap-1.5">
                       {visibleFilterPresets.map((preset) => (
                         <button
                           key={preset.id}
                           type="button"
                           aria-pressed={isPresetActive(preset.id)}
                           onClick={() => applyFilterPreset(preset.id)}
-                          className={`flex items-center justify-center gap-2.5 rounded border px-4 py-2 text-sm font-semibold transition-colors ${
+                          className={`min-w-[88px] rounded border px-3 py-1.5 text-xs font-semibold transition-colors ${
                             isPresetActive(preset.id)
                               ? "border-brand-1 bg-brand-3 text-brand-1"
                               : "border-gray-300 bg-white text-gray-900 hover:bg-gray-100"
@@ -1545,11 +1552,11 @@ const App = ({ onLogout = undefined }) => {
                       ))}
                     </div>
                   ) : null}
-                  <div className="flex flex-col gap-2">
-                    <span className="text-xs font-semibold uppercase tracking-wide text-gray-200">
+                  <div className="flex flex-col gap-1.5">
+                    <span className="text-[11px] font-semibold uppercase tracking-wide text-gray-200">
                       Filtrar lista
                     </span>
-                    <div className="flex flex-wrap gap-2">
+                    <div className="flex flex-wrap items-center gap-1.5">
                       {filterButtons.map((category) => {
                         const active = selectedCategory === category;
 
@@ -1561,7 +1568,7 @@ const App = ({ onLogout = undefined }) => {
                               setSelectedCategory(category);
                               setCurrentOffset(DEFAULT_OFFSET);
                             }}
-                            className={`flex items-center justify-center gap-2.5 rounded border px-4 py-2 text-sm font-semibold transition-colors ${
+                            className={`min-w-[84px] rounded border px-3 py-1.5 text-xs font-semibold transition-colors ${
                               active
                                 ? "border-brand-1 bg-brand-3 text-brand-1"
                                 : "border-gray-300 bg-white text-gray-200"
@@ -1575,7 +1582,7 @@ const App = ({ onLogout = undefined }) => {
                   </div>
                 </div>
 
-                <div className="rounded border border-gray-300 bg-white p-3">
+                <div className="rounded border border-gray-200 bg-white p-3">
             <label
               htmlFor="periodo"
               className="mb-2 block text-sm font-medium text-gray-100"


### PR DESCRIPTION
## What
- restyle filters-card header as a control bar with clearer hierarchy
- add desktop micro-status badge when no filters are active
- compact presets and type filter controls into tighter toolbar-like groups
- keep behavior and handlers unchanged (visual-only)

## Why
- improve dashboard scanability and reduce form-like visual density
- keep controls cohesive in a SaaS-style panel layout

## Validation
- npm -w apps/web run test:run -- src/pages/App.test.jsx
- npm -w apps/web run lint
- npm -w apps/web run build