### PR TITLE
fix(api): allow updating transaction category_id in PATCH

### DIFF
--- a/apps/api/src/services/transactions.service.js
+++ b/apps/api/src/services/transactions.service.js
@@ -696,6 +696,14 @@ export const updateTransactionForUser = async (userId, transactionId, payload = 
   const nextDate = normalizeOptionalDate(payload.date);
   const nextDescription = normalizeOptionalText(payload.description, "Descricao");
   const nextNotes = normalizeOptionalText(payload.notes, "Observacoes");
+  const categoryIdFromPayload = resolveCategoryIdFromPayload(payload);
+  const hasCategoryIdInPayload = typeof categoryIdFromPayload !== "undefined";
+  const nextCategoryId = hasCategoryIdInPayload
+    ? await ensureCategoryBelongsToUser(
+        userId,
+        normalizeOptionalPayloadCategoryId(categoryIdFromPayload),
+      )
+    : undefined;
 
   const fieldsToUpdate = [];
   const queryParams = [];
@@ -728,6 +736,12 @@ export const updateTransactionForUser = async (userId, transactionId, payload = 
   if (typeof nextNotes !== "undefined") {
     fieldsToUpdate.push(`notes = $${parameterIndex}`);
     queryParams.push(nextNotes);
+    parameterIndex += 1;
+  }
+
+  if (typeof nextCategoryId !== "undefined") {
+    fieldsToUpdate.push(`category_id = $${parameterIndex}`);
+    queryParams.push(nextCategoryId);
     parameterIndex += 1;
   }
 


### PR DESCRIPTION
## Context

Transaction PATCH endpoint was ignoring `category_id`, causing
a mismatch between Web UX (which resets removed categories to
“Uncategorized”) and persisted state.

## Fix

- Allow `category_id` to be updated in `PATCH /transactions/:id`
- Accept `null` → persist as `NULL` (Uncategorized)
- Validate ownership and active-category rule
- Return 404 if category is deleted

## Tests Added

- Update transaction to `category_id: null`
- Block update to deleted category
- Persistence verification via list endpoint

## Validation

- npm -w apps/api run test
- npm -w apps/api run lint
- npm run lint
- npm run test
- npm run build
