### PR TITLE
feat(web): add proactive near-limit budget banner

### DIFF
--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -1116,6 +1116,17 @@ const App = ({
         }),
     [monthlyBudgets],
   );
+  const proactiveNearLimitBudget = useMemo(
+    () =>
+      monthlyBudgets
+        .filter(
+          (budget): budget is MonthlyBudget & { status: "near_limit" } =>
+            budget.status === "near_limit",
+        )
+        .sort((leftBudget, rightBudget) => rightBudget.percentage - leftBudget.percentage)[0] ||
+      null,
+    [monthlyBudgets],
+  );
 
   const openCreateModal = () => {
     setEditingTransaction(null);
@@ -2235,6 +2246,16 @@ const App = ({
               aria-live="polite"
             >
               {budgetSuccessMessage}
+            </div>
+          ) : null}
+          {!isLoadingBudgets && !budgetsError && proactiveNearLimitBudget ? (
+            <div
+              className="mb-3 rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800"
+              role="status"
+              aria-live="polite"
+              data-testid="budget-near-limit-banner"
+            >
+              {`Alerta: voce ja utilizou ${formatPercentage(proactiveNearLimitBudget.percentage)} da meta de ${proactiveNearLimitBudget.categoryName} neste mes.`}
             </div>
           ) : null}
           {!isLoadingBudgets && !budgetsError && budgetAlerts.length > 0 ? (


### PR DESCRIPTION
## What changed
- Add a proactive near-limit budget banner on the dashboard when at least one monthly budget is in `near_limit` status.
- Banner message uses the highest `near_limit` percentage for focus and urgency.
- Keep existing budget alert center behavior unchanged (`near_limit` + `exceeded` list).
- Add tests for proactive banner visibility and non-visibility scenarios.

## Why
- Move budget alerting from passive list-only state to a proactive in-app signal.
- Increase actionability without backend changes.

## Scope
- Web-only.
- No API or contract changes.

## Tests
- Added coverage in `App.test.jsx`:
  - renders proactive banner when `near_limit` exists
  - does not render proactive banner when only `exceeded` exists

## Validation
- `npm -w apps/web run typecheck`
- `npm -w apps/web run lint`
- `npm -w apps/web run test:run -- src/pages/App.test.jsx`
- `npm -w apps/web run build`
- `npm run lint`
- `npm run test`
- `npm run build`