### PR TITLE
fix(web): close budget modal before opening transaction or delete overlay

### DIFF
--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -2798,4 +2798,22 @@ describe("App", () => {
       delete window.HTMLElement.prototype.scrollIntoView;
     });
   });
+
+  it("fechar modal de budget ao abrir modal de transacao (isolamento de modais)", async () => {
+    const user = userEvent.setup();
+    transactionsService.listCategories.mockResolvedValueOnce([{ id: 1, name: "Alimentacao" }]);
+
+    render(<App />);
+
+    const newBudgetButton = screen.getByRole("button", { name: "+ Nova meta" });
+    await waitFor(() => expect(newBudgetButton).toBeEnabled());
+    await user.click(newBudgetButton);
+
+    expect(screen.getByRole("dialog", { name: "Meta do mes" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Registrar novo valor" }));
+
+    expect(screen.queryByRole("dialog", { name: "Meta do mes" })).not.toBeInTheDocument();
+    expect(screen.getByText("Registro de valor")).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -1167,12 +1167,14 @@ const App = ({
   );
 
   const openCreateModal = () => {
+    setBudgetModalOpen(false);
     setEditingTransaction(null);
     setModalRequestError("");
     setModalOpen(true);
   };
 
   const openEditModal = (transaction: TransactionWithCategoryName) => {
+    setBudgetModalOpen(false);
     setEditingTransaction(transaction);
     setModalRequestError("");
     setModalOpen(true);
@@ -1235,6 +1237,7 @@ const App = ({
   };
 
   const requestDeleteTransaction = (id: number) => {
+    setBudgetModalOpen(false);
     setPendingDeleteTransactionId(id);
   };
 


### PR DESCRIPTION
## Summary
- Prevents overlay stacking in mobile/desktop flows by enforcing modal isolation
- openCreateModal, openEditModal, and equestDeleteTransaction now close budget modal before opening their own overlay
- Fixes the scenario where Budget modal and Transaction/Delete overlays could appear together

## Files changed
- pps/web/src/pages/App.tsx
  - add setBudgetModalOpen(false) in:
    - openCreateModal
    - openEditModal
    - equestDeleteTransaction
- pps/web/src/pages/App.test.jsx
  - add regression test:
    - open budget modal
    - click Registrar novo valor
    - assert budget dialog is gone
    - assert transaction modal is visible

## Validation
- 
pm -w apps/web run test:run ✅
- Web tests: **112/112** passing
