### PR TITLE
docs(observability): add validation order guide (logs -> explore -> dashboard -> alerts)

### DIFF
--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -1,4 +1,4 @@
-# Observability - Operational Validation Order (Grafana Cloud + Alloy)
+# Observability: Operational Validation Order (Grafana Cloud + Alloy)
 
 This folder versions the baseline observability assets for Control Finance:
 - Grafana Alloy worker config (in `ops/alloy/`)
@@ -61,3 +61,5 @@ After applying:
 - Grafana Cloud setup: `docs/observability/grafana-cloud.md`
 - Release checklist: `docs/runbooks/release-production-checklist.md`
 - Alloy worker: `ops/alloy/README.md`
+- Dashboard: `docs/observability/dashboards/control-finance-api-min.json`
+- Alerts: `docs/observability/alerts/control-finance-api-alerts.yaml`


### PR DESCRIPTION
## What
- Add `docs/observability/README.md` documenting the operational validation order:
  - logs -> explore -> dashboard -> alerts
- Centralize references to Grafana Cloud, runbook, and Alloy worker assets.

## Why
- Prevent time waste and false negatives during observability rollout.
- Make the ingestion verification path reproducible for future releases/onboarding.

## Scope
- Docs only.
- No runtime or infra changes.