### PR TITLE
feat(web): add categories management settings and uncategorized UX

### DIFF
--- a/apps/web/src/AppRoutes.tsx
+++ b/apps/web/src/AppRoutes.tsx
@@ -1,5 +1,6 @@
 import { Navigate, Route, Routes, useNavigate } from "react-router-dom";
 import App from "./pages/App";
+import CategoriesSettings from "./pages/CategoriesSettings";
 import Login from "./pages/Login";
 import ProtectedRoute from "./routers/ProtectedRoute";
 import { useAuth } from "./hooks/useAuth";
@@ -13,7 +14,32 @@ const Dashboard = () => {
     navigate("/", { replace: true });
   };
 
-  return <App onLogout={handleLogout} />;
+  const handleOpenCategoriesSettings = () => {
+    navigate("/app/settings/categories");
+  };
+
+  return (
+    <App
+      onLogout={handleLogout}
+      onOpenCategoriesSettings={handleOpenCategoriesSettings}
+    />
+  );
+};
+
+const CategoriesSettingsRoute = () => {
+  const navigate = useNavigate();
+  const { logout } = useAuth();
+
+  const handleBack = () => {
+    navigate("/app");
+  };
+
+  const handleLogout = () => {
+    logout();
+    navigate("/", { replace: true });
+  };
+
+  return <CategoriesSettings onBack={handleBack} onLogout={handleLogout} />;
 };
 
 const RootRedirect = () => {
@@ -31,6 +57,14 @@ const AppRoutes = () => {
         element={
           <ProtectedRoute>
             <Dashboard />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/app/settings/categories"
+        element={
+          <ProtectedRoute>
+            <CategoriesSettingsRoute />
           </ProtectedRoute>
         }
       />

--- a/apps/web/src/pages/CategoriesSettings.jsx
+++ b/apps/web/src/pages/CategoriesSettings.jsx
@@ -1,0 +1,393 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import PropTypes from "prop-types";
+import { useSearchParams } from "react-router-dom";
+import { categoriesService } from "../services/categories.service";
+
+const parseIncludeDeletedParam = (value) =>
+  String(value || "").toLowerCase() === "true";
+
+const getApiErrorMessage = (error, fallbackMessage) =>
+  error?.response?.data?.message || error?.message || fallbackMessage;
+
+const resolveCategoryMutationErrorMessage = (error, fallbackMessage) => {
+  if (error?.response?.status === 409) {
+    return "Categoria ja existe.";
+  }
+
+  if (error?.response?.status === 404) {
+    return "Categoria nao encontrada.";
+  }
+
+  return getApiErrorMessage(error, fallbackMessage);
+};
+
+const CategoriesSettings = ({ onBack = undefined, onLogout = undefined }) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const includeDeleted = useMemo(
+    () => parseIncludeDeletedParam(searchParams.get("includeDeleted")),
+    [searchParams],
+  );
+  const [categories, setCategories] = useState([]);
+  const [isLoadingCategories, setLoadingCategories] = useState(false);
+  const [isCategoryModalOpen, setCategoryModalOpen] = useState(false);
+  const [editingCategory, setEditingCategory] = useState(null);
+  const [categoryFormName, setCategoryFormName] = useState("");
+  const [isSavingCategory, setSavingCategory] = useState(false);
+  const [pageErrorMessage, setPageErrorMessage] = useState("");
+  const [categoryModalErrorMessage, setCategoryModalErrorMessage] = useState("");
+  const [successMessage, setSuccessMessage] = useState("");
+
+  const loadCategories = useCallback(async () => {
+    setLoadingCategories(true);
+    setPageErrorMessage("");
+
+    try {
+      const response = await categoriesService.listCategories(includeDeleted);
+      setCategories(Array.isArray(response) ? response : []);
+    } catch (error) {
+      setCategories([]);
+      setPageErrorMessage(getApiErrorMessage(error, "Nao foi possivel carregar as categorias."));
+    } finally {
+      setLoadingCategories(false);
+    }
+  }, [includeDeleted]);
+
+  useEffect(() => {
+    void loadCategories();
+  }, [loadCategories]);
+
+  const openCreateCategoryModal = () => {
+    setEditingCategory(null);
+    setCategoryFormName("");
+    setCategoryModalErrorMessage("");
+    setCategoryModalOpen(true);
+  };
+
+  const openRenameCategoryModal = (category) => {
+    setEditingCategory(category);
+    setCategoryFormName(category?.name || "");
+    setCategoryModalErrorMessage("");
+    setCategoryModalOpen(true);
+  };
+
+  const closeCategoryModal = () => {
+    if (isSavingCategory) {
+      return;
+    }
+
+    setCategoryModalOpen(false);
+    setEditingCategory(null);
+    setCategoryFormName("");
+    setCategoryModalErrorMessage("");
+  };
+
+  const handleSubmitCategory = async (event) => {
+    event.preventDefault();
+
+    const normalizedName = String(categoryFormName || "").trim();
+    if (!normalizedName) {
+      setCategoryModalErrorMessage("Nome da categoria e obrigatorio.");
+      return;
+    }
+
+    setSavingCategory(true);
+    setCategoryModalErrorMessage("");
+    setPageErrorMessage("");
+    setSuccessMessage("");
+
+    try {
+      if (editingCategory?.id) {
+        await categoriesService.updateCategory(editingCategory.id, normalizedName);
+        setSuccessMessage("Categoria atualizada.");
+      } else {
+        await categoriesService.createCategory(normalizedName);
+        setSuccessMessage("Categoria criada.");
+      }
+
+      closeCategoryModal();
+      await loadCategories();
+    } catch (error) {
+      setCategoryModalErrorMessage(
+        resolveCategoryMutationErrorMessage(error, "Nao foi possivel salvar a categoria."),
+      );
+    } finally {
+      setSavingCategory(false);
+    }
+  };
+
+  const handleDeleteCategory = async (category) => {
+    const isConfirmed =
+      typeof window === "undefined"
+        ? true
+        : window.confirm(`Remover categoria "${category.name}"?`);
+
+    if (!isConfirmed) {
+      return;
+    }
+
+    setPageErrorMessage("");
+    setSuccessMessage("");
+
+    try {
+      await categoriesService.deleteCategory(category.id);
+      setSuccessMessage("Categoria removida.");
+      await loadCategories();
+    } catch (error) {
+      setPageErrorMessage(
+        resolveCategoryMutationErrorMessage(error, "Nao foi possivel remover a categoria."),
+      );
+    }
+  };
+
+  const handleRestoreCategory = async (category) => {
+    const isConfirmed =
+      typeof window === "undefined"
+        ? true
+        : window.confirm(`Restaurar categoria "${category.name}"?`);
+
+    if (!isConfirmed) {
+      return;
+    }
+
+    setPageErrorMessage("");
+    setSuccessMessage("");
+
+    try {
+      await categoriesService.restoreCategory(category.id);
+      setSuccessMessage("Categoria restaurada.");
+      await loadCategories();
+    } catch (error) {
+      setPageErrorMessage(
+        resolveCategoryMutationErrorMessage(error, "Nao foi possivel restaurar a categoria."),
+      );
+    }
+  };
+
+  const handleToggleIncludeDeleted = (nextCheckedState) => {
+    const nextParams = new URLSearchParams(searchParams);
+
+    if (nextCheckedState) {
+      nextParams.set("includeDeleted", "true");
+    } else {
+      nextParams.delete("includeDeleted");
+    }
+
+    setSearchParams(nextParams, { replace: true });
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-500 py-6">
+      <main className="mx-auto w-full max-w-4xl space-y-4 px-4 sm:px-6">
+        <section className="rounded border border-gray-300 bg-white p-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h1 className="text-xl font-semibold text-gray-100">Settings - Categorias</h1>
+              <p className="mt-1 text-sm text-gray-200">
+                Gerencie categorias ativas e removidas para os lancamentos.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                onClick={onBack}
+                className="rounded border border-gray-300 bg-white px-3 py-1.5 text-xs font-semibold text-gray-100 hover:bg-gray-400"
+              >
+                Voltar ao dashboard
+              </button>
+              {onLogout ? (
+                <button
+                  type="button"
+                  onClick={onLogout}
+                  className="rounded border border-gray-300 bg-white px-3 py-1.5 text-xs font-semibold text-gray-100 hover:bg-gray-400"
+                >
+                  Sair
+                </button>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded border border-gray-200 bg-gray-50 px-3 py-2">
+            <label className="inline-flex cursor-pointer items-center gap-2 text-sm text-gray-700">
+              <input
+                type="checkbox"
+                checked={includeDeleted}
+                onChange={(event) => handleToggleIncludeDeleted(event.target.checked)}
+              />
+              Incluir removidas
+            </label>
+            <button
+              type="button"
+              onClick={openCreateCategoryModal}
+              className="rounded bg-brand-1 px-3 py-1.5 text-xs font-semibold text-white hover:bg-brand-2"
+            >
+              + Nova categoria
+            </button>
+          </div>
+
+          {pageErrorMessage ? (
+            <div
+              className="mt-3 flex items-center justify-between gap-3 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+              role="alert"
+            >
+              <span>{pageErrorMessage}</span>
+              <button
+                type="button"
+                onClick={loadCategories}
+                className="rounded border border-red-300 px-2 py-1 text-xs font-semibold text-red-700 hover:bg-red-100"
+              >
+                Tentar novamente
+              </button>
+            </div>
+          ) : null}
+
+          {!pageErrorMessage && successMessage ? (
+            <p
+              className="mt-3 rounded border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700"
+              role="status"
+              aria-live="polite"
+            >
+              {successMessage}
+            </p>
+          ) : null}
+
+          {isLoadingCategories ? (
+            <div className="mt-3 space-y-2" role="status" aria-live="polite">
+              {Array.from({ length: 4 }).map((_, index) => (
+                <div
+                  key={`categories-skeleton-${index + 1}`}
+                  className="h-12 animate-pulse rounded border border-gray-300 bg-gray-100"
+                />
+              ))}
+              <span className="sr-only">Carregando categorias...</span>
+            </div>
+          ) : null}
+
+          {!isLoadingCategories && categories.length === 0 ? (
+            <div className="mt-3 rounded border border-gray-300 bg-gray-50 px-3 py-3 text-sm text-gray-700">
+              Nenhuma categoria encontrada para o filtro atual.
+            </div>
+          ) : null}
+
+          {!isLoadingCategories && categories.length > 0 ? (
+            <ul className="mt-3 space-y-2">
+              {categories.map((category) => {
+                const isDeleted = Boolean(category.deletedAt);
+
+                return (
+                  <li
+                    key={category.id}
+                    className="flex flex-wrap items-center justify-between gap-3 rounded border border-gray-300 bg-white px-3 py-2"
+                  >
+                    <div className="min-w-0">
+                      <p className="break-words text-sm font-semibold text-gray-900">{category.name}</p>
+                      <p className="text-xs text-gray-500">
+                        {isDeleted ? "Removida" : "Ativa"}
+                      </p>
+                    </div>
+
+                    <div className="flex flex-wrap items-center gap-2">
+                      {isDeleted ? (
+                        <button
+                          type="button"
+                          onClick={() => handleRestoreCategory(category)}
+                          className="rounded border border-green-300 bg-green-50 px-2 py-1 text-xs font-semibold text-green-700 hover:bg-green-100"
+                        >
+                          Restaurar
+                        </button>
+                      ) : (
+                        <>
+                          <button
+                            type="button"
+                            onClick={() => openRenameCategoryModal(category)}
+                            className="rounded border border-gray-300 bg-white px-2 py-1 text-xs font-semibold text-gray-700 hover:bg-gray-100"
+                          >
+                            Renomear
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleDeleteCategory(category)}
+                            className="rounded border border-red-300 bg-red-50 px-2 py-1 text-xs font-semibold text-red-700 hover:bg-red-100"
+                          >
+                            Remover
+                          </button>
+                        </>
+                      )}
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          ) : null}
+        </section>
+      </main>
+
+      {isCategoryModalOpen ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-gray-100 bg-opacity-50 p-4">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="category-modal-title"
+            className="w-full max-w-sm rounded bg-white p-4 shadow-lg"
+          >
+            <h2 id="category-modal-title" className="text-base font-semibold text-gray-900">
+              {editingCategory ? "Renomear categoria" : "Nova categoria"}
+            </h2>
+
+            {categoryModalErrorMessage ? (
+              <p
+                className="mt-3 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+                role="alert"
+              >
+                {categoryModalErrorMessage}
+              </p>
+            ) : null}
+
+            <form onSubmit={handleSubmitCategory} className="mt-3 space-y-3">
+              <div>
+                <label htmlFor="category-name" className="mb-1 block text-xs font-medium text-gray-900">
+                  Nome
+                </label>
+                <input
+                  id="category-name"
+                  type="text"
+                  value={categoryFormName}
+                  onChange={(event) => {
+                    setCategoryFormName(event.target.value);
+                    setCategoryModalErrorMessage("");
+                  }}
+                  placeholder="Ex.: Alimentacao"
+                  className="w-full rounded border border-gray-400 px-3 py-2 text-sm text-gray-900"
+                />
+              </div>
+
+              <div className="flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={closeCategoryModal}
+                  disabled={isSavingCategory}
+                  className="rounded border border-gray-300 px-3 py-1.5 text-sm font-semibold text-gray-700 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  Cancelar
+                </button>
+                <button
+                  type="submit"
+                  disabled={isSavingCategory}
+                  className="rounded bg-brand-1 px-3 py-1.5 text-sm font-semibold text-white hover:bg-brand-2 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isSavingCategory ? "Salvando..." : editingCategory ? "Salvar" : "Criar"}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+CategoriesSettings.propTypes = {
+  onBack: PropTypes.func,
+  onLogout: PropTypes.func,
+};
+
+export default CategoriesSettings;

--- a/apps/web/src/pages/CategoriesSettings.test.jsx
+++ b/apps/web/src/pages/CategoriesSettings.test.jsx
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import CategoriesSettings from "./CategoriesSettings";
+import { categoriesService } from "../services/categories.service";
+
+vi.mock("../services/categories.service", () => ({
+  categoriesService: {
+    listCategories: vi.fn(),
+    createCategory: vi.fn(),
+    updateCategory: vi.fn(),
+    deleteCategory: vi.fn(),
+    restoreCategory: vi.fn(),
+  },
+}));
+
+const buildCategory = (overrides = {}) => ({
+  id: 1,
+  userId: 1,
+  name: "Alimentacao",
+  normalizedName: "alimentacao",
+  deletedAt: null,
+  createdAt: "2026-02-01T12:00:00.000Z",
+  ...overrides,
+});
+
+const renderPage = (initialPath = "/app/settings/categories") =>
+  render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route
+          path="*"
+          element={<CategoriesSettings onBack={vi.fn()} onLogout={vi.fn()} />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+describe("CategoriesSettings", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.stubGlobal("confirm", vi.fn(() => true));
+
+    categoriesService.listCategories.mockResolvedValue([buildCategory()]);
+    categoriesService.createCategory.mockResolvedValue(buildCategory({ id: 2, name: "Mercado" }));
+    categoriesService.updateCategory.mockResolvedValue(buildCategory());
+    categoriesService.deleteCategory.mockResolvedValue(buildCategory({ deletedAt: "2026-02-12T10:00:00.000Z" }));
+    categoriesService.restoreCategory.mockResolvedValue(buildCategory());
+  });
+
+  it("lista categorias ativas por padrao e permite incluir removidas", async () => {
+    const user = userEvent.setup();
+
+    categoriesService.listCategories
+      .mockResolvedValueOnce([buildCategory({ id: 1, name: "Alimentacao" })])
+      .mockResolvedValueOnce([
+        buildCategory({ id: 1, name: "Alimentacao" }),
+        buildCategory({
+          id: 2,
+          name: "Transporte",
+          normalizedName: "transporte",
+          deletedAt: "2026-02-12T10:00:00.000Z",
+        }),
+      ]);
+
+    renderPage();
+
+    expect(await screen.findByText("Alimentacao")).toBeInTheDocument();
+    expect(categoriesService.listCategories).toHaveBeenNthCalledWith(1, false);
+
+    await user.click(screen.getByLabelText("Incluir removidas"));
+
+    expect(await screen.findByText("Transporte")).toBeInTheDocument();
+    expect(categoriesService.listCategories).toHaveBeenNthCalledWith(2, true);
+    expect(screen.getByText("Removida")).toBeInTheDocument();
+  });
+
+  it("cria categoria e recarrega listagem", async () => {
+    const user = userEvent.setup();
+
+    categoriesService.listCategories
+      .mockResolvedValueOnce([buildCategory({ id: 1, name: "Alimentacao" })])
+      .mockResolvedValueOnce([
+        buildCategory({ id: 1, name: "Alimentacao" }),
+        buildCategory({ id: 2, name: "Mercado", normalizedName: "mercado" }),
+      ]);
+
+    renderPage();
+
+    expect(await screen.findByText("Alimentacao")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "+ Nova categoria" }));
+    await user.type(screen.getByLabelText("Nome"), "Mercado");
+    await user.click(screen.getByRole("button", { name: "Criar" }));
+
+    await waitFor(() => {
+      expect(categoriesService.createCategory).toHaveBeenCalledWith("Mercado");
+    });
+
+    expect(await screen.findByText("Categoria criada.")).toBeInTheDocument();
+    expect(await screen.findByText("Mercado")).toBeInTheDocument();
+  });
+
+  it("restaura categoria removida quando includeDeleted esta ativo", async () => {
+    const user = userEvent.setup();
+    const removedCategory = buildCategory({
+      id: 7,
+      name: "Transporte",
+      normalizedName: "transporte",
+      deletedAt: "2026-02-15T09:30:00.000Z",
+    });
+
+    categoriesService.listCategories
+      .mockResolvedValueOnce([removedCategory])
+      .mockResolvedValueOnce([buildCategory({ id: 7, name: "Transporte" })]);
+    categoriesService.restoreCategory.mockResolvedValueOnce(
+      buildCategory({ id: 7, name: "Transporte" }),
+    );
+
+    renderPage("/app/settings/categories?includeDeleted=true");
+
+    expect(await screen.findByText("Transporte")).toBeInTheDocument();
+    expect(categoriesService.listCategories).toHaveBeenNthCalledWith(1, true);
+
+    await user.click(screen.getByRole("button", { name: "Restaurar" }));
+
+    await waitFor(() => {
+      expect(categoriesService.restoreCategory).toHaveBeenCalledWith(7);
+    });
+
+    expect(await screen.findByText("Categoria restaurada.")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/services/categories.service.ts
+++ b/apps/web/src/services/categories.service.ts
@@ -1,0 +1,95 @@
+import { api } from "./api";
+
+export interface CategoryItem {
+  id: number;
+  userId: number;
+  name: string;
+  normalizedName: string;
+  deletedAt: string | null;
+  createdAt: string | null;
+}
+
+interface CategoryApiPayload {
+  id?: unknown;
+  userId?: unknown;
+  user_id?: unknown;
+  name?: unknown;
+  normalizedName?: unknown;
+  normalized_name?: unknown;
+  deletedAt?: unknown;
+  deleted_at?: unknown;
+  createdAt?: unknown;
+  created_at?: unknown;
+}
+
+const normalizeIsoStringOrNull = (value: unknown): string | null => {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalizedValue = value.trim();
+  return normalizedValue || null;
+};
+
+const normalizeCategoryItem = (payload: CategoryApiPayload): CategoryItem => {
+  const normalizedId = Number(payload?.id);
+  const normalizedUserId = Number(payload?.userId ?? payload?.user_id);
+  const normalizedName =
+    typeof payload?.name === "string" ? payload.name.trim() : "";
+  const normalizedKey =
+    typeof payload?.normalizedName === "string"
+      ? payload.normalizedName.trim()
+      : typeof payload?.normalized_name === "string"
+        ? payload.normalized_name.trim()
+        : "";
+
+  return {
+    id: Number.isInteger(normalizedId) && normalizedId > 0 ? normalizedId : 0,
+    userId:
+      Number.isInteger(normalizedUserId) && normalizedUserId > 0
+        ? normalizedUserId
+        : 0,
+    name: normalizedName,
+    normalizedName: normalizedKey,
+    deletedAt: normalizeIsoStringOrNull(payload?.deletedAt ?? payload?.deleted_at),
+    createdAt: normalizeIsoStringOrNull(payload?.createdAt ?? payload?.created_at),
+  };
+};
+
+const isValidCategoryItem = (item: CategoryItem): boolean =>
+  item.id > 0 && item.userId > 0 && Boolean(item.name);
+
+export const categoriesService = {
+  listCategories: async (includeDeleted = false): Promise<CategoryItem[]> => {
+    const params = includeDeleted ? { includeDeleted: "true" } : undefined;
+    const { data } = await api.get("/categories", { params });
+
+    if (!Array.isArray(data)) {
+      return [];
+    }
+
+    return data
+      .map((item) => normalizeCategoryItem(item as CategoryApiPayload))
+      .filter(isValidCategoryItem);
+  },
+
+  createCategory: async (name: string): Promise<CategoryItem> => {
+    const { data } = await api.post("/categories", { name });
+    return normalizeCategoryItem(data as CategoryApiPayload);
+  },
+
+  updateCategory: async (id: number, name: string): Promise<CategoryItem> => {
+    const { data } = await api.patch(`/categories/${id}`, { name });
+    return normalizeCategoryItem(data as CategoryApiPayload);
+  },
+
+  deleteCategory: async (id: number): Promise<CategoryItem> => {
+    const { data } = await api.delete(`/categories/${id}`);
+    return normalizeCategoryItem(data as CategoryApiPayload);
+  },
+
+  restoreCategory: async (id: number): Promise<CategoryItem> => {
+    const { data } = await api.post(`/categories/${id}/restore`);
+    return normalizeCategoryItem(data as CategoryApiPayload);
+  },
+};


### PR DESCRIPTION
### 🔎 Context

This PR delivers the complete evolution of the **Categories domain** to canonical v2, covering both backend (API) and frontend (Web), with focus on:

* Domain integrity
* Safe soft delete with restore
* Name normalization
* Resilient “Uncategorized” UX
* Consistency between analytics and transactions

---

## 🧠 API — Categories v2

### Includes:

* Migration `009_upgrade_categories_domain.sql`

  * `normalized_name`
  * `deleted_at`
  * partial unique index `(user_id, normalized_name) WHERE deleted_at IS NULL`
* Full CRUD:

  * `POST /categories`
  * `GET /categories?includeDeleted=true`
  * `PATCH /categories/:id`
  * `DELETE /categories/:id` (soft delete)
  * `POST /categories/:id/restore`
* Active-category guards:

  * Prevent usage of deleted categories in transactions and budgets
* Backfill tooling:

  ```bash
  npm -w apps/api run db:backfill:categories-normalized
  ```
* Contract tests:

  * restore conflict
  * ownership validation
  * includeDeleted behavior
  * active-category guards

---

## 🎨 Web — Categories Management UI

### New protected route:

```bash
/app/settings/categories
```

### Features:

* Active categories listed by default
* `includeDeleted` toggle (URL-synced)
* Create / Rename / Soft Delete / Restore
* Header navigation entry (desktop + mobile)
* Dedicated service layer: `categories.service.ts`

---

## 💡 UX Improvements

### Transaction Modal

* “Uncategorized” treated as a first-class option
* If editing a transaction with a deleted category:

  * warning message displayed
  * auto-reset to “Uncategorized” on save
* If API returns:

  ```
  Categoria nao encontrada.
  ```

  → user receives clear guidance to choose another category or use “Uncategorized”

---

## 📊 Dashboard

* New block:
  **“Expenses by category”**
* “Uncategorized” appears explicitly when present in monthly summary

---

## 🧪 Validation

Executed successfully:

```bash
npm run lint
npm run test
npm run build
```

Web and API pipelines are green.

