### PR TITLE
chore(release): v1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.13.0] - 2026-02-20
+
+### Added
+
+- End-to-end request correlation via `x-request-id` (Web -> API).
+- Structured JSON logging for HTTP lifecycle, errors and startup events.
+- Prometheus metrics endpoint (`GET /metrics`) with:
+  - HTTP request counter
+  - Latency histogram
+  - Bearer token protection in production.
+- Expanded `GET /health` with:
+  - `buildTimestamp`
+  - `uptimeSeconds`
+  - `db.status`
+  - `db.latencyMs`
+  - `requestId`
+- Safe ISO timestamp validation with fallback to `"unknown"`.
+
+### Behavior
+
+- `/health` returns `200` when DB is healthy.
+- `/health` returns `503` when DB fails (`ok: false`).
+- `/metrics` requires `Authorization: Bearer <METRICS_AUTH_TOKEN>` in production.
+
+### Scope
+
+- Observability-only. No business or domain behavior changes.
+
+### Technical
+
+- Merge commit: `cf6936cf6674bacbef1bc2bd316575c13f35e554`
+- PR: #109
+
 ## [1.12.0] - 2026-02-20
 
 ### Added

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/api",
   "private": true,
-  "version": "1.12.0",
+  "version": "1.13.0",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/web",
   "private": true,
-  "version": "1.12.0",
+  "version": "1.13.0",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "control-finance-monorepo",
   "private": true,
-  "version": "1.12.0",
+  "version": "1.13.0",
   "engines": {
     "node": "24.x"
   },


### PR DESCRIPTION
## What changed
- Bump version to `1.13.0` in:
  - `package.json`
  - `apps/api/package.json`
  - `apps/web/package.json`
- Add `[1.13.0]` entry at the top of `CHANGELOG.md`.

## Why
Release preparation only: align version metadata and changelog before tagging and publishing `v1.13.0`.

## Scope
- No feature/runtime behavior changes
- Metadata + changelog only

## Validation
- `npm run lint`
- `npm run test`
- `npm run build`