### PR TITLE
feat(billing): add POST /billing/checkout for Stripe Checkout Session creation

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -26,7 +26,8 @@
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.0.2",
     "pg": "^8.16.3",
-    "prom-client": "^15.1.3"
+    "prom-client": "^15.1.3",
+    "stripe": "^20.3.1"
   },
   "devDependencies": {
     "eslint": "^8.57.1",

--- a/apps/api/src/billing-checkout.test.js
+++ b/apps/api/src/billing-checkout.test.js
@@ -1,0 +1,143 @@
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import app from "./app.js";
+import { clearDbClientForTests, dbQuery } from "./db/index.js";
+import { resetLoginProtectionState } from "./middlewares/login-protection.middleware.js";
+import {
+  resetImportRateLimiterState,
+  resetWriteRateLimiterState,
+} from "./middlewares/rate-limit.middleware.js";
+import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
+import { makeProUser, registerAndLogin, setupTestDb } from "./test-helpers.js";
+
+const { mockSessionCreate } = vi.hoisted(() => ({
+  mockSessionCreate: vi.fn(),
+}));
+
+vi.mock("stripe", () => ({
+  default: vi.fn().mockImplementation(() => ({
+    checkout: { sessions: { create: mockSessionCreate } },
+  })),
+}));
+
+describe("billing checkout", () => {
+  beforeAll(async () => {
+    await setupTestDb();
+    process.env.STRIPE_SECRET_KEY = "sk_test_mock_controlfinance";
+    process.env.STRIPE_CHECKOUT_SUCCESS_URL = "https://app.test/billing/success";
+    process.env.STRIPE_CHECKOUT_CANCEL_URL = "https://app.test/billing/cancel";
+    await dbQuery(`UPDATE plans SET stripe_price_id = 'price_pro_monthly' WHERE name = 'pro'`);
+  });
+
+  afterAll(async () => {
+    await clearDbClientForTests();
+    delete process.env.STRIPE_SECRET_KEY;
+    delete process.env.STRIPE_CHECKOUT_SUCCESS_URL;
+    delete process.env.STRIPE_CHECKOUT_CANCEL_URL;
+  });
+
+  beforeEach(async () => {
+    resetLoginProtectionState();
+    resetImportRateLimiterState();
+    resetWriteRateLimiterState();
+    resetHttpMetricsForTests();
+    await dbQuery("DELETE FROM subscriptions");
+    await dbQuery("DELETE FROM transactions");
+    await dbQuery("DELETE FROM users");
+    mockSessionCreate.mockReset();
+    mockSessionCreate.mockResolvedValue({ url: "https://checkout.stripe.com/test-session-001" });
+  });
+
+  it("retorna 401 sem token", async () => {
+    const response = await request(app).post("/billing/checkout");
+    expect(response.status).toBe(401);
+  });
+
+  it("retorna 409 se usuario ja possui assinatura ativa", async () => {
+    const email = "checkout-already-pro@controlfinance.dev";
+    const token = await registerAndLogin(email);
+    await makeProUser(email);
+
+    const response = await request(app)
+      .post("/billing/checkout")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(409);
+    expect(response.body.message).toBe("Voce ja possui uma assinatura ativa.");
+    expect(mockSessionCreate).not.toHaveBeenCalled();
+  });
+
+  it("retorna 201 com url para usuario free", async () => {
+    const token = await registerAndLogin("checkout-free@controlfinance.dev");
+
+    const response = await request(app)
+      .post("/billing/checkout")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(201);
+    expect(response.body.url).toBe("https://checkout.stripe.com/test-session-001");
+  });
+
+  it("passa metadata.userId, price_id e URLs corretos para Stripe", async () => {
+    const email = "checkout-meta@controlfinance.dev";
+    const token = await registerAndLogin(email);
+    const userResult = await dbQuery(`SELECT id FROM users WHERE email = $1`, [email]);
+    const userId = userResult.rows[0].id;
+
+    await request(app)
+      .post("/billing/checkout")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(mockSessionCreate).toHaveBeenCalledOnce();
+    const args = mockSessionCreate.mock.calls[0][0];
+    expect(args.mode).toBe("subscription");
+    expect(args.line_items[0].price).toBe("price_pro_monthly");
+    expect(args.line_items[0].quantity).toBe(1);
+    expect(args.metadata.userId).toBe(String(userId));
+    expect(args.success_url).toBe("https://app.test/billing/success");
+    expect(args.cancel_url).toBe("https://app.test/billing/cancel");
+  });
+
+  it("passa customer_email quando disponivel no token", async () => {
+    const email = "checkout-email@controlfinance.dev";
+    const token = await registerAndLogin(email);
+
+    await request(app)
+      .post("/billing/checkout")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(mockSessionCreate).toHaveBeenCalledOnce();
+    const args = mockSessionCreate.mock.calls[0][0];
+    expect(args.customer_email).toBe(email);
+  });
+
+  it("retorna 500 se STRIPE_SECRET_KEY nao configurado", async () => {
+    const saved = process.env.STRIPE_SECRET_KEY;
+    delete process.env.STRIPE_SECRET_KEY;
+    try {
+      const token = await registerAndLogin("checkout-no-key@controlfinance.dev");
+      const response = await request(app)
+        .post("/billing/checkout")
+        .set("Authorization", `Bearer ${token}`);
+      expect(response.status).toBe(500);
+      expect(mockSessionCreate).not.toHaveBeenCalled();
+    } finally {
+      process.env.STRIPE_SECRET_KEY = saved;
+    }
+  });
+
+  it("retorna 500 se checkout URLs nao configurados", async () => {
+    const saved = process.env.STRIPE_CHECKOUT_SUCCESS_URL;
+    delete process.env.STRIPE_CHECKOUT_SUCCESS_URL;
+    try {
+      const token = await registerAndLogin("checkout-no-url@controlfinance.dev");
+      const response = await request(app)
+        .post("/billing/checkout")
+        .set("Authorization", `Bearer ${token}`);
+      expect(response.status).toBe(500);
+      expect(mockSessionCreate).not.toHaveBeenCalled();
+    } finally {
+      process.env.STRIPE_CHECKOUT_SUCCESS_URL = saved;
+    }
+  });
+});

--- a/apps/api/src/routes/billing.routes.js
+++ b/apps/api/src/routes/billing.routes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { authMiddleware } from "../middlewares/auth.middleware.js";
 import { getSubscriptionSummaryForUser } from "../services/billing.service.js";
+import { createCheckoutSession } from "../services/stripe-checkout.service.js";
 
 const router = Router();
 
@@ -10,6 +11,18 @@ router.get("/subscription", async (req, res, next) => {
   try {
     const summary = await getSubscriptionSummaryForUser(req.user.id);
     res.status(200).json(summary);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post("/checkout", async (req, res, next) => {
+  try {
+    const result = await createCheckoutSession({
+      userId: req.user.id,
+      userEmail: req.user.email,
+    });
+    res.status(201).json(result);
   } catch (error) {
     next(error);
   }

--- a/apps/api/src/services/stripe-checkout.service.js
+++ b/apps/api/src/services/stripe-checkout.service.js
@@ -1,0 +1,56 @@
+import Stripe from "stripe";
+import { dbQuery } from "../db/index.js";
+
+const createError = (status, message) => {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+};
+
+const resolvePriceId = async () => {
+  const dbResult = await dbQuery(
+    `SELECT stripe_price_id FROM plans
+      WHERE name = 'pro' AND is_active = true AND stripe_price_id IS NOT NULL
+      LIMIT 1`,
+  );
+  if (dbResult.rows.length > 0) return dbResult.rows[0].stripe_price_id;
+
+  const envPriceId = process.env.STRIPE_PRICE_ID_PRO;
+  if (envPriceId) return envPriceId;
+
+  throw createError(500, "Pro plan price not configured.");
+};
+
+export const createCheckoutSession = async ({ userId, userEmail }) => {
+  const secretKey = process.env.STRIPE_SECRET_KEY;
+  if (!secretKey) throw createError(500, "Stripe secret key not configured.");
+
+  const successUrl = process.env.STRIPE_CHECKOUT_SUCCESS_URL;
+  const cancelUrl = process.env.STRIPE_CHECKOUT_CANCEL_URL;
+  if (!successUrl || !cancelUrl) throw createError(500, "Checkout URLs not configured.");
+
+  const existing = await dbQuery(
+    `SELECT id FROM subscriptions
+      WHERE user_id = $1 AND status IN ('active', 'trialing', 'past_due')
+      LIMIT 1`,
+    [userId],
+  );
+  if (existing.rows.length > 0) throw createError(409, "Voce ja possui uma assinatura ativa.");
+
+  const priceId = await resolvePriceId();
+
+  const stripe = new Stripe(secretKey, { apiVersion: "2026-01-28.clover" });
+
+  const session = await stripe.checkout.sessions.create({
+    mode: "subscription",
+    line_items: [{ price: priceId, quantity: 1 }],
+    success_url: successUrl,
+    cancel_url: cancelUrl,
+    metadata: { userId: String(userId) },
+    ...(userEmail ? { customer_email: userEmail } : {}),
+    allow_promotion_codes: true,
+    billing_address_collection: "auto",
+  });
+
+  return { url: session.url };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "control-finance-monorepo",
-  "version": "1.12.0",
+  "version": "1.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "control-finance-monorepo",
-      "version": "1.12.0",
+      "version": "1.23.0",
       "workspaces": [
         "apps/web",
         "apps/api"
@@ -20,7 +20,7 @@
     },
     "apps/api": {
       "name": "@control-finance/api",
-      "version": "1.12.0",
+      "version": "1.23.0",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
@@ -31,7 +31,8 @@
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.2",
         "pg": "^8.16.3",
-        "prom-client": "^15.1.3"
+        "prom-client": "^15.1.3",
+        "stripe": "^20.3.1"
       },
       "devDependencies": {
         "eslint": "^8.57.1",
@@ -45,7 +46,7 @@
     },
     "apps/web": {
       "name": "@control-finance/web",
-      "version": "1.12.0",
+      "version": "1.19.0",
       "dependencies": {
         "autoprefixer": "^10.4.24",
         "axios": "^1.8.4",
@@ -1859,7 +1860,7 @@
       "version": "25.2.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
       "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -8229,6 +8230,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stripe": {
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-20.3.1.tgz",
+      "integrity": "sha512-k990yOT5G5rhX3XluRPw5Y8RLdJDW4dzQ29wWT66piHrbnM2KyamJ1dKgPsw4HzGHRWjDiSSdcI2WdxQUPV3aQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@types/node": ">=16"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/sucrase": {
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
@@ -8833,7 +8851,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
## Summary
- Adds POST /billing/checkout (auth required) — creates a Stripe Checkout Session and returns { url } for frontend redirect
- Price ID resolved from plans.stripe_price_id (DB) with fallback to STRIPE_PRICE_ID_PRO env var
- Returns 409 if user already has an active/trialing/past_due subscription
- Session metadata includes userId for webhook reconciliation (used by existing checkout.session.completed handler)
- Uses stripe@20.3.1 (API version 2026-01-28.clover)

## Env vars required (Render)
- STRIPE_SECRET_KEY — sk_live_... or sk_test_...
- STRIPE_CHECKOUT_SUCCESS_URL — redirect after payment success
- STRIPE_CHECKOUT_CANCEL_URL — redirect on cancel

## Tests
- 7 integration tests in illing-checkout.test.js (Stripe SDK mocked via i.hoisted + i.mock)
- Full suite: **156/156**

## Important note
The two 500-path tests (missing STRIPE_SECRET_KEY, missing checkout URLs) assert status only. Error messages are intentionally masked to Unexpected error. by the global error middleware for security.
