### PR TITLE
chore(release): v1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.13.1] - 2026-02-20
+
+### Added
+
+- CSV export now includes `category_name` (`id,type,value,date,description,notes,category_name,created_at`).
+- Export category labels with fallbacks:
+  - `Sem categoria` for null category.
+  - `Categoria nao encontrada` when category id is unresolved.
+
+### Changed
+
+- Release runbook updated with incident severity and escalation criteria (`P1/P2/P3`).
+- Release runbook now includes `APP_BUILD_TIMESTAMP` in deploy verification checks.
+
+### Ops
+
+- Production `buildTimestamp` in `/health` configured and validated.
+- Post-release check now enforces `/health.commit == origin/main`.
+
 ## [1.13.0] - 2026-02-20
 
 ### Added

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/api",
   "private": true,
-  "version": "1.13.0",
+  "version": "1.13.1",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/web",
   "private": true,
-  "version": "1.13.0",
+  "version": "1.13.1",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "control-finance-monorepo",
   "private": true,
-  "version": "1.13.0",
+  "version": "1.13.1",
   "engines": {
     "node": "24.x"
   },


### PR DESCRIPTION
## What changed
- Bump version to `1.13.1` across workspace packages.
- Add `[1.13.1]` entry to `CHANGELOG.md`.

## Why
Patch release consolidating:
- CSV export `category_name` enrichment
- Incident severity runbook hardening
- `APP_BUILD_TIMESTAMP` production validation

## Scope
- Metadata + changelog only.
- No runtime or behavior changes.

## Validation
- `npm run lint`
- `npm run test`
- `npm run build`
