### PR TITLE
feat(ui): rename filter type section label

### DIFF
--- a/apps/web/src/pages/App.jsx
+++ b/apps/web/src/pages/App.jsx
@@ -1529,7 +1529,7 @@ const App = ({ onLogout = undefined }) => {
                   ) : null}
                   <div className="flex flex-col gap-1.5">
                     <span className="text-[11px] font-semibold uppercase tracking-wide text-gray-200">
-                      Filtrar lista
+                      Tipo
                     </span>
                     <div className="flex flex-wrap items-center gap-1.5">
                       {filterButtons.map((category) => {


### PR DESCRIPTION
## What
- rename the visible filters section label from 'Filtrar lista' to 'Tipo'

## Why
- improve semantic clarity: this control filters transaction type only
- reduce ambiguity with other filter controls in the panel

## Scope
- visual-only (no logic or contract changes)

## Validation
- npm -w apps/web run test:run -- src/pages/App.test.jsx
- npm -w apps/web run lint
- npm -w apps/web run build