### PR TITLE
feat(billing): add entitlement system foundation (plans, subscriptions, feature gates)

### DIFF
--- a/apps/api/src/analytics.test.js
+++ b/apps/api/src/analytics.test.js
@@ -55,7 +55,7 @@ describe("analytics", () => {
     },
   );
 
-  it("GET /analytics/trend retorna 6 meses por padrao com months vazios zerados", async () => {
+  it("GET /analytics/trend retorna 3 meses por padrao para usuario free (limite do plano)", async () => {
     const token = await registerAndLogin("analytics-trend-default@controlfinance.dev");
 
     const response = await request(app)
@@ -64,8 +64,8 @@ describe("analytics", () => {
 
     expect(response.status).toBe(200);
     expect(Array.isArray(response.body)).toBe(true);
-    expect(response.body).toHaveLength(6);
-    expect(response.body.map((item) => item.month)).toEqual(getExpectedTrendMonths(6));
+    expect(response.body).toHaveLength(3);
+    expect(response.body.map((item) => item.month)).toEqual(getExpectedTrendMonths(3));
     response.body.forEach((item) => {
       expect(typeof item.month).toBe("string");
       expect(item.month).toMatch(/^\d{4}-\d{2}$/);

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -8,6 +8,7 @@ import categoriesRoutes from "./routes/categories.routes.js";
 import budgetsRoutes from "./routes/budgets.routes.js";
 import analyticsRoutes from "./routes/analytics.routes.js";
 import transactionsRoutes from "./routes/transactions.routes.js";
+import billingRoutes from "./routes/billing.routes.js";
 import { notFoundHandler, errorHandler } from "./middlewares/error.middleware.js";
 import { requestIdMiddleware } from "./middlewares/request-id.middleware.js";
 import { requestLoggingMiddleware } from "./middlewares/request-logging.middleware.js";
@@ -78,6 +79,7 @@ app.use("/categories", categoriesRoutes);
 app.use("/budgets", budgetsRoutes);
 app.use("/analytics", analyticsRoutes);
 app.use("/transactions", transactionsRoutes);
+app.use("/billing", billingRoutes);
 
 app.use(notFoundHandler);
 app.use(errorHandler);

--- a/apps/api/src/billing.test.js
+++ b/apps/api/src/billing.test.js
@@ -1,0 +1,148 @@
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import app from "./app.js";
+import { clearDbClientForTests, dbQuery } from "./db/index.js";
+import { resetLoginProtectionState } from "./middlewares/login-protection.middleware.js";
+import {
+  resetImportRateLimiterState,
+  resetWriteRateLimiterState,
+} from "./middlewares/rate-limit.middleware.js";
+import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
+import {
+  expectErrorResponseWithRequestId,
+  makeProUser,
+  registerAndLogin,
+  setupTestDb,
+} from "./test-helpers.js";
+
+describe("billing", () => {
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  afterAll(async () => {
+    await clearDbClientForTests();
+  });
+
+  beforeEach(async () => {
+    resetLoginProtectionState();
+    resetImportRateLimiterState();
+    resetWriteRateLimiterState();
+    resetHttpMetricsForTests();
+    await dbQuery("DELETE FROM subscriptions");
+    await dbQuery("DELETE FROM transactions");
+    await dbQuery("DELETE FROM users");
+  });
+
+  it("GET /billing/subscription retorna 401 sem token", async () => {
+    const response = await request(app).get("/billing/subscription");
+
+    expectErrorResponseWithRequestId(response, 401, "Token de autenticacao ausente ou invalido.");
+  });
+
+  it("GET /billing/subscription retorna plano free para novo usuario sem subscription", async () => {
+    const token = await registerAndLogin("billing-free@controlfinance.dev");
+
+    const response = await request(app)
+      .get("/billing/subscription")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.plan).toBe("free");
+    expect(response.body.subscription).toBeNull();
+  });
+
+  it("GET /billing/subscription retorna shape consistente", async () => {
+    const email = "billing-shape@controlfinance.dev";
+    const token = await registerAndLogin(email);
+
+    const response = await request(app)
+      .get("/billing/subscription")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    expect(typeof response.body.plan).toBe("string");
+    expect(typeof response.body.displayName).toBe("string");
+    expect(typeof response.body.features).toBe("object");
+    expect(response.body.features).toMatchObject({
+      csv_import: expect.any(Boolean),
+      csv_export: expect.any(Boolean),
+      analytics_months_max: expect.any(Number),
+      budget_tracking: expect.any(Boolean),
+    });
+  });
+
+  it("POST /transactions/import/dry-run retorna 402 para usuario free", async () => {
+    const token = await registerAndLogin("billing-dryrun-free@controlfinance.dev");
+
+    const response = await request(app)
+      .post("/transactions/import/dry-run")
+      .set("Authorization", `Bearer ${token}`)
+      .send({});
+
+    expectErrorResponseWithRequestId(response, 402, "Recurso disponivel apenas no plano Pro.");
+  });
+
+  it("GET /transactions/export.csv retorna 402 para usuario free", async () => {
+    const token = await registerAndLogin("billing-export-free@controlfinance.dev");
+
+    const response = await request(app)
+      .get("/transactions/export.csv")
+      .set("Authorization", `Bearer ${token}`);
+
+    expectErrorResponseWithRequestId(response, 402, "Recurso disponivel apenas no plano Pro.");
+  });
+
+  it("GET /analytics/trend retorna 3 meses para usuario free (limite do plano)", async () => {
+    const token = await registerAndLogin("billing-trend-free@controlfinance.dev");
+
+    const response = await request(app)
+      .get("/analytics/trend")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    expect(Array.isArray(response.body)).toBe(true);
+    expect(response.body).toHaveLength(3);
+  });
+
+  it("GET /analytics/trend retorna 402 ao solicitar 6 meses com plano free", async () => {
+    const token = await registerAndLogin("billing-trend-exceeded@controlfinance.dev");
+
+    const response = await request(app)
+      .get("/analytics/trend")
+      .query({ months: 6 })
+      .set("Authorization", `Bearer ${token}`);
+
+    expectErrorResponseWithRequestId(response, 402, "Limite de historico excedido no plano gratuito.");
+  });
+
+  it("usuario pro acessa dry-run normalmente", async () => {
+    const email = "billing-dryrun-pro@controlfinance.dev";
+    const token = await registerAndLogin(email);
+    await makeProUser(email);
+
+    const csvContent = "type,value,date,description\nEntrada,100,2026-01-01,Salario";
+
+    const response = await request(app)
+      .post("/transactions/import/dry-run")
+      .set("Authorization", `Bearer ${token}`)
+      .attach("file", Buffer.from(csvContent, "utf8"), {
+        filename: "import.csv",
+        contentType: "text/csv",
+      });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("usuario pro acessa export.csv normalmente", async () => {
+    const email = "billing-export-pro@controlfinance.dev";
+    const token = await registerAndLogin(email);
+    await makeProUser(email);
+
+    const response = await request(app)
+      .get("/transactions/export.csv")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+  });
+});

--- a/apps/api/src/db/migrations/010_create_billing_plans.sql
+++ b/apps/api/src/db/migrations/010_create_billing_plans.sql
@@ -1,0 +1,28 @@
+CREATE TABLE IF NOT EXISTS plans (
+  id              SERIAL PRIMARY KEY,
+  name            VARCHAR(50)   NOT NULL UNIQUE,
+  display_name    VARCHAR(100)  NOT NULL,
+  price_cents     INTEGER       NOT NULL DEFAULT 0,
+  stripe_price_id VARCHAR(100),
+  features        JSONB         NOT NULL DEFAULT '{}',
+  is_active       BOOLEAN       NOT NULL DEFAULT true,
+  created_at      TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO plans (name, display_name, price_cents, features, is_active)
+VALUES
+  (
+    'free',
+    'Gratuito',
+    0,
+    '{"csv_import":false,"csv_export":false,"analytics_months_max":3,"budget_tracking":true}',
+    true
+  ),
+  (
+    'pro',
+    'Pro',
+    1990,
+    '{"csv_import":true,"csv_export":true,"analytics_months_max":24,"budget_tracking":true}',
+    true
+  )
+ON CONFLICT (name) DO NOTHING;

--- a/apps/api/src/db/migrations/011_create_user_subscriptions.sql
+++ b/apps/api/src/db/migrations/011_create_user_subscriptions.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS subscriptions (
+  id                      SERIAL PRIMARY KEY,
+  user_id                 INTEGER     NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  plan_id                 INTEGER     NOT NULL REFERENCES plans(id),
+  status                  VARCHAR(20) NOT NULL DEFAULT 'active',
+  stripe_customer_id      VARCHAR(100),
+  stripe_subscription_id  VARCHAR(100),
+  current_period_start    TIMESTAMPTZ,
+  current_period_end      TIMESTAMPTZ,
+  cancel_at_period_end    BOOLEAN     NOT NULL DEFAULT false,
+  created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Enforce at most one active/trialing/past_due subscription per user
+CREATE UNIQUE INDEX IF NOT EXISTS idx_subscriptions_user_active
+  ON subscriptions (user_id)
+  WHERE status IN ('active', 'trialing', 'past_due');
+
+CREATE INDEX IF NOT EXISTS idx_subscriptions_user_id
+  ON subscriptions (user_id);

--- a/apps/api/src/middlewares/entitlement.middleware.js
+++ b/apps/api/src/middlewares/entitlement.middleware.js
@@ -1,0 +1,45 @@
+import { getActivePlanFeaturesForUser } from "../services/billing.service.js";
+
+const createPaymentRequiredError = () => {
+  const error = new Error("Recurso disponivel apenas no plano Pro.");
+  error.status = 402;
+  return error;
+};
+
+/**
+ * Middleware factory for boolean feature gates.
+ * Returns 402 if the authenticated user's active plan has featureName === false.
+ *
+ * Usage:
+ *   router.post("/import/dry-run", requireFeature("csv_import"), handler)
+ */
+export const requireFeature = (featureName) => async (req, res, next) => {
+  try {
+    const features = await getActivePlanFeaturesForUser(req.user.id);
+
+    if (features[featureName] === false) {
+      return next(createPaymentRequiredError());
+    }
+
+    return next();
+  } catch (error) {
+    return next(error);
+  }
+};
+
+/**
+ * Middleware that attaches the user's full plan features to req.entitlements.
+ * Used for numeric caps (e.g. analytics_months_max) where the route needs the value.
+ *
+ * Usage:
+ *   router.get("/trend", attachEntitlements, handler)
+ *   // then in handler: req.entitlements.analytics_months_max
+ */
+export const attachEntitlements = async (req, res, next) => {
+  try {
+    req.entitlements = await getActivePlanFeaturesForUser(req.user.id);
+    return next();
+  } catch (error) {
+    return next(error);
+  }
+};

--- a/apps/api/src/routes/analytics.routes.js
+++ b/apps/api/src/routes/analytics.routes.js
@@ -1,14 +1,32 @@
 import { Router } from "express";
 import { authMiddleware } from "../middlewares/auth.middleware.js";
+import { attachEntitlements } from "../middlewares/entitlement.middleware.js";
 import { getMonthlyTrendForUser } from "../services/analytics.service.js";
 
 const router = Router();
 
+const DEFAULT_MONTHS = 6;
+const MAX_MONTHS = 24;
+
 router.use(authMiddleware);
 
-router.get("/trend", async (req, res, next) => {
+router.get("/trend", attachEntitlements, async (req, res, next) => {
   try {
-    const trend = await getMonthlyTrendForUser(req.user.id, req.query?.months);
+    const cap = req.entitlements.analytics_months_max;
+    const rawMonths = req.query?.months;
+
+    if (rawMonths !== undefined) {
+      const parsedMonths = Number(String(rawMonths).trim());
+
+      if (Number.isInteger(parsedMonths) && parsedMonths >= 1 && parsedMonths <= MAX_MONTHS && parsedMonths > cap) {
+        const error = new Error("Limite de historico excedido no plano gratuito.");
+        error.status = 402;
+        return next(error);
+      }
+    }
+
+    const effectiveMonths = rawMonths !== undefined ? rawMonths : Math.min(DEFAULT_MONTHS, cap);
+    const trend = await getMonthlyTrendForUser(req.user.id, effectiveMonths);
     res.status(200).json(trend);
   } catch (error) {
     next(error);

--- a/apps/api/src/routes/billing.routes.js
+++ b/apps/api/src/routes/billing.routes.js
@@ -1,0 +1,18 @@
+import { Router } from "express";
+import { authMiddleware } from "../middlewares/auth.middleware.js";
+import { getSubscriptionSummaryForUser } from "../services/billing.service.js";
+
+const router = Router();
+
+router.use(authMiddleware);
+
+router.get("/subscription", async (req, res, next) => {
+  try {
+    const summary = await getSubscriptionSummaryForUser(req.user.id);
+    res.status(200).json(summary);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/apps/api/src/routes/transactions.routes.js
+++ b/apps/api/src/routes/transactions.routes.js
@@ -6,6 +6,7 @@ import {
   importRateLimiter,
   transactionsWriteRateLimiter,
 } from "../middlewares/rate-limit.middleware.js";
+import { requireFeature } from "../middlewares/entitlement.middleware.js";
 import {
   createElapsedTimer,
   logImportEvent,
@@ -89,7 +90,7 @@ const getListFiltersFromQuery = (query = {}, options = {}) => {
   return filters;
 };
 
-router.get("/export.csv", async (req, res, next) => {
+router.get("/export.csv", requireFeature("csv_export"), async (req, res, next) => {
   try {
     const csvExport = await exportTransactionsCsvByUser(
       req.user.id,
@@ -265,7 +266,7 @@ router.post("/:id/restore", transactionsWriteRateLimiter, async (req, res, next)
   }
 });
 
-router.post("/import/dry-run", importRateLimiter, (req, res, next) => {
+router.post("/import/dry-run", importRateLimiter, requireFeature("csv_import"), (req, res, next) => {
   const elapsedTimer = createElapsedTimer();
   const userId = Number(req.user.id);
   const requestId = req.requestId || null;
@@ -331,7 +332,7 @@ router.post("/import/dry-run", importRateLimiter, (req, res, next) => {
   });
 });
 
-router.post("/import/commit", importRateLimiter, async (req, res, next) => {
+router.post("/import/commit", importRateLimiter, requireFeature("csv_import"), async (req, res, next) => {
   const elapsedTimer = createElapsedTimer();
   const userId = Number(req.user.id);
   const requestId = req.requestId || null;

--- a/apps/api/src/services/billing.service.js
+++ b/apps/api/src/services/billing.service.js
@@ -1,0 +1,108 @@
+import { dbQuery } from "../db/index.js";
+
+const createError = (status, message) => {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+};
+
+const normalizeUserId = (value) => {
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw createError(401, "Usuario nao autenticado.");
+  }
+
+  return parsed;
+};
+
+/**
+ * Returns the active plan features for a user.
+ * If no active/trialing/past_due subscription exists, falls back to the free plan.
+ */
+export const getActivePlanFeaturesForUser = async (userId) => {
+  const normalizedUserId = normalizeUserId(userId);
+
+  const subscriptionResult = await dbQuery(
+    `
+      SELECT p.features
+      FROM subscriptions s
+      JOIN plans p ON p.id = s.plan_id
+      WHERE s.user_id = $1
+        AND s.status IN ('active', 'trialing', 'past_due')
+      LIMIT 1
+    `,
+    [normalizedUserId],
+  );
+
+  if (subscriptionResult.rows.length > 0) {
+    return subscriptionResult.rows[0].features;
+  }
+
+  const freePlanResult = await dbQuery(
+    `SELECT features FROM plans WHERE name = 'free' AND is_active = true LIMIT 1`,
+  );
+
+  if (freePlanResult.rows.length === 0) {
+    throw createError(500, "Plano gratuito nao encontrado.");
+  }
+
+  return freePlanResult.rows[0].features;
+};
+
+/**
+ * Returns a summary of the user's current subscription for the /billing/subscription endpoint.
+ */
+export const getSubscriptionSummaryForUser = async (userId) => {
+  const normalizedUserId = normalizeUserId(userId);
+
+  const result = await dbQuery(
+    `
+      SELECT
+        p.name          AS plan,
+        p.display_name  AS "displayName",
+        p.features,
+        s.status,
+        s.current_period_end AS "currentPeriodEnd",
+        s.cancel_at_period_end AS "cancelAtPeriodEnd"
+      FROM subscriptions s
+      JOIN plans p ON p.id = s.plan_id
+      WHERE s.user_id = $1
+        AND s.status IN ('active', 'trialing', 'past_due')
+      LIMIT 1
+    `,
+    [normalizedUserId],
+  );
+
+  if (result.rows.length > 0) {
+    const row = result.rows[0];
+
+    return {
+      plan: row.plan,
+      displayName: row.displayName,
+      features: row.features,
+      subscription: {
+        status: row.status,
+        currentPeriodEnd: row.currentPeriodEnd,
+        cancelAtPeriodEnd: row.cancelAtPeriodEnd,
+      },
+    };
+  }
+
+  const freePlanResult = await dbQuery(
+    `SELECT name, display_name AS "displayName", features FROM plans WHERE name = 'free' AND is_active = true LIMIT 1`,
+  );
+
+  if (freePlanResult.rows.length === 0) {
+    throw createError(500, "Plano gratuito nao encontrado.");
+  }
+
+  const freePlan = freePlanResult.rows[0];
+
+  return {
+    plan: freePlan.name,
+    displayName: freePlan.displayName,
+    features: freePlan.features,
+    subscription: null,
+  };
+};

--- a/apps/api/src/test-helpers.js
+++ b/apps/api/src/test-helpers.js
@@ -42,6 +42,18 @@ export const csvFile = (content, fileName = "import.csv") => ({
   fileName,
 });
 
+export const makeProUser = async (email) => {
+  const userId = await getUserIdByEmail(email);
+  const planResult = await dbQuery(
+    `SELECT id FROM plans WHERE name = 'pro' AND is_active = true LIMIT 1`,
+  );
+  const planId = planResult.rows[0].id;
+  await dbQuery(
+    `INSERT INTO subscriptions (user_id, plan_id, status) VALUES ($1, $2, 'active')`,
+    [userId, planId],
+  );
+};
+
 export const createTransactionsForUser = async (token, count) => {
   await Promise.all(
     Array.from({ length: count }, (_, index) =>

--- a/apps/api/src/transactions.test.js
+++ b/apps/api/src/transactions.test.js
@@ -13,6 +13,7 @@ import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
 import {
   createTransactionsForUser,
   expectErrorResponseWithRequestId,
+  makeProUser,
   registerAndLogin,
   setupTestDb,
 } from "./test-helpers.js";
@@ -32,6 +33,7 @@ describe("transactions", () => {
     resetWriteRateLimiterState();
     resetHttpMetricsForTests();
     await dbQuery("DELETE FROM transactions");
+    await dbQuery("DELETE FROM subscriptions");
     await dbQuery("DELETE FROM users");
   });
 
@@ -620,6 +622,7 @@ describe("transactions", () => {
 
   it("exporta CSV filtrado com totais", async () => {
     const token = await registerAndLogin("export@controlfinance.dev");
+    await makeProUser("export@controlfinance.dev");
 
     await request(app)
       .post("/transactions")
@@ -669,6 +672,7 @@ describe("transactions", () => {
 
   it("exporta CSV incluindo category_name quando a transacao possui categoria", async () => {
     const token = await registerAndLogin("export-category@controlfinance.dev");
+    await makeProUser("export-category@controlfinance.dev");
 
     const categoryResponse = await request(app)
       .post("/categories")


### PR DESCRIPTION
## Summary
- Add provider-agnostic billing foundation with plans/subscriptions and feature entitlements.
- Introduce feature-gate middleware for premium capabilities and numeric caps.
- Add billing API endpoint for subscription visibility.

## Database
- Add migration pps/api/src/db/migrations/010_create_billing_plans.sql
  - Creates plans
  - Seeds ree and pro with JSONB eatures
- Add migration pps/api/src/db/migrations/011_create_user_subscriptions.sql
  - Creates subscriptions
  - Adds partial unique index to enforce a single active/trialing/past_due subscription per user

## API / Services
- Add pps/api/src/services/billing.service.js
  - getActivePlanFeaturesForUser() with lazy fallback to free
  - getSubscriptionSummaryForUser() for /billing/subscription
- Add pps/api/src/middlewares/entitlement.middleware.js
  - equireFeature(feature) returns 402 with Recurso disponivel apenas no plano Pro.
  - ttachEntitlements enriches eq.entitlements for numeric caps
- Add pps/api/src/routes/billing.routes.js
  - GET /billing/subscription (auth required)

## Feature Gates Applied
- Import CSV dry-run + commit require csv_import
- CSV export requires csv_export
- Analytics trend capped by nalytics_months_max
  - free users: default capped to 3
  - explicit request over cap returns 402 with Limite de historico excedido no plano gratuito.

## Tests
- Add pps/api/src/billing.test.js with 9 scenarios
- Update existing suites to reflect gating behavior with makeProUser helper in pps/api/src/test-helpers.js

## Validation
- 
pm -w apps/api run lint ✅
- 
pm -w apps/api run test ✅ (135/135)
