### PR TITLE
ci: enforce full typecheck in pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Lint (web)
         run: npm -w apps/web run lint
 
-      - name: Typecheck auth (web)
-        run: npm -w apps/web run typecheck:auth
+      - name: Typecheck (web)
+        run: npm run typecheck
 
       - name: Test (web)
         run: npm -w apps/web run test:run

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "scripts": {
     "dev": "concurrently \"npm -w apps/api run dev\" \"npm -w apps/web run dev\"",
     "lint": "npm -w apps/web run lint && npm -w apps/api run lint",
-    "typecheck": "npm -w apps/web run typecheck",
+    "typecheck:web": "npm -w apps/web run typecheck",
+    "typecheck": "npm run typecheck:web",
     "test": "npm -w apps/web run test:run && npm -w apps/api run test",
     "test:run": "npm run test",
     "build": "npm -w apps/web run build && npm -w apps/api run build",


### PR DESCRIPTION
## What changed
- Add root script `typecheck:web`.
- Keep root `typecheck` as the aggregate entrypoint (`npm run typecheck:web`).
- Update CI web job to run full web typecheck via `npm run typecheck` (replacing `typecheck:auth`).

## Why
`typecheck:auth` only covered a subset of the app. This PR makes TypeScript type safety a full PR gate.

## Scope
- CI + scripts only.
- No runtime behavior changes.

## Validation
- npm run typecheck
- npm run lint
- npm run test
- npm run build