### PR TITLE
feat(api): apply per-user rate limiting to write endpoints

### DIFF
--- a/apps/api/src/middlewares/rate-limit.middleware.js
+++ b/apps/api/src/middlewares/rate-limit.middleware.js
@@ -2,6 +2,9 @@ import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 
 const DEFAULT_IMPORT_RATE_LIMIT_WINDOW_MS = 60 * 1000;
 const DEFAULT_IMPORT_RATE_LIMIT_MAX_REQUESTS = 10;
+const DEFAULT_WRITE_RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const DEFAULT_WRITE_RATE_LIMIT_MAX_REQUESTS = 60;
+const WRITE_RATE_LIMIT_ERROR_MESSAGE = "Muitas requisicoes. Tente novamente em instantes.";
 
 const parsePositiveInteger = (value, fallbackValue) => {
   const parsedValue = Number(value);
@@ -25,25 +28,79 @@ const getImportRateLimitMaxRequests = () =>
     DEFAULT_IMPORT_RATE_LIMIT_MAX_REQUESTS,
   );
 
+const getWriteRateLimitWindowMs = () =>
+  parsePositiveInteger(
+    process.env.WRITE_RATE_LIMIT_WINDOW_MS,
+    DEFAULT_WRITE_RATE_LIMIT_WINDOW_MS,
+  );
+
+const getWriteRateLimitMaxRequests = () =>
+  parsePositiveInteger(
+    process.env.WRITE_RATE_LIMIT_MAX,
+    DEFAULT_WRITE_RATE_LIMIT_MAX_REQUESTS,
+  );
+
 const createError = (status, message) => {
   const error = new Error(message);
   error.status = status;
   return error;
 };
 
+const resolveRateLimitKey = (request, keyPrefix = "") => {
+  const requestKey = request.user?.id
+    ? `user:${request.user.id}`
+    : `ip:${ipKeyGenerator(request.ip || "")}`;
+
+  if (!keyPrefix) {
+    return requestKey;
+  }
+
+  return `${keyPrefix}:${requestKey}`;
+};
+
+const createRateLimitExceededHandler =
+  (message = WRITE_RATE_LIMIT_ERROR_MESSAGE) =>
+  (_request, _response, next) => {
+    next(createError(429, message));
+  };
+
+const createUserWriteRateLimiter = (keyPrefix) =>
+  rateLimit({
+    windowMs: getWriteRateLimitWindowMs(),
+    max: getWriteRateLimitMaxRequests(),
+    standardHeaders: true,
+    legacyHeaders: false,
+    keyGenerator: (request) => resolveRateLimitKey(request, keyPrefix),
+    handler: createRateLimitExceededHandler(),
+  });
+
 export const importRateLimiter = rateLimit({
   windowMs: getImportRateLimitWindowMs(),
   max: getImportRateLimitMaxRequests(),
   standardHeaders: true,
   legacyHeaders: false,
-  keyGenerator: (request) => String(request.user?.id || ipKeyGenerator(request.ip || "")),
-  handler: (_request, _response, next) => {
-    next(createError(429, "Muitas requisicoes. Tente novamente em instantes."));
-  },
+  keyGenerator: (request) => resolveRateLimitKey(request, "import"),
+  handler: createRateLimitExceededHandler(),
 });
+
+export const transactionsWriteRateLimiter = createUserWriteRateLimiter("transactions-write");
+export const categoriesWriteRateLimiter = createUserWriteRateLimiter("categories-write");
+export const budgetsWriteRateLimiter = createUserWriteRateLimiter("budgets-write");
 
 export const resetImportRateLimiterState = () => {
   if (importRateLimiter?.store?.resetAll) {
     importRateLimiter.store.resetAll();
   }
+};
+
+export const resetWriteRateLimiterState = () => {
+  [
+    transactionsWriteRateLimiter,
+    categoriesWriteRateLimiter,
+    budgetsWriteRateLimiter,
+  ].forEach((limiter) => {
+    if (limiter?.store?.resetAll) {
+      limiter.store.resetAll();
+    }
+  });
 };

--- a/apps/api/src/routes/budgets.routes.js
+++ b/apps/api/src/routes/budgets.routes.js
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { authMiddleware } from "../middlewares/auth.middleware.js";
+import { budgetsWriteRateLimiter } from "../middlewares/rate-limit.middleware.js";
 import {
   deleteMonthlyBudgetForUser,
   listMonthlyBudgetsByUser,
@@ -19,7 +20,7 @@ router.get("/", async (req, res, next) => {
   }
 });
 
-router.post("/", async (req, res, next) => {
+router.post("/", budgetsWriteRateLimiter, async (req, res, next) => {
   try {
     const budget = await upsertMonthlyBudgetForUser(req.user.id, req.body || {});
     res.status(200).json(budget);
@@ -28,7 +29,7 @@ router.post("/", async (req, res, next) => {
   }
 });
 
-router.delete("/:id", async (req, res, next) => {
+router.delete("/:id", budgetsWriteRateLimiter, async (req, res, next) => {
   try {
     await deleteMonthlyBudgetForUser(req.user.id, req.params.id);
     res.status(204).send();

--- a/apps/api/src/routes/categories.routes.js
+++ b/apps/api/src/routes/categories.routes.js
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { authMiddleware } from "../middlewares/auth.middleware.js";
+import { categoriesWriteRateLimiter } from "../middlewares/rate-limit.middleware.js";
 import {
   createCategoryForUser,
   deleteCategoryForUser,
@@ -23,7 +24,7 @@ router.get("/", async (req, res, next) => {
   }
 });
 
-router.post("/", async (req, res, next) => {
+router.post("/", categoriesWriteRateLimiter, async (req, res, next) => {
   try {
     const category = await createCategoryForUser(req.user.id, req.body || {});
     res.status(201).json(category);
@@ -32,7 +33,7 @@ router.post("/", async (req, res, next) => {
   }
 });
 
-router.patch("/:id", async (req, res, next) => {
+router.patch("/:id", categoriesWriteRateLimiter, async (req, res, next) => {
   try {
     const updatedCategory = await updateCategoryForUser(req.user.id, req.params.id, req.body || {});
     res.status(200).json(updatedCategory);
@@ -41,7 +42,7 @@ router.patch("/:id", async (req, res, next) => {
   }
 });
 
-router.delete("/:id", async (req, res, next) => {
+router.delete("/:id", categoriesWriteRateLimiter, async (req, res, next) => {
   try {
     const deletedCategory = await deleteCategoryForUser(req.user.id, req.params.id);
     res.status(200).json(deletedCategory);
@@ -50,7 +51,7 @@ router.delete("/:id", async (req, res, next) => {
   }
 });
 
-router.post("/:id/restore", async (req, res, next) => {
+router.post("/:id/restore", categoriesWriteRateLimiter, async (req, res, next) => {
   try {
     const restoredCategory = await restoreCategoryForUser(req.user.id, req.params.id);
     res.status(200).json(restoredCategory);

--- a/apps/api/src/routes/transactions.routes.js
+++ b/apps/api/src/routes/transactions.routes.js
@@ -2,7 +2,10 @@ import { Router } from "express";
 import path from "node:path";
 import multer from "multer";
 import { authMiddleware } from "../middlewares/auth.middleware.js";
-import { importRateLimiter } from "../middlewares/rate-limit.middleware.js";
+import {
+  importRateLimiter,
+  transactionsWriteRateLimiter,
+} from "../middlewares/rate-limit.middleware.js";
 import {
   createElapsedTimer,
   logImportEvent,
@@ -215,7 +218,7 @@ router.get("/", async (req, res, next) => {
   }
 });
 
-router.post("/", async (req, res, next) => {
+router.post("/", transactionsWriteRateLimiter, async (req, res, next) => {
   try {
     const transaction = await createTransactionForUser(req.user.id, req.body || {});
     res.status(201).json(transaction);
@@ -224,7 +227,7 @@ router.post("/", async (req, res, next) => {
   }
 });
 
-router.patch("/:id", async (req, res, next) => {
+router.patch("/:id", transactionsWriteRateLimiter, async (req, res, next) => {
   try {
     const updatedTransaction = await updateTransactionForUser(
       req.user.id,
@@ -237,7 +240,7 @@ router.patch("/:id", async (req, res, next) => {
   }
 });
 
-router.delete("/:id", async (req, res, next) => {
+router.delete("/:id", transactionsWriteRateLimiter, async (req, res, next) => {
   try {
     const removedTransaction = await deleteTransactionForUser(req.user.id, req.params.id);
     res.status(200).json({
@@ -249,7 +252,7 @@ router.delete("/:id", async (req, res, next) => {
   }
 });
 
-router.post("/:id/restore", async (req, res, next) => {
+router.post("/:id/restore", transactionsWriteRateLimiter, async (req, res, next) => {
   try {
     const restoredTransaction = await restoreTransactionForUser(req.user.id, req.params.id);
     res.status(200).json(restoredTransaction);


### PR DESCRIPTION
## What changed
- Added per-user write rate limiters for authenticated write endpoints:
  - `transactions`: `POST /`, `PATCH /:id`, `DELETE /:id`, `POST /:id/restore`
  - `categories`: `POST /`, `PATCH /:id`, `DELETE /:id`, `POST /:id/restore`
  - `budgets`: `POST /`, `DELETE /:id`
- Reused `express-rate-limit` with user-scoped keying (`user:<id>`), with IP fallback for non-authenticated flows.
- Added dedicated write limiter reset helper for deterministic tests.

## Why
- Enforce runtime protection against burst writes per user.
- Reduce incident risk from accidental or abusive write traffic.

## Tests
- Added API contract test to assert `429` after exceeding write limit.
- Reset write limiter state in `beforeEach` to avoid cross-test contamination.

## Validation
- `npm -w apps/api run lint`
- `npm -w apps/api run test`
- `npm run lint`
- `npm run test`
- `npm run build`