### PR TITLE
feat(web): TrendChart UX polish — pt-BR labels, selected month indicator, click affordance

### DIFF
--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -11,9 +11,12 @@ vi.mock("../components/TransactionChart", () => ({
 }));
 
 vi.mock("../components/TrendChart", () => ({
-  default: ({ data, onMonthClick }) =>
+  default: ({ data, onMonthClick, selectedMonth }) =>
     Array.isArray(data) && data.length > 0 ? (
       <div data-testid="trend-chart">
+        {selectedMonth && (
+          <span data-testid="trend-selected-month">{selectedMonth}</span>
+        )}
         {data.map((point) => (
           <button
             key={point.month}
@@ -2753,6 +2756,28 @@ describe("App", () => {
 
       await waitFor(() => {
         expect(transactionsService.getMonthlySummary).toHaveBeenCalledWith("2025-12");
+      });
+    });
+
+    it("passa selectedMonth corrente para o TrendChart", async () => {
+      window.history.replaceState(null, "", "/app?summaryMonth=2025-11");
+
+      render(<App />);
+
+      await screen.findByTestId("trend-chart");
+
+      expect(screen.getByTestId("trend-selected-month")).toHaveTextContent("2025-11");
+    });
+
+    it("atualiza selectedMonth no TrendChart apos clique num mes", async () => {
+      render(<App />);
+
+      await screen.findByTestId("trend-chart");
+
+      await userEvent.click(screen.getByTestId("trend-month-2025-10"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("trend-selected-month")).toHaveTextContent("2025-10");
       });
     });
   });

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -2596,7 +2596,11 @@ const App = ({
               </div>
             }
           >
-            <TrendChart data={trend} onMonthClick={handleTrendMonthClick} />
+            <TrendChart
+                data={trend}
+                onMonthClick={handleTrendMonthClick}
+                selectedMonth={selectedSummaryMonth}
+              />
           </Suspense>
         )}
       </section>


### PR DESCRIPTION
## What changed

### TrendChart.tsx
- `formatMonthLabel`: converts `YYYY-MM` → `Fev/26` pt-BR style (static array, no `Intl` / locale risk)
- `XAxis` `tickFormatter` uses `formatMonthLabel`
- `CustomTooltip` header also formats the month label
- `selectedMonth?: string` prop: renders a `ReferenceLine` (brand purple, dashed) when the active month falls within the trend range
- Click affordance: heading shows `— clique em um mes para navegar` hint when `onMonthClick` is wired

### App.tsx
- Passes `selectedMonth={selectedSummaryMonth}` to `<TrendChart>`

### App.test.jsx
- TrendChart mock updated: renders `data-testid="trend-selected-month"` when `selectedMonth` is set
- Test: `selectedMonth` from URL init is passed to TrendChart
- Test: after month click, `trend-selected-month` reflects new month

## Why
The chart already works (click → navigates). These changes make it feel complete:
- Humans read `Fev/26`, not `2026-02`
- The active month needs to be visible in the chart itself
- The hint removes discoverability friction

## Scope
- Web-only. `TrendChart.tsx` + `App.tsx` (1 line) + tests.
- No API changes.

## Validation
- `npm -w apps/web run typecheck` ✅
- `npm -w apps/web run lint` ✅
- `npm -w apps/web run test:run` ✅ (100/100)
- `npm -w apps/web run build` ✅ (TrendChart 13.27 kB, +0.56 kB from ReferenceLine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)