### PR TITLE
chore(release): v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.12.0] - 2026-02-20
+
+### Added
+
+- Categories v2 (soft delete, restore, `normalized_name`, partial unique index).
+- Categories management UI.
+- Backfill tooling (`db:backfill:categories-normalized`).
+- Automated smoke validation script (`scripts/smoke-categories-v2.ps1`).
+- Operational Maturity section in README.
+- Release runbook documentation.
+
+### Changed
+
+- `PATCH /transactions/:id` now supports updating `category_id`.
+- Allows `category_id = null` (Uncategorized).
+- Enforces active-category and ownership validation on update.
+
+### Fixed
+
+- Resolved inconsistency where Web reset category to "Uncategorized" but backend ignored `category_id` in PATCH.
+
+### Integrity
+
+- Domain guards for deleted categories and restore conflicts.
+- Expanded contract test coverage.
+
+### Ops
+
+- Runtime `/health` exposes version and commit.
+- CI governance enforced before merge to `main`.
+
 ## [1.11.0] - 2026-02-19
 
 ### Highlights

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/api",
   "private": true,
-  "version": "1.11.0",
+  "version": "1.12.0",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/web",
   "private": true,
-  "version": "1.11.0",
+  "version": "1.12.0",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "control-finance-monorepo",
   "private": true,
-  "version": "1.11.0",
+  "version": "1.12.0",
   "engines": {
     "node": "24.x"
   },


### PR DESCRIPTION
## Context

Prepares v1.12.0 for release by aligning version metadata and changelog.

This PR does not introduce runtime changes. It formalizes the release state after:
- Categories v2 domain upgrade
- Categories management UI
- Transaction category PATCH integrity fix (#106)
- Operational maturity documentation and tooling

## Changes

- Bump version to `1.12.0` across:
  - root `package.json`
  - `apps/api/package.json`
  - `apps/web/package.json`
- Add `[1.12.0]` entry to `CHANGELOG.md`

## Validation

- npm run lint
- npm run test
- npm run build

All checks are green.

## Scope

Release preparation only.
No functional or behavioral changes.
