### PR TITLE
chore(release): v1.22.0

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/api",
   "private": true,
-  "version": "1.21.0",
+  "version": "1.22.0",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "control-finance-monorepo",
   "private": true,
-  "version": "1.21.0",
+  "version": "1.22.0",
   "engines": {
     "node": "24.x"
   },


### PR DESCRIPTION
## What changed
- Bump release version to 1.22.0:
  - package.json
  - pps/api/package.json
- Add 1.22.0 entry to CHANGELOG.md.

## Release focus
Stripe webhook lifecycle ingestion for billing:
- /billing/webhooks/stripe added with raw-body signature verification
- subscription lifecycle handlers (checkout completed, subscription updated/deleted, payment failed)
- signature hardening (hex-byte comparison, raw buffer signing, multi-v1 support)

## Scope
- Release metadata + changelog only.
- No runtime behavior changes in this PR.

## Validation
- 
pm run lint ✅
- 
pm run test ✅ (web 111/111 + api 147/147)
- 
pm run build ✅
