### PR TITLE
feat(observability): expand health, logging and metrics foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ Aplicacao web para controle financeiro pessoal com entradas/saidas, filtros por 
 ## Operational Model
 
 - Deploy trigger: merge na `main` (Render Auto Deploy) ou manual via **Deploy latest commit**.
-- Health endpoint: `/health` retorna `{ ok, version, commit }`.
+- Health endpoint: `/health` retorna `{ ok, version, commit, buildTimestamp, uptimeSeconds, db, requestId }`.
   - `version`: usa a versao de `apps/api/package.json`; fallback para `APP_VERSION` e depois `sha-<short>`.
   - `commit`: resolvido via `RENDER_GIT_COMMIT` (ou fallback) e representa exatamente o codigo em runtime.
+- Metrics endpoint: `/metrics` em formato Prometheus (`text/plain`).
+  - Em `production`, exige `Authorization: Bearer <METRICS_AUTH_TOKEN>`.
 - CI gates (web): `lint`, `typecheck`, `typecheck:auth`, `test`, `build`.
 - Git tag/release: `vX.Y.Z`.
 - Render `APP_VERSION`: opcional (`X.Y.Z`, sem `v`) para override/fallback.
@@ -221,9 +223,15 @@ Notes:
 
 ## API (apps/api)
 
-- `GET /health` retorna `{ ok: true, version, commit }`
+- `GET /health` retorna `{ ok, version, commit, buildTimestamp, uptimeSeconds, db, requestId }`
   - `version`: `apps/api/package.json` por padrao, com fallback opcional `APP_VERSION` e depois `sha-<commit-curto>`
   - `commit`: prioriza `RENDER_GIT_COMMIT`, com fallback para `APP_COMMIT`/`COMMIT_SHA`
+  - `buildTimestamp`: prioriza `APP_BUILD_TIMESTAMP`, fallback para `BUILD_TIMESTAMP`
+  - `db`: `{ status: "ok" | "error", latencyMs }`; em falha de DB o endpoint retorna `503` com `ok: false`
+- `GET /metrics` expõe metricas HTTP em formato Prometheus
+  - `http_requests_total{status="2xx|3xx|4xx|5xx"}`
+  - `http_request_latency_ms` (histograma para `/transactions`, `/categories`, `/auth/login`)
+  - Em `production`, requer bearer token configurado em `METRICS_AUTH_TOKEN`
 - `POST /auth/register` cria usuario no Postgres
 - `POST /auth/login` retorna `{ token, user }`
 - `/auth/login` aplica rate limit por IP e bloqueio temporario por brute force
@@ -281,7 +289,8 @@ npm run dev
 - Em deploy com proxy (Render), use `TRUST_PROXY=1` na API
 - `CORS_ORIGIN` da API pode receber lista separada por virgula (local + dominios de deploy)
 - Hardening de login: `AUTH_RATE_LIMIT_*` e `AUTH_BRUTE_FORCE_*`
-- Build identity da API no healthcheck: versao do `apps/api/package.json` e commit automatico via `RENDER_GIT_COMMIT`
+- Build identity da API no healthcheck: versao do `apps/api/package.json`, commit (`RENDER_GIT_COMMIT`) e timestamp de build (`APP_BUILD_TIMESTAMP`/`BUILD_TIMESTAMP`)
+- Observabilidade de metricas em producao: `METRICS_AUTH_TOKEN`
 
 ## Scripts (root)
 
@@ -380,7 +389,14 @@ Returns:
 {
   "ok": true,
   "version": "x.y.z",
-  "commit": "abcdef1"
+  "commit": "abcdef1",
+  "buildTimestamp": "2026-02-21T03:45:00.000Z",
+  "uptimeSeconds": 1234,
+  "db": {
+    "status": "ok",
+    "latencyMs": 3
+  },
+  "requestId": "rid-123"
 }
 ```
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,14 +18,15 @@
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",
-    "csv-parse": "^5.6.0",
     "cors": "^2.8.5",
+    "csv-parse": "^5.6.0",
     "dotenv": "^16.4.5",
     "express": "^4.21.2",
     "express-rate-limit": "^8.2.1",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.0.2",
-    "pg": "^8.16.3"
+    "pg": "^8.16.3",
+    "prom-client": "^15.1.3"
   },
   "devDependencies": {
     "eslint": "^8.57.1",

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -2,12 +2,15 @@ import express from "express";
 import cors from "cors";
 import dotenv from "dotenv";
 import healthRoutes from "./routes/health.routes.js";
+import metricsRoutes from "./routes/metrics.routes.js";
 import authRoutes from "./routes/auth.routes.js";
 import categoriesRoutes from "./routes/categories.routes.js";
 import budgetsRoutes from "./routes/budgets.routes.js";
 import transactionsRoutes from "./routes/transactions.routes.js";
 import { notFoundHandler, errorHandler } from "./middlewares/error.middleware.js";
 import { requestIdMiddleware } from "./middlewares/request-id.middleware.js";
+import { requestLoggingMiddleware } from "./middlewares/request-logging.middleware.js";
+import { httpMetricsMiddleware } from "./observability/http-metrics.js";
 
 dotenv.config();
 
@@ -39,6 +42,8 @@ const resolveTrustProxyValue = () => {
 
 app.set("trust proxy", resolveTrustProxyValue());
 app.use(requestIdMiddleware);
+app.use(httpMetricsMiddleware);
+app.use(requestLoggingMiddleware);
 
 const allowedOrigins = (process.env.CORS_ORIGIN || "http://localhost:5173")
   .split(",")
@@ -66,6 +71,7 @@ app.use(
 
 app.use(express.json());
 app.use("/health", healthRoutes);
+app.use("/metrics", metricsRoutes);
 app.use("/auth", authRoutes);
 app.use("/categories", categoriesRoutes);
 app.use("/budgets", budgetsRoutes);

--- a/apps/api/src/app.test.js
+++ b/apps/api/src/app.test.js
@@ -9,6 +9,9 @@ import {
   resetLoginProtectionState,
 } from "./middlewares/login-protection.middleware.js";
 import { resetImportRateLimiterState } from "./middlewares/rate-limit.middleware.js";
+import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
+
+let testDbPool;
 
 const registerAndLogin = async (email, password = "Senha123") => {
   await request(app).post("/auth/register").send({
@@ -98,9 +101,9 @@ describe("API auth and transactions", () => {
       autoCreateForeignKeyIndices: true,
     });
     const pgAdapter = inMemoryDatabase.adapters.createPg();
-    const pool = new pgAdapter.Pool();
+    testDbPool = new pgAdapter.Pool();
 
-    setDbClientForTests(pool);
+    setDbClientForTests(testDbPool);
     await runMigrations();
   });
 
@@ -111,11 +114,12 @@ describe("API auth and transactions", () => {
   beforeEach(async () => {
     resetLoginProtectionState();
     resetImportRateLimiterState();
+    resetHttpMetricsForTests();
     await dbQuery("DELETE FROM transactions");
     await dbQuery("DELETE FROM users");
   });
 
-  it("GET /health responde com status 200 e versao", async () => {
+  it("GET /health responde com status 200 e sinais operacionais", async () => {
     const response = await request(app).get("/health");
 
     expect(response.status).toBe(200);
@@ -124,6 +128,41 @@ describe("API auth and transactions", () => {
     expect(response.body.version.length).toBeGreaterThan(0);
     expect(typeof response.body.commit).toBe("string");
     expect(response.body.commit.length).toBeGreaterThan(0);
+    expect(typeof response.body.buildTimestamp).toBe("string");
+    expect(response.body.buildTimestamp.length).toBeGreaterThan(0);
+    expect(typeof response.body.uptimeSeconds).toBe("number");
+    expect(response.body.uptimeSeconds).toBeGreaterThanOrEqual(0);
+    expect(response.body.db).toMatchObject({
+      status: "ok",
+    });
+    expect(typeof response.body.db.latencyMs).toBe("number");
+    expect(response.body.db.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(typeof response.body.requestId).toBe("string");
+    expect(response.body.requestId.length).toBeGreaterThan(0);
+    expect(response.body.requestId).toBe(response.headers["x-request-id"]);
+  });
+
+  it("GET /health retorna ok=false e status 503 quando DB falha", async () => {
+    setDbClientForTests({
+      query: () => Promise.reject(new Error("db unavailable")),
+    });
+
+    try {
+      const response = await request(app).get("/health");
+
+      expect(response.status).toBe(503);
+      expect(response.body.ok).toBe(false);
+      expect(response.body.db).toMatchObject({
+        status: "error",
+      });
+      expect(typeof response.body.db.latencyMs).toBe("number");
+      expect(response.body.db.latencyMs).toBeGreaterThanOrEqual(0);
+      expect(typeof response.body.requestId).toBe("string");
+      expect(response.body.requestId.length).toBeGreaterThan(0);
+      expect(response.body.requestId).toBe(response.headers["x-request-id"]);
+    } finally {
+      setDbClientForTests(testDbPool);
+    }
   });
 
   it("echoa x-request-id quando informado no header", async () => {
@@ -159,6 +198,77 @@ describe("API auth and transactions", () => {
     expectErrorResponseWithRequestId(response, 404, "Route not found");
     expect(response.body.requestId).toBe("rid-123");
     expect(response.headers["x-request-id"]).toBe("rid-123");
+  });
+
+  it("GET /metrics expõe formato Prometheus e inclui request counters por classe de status", async () => {
+    const successResponse = await request(app).get("/health");
+    const notFoundResponse = await request(app).get("/__not_found__");
+    const metricsResponse = await request(app).get("/metrics");
+
+    expect(successResponse.status).toBe(200);
+    expect(notFoundResponse.status).toBe(404);
+    expect(metricsResponse.status).toBe(200);
+    expect(metricsResponse.headers["content-type"]).toContain("text/plain");
+    expect(metricsResponse.text).toContain("# HELP http_requests_total");
+
+    const status2xxMatch = metricsResponse.text.match(/http_requests_total\{status="2xx"\}\s+([0-9.]+)/);
+    const status4xxMatch = metricsResponse.text.match(/http_requests_total\{status="4xx"\}\s+([0-9.]+)/);
+
+    expect(status2xxMatch).not.toBeNull();
+    expect(status4xxMatch).not.toBeNull();
+    expect(Number(status2xxMatch[1])).toBeGreaterThanOrEqual(1);
+    expect(Number(status4xxMatch[1])).toBeGreaterThanOrEqual(1);
+  });
+
+  it("GET /metrics registra histograma de latencia para endpoint crítico /auth/login", async () => {
+    const loginResponse = await request(app).post("/auth/login").send({
+      email: "",
+      password: "Senha123",
+    });
+    const metricsResponse = await request(app).get("/metrics");
+
+    expect(loginResponse.status).toBe(400);
+    expect(metricsResponse.status).toBe(200);
+    expect(metricsResponse.text).toContain('# HELP http_request_latency_ms');
+    expect(metricsResponse.text).toMatch(
+      /http_request_latency_ms_bucket\{[^}]*endpoint="\/auth\/login"[^}]*\}/,
+    );
+    expect(metricsResponse.text).toContain('http_request_latency_ms_count{endpoint="/auth/login"}');
+  });
+
+  it("GET /metrics exige token em production", async () => {
+    const envSnapshot = {
+      NODE_ENV: process.env.NODE_ENV,
+      METRICS_AUTH_TOKEN: process.env.METRICS_AUTH_TOKEN,
+    };
+
+    process.env.NODE_ENV = "production";
+    process.env.METRICS_AUTH_TOKEN = "metrics-secret";
+
+    try {
+      const forbiddenResponse = await request(app).get("/metrics");
+      expectErrorResponseWithRequestId(forbiddenResponse, 403, "Forbidden.");
+
+      const authorizedResponse = await request(app)
+        .get("/metrics")
+        .set("Authorization", "Bearer metrics-secret");
+
+      expect(authorizedResponse.status).toBe(200);
+      expect(authorizedResponse.headers["content-type"]).toContain("text/plain");
+      expect(authorizedResponse.text).toContain("# HELP http_requests_total");
+    } finally {
+      if (typeof envSnapshot.NODE_ENV === "undefined") {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = envSnapshot.NODE_ENV;
+      }
+
+      if (typeof envSnapshot.METRICS_AUTH_TOKEN === "undefined") {
+        delete process.env.METRICS_AUTH_TOKEN;
+      } else {
+        process.env.METRICS_AUTH_TOKEN = envSnapshot.METRICS_AUTH_TOKEN;
+      }
+    }
   });
 
   it("POST /auth/register cria usuario", async () => {

--- a/apps/api/src/config/version.js
+++ b/apps/api/src/config/version.js
@@ -10,6 +10,15 @@ const normalizeEnvValue = (value) => {
   return value.trim();
 };
 
+const isValidIsoTimestamp = (value) => {
+  if (!value) {
+    return false;
+  }
+
+  const parsedTimestamp = Date.parse(value);
+  return Number.isFinite(parsedTimestamp);
+};
+
 const resolvePackageVersion = () => {
   try {
     const currentFilePath = fileURLToPath(import.meta.url);
@@ -43,6 +52,22 @@ export const resolveApiCommit = (env = process.env) => {
 
   if (commitFromGenericEnv) {
     return commitFromGenericEnv;
+  }
+
+  return "unknown";
+};
+
+export const resolveApiBuildTimestamp = (env = process.env) => {
+  const buildTimestampFromAppEnv = normalizeEnvValue(env.APP_BUILD_TIMESTAMP);
+
+  if (isValidIsoTimestamp(buildTimestampFromAppEnv)) {
+    return buildTimestampFromAppEnv;
+  }
+
+  const buildTimestampFromGenericEnv = normalizeEnvValue(env.BUILD_TIMESTAMP);
+
+  if (isValidIsoTimestamp(buildTimestampFromGenericEnv)) {
+    return buildTimestampFromGenericEnv;
   }
 
   return "unknown";

--- a/apps/api/src/config/version.test.js
+++ b/apps/api/src/config/version.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveApiCommit, resolveApiVersion } from "./version.js";
+import { resolveApiBuildTimestamp, resolveApiCommit, resolveApiVersion } from "./version.js";
 
 describe("version config", () => {
   it("prioriza RENDER_GIT_COMMIT para commit", () => {
@@ -74,5 +74,46 @@ describe("version config", () => {
     const version = resolveApiVersion({}, { packageVersion: "" });
 
     expect(version).toBe("unknown");
+  });
+
+  it("prioriza APP_BUILD_TIMESTAMP quando informado", () => {
+    const buildTimestamp = resolveApiBuildTimestamp({
+      APP_BUILD_TIMESTAMP: "2026-02-21T03:45:00.000Z",
+      BUILD_TIMESTAMP: "2026-02-20T10:00:00.000Z",
+    });
+
+    expect(buildTimestamp).toBe("2026-02-21T03:45:00.000Z");
+  });
+
+  it("usa BUILD_TIMESTAMP quando APP_BUILD_TIMESTAMP nao existe", () => {
+    const buildTimestamp = resolveApiBuildTimestamp({
+      BUILD_TIMESTAMP: "2026-02-20T10:00:00.000Z",
+    });
+
+    expect(buildTimestamp).toBe("2026-02-20T10:00:00.000Z");
+  });
+
+  it("ignora APP_BUILD_TIMESTAMP invalido e usa BUILD_TIMESTAMP valido", () => {
+    const buildTimestamp = resolveApiBuildTimestamp({
+      APP_BUILD_TIMESTAMP: "invalid-timestamp",
+      BUILD_TIMESTAMP: "2026-02-20T10:00:00.000Z",
+    });
+
+    expect(buildTimestamp).toBe("2026-02-20T10:00:00.000Z");
+  });
+
+  it("retorna unknown quando APP_BUILD_TIMESTAMP e BUILD_TIMESTAMP sao invalidos", () => {
+    const buildTimestamp = resolveApiBuildTimestamp({
+      APP_BUILD_TIMESTAMP: "invalid-timestamp",
+      BUILD_TIMESTAMP: "not-a-date",
+    });
+
+    expect(buildTimestamp).toBe("unknown");
+  });
+
+  it("retorna unknown quando timestamp de build nao existe", () => {
+    const buildTimestamp = resolveApiBuildTimestamp({});
+
+    expect(buildTimestamp).toBe("unknown");
   });
 });

--- a/apps/api/src/db/index.js
+++ b/apps/api/src/db/index.js
@@ -106,6 +106,24 @@ export const dbQuery = async (text, params = []) => {
   return dbClient.query(text, params);
 };
 
+export const checkDatabaseHealth = async () => {
+  const startedAt = Date.now();
+
+  try {
+    await dbQuery("SELECT 1");
+
+    return {
+      status: "ok",
+      latencyMs: Math.max(0, Date.now() - startedAt),
+    };
+  } catch {
+    return {
+      status: "error",
+      latencyMs: Math.max(0, Date.now() - startedAt),
+    };
+  }
+};
+
 export const withDbTransaction = async (callback) => {
   const dbClient = getDbClient();
 

--- a/apps/api/src/middlewares/request-id.middleware.js
+++ b/apps/api/src/middlewares/request-id.middleware.js
@@ -26,9 +26,17 @@ export const requestIdMiddleware = (req, res, next) => {
   const requestIdFromCorrelation = normalizeRequestIdValue(req.headers["x-correlation-id"]);
   const requestId = requestIdFromHeader || requestIdFromCorrelation || randomUUID();
 
+  const existingContext =
+    req.context && typeof req.context === "object" && !Array.isArray(req.context)
+      ? req.context
+      : {};
+
+  req.context = {
+    ...existingContext,
+    requestId,
+  };
   req.requestId = requestId;
   res.setHeader("x-request-id", requestId);
 
   next();
 };
-

--- a/apps/api/src/middlewares/request-logging.middleware.js
+++ b/apps/api/src/middlewares/request-logging.middleware.js
@@ -1,0 +1,41 @@
+import { logInfo } from "../observability/logger.js";
+
+const resolveRoutePath = (req) => {
+  const fullPath = typeof req?.originalUrl === "string" ? req.originalUrl : req?.url || "/";
+  const [pathWithoutQuery] = String(fullPath).split("?");
+
+  return pathWithoutQuery || "/";
+};
+
+const resolveLatencyMs = (startedAt) => {
+  if (!Number.isFinite(startedAt)) {
+    return null;
+  }
+
+  return Math.max(0, Date.now() - startedAt);
+};
+
+const resolveUserId = (req) => {
+  const parsedUserId = Number(req?.user?.id);
+  return Number.isInteger(parsedUserId) && parsedUserId > 0 ? parsedUserId : null;
+};
+
+export const requestLoggingMiddleware = (req, res, next) => {
+  const startedAt = Date.now();
+
+  req.requestStartedAt = startedAt;
+
+  res.on("finish", () => {
+    logInfo({
+      event: "http.request.completed",
+      requestId: req.requestId || null,
+      method: req.method,
+      route: resolveRoutePath(req),
+      status: res.statusCode,
+      latencyMs: resolveLatencyMs(startedAt),
+      userId: resolveUserId(req),
+    });
+  });
+
+  next();
+};

--- a/apps/api/src/observability/http-metrics.js
+++ b/apps/api/src/observability/http-metrics.js
@@ -1,0 +1,101 @@
+import { Counter, Histogram, Registry } from "prom-client";
+
+const METRICS_ENDPOINT_PATH = "/metrics";
+const CRITICAL_ENDPOINTS = new Set(["/transactions", "/categories", "/auth/login"]);
+
+const metricsRegistry = new Registry();
+
+const httpRequestsTotalCounter = new Counter({
+  name: "http_requests_total",
+  help: "Total de requisicoes HTTP agrupadas por classe de status.",
+  labelNames: ["status"],
+  registers: [metricsRegistry],
+});
+
+const httpRequestLatencyHistogram = new Histogram({
+  name: "http_request_latency_ms",
+  help: "Latencia HTTP em milissegundos para endpoints criticos.",
+  labelNames: ["endpoint"],
+  buckets: [5, 10, 25, 50, 100, 250, 500, 1000, 2000, 5000, 10000],
+  registers: [metricsRegistry],
+});
+
+const resolveRoutePath = (req) => {
+  const fullPath = typeof req?.originalUrl === "string" ? req.originalUrl : req?.url || "/";
+  const [pathWithoutQuery] = String(fullPath).split("?");
+  return pathWithoutQuery || "/";
+};
+
+const resolveStatusClass = (statusCode) => {
+  if (!Number.isInteger(statusCode) || statusCode < 100) {
+    return "unknown";
+  }
+
+  if (statusCode >= 200 && statusCode < 300) {
+    return "2xx";
+  }
+
+  if (statusCode >= 300 && statusCode < 400) {
+    return "3xx";
+  }
+
+  if (statusCode >= 400 && statusCode < 500) {
+    return "4xx";
+  }
+
+  if (statusCode >= 500 && statusCode < 600) {
+    return "5xx";
+  }
+
+  return "unknown";
+};
+
+const resolveCriticalEndpoint = (routePath) => {
+  if (routePath === "/auth/login") {
+    return "/auth/login";
+  }
+
+  if (routePath.startsWith("/transactions")) {
+    return "/transactions";
+  }
+
+  if (routePath.startsWith("/categories")) {
+    return "/categories";
+  }
+
+  return null;
+};
+
+export const httpMetricsMiddleware = (req, res, next) => {
+  const startedAt = Date.now();
+
+  res.on("finish", () => {
+    const routePath = resolveRoutePath(req);
+
+    if (routePath === METRICS_ENDPOINT_PATH) {
+      return;
+    }
+
+    const statusClass = resolveStatusClass(res.statusCode);
+    httpRequestsTotalCounter.inc({ status: statusClass });
+
+    const criticalEndpoint = resolveCriticalEndpoint(routePath);
+
+    if (!criticalEndpoint || !CRITICAL_ENDPOINTS.has(criticalEndpoint)) {
+      return;
+    }
+
+    const latencyMs = Math.max(0, Date.now() - startedAt);
+    httpRequestLatencyHistogram.observe({ endpoint: criticalEndpoint }, latencyMs);
+  });
+
+  next();
+};
+
+export const getMetricsContentType = () => metricsRegistry.contentType;
+
+export const getMetricsSnapshot = async () => metricsRegistry.metrics();
+
+export const resetHttpMetricsForTests = () => {
+  metricsRegistry.resetMetrics();
+};

--- a/apps/api/src/observability/import-observability.js
+++ b/apps/api/src/observability/import-observability.js
@@ -1,3 +1,5 @@
+import { logError, logInfo } from "./logger.js";
+
 const METRIC_NAMES = {
   dryRunTotal: "import_dry_run_total",
   commitTotal: "import_commit_total",
@@ -100,7 +102,12 @@ export const logImportEvent = (eventName, payload = {}) => {
     metrics: getImportMetricsSnapshot(),
   };
 
-  console.log(JSON.stringify(structuredLogPayload));
+  if (String(eventName || "").toLowerCase().includes("error")) {
+    logError(structuredLogPayload);
+    return;
+  }
+
+  logInfo(structuredLogPayload);
 };
 
 export const resetImportObservabilityForTests = () => {
@@ -108,4 +115,3 @@ export const resetImportObservabilityForTests = () => {
     importMetricsState[metricName] = 0;
   });
 };
-

--- a/apps/api/src/observability/logger.js
+++ b/apps/api/src/observability/logger.js
@@ -1,0 +1,99 @@
+const LOG_LEVELS = {
+  info: "info",
+  warn: "warn",
+  error: "error",
+};
+
+const normalizeTextValue = (value) => {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  return value.trim();
+};
+
+const toLogSafeValue = (value) => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(toLogSafeValue);
+  }
+
+  if (typeof value === "object") {
+    return Object.entries(value).reduce((accumulator, [key, entryValue]) => {
+      const normalizedValue = toLogSafeValue(entryValue);
+      if (typeof normalizedValue !== "undefined") {
+        accumulator[key] = normalizedValue;
+      }
+      return accumulator;
+    }, {});
+  }
+
+  return value;
+};
+
+const shouldEmitStructuredLogs = () => {
+  const isVitestRuntime = normalizeTextValue(process.env.VITEST).toLowerCase() === "true";
+  const isTestEnvironment = process.env.NODE_ENV === "test" || isVitestRuntime;
+
+  if (!isTestEnvironment) {
+    return true;
+  }
+
+  return normalizeTextValue(process.env.LOG_API_EVENTS_IN_TEST).toLowerCase() === "true";
+};
+
+const resolveLogLevel = (level) => {
+  const normalizedLevel = normalizeTextValue(level).toLowerCase();
+
+  if (normalizedLevel === LOG_LEVELS.warn) {
+    return LOG_LEVELS.warn;
+  }
+
+  if (normalizedLevel === LOG_LEVELS.error) {
+    return LOG_LEVELS.error;
+  }
+
+  return LOG_LEVELS.info;
+};
+
+export const logStructuredEvent = (level, payload = {}) => {
+  if (!shouldEmitStructuredLogs()) {
+    return;
+  }
+
+  const normalizedLevel = resolveLogLevel(level);
+  const normalizedPayload = toLogSafeValue(payload);
+  const logPayload = {
+    level: normalizedLevel,
+    timestamp: new Date().toISOString(),
+    ...(typeof normalizedPayload === "object" && normalizedPayload ? normalizedPayload : {}),
+  };
+
+  const serializedPayload = JSON.stringify(logPayload);
+
+  if (normalizedLevel === LOG_LEVELS.error) {
+    console.error(serializedPayload);
+    return;
+  }
+
+  console.log(serializedPayload);
+};
+
+export const logInfo = (payload) => {
+  logStructuredEvent(LOG_LEVELS.info, payload);
+};
+
+export const logWarn = (payload) => {
+  logStructuredEvent(LOG_LEVELS.warn, payload);
+};
+
+export const logError = (payload) => {
+  logStructuredEvent(LOG_LEVELS.error, payload);
+};

--- a/apps/api/src/routes/health.routes.js
+++ b/apps/api/src/routes/health.routes.js
@@ -1,14 +1,30 @@
 import { Router } from "express";
-import { resolveApiCommit, resolveApiVersion } from "../config/version.js";
+import {
+  resolveApiBuildTimestamp,
+  resolveApiCommit,
+  resolveApiVersion,
+} from "../config/version.js";
+import { checkDatabaseHealth } from "../db/index.js";
 
 const router = Router();
 
-router.get("/", (_req, res) => {
-  res.status(200).json({
-    ok: true,
-    version: resolveApiVersion(),
-    commit: resolveApiCommit(),
-  });
+router.get("/", async (req, res, next) => {
+  try {
+    const db = await checkDatabaseHealth();
+    const responsePayload = {
+      ok: db.status === "ok",
+      version: resolveApiVersion(),
+      commit: resolveApiCommit(),
+      buildTimestamp: resolveApiBuildTimestamp(),
+      uptimeSeconds: Math.floor(process.uptime()),
+      db,
+      requestId: req.requestId || null,
+    };
+
+    return res.status(responsePayload.ok ? 200 : 503).json(responsePayload);
+  } catch (error) {
+    return next(error);
+  }
 });
 
 export default router;

--- a/apps/api/src/routes/metrics.routes.js
+++ b/apps/api/src/routes/metrics.routes.js
@@ -1,0 +1,49 @@
+import { Router } from "express";
+import { getMetricsContentType, getMetricsSnapshot } from "../observability/http-metrics.js";
+
+const router = Router();
+
+const resolveMetricsAuthToken = () => {
+  const configuredToken = String(process.env.METRICS_AUTH_TOKEN || "").trim();
+  return configuredToken;
+};
+
+const resolveAuthorizationToken = (authorizationHeader) => {
+  if (typeof authorizationHeader !== "string") {
+    return "";
+  }
+
+  if (!authorizationHeader.startsWith("Bearer ")) {
+    return "";
+  }
+
+  return authorizationHeader.slice("Bearer ".length).trim();
+};
+
+const shouldProtectMetricsEndpoint = () => process.env.NODE_ENV === "production";
+
+router.get("/", async (req, res, next) => {
+  try {
+    if (shouldProtectMetricsEndpoint()) {
+      const expectedToken = resolveMetricsAuthToken();
+      const providedToken = resolveAuthorizationToken(req.headers.authorization);
+
+      if (!expectedToken || providedToken !== expectedToken) {
+        return res.status(403).json({
+          message: "Forbidden.",
+          requestId: req.requestId || null,
+        });
+      }
+    }
+
+    const metricsPayload = await getMetricsSnapshot();
+    res.setHeader("Content-Type", getMetricsContentType());
+    res.setHeader("Cache-Control", "no-store");
+
+    return res.status(200).send(metricsPayload);
+  } catch (error) {
+    return next(error);
+  }
+});
+
+export default router;

--- a/apps/web/src/services/api.test.js
+++ b/apps/web/src/services/api.test.js
@@ -107,6 +107,18 @@ describe("api service", () => {
     });
 
     expect(nextConfig.headers.Authorization).toBe("Bearer jwt_token");
+    expect(typeof nextConfig.headers["x-request-id"]).toBe("string");
+    expect(nextConfig.headers["x-request-id"].length).toBeGreaterThan(0);
+  });
+
+  it("injeta x-request-id mesmo sem token", () => {
+    const nextConfig = requestInterceptor({
+      headers: {},
+    });
+
+    expect(nextConfig.headers.Authorization).toBeUndefined();
+    expect(typeof nextConfig.headers["x-request-id"]).toBe("string");
+    expect(nextConfig.headers["x-request-id"].length).toBeGreaterThan(0);
   });
 
   it("limpa token e executa handler quando API retorna 401", async () => {

--- a/docs/runbooks/release-production-checklist.md
+++ b/docs/runbooks/release-production-checklist.md
@@ -12,7 +12,12 @@ Standardize post-release verification for API + Web in production, with traceabl
   - [ ] No duplicate migration errors.
   - [ ] `schema_migrations` updated when release includes new migrations.
   - [ ] No Postgres connection errors.
-- [ ] Confirm `GET /health` returns `{ ok: true, version, commit }`.
+- [ ] Confirm `GET /health` returns:
+  - [ ] `ok: true`
+  - [ ] expected `version` and `commit`
+  - [ ] `buildTimestamp` filled
+  - [ ] `uptimeSeconds` greater than zero
+  - [ ] `db.status = "ok"` with `latencyMs` reported
 - [ ] Validate required environment variables:
   - [ ] `DATABASE_URL`
   - [ ] `JWT_SECRET`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "control-finance-monorepo",
-  "version": "1.8.1",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "control-finance-monorepo",
-      "version": "1.8.1",
+      "version": "1.12.0",
       "workspaces": [
         "apps/web",
         "apps/api"
@@ -20,7 +20,7 @@
     },
     "apps/api": {
       "name": "@control-finance/api",
-      "version": "1.8.1",
+      "version": "1.12.0",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
@@ -30,7 +30,8 @@
         "express-rate-limit": "^8.2.1",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.2",
-        "pg": "^8.16.3"
+        "pg": "^8.16.3",
+        "prom-client": "^15.1.3"
       },
       "devDependencies": {
         "eslint": "^8.57.1",
@@ -44,7 +45,7 @@
     },
     "apps/web": {
       "name": "@control-finance/web",
-      "version": "1.8.1",
+      "version": "1.12.0",
       "dependencies": {
         "autoprefixer": "^10.4.24",
         "axios": "^1.8.4",
@@ -1230,6 +1231,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@paralleldrive/cuid2": {
@@ -2701,6 +2711,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.4",
@@ -7042,6 +7058,19 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -8410,6 +8439,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/text-table": {


### PR DESCRIPTION
## What
Enhance observability foundations across API and Web:
- End-to-end request correlation via `x-request-id` (Web -> API)
- Structured JSON logging for HTTP lifecycle, errors and server startup
- Prometheus metrics endpoint (`GET /metrics`) with HTTP counters and latency histogram
- Expanded `GET /health` with `buildTimestamp`, `uptimeSeconds`, `db.status`, `db.latencyMs`, and `requestId`

## Behavior
- `/health` returns `200` when DB is healthy and `503` when DB fails (`ok: false`)
- `/metrics` requires `Authorization: Bearer <METRICS_AUTH_TOKEN>` in production
- Invalid build timestamps safely fall back to `unknown`

## Validation
- `npm run lint`
- `npm run test`
- `npm run build`

## Scope
Observability-only. No business/domain behavior changes.