### PR TITLE
chore(release): v1.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.23.0] - 2026-02-21
+
+### Title
+
+v1.23.0 - Auth Identity Endpoint
+
+### Added
+
+- `GET /auth/me` (requires Bearer token) — returns `{ id, email }` from JWT without DB access.
+  Enables userId resolution in operational smoke tests and unblocks the billing checkout flow (PR-K).
+
+### Quality
+
+- 2 new tests in `apps/api/src/auth.test.js` covering 401 (no token) and 200 (valid token) cases.
+- Full suite green: **149/149**.
+
 ## [1.22.0] - 2026-02-21
 
 ### Title

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/api",
   "private": true,
-  "version": "1.22.0",
+  "version": "1.23.0",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "control-finance-monorepo",
   "private": true,
-  "version": "1.22.0",
+  "version": "1.23.0",
   "engines": {
     "node": "24.x"
   },


### PR DESCRIPTION
## What changed
- Bump release version to 1.23.0: package.json, pps/api/package.json
- Add 1.23.0 entry to CHANGELOG.md

## Release focus
GET /auth/me — returns { id, email } from JWT without DB access.
Unblocks userId resolution in operational smoke tests and billing checkout flow (PR-K).

## Scope
Release metadata + changelog only. No runtime behavior changes in this PR.

## Validation
- 
pm run lint ✅
- 
pm run test ✅ (149/149)
- 
pm run build ✅
