### PR TITLE
feat(web): add trend chart and month click sync

### DIFF
--- a/apps/web/src/components/TrendChart.tsx
+++ b/apps/web/src/components/TrendChart.tsx
@@ -1,0 +1,119 @@
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { TrendPoint } from "../services/analytics.service";
+
+const formatCurrency = (value: number) => `R$ ${Number(value || 0).toFixed(2)}`;
+
+interface TooltipEntry {
+  dataKey?: string;
+  name?: string;
+  value?: number;
+  color?: string;
+}
+
+interface CustomTooltipProps {
+  active?: boolean;
+  payload?: TooltipEntry[];
+  label?: string;
+}
+
+const CustomTooltip = ({ active, payload, label }: CustomTooltipProps) => {
+  if (!active || !Array.isArray(payload) || payload.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="rounded border border-gray-300 bg-white px-3 py-2 text-xs shadow-sm">
+      <p className="mb-1 font-semibold text-gray-900">{label}</p>
+      {payload.map((entry) => (
+        <p key={entry.dataKey} style={{ color: entry.color }}>
+          {entry.name}: {formatCurrency(Number(entry.value || 0))}
+        </p>
+      ))}
+    </div>
+  );
+};
+
+interface ChartClickData {
+  activeLabel?: string;
+}
+
+interface TrendChartProps {
+  data: TrendPoint[];
+  onMonthClick?: (month: string) => void;
+}
+
+const TrendChart = ({ data, onMonthClick }: TrendChartProps) => {
+  const hasAnyValue = data.some(
+    (point) => point.income > 0 || point.expense > 0 || point.balance !== 0,
+  );
+
+  if (!hasAnyValue) {
+    return (
+      <div className="rounded border border-brand-1 bg-gray-500 p-4 text-center text-sm text-gray-100">
+        Sem dados suficientes para exibir a evolucao historica.
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded border border-brand-1 bg-white p-4">
+      <h3 className="mb-3 text-sm font-semibold text-gray-100">Evolucao (ultimos 6 meses)</h3>
+      <div className="h-64 w-full">
+        <ResponsiveContainer>
+          <LineChart
+          data={data}
+          margin={{ top: 8, right: 8, left: 8, bottom: 8 }}
+          onClick={(chartData: ChartClickData) => {
+            const month = chartData?.activeLabel;
+            if (typeof month === "string" && month && onMonthClick) {
+              onMonthClick(month);
+            }
+          }}
+          style={{ cursor: onMonthClick ? "pointer" : undefined }}
+        >
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="month" stroke="#495057" />
+            <YAxis stroke="#495057" width={90} tickFormatter={formatCurrency} />
+            <Tooltip content={<CustomTooltip />} />
+            <Legend />
+            <Line
+              type="monotone"
+              dataKey="income"
+              name="Entradas"
+              stroke="#16a34a"
+              dot={false}
+              strokeWidth={2}
+            />
+            <Line
+              type="monotone"
+              dataKey="expense"
+              name="Saidas"
+              stroke="#dc2626"
+              dot={false}
+              strokeWidth={2}
+            />
+            <Line
+              type="monotone"
+              dataKey="balance"
+              name="Saldo"
+              stroke="#6741D9"
+              dot={false}
+              strokeWidth={2}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+};
+
+export default TrendChart;

--- a/apps/web/src/services/analytics.service.ts
+++ b/apps/web/src/services/analytics.service.ts
@@ -1,0 +1,38 @@
+import { api } from "./api";
+
+export interface TrendPoint {
+  month: string;
+  income: number;
+  expense: number;
+  balance: number;
+}
+
+interface TrendPointApiResponse {
+  month?: unknown;
+  income?: unknown;
+  expense?: unknown;
+  balance?: unknown;
+}
+
+const normalizeTrendPoint = (item: TrendPointApiResponse): TrendPoint => ({
+  month: typeof item?.month === "string" && item.month.trim() ? item.month.trim() : "",
+  income: Number(item?.income) || 0,
+  expense: Number(item?.expense) || 0,
+  balance: Number(item?.balance) || 0,
+});
+
+export const analyticsService = {
+  getMonthlyTrend: async (months: number = 6): Promise<TrendPoint[]> => {
+    const { data } = await api.get("/analytics/trend", {
+      params: { months: String(months) },
+    });
+
+    if (!Array.isArray(data)) {
+      return [];
+    }
+
+    return (data as TrendPointApiResponse[])
+      .map(normalizeTrendPoint)
+      .filter((point) => Boolean(point.month));
+  },
+};


### PR DESCRIPTION
﻿## What changed
- Add a new dashboard historical section, **Evolucao (ultimos 6 meses)**, backed by `GET /analytics/trend?months=6`.
- Create `apps/web/src/services/analytics.service.ts` with typed normalization (`TrendPoint`) for trend payloads.
- Add lazy-loaded `apps/web/src/components/TrendChart.tsx` (income, expense, balance lines + tooltip + empty state).
- Wire `App.tsx` with trend loading/error states and render flow.
- Add month-click interaction: selecting a month in the trend chart updates `selectedSummaryMonth`, reloading summary, compare, and budgets in sync.

## Why
- Provide historical context directly in the dashboard to improve decision support and retention.
- Keep summary, MoM compare, budgets, and trend connected through a single user interaction.

## Scope
- Web-only.
- No API contract changes.

## Tests
- Added trend coverage in `App.test.jsx`:
  - renders chart when trend data is available
  - renders error fallback when trend request fails
  - renders loading state while request is pending
  - calls trend endpoint with `months=6`
  - month click applies selected month and re-fetches summary/compare/budgets
  - sequential month clicks trigger sequential synchronized reloads

## Validation
- `npm -w apps/web run typecheck`
- `npm -w apps/web run lint`
- `npm -w apps/web run test:run`
- `npm -w apps/web run build`
