### PR TITLE
chore(release): v1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.14.0] - 2026-02-21
+
+### Added
+
+- Web core pages migrated to TypeScript:
+  - `App.tsx`
+  - `Login.tsx`
+  - `CategoriesSettings.tsx`
+- Observability operational assets:
+  - Grafana Alloy worker config for authenticated `/metrics` scrape and remote_write
+  - baseline dashboard and alert rules
+  - warmup traffic script for metrics ingestion
+  - observability validation order guide
+- Availability SLI/SLO baseline documentation and runbook integration.
+
+### Changed
+
+- CI now enforces full Web typecheck in pull requests.
+- API write endpoints now apply per-user rate limiting.
+- Alloy config now uses inline static targets in `prometheus.scrape` (removing unsupported `discovery.static` usage).
+
+### Security
+
+- `/metrics` remains protected in production with `Authorization: Bearer <METRICS_AUTH_TOKEN>`.
+- Added `ops/alloy/.env.example` with safe placeholders for Render Worker configuration.
+
+### Quality
+
+- Production observability ingestion validated in Grafana Cloud (`http_requests_total` rate > 0).
+- CI checks remained green across API/Web/Vercel for release-line pull requests.
+
+### Scope
+
+- Release focused on type safety, observability operability, and runtime hardening.
+
 ## [1.13.1] - 2026-02-20
 
 ### Added

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/api",
   "private": true,
-  "version": "1.13.1",
+  "version": "1.14.0",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/web",
   "private": true,
-  "version": "1.13.1",
+  "version": "1.14.0",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "control-finance-monorepo",
   "private": true,
-  "version": "1.13.1",
+  "version": "1.14.0",
   "engines": {
     "node": "24.x"
   },


### PR DESCRIPTION
## What changed
- Bump version to `1.14.0` across workspace packages:
  - `package.json`
  - `apps/api/package.json`
  - `apps/web/package.json`
- Add `[1.14.0]` entry to `CHANGELOG.md`.

## Why
Release preparation for v1.14.0 (TypeScript core migration, CI typecheck gate, per-user write rate limiting, and actionable observability assets).

## Scope
- Metadata + changelog only.
- No runtime or behavior changes.

## Validation
- `npm run lint`
- `npm run test`
- `npm run build`