### PR TITLE
docs(observability): define 5xx SLO baseline and incident runbook

### DIFF
--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -5,6 +5,8 @@ This folder versions the baseline observability assets for Control Finance:
 - Dashboard JSON (in `docs/observability/dashboards/`)
 - Alert rules YAML (in `docs/observability/alerts/`)
 - Setup guide (in `docs/observability/grafana-cloud.md`)
+- SLO baseline (in `docs/observability/slo.md`)
+- 5xx incident runbook (in `docs/runbooks/api-5xx-incident.md`)
 
 ## Golden Validation Order (do not skip)
 
@@ -59,6 +61,8 @@ After applying:
 
 ## References
 - Grafana Cloud setup: `docs/observability/grafana-cloud.md`
+- SLO baseline: `docs/observability/slo.md`
+- 5xx runbook: `docs/runbooks/api-5xx-incident.md`
 - Release checklist: `docs/runbooks/release-production-checklist.md`
 - Alloy worker: `ops/alloy/README.md`
 - Dashboard: `docs/observability/dashboards/control-finance-api-min.json`

--- a/docs/observability/alerts/control-finance-api-alerts.yaml
+++ b/docs/observability/alerts/control-finance-api-alerts.yaml
@@ -16,6 +16,7 @@ groups:
         annotations:
           summary: "p95 latency high on /transactions"
           description: "p95 latency on /transactions is above 500ms for 10 minutes."
+          runbook_url: "docs/runbooks/api-5xx-incident.md"
 
       - alert: ControlFinanceApi5xxRateHigh
         expr: |
@@ -27,6 +28,7 @@ groups:
         annotations:
           summary: "5xx rate is high"
           description: "5xx rate is above 0.2 req/s for 5 minutes. Investigate errors and evaluate rollback."
+          runbook_url: "docs/runbooks/api-5xx-incident.md"
 
       - alert: ControlFinanceApi5xxPercentHigh
         expr: |
@@ -42,3 +44,4 @@ groups:
         annotations:
           summary: "5xx error ratio elevated"
           description: "5xx ratio is above 2% for 5 minutes."
+          runbook_url: "docs/runbooks/api-5xx-incident.md"

--- a/docs/observability/slo.md
+++ b/docs/observability/slo.md
@@ -1,11 +1,13 @@
 # Observability SLO Baseline
 
 ## Scope
-This document defines the initial availability objective for Control Finance API based on the `/health` endpoint.
+This document defines the minimum SLO baseline for Control Finance API with two production signals:
+- `/health` availability (external monitor)
+- API `5xx` error ratio (Prometheus metric)
 
-## Service Level Indicator (SLI)
+## Service Level Indicators (SLI)
 
-### Availability SLI
+### 1) Health Availability SLI
 Percentage of successful health checks (`HTTP 200`) for:
 
 `GET /health`
@@ -14,39 +16,71 @@ Measurement window:
 - rolling 30 days
 
 Success criteria:
-- HTTP status code is `200`
+- `HTTP 200`
 
 Failure criteria:
-- any non-200 status code (`4xx` or `5xx`)
+- any non-200 status code
 - timeout or network error
 
 Formula:
 
 `availability = successful_checks / total_checks * 100`
 
-## Service Level Objective (SLO)
+### 2) API 5xx Error Ratio SLI
+Percentage of API requests that return `5xx`, using:
 
-- Availability target: `>= 99.5%` over 30 days.
+`http_requests_total{job="control-finance-api"}`
 
-### Error Budget
-- Allowed unavailability per 30-day window: `0.5%`.
-- 30 days ~= 43,200 minutes.
-- Error budget: `43,200 * 0.005 = 216 minutes`.
+Reference query (short window, operational):
 
-## Alerting Baseline (UptimeRobot)
+```promql
+(
+  sum(rate(http_requests_total{job="control-finance-api", status="5xx"}[5m]))
+  /
+  clamp_min(sum(rate(http_requests_total{job="control-finance-api"}[5m])), 0.001)
+)
+```
+
+Measurement window:
+- rolling 30 days (SLO)
+- rolling 5 minutes (alerting)
+
+## Service Level Objectives (SLO)
+
+- Availability target: `>= 99.5%` over 30 days
+- 5xx ratio target: `<= 1.0%` over 30 days
+
+## Error Budgets
+
+- Availability budget: `0.5%` unavailability
+  - 30 days ~= 43,200 minutes
+  - budget ~= `216 minutes` per 30 days
+- 5xx budget: `1.0%` of total requests per 30 days
+
+## Alerting Baseline
+
+Reference rules are versioned in:
+- `docs/observability/alerts/control-finance-api-alerts.yaml`
+
+Current baseline:
+- `ControlFinanceApi5xxRateHigh` (`P1`): 5xx rate `> 0.2 req/s` for 5 minutes
+- `ControlFinanceApi5xxPercentHigh` (`P2`): 5xx ratio `> 2%` for 5 minutes
+- `ControlFinanceTransactionsP95High` (`P2`): p95 latency on `/transactions` `> 500ms` for 10 minutes
+
+Incident runbook:
+- `docs/runbooks/api-5xx-incident.md`
+
+## UptimeRobot Baseline
 
 Recommended monitor settings:
 - Monitor type: `HTTP(s)`
 - URL: `https://control-finance-react-tailwind.onrender.com/health`
 - Check interval: `1 minute`
 - Timeout: `10 seconds`
-- Trigger threshold: `2 consecutive failures` (~2 minutes)
+- Trigger threshold: `2 consecutive failures`
 
 ## Severity Mapping
-- `P1`: health endpoint unavailable for more than 2 minutes.
-- `P2`: partial degradation or recurring intermittent errors.
-- `P3`: informational or low-impact signal.
 
-## Operational Notes
-- This baseline is intentionally simple and low-risk.
-- Latency SLOs and endpoint-level error SLOs are planned for the next observability increment (Grafana/Prometheus alerting).
+- `P1`: sustained high 5xx rate or health endpoint unavailable for more than 2 minutes
+- `P2`: elevated 5xx ratio or recurring endpoint degradation
+- `P3`: informational or low-impact operational signal

--- a/docs/runbooks/api-5xx-incident.md
+++ b/docs/runbooks/api-5xx-incident.md
@@ -1,0 +1,57 @@
+# API 5xx Incident Runbook
+
+## Scope
+Operational response for `5xx` alerts from:
+- `ControlFinanceApi5xxRateHigh`
+- `ControlFinanceApi5xxPercentHigh`
+- `ControlFinanceTransactionsP95High` (when accompanied by errors)
+
+## Alert Thresholds
+- `P1`: 5xx rate > `0.2 req/s` for 5 minutes
+- `P2`: 5xx ratio > `2%` for 5 minutes
+- `P2`: p95 `/transactions` > `500ms` for 10 minutes
+
+## First 15 Minutes
+1. Confirm alert still firing in Grafana Alerting.
+2. Capture timestamp, rule name, and affected endpoint(s).
+3. Check API logs for:
+   - status `500-599`
+   - endpoint distribution (`/auth`, `/transactions`, `/transactions/import/*`, `/budgets`)
+   - recurring error message signature
+4. Validate health:
+   - `GET /health` status and `db.status`
+5. Validate metrics:
+   - `sum(rate(http_requests_total{job="control-finance-api", status="5xx"}[5m]))`
+   - `(sum(rate(http_requests_total{job="control-finance-api", status="5xx"}[5m])) / clamp_min(sum(rate(http_requests_total{job="control-finance-api"}[5m])), 0.001))`
+   - `histogram_quantile(0.95, sum by (le) (rate(http_request_latency_ms_bucket{job="control-finance-api", endpoint="/transactions"}[5m])))`
+
+## Triage Decision
+- If impact is broad (auth or transaction writes failing): classify `P1`.
+- If impact is localized with workaround: classify `P2`.
+- If alert clears quickly and impact is low: classify `P3` and keep monitoring.
+
+## Mitigation Path
+1. If config-related: rollback env/config change first.
+2. If release-related and sustained user impact:
+   - rollback API to last stable commit in Render
+   - verify `GET /health` and `/metrics`
+3. Keep monitor window active for 30 minutes after mitigation.
+
+## Closure Criteria
+- Alert resolved and remains clear for 30 minutes.
+- `/health` stable (`200`, `db.status=ok`).
+- 5xx rate back to baseline.
+- Incident notes recorded in release/runbook evidence.
+
+## Evidence Template
+```md
+Incident Start (UTC):
+Severity (P1/P2/P3):
+Alert Rule:
+Impact Scope:
+Root Cause:
+Mitigation:
+Rollback: yes/no
+Recovery Time:
+Owner:
+```

--- a/docs/runbooks/release-production-checklist.md
+++ b/docs/runbooks/release-production-checklist.md
@@ -86,13 +86,16 @@ Confirm:
 Reference:
 - [ ] [`docs/observability/slo.md`](../observability/slo.md) reviewed for current SLI/SLO definitions.
 - [ ] [`docs/observability/grafana-cloud.md`](../observability/grafana-cloud.md) reviewed for metrics ingestion and alerting setup.
+- [ ] [`docs/runbooks/api-5xx-incident.md`](./api-5xx-incident.md) reviewed for incident response.
 
 ### SLI
 - [ ] Availability SLI is based on `GET /health` success rate (`HTTP 200`).
+- [ ] 5xx SLI is based on `http_requests_total{status="5xx"}` ratio.
 
 ### SLO
 - [ ] Target availability: `>= 99.5%` over a rolling 30-day window.
 - [ ] Error budget acknowledged: `216 minutes` per 30 days.
+- [ ] Target 5xx ratio: `<= 1.0%` over a rolling 30-day window.
 
 ### UptimeRobot Baseline
 - [ ] Monitor type: HTTP(s)
@@ -111,7 +114,8 @@ Reference:
 
 ### Alert Severity Mapping
 - [ ] P1: `/health` unavailable for > 2 minutes.
-- [ ] P2: recurring degradation or partial service impact.
+- [ ] P1: `5xx` absolute rate above baseline threshold for sustained window.
+- [ ] P2: recurring degradation, elevated `5xx` ratio, or partial service impact.
 - [ ] P3: informational/low-impact alert.
 
 ## 5. Incident Severity and Escalation


### PR DESCRIPTION
## Summary
- Extend docs/observability/slo.md with explicit 5xx SLI/SLO baseline.
- Keep availability SLO and add a 5xx ratio target (<= 1.0% over 30d).
- Add unbook_url annotations to alert rules in docs/observability/alerts/control-finance-api-alerts.yaml.
- Add new incident guide docs/runbooks/api-5xx-incident.md.
- Update observability and release checklist references to include the new runbook and 5xx SLI/SLO checks.

## Why
This closes the Fase 0 observability gap: SLO definition is explicit and alert rules now point to a concrete operational runbook for 5xx incidents.

## Validation
- 
pm run lint ✅
- 
pm run test ✅ (web 111/111 + api 126/126)
- 
pm run build ✅
