### PR TITLE
chore(release): v1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.18.0] - 2026-02-21
+
+### Title
+
+v1.18.0 — Deep-linked Month Navigation + Trend UX Polish
+
+### Highlights
+
+- The selected month in the dashboard is now persistent: shareable via URL, refresh-safe, and Back/Forward-aware.
+- The trend chart speaks the user's language: pt-BR labels, a visible marker on the active month, and an explicit click affordance.
+
+### Added
+
+- URL persistence for `selectedSummaryMonth` (Web):
+  - `?summaryMonth=YYYY-MM` read on init via `getInitialSummaryMonth()`; invalid values fall back to current month
+  - Existing URL-sync `useEffect` extended: writes `summaryMonth` alongside all filter/pagination params
+  - `popstate` listener syncs state on browser Back/Forward
+- TrendChart UX polish (Web):
+  - `formatMonthLabel`: converts `YYYY-MM` to `Fev/26` style (pt-BR static array, no `Intl` / locale risk)
+  - `XAxis tickFormatter` and `CustomTooltip` header both use `formatMonthLabel`
+  - `selectedMonth?: string` prop: `ReferenceLine` (brand purple, dashed) marks the active month when it falls within the trend data range
+  - Click affordance: heading appends `— clique em um mes para navegar` hint when `onMonthClick` is wired
+
+### Changed
+
+- Dashboard month selection now persists in URL and survives refresh, deep-link, and browser navigation.
+- Trend chart axis labels changed from raw `YYYY-MM` to `Mmm/YY` (pt-BR).
+
+### Quality
+
+- 6 new tests in `App.test.jsx`:
+  - Initializes `selectedSummaryMonth` from valid `?summaryMonth` in URL
+  - Ignores invalid `?summaryMonth` and falls back to current month
+  - Month click updates `summaryMonth` in URL
+  - Other query params preserved when updating `summaryMonth`
+  - `selectedMonth` prop passed to TrendChart from URL init
+  - `selectedMonth` prop reflects new month after chart click
+- Web gates green (`typecheck`, `lint`, `test` 100/100, `build`)
+- CI green across `api`, `web`, `Vercel` for both PRs (#136, #137)
+
+### Impact
+
+- From: "Click a month, lose it on refresh."
+- To: "Click a month, share the link, come back tomorrow — same context."
+
 ## [1.17.0] - 2026-02-21
 
 ### Title

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/web",
   "private": true,
-  "version": "1.17.0",
+  "version": "1.18.0",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "control-finance-monorepo",
   "private": true,
-  "version": "1.17.0",
+  "version": "1.18.0",
   "engines": {
     "node": "24.x"
   },


### PR DESCRIPTION
## What changed
- Bump version to `1.18.0`:
  - `package.json`
  - `apps/web/package.json`
- Add `[1.18.0]` entry to `CHANGELOG.md`.

## Why
Release preparation for v1.18.0 (Web-only, two PRs post v1.17.0 tag):
- **#136** — `summaryMonth` persists in URL: deep-link, refresh-safe, Back/Forward aware
- **#137** — TrendChart UX: pt-BR axis labels, selected month ReferenceLine, click affordance

## Scope
Metadata + changelog only. No runtime behavior changes in this PR.

## Validation
- `npm run lint` ✅
- `npm run test` ✅ (web 100/100 + api 126/126)
- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)