### PR TITLE
feat(api): add analytics trend endpoint (monthly aggregates)

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -6,6 +6,7 @@ import metricsRoutes from "./routes/metrics.routes.js";
 import authRoutes from "./routes/auth.routes.js";
 import categoriesRoutes from "./routes/categories.routes.js";
 import budgetsRoutes from "./routes/budgets.routes.js";
+import analyticsRoutes from "./routes/analytics.routes.js";
 import transactionsRoutes from "./routes/transactions.routes.js";
 import { notFoundHandler, errorHandler } from "./middlewares/error.middleware.js";
 import { requestIdMiddleware } from "./middlewares/request-id.middleware.js";
@@ -75,6 +76,7 @@ app.use("/metrics", metricsRoutes);
 app.use("/auth", authRoutes);
 app.use("/categories", categoriesRoutes);
 app.use("/budgets", budgetsRoutes);
+app.use("/analytics", analyticsRoutes);
 app.use("/transactions", transactionsRoutes);
 
 app.use(notFoundHandler);

--- a/apps/api/src/app.test.js
+++ b/apps/api/src/app.test.js
@@ -74,6 +74,23 @@ const createTransactionsForUser = async (token, count) => {
   );
 };
 
+const addMonthsUtc = (baseDate, monthsToAdd) =>
+  new Date(Date.UTC(baseDate.getUTCFullYear(), baseDate.getUTCMonth() + monthsToAdd, 1));
+
+const toMonthValue = (value) => {
+  const date = new Date(value);
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`;
+};
+
+const getExpectedTrendMonths = (months) => {
+  const now = new Date();
+  const currentMonthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+
+  return Array.from({ length: months }, (_unused, index) =>
+    toMonthValue(addMonthsUtc(currentMonthStart, index - (months - 1))),
+  );
+};
+
 const AUTH_SECURITY_ENV_KEYS = [
   "AUTH_BRUTE_FORCE_MAX_ATTEMPTS",
   "AUTH_BRUTE_FORCE_WINDOW_MS",
@@ -1068,6 +1085,110 @@ describe("API auth and transactions", () => {
     const response = await request(app).get("/transactions/summary");
 
     expect(response.status).toBe(401);
+  });
+
+  it("GET /analytics/trend bloqueia sem token", async () => {
+    const response = await request(app).get("/analytics/trend");
+
+    expectErrorResponseWithRequestId(response, 401, "Token de autenticacao ausente ou invalido.");
+  });
+
+  it.each([{ months: "0" }, { months: "abc" }, { months: "999" }, { months: "1.5" }, { months: "" }])(
+    "GET /analytics/trend retorna 400 para months invalido (%o)",
+    async ({ months }) => {
+      const token = await registerAndLogin("analytics-trend-months-invalid@controlfinance.dev");
+
+      const response = await request(app)
+        .get("/analytics/trend")
+        .query({ months })
+        .set("Authorization", `Bearer ${token}`);
+
+      expectErrorResponseWithRequestId(response, 400, "months invalido. Use inteiro entre 1 e 24.");
+    },
+  );
+
+  it("GET /analytics/trend retorna 6 meses por padrao com months vazios zerados", async () => {
+    const token = await registerAndLogin("analytics-trend-default@controlfinance.dev");
+
+    const response = await request(app)
+      .get("/analytics/trend")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    expect(Array.isArray(response.body)).toBe(true);
+    expect(response.body).toHaveLength(6);
+    expect(response.body.map((item) => item.month)).toEqual(getExpectedTrendMonths(6));
+    response.body.forEach((item) => {
+      expect(typeof item.month).toBe("string");
+      expect(item.month).toMatch(/^\d{4}-\d{2}$/);
+      expect(item.income).toBe(0);
+      expect(item.expense).toBe(0);
+      expect(item.balance).toBe(0);
+    });
+  });
+
+  it("GET /analytics/trend preenche meses vazios e calcula income/expense/balance", async () => {
+    const token = await registerAndLogin("analytics-trend-calc@controlfinance.dev");
+    const expectedMonths = getExpectedTrendMonths(3);
+    const [oldestMonth, previousMonth, currentMonth] = expectedMonths;
+
+    await request(app)
+      .post("/transactions")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        type: "Saida",
+        value: 200,
+        date: `${previousMonth}-10`,
+        description: "Transporte",
+      });
+
+    await request(app)
+      .post("/transactions")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        type: "Entrada",
+        value: 1000,
+        date: `${currentMonth}-12`,
+        description: "Salario",
+      });
+
+    await request(app)
+      .post("/transactions")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        type: "Saida",
+        value: 250,
+        date: `${currentMonth}-13`,
+        description: "Mercado",
+      });
+
+    const deletedTransactionResponse = await request(app)
+      .post("/transactions")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        type: "Entrada",
+        value: 999,
+        date: `${currentMonth}-14`,
+        description: "Ignorada",
+      });
+
+    await request(app)
+      .delete(`/transactions/${deletedTransactionResponse.body.id}`)
+      .set("Authorization", `Bearer ${token}`);
+
+    const response = await request(app)
+      .get("/analytics/trend")
+      .query({ months: 3 })
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveLength(3);
+    expect(response.body.map((item) => item.month)).toEqual([oldestMonth, previousMonth, currentMonth]);
+    expect(response.body).toEqual([
+      { month: oldestMonth, income: 0, expense: 0, balance: 0 },
+      { month: previousMonth, income: 0, expense: 200, balance: -200 },
+      { month: currentMonth, income: 1000, expense: 250, balance: 750 },
+    ]);
   });
 
   it("GET /transactions/imports bloqueia sem token", async () => {

--- a/apps/api/src/constants/transaction-types.js
+++ b/apps/api/src/constants/transaction-types.js
@@ -1,0 +1,2 @@
+export const TRANSACTION_TYPE_ENTRY = "Entrada";
+export const TRANSACTION_TYPE_EXIT = "Saida";

--- a/apps/api/src/routes/analytics.routes.js
+++ b/apps/api/src/routes/analytics.routes.js
@@ -1,0 +1,18 @@
+import { Router } from "express";
+import { authMiddleware } from "../middlewares/auth.middleware.js";
+import { getMonthlyTrendForUser } from "../services/analytics.service.js";
+
+const router = Router();
+
+router.use(authMiddleware);
+
+router.get("/trend", async (req, res, next) => {
+  try {
+    const trend = await getMonthlyTrendForUser(req.user.id, req.query?.months);
+    res.status(200).json(trend);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/apps/api/src/services/analytics.service.js
+++ b/apps/api/src/services/analytics.service.js
@@ -1,0 +1,189 @@
+import { dbQuery } from "../db/index.js";
+import {
+  TRANSACTION_TYPE_ENTRY,
+  TRANSACTION_TYPE_EXIT,
+} from "../constants/transaction-types.js";
+
+const CATEGORY_ENTRY = TRANSACTION_TYPE_ENTRY;
+const CATEGORY_EXIT = TRANSACTION_TYPE_EXIT;
+const DEFAULT_MONTHS = 6;
+const MIN_MONTHS = 1;
+const MAX_MONTHS = 24;
+
+const createError = (status, message) => {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+};
+
+const normalizeUserId = (value) => {
+  const parsedValue = Number(value);
+
+  if (!Number.isInteger(parsedValue) || parsedValue <= 0) {
+    throw createError(401, "Usuario nao autenticado.");
+  }
+
+  return parsedValue;
+};
+
+const normalizeMonths = (value) => {
+  if (typeof value === "undefined" || value === null) {
+    return DEFAULT_MONTHS;
+  }
+
+  const normalizedValue = String(value).trim();
+
+  if (!normalizedValue) {
+    throw createError(400, "months invalido. Use inteiro entre 1 e 24.");
+  }
+
+  const parsedValue = Number(normalizedValue);
+
+  if (!Number.isInteger(parsedValue) || parsedValue < MIN_MONTHS || parsedValue > MAX_MONTHS) {
+    throw createError(400, "months invalido. Use inteiro entre 1 e 24.");
+  }
+
+  return parsedValue;
+};
+
+const addMonthsUtc = (baseDate, monthsToAdd) =>
+  new Date(Date.UTC(baseDate.getUTCFullYear(), baseDate.getUTCMonth() + monthsToAdd, 1));
+
+const toMonthValue = (value) => {
+  const date = new Date(value);
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+
+  return `${year}-${month}`;
+};
+
+const toIsoDate = (value) => {
+  const date = new Date(value);
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+
+  return `${year}-${month}-${day}`;
+};
+
+const resolveTrendRange = (months) => {
+  const now = new Date();
+  const currentMonthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+  const startMonth = addMonthsUtc(currentMonthStart, -(months - 1));
+
+  return {
+    startMonthDate: startMonth,
+    endMonthDate: currentMonthStart,
+    startMonth: toIsoDate(startMonth),
+    endMonth: toIsoDate(currentMonthStart),
+  };
+};
+
+const resolveMonthSeries = (startMonthDate, months) =>
+  Array.from({ length: months }, (_unusedValue, index) =>
+    toMonthValue(addMonthsUtc(startMonthDate, index)),
+  );
+
+const mapTrendRow = (row) => ({
+  month: String(row?.month || ""),
+  income: Number(row?.income || 0),
+  expense: Number(row?.expense || 0),
+  balance: Number(row?.balance || 0),
+});
+
+export const getMonthlyTrendForUser = async (userId, months) => {
+  const normalizedUserId = normalizeUserId(userId);
+  const normalizedMonths = normalizeMonths(months);
+  const trendRange = resolveTrendRange(normalizedMonths);
+  const queryParams = [
+    normalizedUserId,
+    trendRange.startMonth,
+    trendRange.endMonth,
+    CATEGORY_ENTRY,
+    CATEGORY_EXIT,
+  ];
+
+  try {
+    const result = await dbQuery(
+      `
+        WITH series AS (
+          SELECT
+            generate_series($2::date, $3::date, '1 month'::interval)::date AS month_start
+        ),
+        agg AS (
+          SELECT
+            date_trunc('month', t.date)::date AS month_start,
+            COALESCE(SUM(CASE WHEN t.type = $4 THEN t.value ELSE 0 END), 0)::numeric AS income,
+            COALESCE(SUM(CASE WHEN t.type = $5 THEN t.value ELSE 0 END), 0)::numeric AS expense
+          FROM transactions t
+          WHERE t.user_id = $1
+            AND t.deleted_at IS NULL
+            AND t.date >= $2::date
+            AND t.date < ($3::date + interval '1 month')
+          GROUP BY 1
+        )
+        SELECT
+          to_char(s.month_start, 'YYYY-MM') AS month,
+          COALESCE(a.income, 0) AS income,
+          COALESCE(a.expense, 0) AS expense,
+          (COALESCE(a.income, 0) - COALESCE(a.expense, 0)) AS balance
+        FROM series s
+        LEFT JOIN agg a ON a.month_start = s.month_start
+        ORDER BY s.month_start ASC
+      `,
+      queryParams,
+    );
+
+    return result.rows.map(mapTrendRow);
+  } catch (error) {
+    const errorMessage = String(error?.message || "").toLowerCase();
+
+    if (!errorMessage.includes("generate_series")) {
+      throw error;
+    }
+  }
+
+  const fallbackTransactionsResult = await dbQuery(
+    `
+      SELECT
+        t.type,
+        t.value,
+        t.date
+      FROM transactions t
+      WHERE t.user_id = $1
+        AND t.deleted_at IS NULL
+        AND t.date >= $2::date
+        AND t.date < ($3::date + interval '1 month')
+      ORDER BY t.date ASC, t.id ASC
+    `,
+    [queryParams[0], queryParams[1], queryParams[2]],
+  );
+
+  const totalsByMonth = new Map();
+  fallbackTransactionsResult.rows.forEach((row) => {
+    const month = toMonthValue(row?.date);
+    const currentTotals = totalsByMonth.get(month) || { income: 0, expense: 0 };
+    const normalizedValue = Number(row?.value || 0);
+
+    if (row?.type === CATEGORY_ENTRY) {
+      currentTotals.income += normalizedValue;
+    } else if (row?.type === CATEGORY_EXIT) {
+      currentTotals.expense += normalizedValue;
+    }
+
+    totalsByMonth.set(month, currentTotals);
+  });
+
+  return resolveMonthSeries(trendRange.startMonthDate, normalizedMonths).map((month) => {
+    const monthTotals = totalsByMonth.get(month) || { income: 0, expense: 0 };
+    const income = Number(monthTotals.income || 0);
+    const expense = Number(monthTotals.expense || 0);
+
+    return {
+      month,
+      income,
+      expense,
+      balance: income - expense,
+    };
+  });
+};

--- a/apps/api/src/services/budgets.service.js
+++ b/apps/api/src/services/budgets.service.js
@@ -1,10 +1,11 @@
 import { dbQuery } from "../db/index.js";
+import { TRANSACTION_TYPE_EXIT } from "../constants/transaction-types.js";
 
 const ISO_MONTH_REGEX = /^\d{4}-(0[1-9]|1[0-2])$/;
 const STATUS_OK = "ok";
 const STATUS_NEAR_LIMIT = "near_limit";
 const STATUS_EXCEEDED = "exceeded";
-const CATEGORY_EXIT = "Saida";
+const CATEGORY_EXIT = TRANSACTION_TYPE_EXIT;
 
 const createError = (status, message) => {
   const error = new Error(message);

--- a/apps/api/src/services/transactions-import.service.js
+++ b/apps/api/src/services/transactions-import.service.js
@@ -1,10 +1,14 @@
 import { randomUUID } from "node:crypto";
 import { parse as parseCsv } from "csv-parse/sync";
 import { dbQuery, withDbTransaction } from "../db/index.js";
+import {
+  TRANSACTION_TYPE_ENTRY,
+  TRANSACTION_TYPE_EXIT,
+} from "../constants/transaction-types.js";
 import { normalizeCategoryNameKey } from "./categories-normalization.js";
 
-const CATEGORY_ENTRY = "Entrada";
-const CATEGORY_EXIT = "Saida";
+const CATEGORY_ENTRY = TRANSACTION_TYPE_ENTRY;
+const CATEGORY_EXIT = TRANSACTION_TYPE_EXIT;
 const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const IMPORT_TTL_MINUTES = 30;

--- a/apps/api/src/services/transactions.service.js
+++ b/apps/api/src/services/transactions.service.js
@@ -1,7 +1,11 @@
 import { dbQuery } from "../db/index.js";
+import {
+  TRANSACTION_TYPE_ENTRY,
+  TRANSACTION_TYPE_EXIT,
+} from "../constants/transaction-types.js";
 
-const CATEGORY_ENTRY = "Entrada";
-const CATEGORY_EXIT = "Saida";
+const CATEGORY_ENTRY = TRANSACTION_TYPE_ENTRY;
+const CATEGORY_EXIT = TRANSACTION_TYPE_EXIT;
 const VALID_TYPES = new Set([CATEGORY_ENTRY, CATEGORY_EXIT]);
 const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 const ISO_MONTH_REGEX = /^\d{4}-\d{2}$/;


### PR DESCRIPTION
## What changed
- Added authenticated endpoint `GET /analytics/trend`.
- Added `analytics.service` with monthly aggregates (`income`, `expense`, `balance`) and zero-filled month series.
- Added validation for `months` query param (default `6`, valid range `1..24`).
- Mounted new analytics routes in API app.
- Added contract tests for 401/400/happy-path with empty months and soft-delete behavior.

## Technical notes
- Primary query uses `generate_series` + monthly aggregation in SQL.
- Added fallback path for test environment limitations (`pg-mem`) while preserving response contract.
- Consolidated transaction type literals by introducing shared constants in `apps/api/src/constants/transaction-types.js`.

## Validation
- `npm -w apps/api run lint`
- `npm -w apps/api run test`
- `npm run lint`
- `npm run test`
- `npm run build`
