### PR TITLE
chore(release): v1.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.24.0] - 2026-02-21
+
+### Title
+
+v1.24.0 - Stripe Checkout & Modal Isolation
+
+### Added
+
+- `POST /billing/checkout` (requires Bearer token) — creates a Stripe Checkout Session for Pro plan upgrade.
+  - Returns `{ url }` (201) pointing to the hosted Stripe Checkout page.
+  - 409 if the user already has an `active`, `trialing`, or `past_due` subscription.
+  - Price resolved from DB (`plans.stripe_price_id WHERE name='pro'`) with `STRIPE_PRICE_ID_PRO` env fallback.
+  - Passes `metadata.userId`, `customer_email`, `allow_promotion_codes`, `billing_address_collection: "auto"`.
+  - New env vars required at runtime: `STRIPE_SECRET_KEY`, `STRIPE_CHECKOUT_SUCCESS_URL`, `STRIPE_CHECKOUT_CANCEL_URL`.
+
+### Fixed
+
+- Budget modal now closes before transaction create, transaction edit, or delete confirm overlays open,
+  preventing two `z-50` layers from stacking simultaneously (`openCreateModal`, `openEditModal`,
+  `requestDeleteTransaction` in `App.tsx`).
+
+### Quality
+
+- 7 new integration tests in `apps/api/src/billing-checkout.test.js` — auth guard, conflict guard,
+  Stripe session arg contract (price, metadata, URLs), `customer_email` passthrough, env-var guard paths.
+- Regression test in `apps/web/src/pages/App.test.jsx` asserting budget modal closes on
+  "Registrar novo valor" click.
+- Full suite green: **156/156** (api), **112/112** (web).
+
 ## [1.23.0] - 2026-02-21
 
 ### Title

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@control-finance/api",
   "private": true,
-  "version": "1.23.0",
+  "version": "1.24.0",
   "type": "module",
   "engines": {
     "node": "24.x"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "control-finance-monorepo",
   "private": true,
-  "version": "1.23.0",
+  "version": "1.24.0",
   "engines": {
     "node": "24.x"
   },


### PR DESCRIPTION
## v1.24.0 — Stripe Checkout & Modal Isolation

### Added
- `POST /billing/checkout` — creates Stripe Checkout Session for Pro upgrade (returns `{ url }`, 201)
  - 409 if user already has active/trialing/past_due subscription
  - Price resolved from DB (`plans.stripe_price_id`) with `STRIPE_PRICE_ID_PRO` env fallback
  - Requires: `STRIPE_SECRET_KEY`, `STRIPE_CHECKOUT_SUCCESS_URL`, `STRIPE_CHECKOUT_CANCEL_URL`

### Fixed
- Budget modal closes before transaction create/edit/delete overlays open (prevents z-50 stacking)

### Quality
- 7 new API integration tests (`billing-checkout.test.js`)
- 1 regression test in `App.test.jsx` for modal isolation
- Full suite green: **156/156** (api), **112/112** (web)

## Checklist
- [x] CHANGELOG.md updated
- [x] root `package.json` bumped to 1.24.0
- [x] `apps/api/package.json` bumped to 1.24.0
- [ ] Squash merge → tag `v1.24.0` → GitHub Release