### PR TITLE
refactor(ui): separate presets from canonical type filter

### DIFF
--- a/apps/web/src/pages/App.jsx
+++ b/apps/web/src/pages/App.jsx
@@ -39,9 +39,6 @@ const SORT_OPTIONS = [
 ];
 const FILTER_PRESETS = [
   { id: "this-month", label: "Este mes" },
-  { id: "income", label: "Entradas" },
-  { id: "expense", label: "Saidas" },
-  { id: "clear", label: "Limpar filtros" },
 ];
 const FILTER_BUTTON_LABELS = {
   [CATEGORY_ALL]: "Todas",
@@ -1009,20 +1006,6 @@ const App = ({ onLogout = undefined }) => {
       return;
     }
 
-    if (presetId === "income") {
-      setSelectedCategory(CATEGORY_ENTRY);
-      setCurrentOffset(DEFAULT_OFFSET);
-      scrollToListTop();
-      return;
-    }
-
-    if (presetId === "expense") {
-      setSelectedCategory(CATEGORY_EXIT);
-      setCurrentOffset(DEFAULT_OFFSET);
-      scrollToListTop();
-      return;
-    }
-
     if (presetId === "clear") {
       setSelectedCategory(CATEGORY_ALL);
       setSelectedPeriod(PERIOD_ALL);
@@ -1294,7 +1277,7 @@ const App = ({ onLogout = undefined }) => {
     selectedSort,
     selectedTransactionCategoryId,
   ]);
-  const visibleFilterPresets = FILTER_PRESETS.filter((preset) => preset.id !== "clear");
+  const visibleFilterPresets = FILTER_PRESETS;
   const isPresetActive = (presetId) => {
     if (presetId === "this-month") {
       return (
@@ -1302,14 +1285,6 @@ const App = ({ onLogout = undefined }) => {
         customStartDate === currentMonthRange.startDate &&
         customEndDate === currentMonthRange.endDate
       );
-    }
-
-    if (presetId === "income") {
-      return selectedCategory === CATEGORY_ENTRY;
-    }
-
-    if (presetId === "expense") {
-      return selectedCategory === CATEGORY_EXIT;
     }
 
     return false;

--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -894,8 +894,6 @@ describe("App", () => {
 
     expect(await screen.findByText("Sem filtros ativos")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Este mes" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Entradas" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Saidas" })).toBeInTheDocument();
     expect(screen.queryByText(/Filtros ativos \(\d+\)/)).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Limpar tudo" })).not.toBeInTheDocument();
 
@@ -906,8 +904,6 @@ describe("App", () => {
     expect(screen.getByText("Filtros ativos (1)")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Limpar tudo" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Este mes" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Entradas" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Saidas" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Editar filtros" })).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Filtrar entradas" }));


### PR DESCRIPTION
## What
- keep only smart preset(s) in the presets group (currently: 'Este mes')
- remove duplicated type presets ('Entradas'/'Saidas') from the top shortcuts
- keep 'Filtrar lista' (Todas/Entradas/Saidas) as the single canonical type filter control
- update tests that expected removed top presets

## Why
- eliminate duplicated controls that changed the same state (selectedCategory)
- make filter responsibilities explicit: presets vs direct type filter
- reduce UX ambiguity in the filters panel

## Validation
- npm -w apps/web run test:run -- src/pages/App.test.jsx
- npm -w apps/web run lint
- npm -w apps/web run build