### PR TITLE
feat(api): add compare=prev support to transactions summary

### DIFF
--- a/apps/api/src/routes/transactions.routes.js
+++ b/apps/api/src/routes/transactions.routes.js
@@ -110,7 +110,11 @@ router.get("/export.csv", async (req, res, next) => {
 
 router.get("/summary", async (req, res, next) => {
   try {
-    const summary = await getMonthlySummaryForUser(req.user.id, req.query.month);
+    const summary = await getMonthlySummaryForUser(
+      req.user.id,
+      req.query.month,
+      req.query.compare,
+    );
     res.status(200).json(summary);
   } catch (error) {
     next(error);


### PR DESCRIPTION
## What changed
- Added `compare=prev` support to `GET /transactions/summary`.
- Summary endpoint now supports two modes:
  - default: current month summary (existing contract, unchanged)
  - `compare=prev`: current vs previous month with computed deltas
- Added monthly category comparison (`byCategoryDelta`) including categories that appear in only one of the two months.
- Route updated to pass `compare` query param to service layer.

## Response shape for compare mode
```json
{
  "current": { "income": 0, "expense": 0, "balance": 0 },
  "previous": { "income": 0, "expense": 0, "balance": 0 },
  "delta": {
    "income": 0, "expense": 0, "balance": 0,
    "incomePct": 0, "expensePct": 0, "balancePct": 0
  },
  "byCategoryDelta": [
    {
      "categoryId": 1,
      "category": "Food",
      "current": 700,
      "previous": 500,
      "delta": 200,
      "deltaPct": 40
    }
  ]
}
```

## Validation and behavior
- `compare` validation: only `prev` is accepted (`400` for invalid values).
- Soft-deleted transactions remain excluded (`deleted_at IS NULL`).
- Existing `/transactions/summary?month=YYYY-MM` behavior is preserved.

## Tests added
- `400` when `compare` is invalid.
- `compare=prev` returns correct current/previous totals, deltas and category deltas.
- Contract includes soft-delete exclusion in compare mode.

## Validation
- `npm -w apps/api run lint`
- `npm -w apps/api run test`
- `npm run lint`
- `npm run test`
- `npm run build`
