### PR TITLE
fix(alloy): inline scrape targets and add safe env example

### DIFF
--- a/ops/alloy/.env.example
+++ b/ops/alloy/.env.example
@@ -1,0 +1,15 @@
+# Grafana Alloy Worker env vars
+# Copy to .env for local docker runs, or configure directly in Render Worker.
+
+API_HOST=control-finance-react-tailwind.onrender.com
+ENVIRONMENT=prod
+SCRAPE_INTERVAL=30s
+SCRAPE_TIMEOUT=10s
+
+# Must match API /metrics protection token
+METRICS_AUTH_TOKEN=replace_with_metrics_token
+
+# Grafana Cloud remote_write (Mimir)
+GRAFANA_CLOUD_REMOTE_WRITE_URL=https://prometheus-prod-xx.grafana.net/api/prom/push
+GRAFANA_CLOUD_USERNAME=replace_with_instance_id
+GRAFANA_CLOUD_API_KEY=replace_with_metrics_publisher_key

--- a/ops/alloy/alloy.config.alloy
+++ b/ops/alloy/alloy.config.alloy
@@ -2,7 +2,7 @@
 // This worker scrapes API /metrics with Bearer auth and ships metrics
 // to Grafana Cloud (Mimir) via remote_write.
 
-discovery.static "control_finance_api" {
+prometheus.scrape "control_finance_api" {
   targets = [
     {
       __address__      = env("API_HOST"),
@@ -12,10 +12,6 @@ discovery.static "control_finance_api" {
       environment      = env("ENVIRONMENT"),
     },
   ]
-}
-
-prometheus.scrape "control_finance_api" {
-  targets         = discovery.static.control_finance_api.targets
   scrape_interval = env("SCRAPE_INTERVAL")
   scrape_timeout  = env("SCRAPE_TIMEOUT")
 


### PR DESCRIPTION
## What\n- Replace unsupported discovery.static usage in Alloy config with inline static targets inside prometheus.scrape.\n- Add ops/alloy/.env.example with safe placeholders for Render Worker setup.\n\n## Why\n- Fix Alloy startup failure in Render (cannot find the definition of component name discovery.static).\n- Standardize required worker environment variables without committing secrets.\n\n## Scope\n- Observability infra config/docs only.\n- No application runtime/domain logic changes.