### PR TITLE
feat(auth): add GET /auth/me endpoint

### DIFF
--- a/apps/api/src/auth.test.js
+++ b/apps/api/src/auth.test.js
@@ -239,4 +239,24 @@ describe("auth", () => {
 
     expect(response.status).toBe(201);
   });
+
+  it("GET /auth/me retorna 401 sem token", async () => {
+    const response = await request(app).get("/auth/me");
+    expect(response.status).toBe(401);
+  });
+
+  it("GET /auth/me retorna id e email do usuario autenticado", async () => {
+    const reg = await request(app)
+      .post("/auth/register")
+      .send({ email: "me@controlfinance.dev", password: "Senha123" });
+
+    const response = await request(app)
+      .get("/auth/me")
+      .set("Authorization", `Bearer ${reg.body.token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.email).toBe("me@controlfinance.dev");
+    expect(Number.isInteger(response.body.id)).toBe(true);
+    expect(response.body.id).toBeGreaterThan(0);
+  });
 });

--- a/apps/api/src/routes/auth.routes.js
+++ b/apps/api/src/routes/auth.routes.js
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { loginUser, registerUser } from "../services/auth.service.js";
+import { authMiddleware } from "../middlewares/auth.middleware.js";
 import {
   bruteForceLoginGuard,
   clearLoginFailures,
@@ -32,6 +33,10 @@ router.post("/login", loginRateLimiter, bruteForceLoginGuard, async (req, res, n
 
     next(error);
   }
+});
+
+router.get("/me", authMiddleware, (req, res) => {
+  res.status(200).json({ id: req.user.id, email: req.user.email });
 });
 
 export default router;


### PR DESCRIPTION
## Summary
- Add GET /auth/me protected by uthMiddleware
- Return authenticated user identity directly from JWT context: { id, email }
- Close smoke-test gap for Stripe lifecycle flow by enabling userId resolution without direct DB access

## Changes
- pps/api/src/routes/auth.routes.js
  - add route:
    - GET /auth/me -> 200 { id, email } when token is valid
    - 401 when token is missing/invalid (via existing middleware)
- pps/api/src/auth.test.js
  - add 2 tests:
    - GET /auth/me without token -> 401
    - GET /auth/me with valid token -> 200 { id, email }

## Validation
- 
pm -w apps/api test ✅
- Full API suite: **149/149** passing
