### PR TITLE
test(web): add direct tests for TrendChart and ImportCsvModal

### DIFF
--- a/apps/web/src/components/ImportCsvModal.test.jsx
+++ b/apps/web/src/components/ImportCsvModal.test.jsx
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ImportCsvModal from "./ImportCsvModal";
+import { transactionsService } from "../services/transactions.service";
+
+vi.mock("../services/transactions.service", () => ({
+  transactionsService: {
+    dryRunImportCsv: vi.fn(),
+    commitImportCsv: vi.fn(),
+  },
+}));
+
+const buildDryRunResponse = (overrides = {}) => ({
+  importId: "import-session-1",
+  expiresAt: "2026-02-21T23:59:59Z",
+  summary: {
+    totalRows: 2,
+    validRows: 1,
+    invalidRows: 1,
+    income: 100,
+    expense: 20,
+  },
+  rows: [
+    {
+      line: 2,
+      status: "valid",
+      raw: {
+        date: "2026-02-21",
+        type: "Entrada",
+        value: "100",
+        description: "Salario",
+        notes: "",
+        category: "Trabalho",
+      },
+      normalized: {
+        date: "2026-02-21",
+        type: "Entrada",
+        value: 100,
+        description: "Salario",
+        notes: "",
+        categoryId: 1,
+      },
+      errors: [],
+    },
+  ],
+  ...overrides,
+});
+
+describe("ImportCsvModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not render when isOpen is false", () => {
+    render(<ImportCsvModal isOpen={false} onClose={vi.fn()} />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("shows validation message when preview is requested without file", async () => {
+    render(<ImportCsvModal isOpen onClose={vi.fn()} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Pre-visualizar" }));
+
+    expect(screen.getByText("Selecione um arquivo CSV.")).toBeInTheDocument();
+    expect(transactionsService.dryRunImportCsv).not.toHaveBeenCalled();
+  });
+
+  it("runs dry-run and renders summary", async () => {
+    const file = new File(["date,type,value"], "import.csv", { type: "text/csv" });
+    transactionsService.dryRunImportCsv.mockResolvedValueOnce(buildDryRunResponse());
+
+    render(<ImportCsvModal isOpen onClose={vi.fn()} />);
+
+    await userEvent.upload(screen.getByLabelText("Arquivo CSV"), file);
+    await userEvent.click(screen.getByRole("button", { name: "Pre-visualizar" }));
+
+    await waitFor(() => {
+      expect(transactionsService.dryRunImportCsv).toHaveBeenCalledWith(file);
+    });
+
+    const validRowsCard = screen.getByText("Validas").closest("div");
+    const invalidRowsCard = screen.getByText("Invalidas").closest("div");
+
+    expect(validRowsCard).toHaveTextContent("1");
+    expect(invalidRowsCard).toHaveTextContent("1");
+  });
+
+  it("commits import and calls onImported callback", async () => {
+    const onImported = vi.fn();
+    const file = new File(["date,type,value"], "import.csv", { type: "text/csv" });
+
+    transactionsService.dryRunImportCsv.mockResolvedValueOnce(buildDryRunResponse());
+    transactionsService.commitImportCsv.mockResolvedValueOnce({
+      imported: 1,
+      summary: { income: 100, expense: 20, balance: 80 },
+    });
+
+    render(<ImportCsvModal isOpen onClose={vi.fn()} onImported={onImported} />);
+
+    await userEvent.upload(screen.getByLabelText("Arquivo CSV"), file);
+    await userEvent.click(screen.getByRole("button", { name: "Pre-visualizar" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Importar" })).not.toBeDisabled();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Importar" }));
+
+    await waitFor(() => {
+      expect(transactionsService.commitImportCsv).toHaveBeenCalledWith("import-session-1");
+      expect(onImported).toHaveBeenCalled();
+    });
+  });
+
+  it("shows expired session message on commit error", async () => {
+    const file = new File(["date,type,value"], "import.csv", { type: "text/csv" });
+
+    transactionsService.dryRunImportCsv.mockResolvedValueOnce(buildDryRunResponse());
+    transactionsService.commitImportCsv.mockRejectedValueOnce({
+      response: { data: { message: "Sessao de importacao expirada." } },
+    });
+
+    render(<ImportCsvModal isOpen onClose={vi.fn()} />);
+
+    await userEvent.upload(screen.getByLabelText("Arquivo CSV"), file);
+    await userEvent.click(screen.getByRole("button", { name: "Pre-visualizar" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Importar" })).not.toBeDisabled();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Importar" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Sessao de importacao expirada. Rode a pre-visualizacao novamente."),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/TrendChart.test.tsx
+++ b/apps/web/src/components/TrendChart.test.tsx
@@ -1,0 +1,107 @@
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import TrendChart from "./TrendChart";
+
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  LineChart: ({
+    children,
+    className,
+    data,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+    data?: Array<{ month?: string }>;
+    onClick?: (payload: { activeLabel?: string }) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="line-chart"
+      className={className}
+      onClick={() => onClick?.({ activeLabel: data?.[1]?.month })}
+    >
+      {children}
+    </button>
+  ),
+  CartesianGrid: () => <div data-testid="cartesian-grid" />,
+  Legend: () => <div data-testid="legend" />,
+  Line: ({ name }: { name?: string }) => <div>{name}</div>,
+  ReferenceLine: ({ x, label }: { x?: string; label?: { value?: string } }) => (
+    <div data-testid="reference-line">{`${x || ""}|${label?.value || ""}`}</div>
+  ),
+  Tooltip: ({ content }: { content?: React.ReactElement }) => (
+    <div data-testid="tooltip">
+      {content
+        ? React.cloneElement(content, {
+            active: true,
+            label: "2025-10",
+            payload: [
+              { dataKey: "income", name: "Entradas", value: 2000, color: "#16a34a" },
+              { dataKey: "expense", name: "Saidas", value: 700, color: "#dc2626" },
+            ],
+          })
+        : null}
+    </div>
+  ),
+  XAxis: ({ tickFormatter }: { tickFormatter?: (value: string) => string }) => (
+    <div data-testid="x-axis-label">{tickFormatter ? tickFormatter("2025-10") : "2025-10"}</div>
+  ),
+  YAxis: ({ tickFormatter }: { tickFormatter?: (value: number) => string }) => (
+    <div data-testid="y-axis-label">{tickFormatter ? tickFormatter(1234.5) : "1234.5"}</div>
+  ),
+}));
+
+const trendData = [
+  { month: "2025-09", income: 1800, expense: 600, balance: 1200 },
+  { month: "2025-10", income: 2000, expense: 700, balance: 1300 },
+];
+
+describe("TrendChart", () => {
+  it("renders empty state when all values are zero", () => {
+    render(
+      <TrendChart
+        data={[{ month: "2025-10", income: 0, expense: 0, balance: 0 }]}
+      />,
+    );
+
+    expect(
+      screen.getByText("Sem dados suficientes para exibir a evolucao historica."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders chart heading, month label formatting, and click hint", () => {
+    render(<TrendChart data={trendData} onMonthClick={vi.fn()} />);
+
+    expect(screen.getByText("Evolucao (ultimos 6 meses)")).toBeInTheDocument();
+    expect(screen.getByText("— clique em um mes para navegar")).toBeInTheDocument();
+    expect(screen.getByTestId("x-axis-label")).toHaveTextContent("Out/25");
+  });
+
+  it("calls onMonthClick when chart is clicked on a month", () => {
+    const onMonthClick = vi.fn();
+
+    render(<TrendChart data={trendData} onMonthClick={onMonthClick} />);
+    fireEvent.click(screen.getByTestId("line-chart"));
+
+    expect(onMonthClick).toHaveBeenCalledWith("2025-10");
+  });
+
+  it("shows selected month marker when selectedMonth is in data range", () => {
+    render(<TrendChart data={trendData} selectedMonth="2025-10" />);
+
+    expect(screen.getByTestId("reference-line")).toHaveTextContent("2025-10|Out/25");
+  });
+
+  it("shows absolute values and month-over-month deltas in tooltip", () => {
+    render(<TrendChart data={trendData} />);
+
+    expect(screen.getByText("Entradas: R$ 2000.00")).toBeInTheDocument();
+    expect(screen.getByText("+R$ 200.00", { exact: false })).toBeInTheDocument();
+    expect(screen.getByText("Saidas: R$ 700.00")).toBeInTheDocument();
+    expect(screen.getByText("+R$ 100.00", { exact: false })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Add direct unit tests for TrendChart (pps/web/src/components/TrendChart.test.tsx).
- Add direct component tests for ImportCsvModal (pps/web/src/components/ImportCsvModal.test.jsx).
- Keep existing integration coverage in App.test.jsx; this PR adds isolated coverage for the most critical dashboard/import UI pieces.

## Covered scenarios
### TrendChart
- empty-state rendering when no meaningful data exists
- heading + click hint + month label formatting
- month click callback (onMonthClick) wiring
- selected month marker (ReferenceLine) rendering
- tooltip absolute + delta rendering

### ImportCsvModal
- hidden when isOpen=false
- validation when preview is requested without file
- dry-run success path with summary rendering
- commit success path and onImported callback
- expired import session error mapping on commit

## Validation
- 
pm -w apps/web run typecheck ✅
- 
pm -w apps/web run lint ✅
- 
pm -w apps/web run test:run ✅ (111/111)
- 
pm -w apps/web run build ✅