### PR TITLE
fix(alloy): add missing commas in static targets

### DIFF
--- a/ops/alloy/alloy.config.alloy
+++ b/ops/alloy/alloy.config.alloy
@@ -5,11 +5,11 @@
 discovery.static "control_finance_api" {
   targets = [
     {
-      __address__     = env("API_HOST")
-      __scheme__      = "https"
-      __metrics_path__ = "/metrics"
-      job             = "control-finance-api"
-      environment     = env("ENVIRONMENT")
+      __address__      = env("API_HOST"),
+      __scheme__       = "https",
+      __metrics_path__ = "/metrics",
+      job              = "control-finance-api",
+      environment      = env("ENVIRONMENT"),
     },
   ]
 }


### PR DESCRIPTION
## What
- Fix Alloy syntax in `discovery.static` target object by adding missing commas between fields.

## Why
- Render deploy failed with `missing ',' in field list` while loading `/etc/alloy/config.alloy`.

## Scope
- Single-file fix in `ops/alloy/alloy.config.alloy`.
- No API/Web runtime behavior changes.