### PR TITLE
fix(web): collapse filter panel by default on all viewports

### DIFF
--- a/apps/web/src/features/filters/useFilters.ts
+++ b/apps/web/src/features/filters/useFilters.ts
@@ -165,7 +165,7 @@ export function useFilters({
     isCompactFiltersPanelMode(),
   );
   const [isFiltersPanelOpen, setIsFiltersPanelOpen] = useState(
-    () => !isCompactFiltersPanelMode() || hasInitialActiveFilters(initialState),
+    () => hasInitialActiveFilters(initialState),
   );
 
   // Sync responsive layout on window resize
@@ -175,9 +175,6 @@ export function useFilters({
     const syncMobileFiltersMode = () => {
       const isMobileMode = isCompactFiltersPanelMode();
       setIsMobileFiltersPanel(isMobileMode);
-      if (!isMobileMode) {
-        setIsFiltersPanelOpen(true);
-      }
     };
 
     syncMobileFiltersMode();
@@ -358,9 +355,7 @@ export function useFilters({
   );
 
   const handleEditFilters = useCallback(() => {
-    if (isMobileFiltersPanel) {
-      setIsFiltersPanelOpen(true);
-    }
+    setIsFiltersPanelOpen(true);
 
     const focusSearchInput = () => {
       searchInputRef.current?.focus();
@@ -368,19 +363,15 @@ export function useFilters({
 
     if (typeof window !== "undefined" && typeof window.requestAnimationFrame === "function") {
       window.requestAnimationFrame(() => {
-        if (isMobileFiltersPanel) {
-          filtersPanelRef.current?.scrollIntoView?.({ behavior: "smooth", block: "start" });
-        }
+        filtersPanelRef.current?.scrollIntoView?.({ behavior: "smooth", block: "start" });
         window.requestAnimationFrame(focusSearchInput);
       });
       return;
     }
 
-    if (isMobileFiltersPanel) {
-      filtersPanelRef.current?.scrollIntoView?.({ block: "start" });
-    }
+    filtersPanelRef.current?.scrollIntoView?.({ block: "start" });
     focusSearchInput();
-  }, [isMobileFiltersPanel]);
+  }, []);
 
   return {
     selectedCategory,

--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -534,6 +534,7 @@ describe("App", () => {
       expect(lastCall.to).toMatch(/^\d{4}-\d{2}-\d{2}$/);
     });
 
+    await user.click(screen.getByRole("button", { name: "Filtros" }));
     expect(screen.getByLabelText("Categoria")).toHaveValue("5");
   });
 
@@ -694,6 +695,7 @@ describe("App", () => {
       expect(lastCall.to).toMatch(/^\d{4}-\d{2}-\d{2}$/);
     });
 
+    await user.click(screen.getByRole("button", { name: "Filtros" }));
     expect(screen.getByLabelText("Categoria")).toHaveValue("9");
   });
 
@@ -931,6 +933,7 @@ describe("App", () => {
     render(<App />);
 
     expect(await screen.findByText("Inicial")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Filtros" }));
     await user.selectOptions(screen.getByLabelText("Categoria"), "1");
     expect(await screen.findByText("Filtrada")).toBeInTheDocument();
     expect(screen.getAllByText("Categoria: Alimentacao").length).toBeGreaterThan(0);
@@ -946,6 +949,7 @@ describe("App", () => {
   });
 
   it("aplica sort da querystring ao carregar transacoes", async () => {
+    const user = userEvent.setup();
     window.history.replaceState(null, "", "/app?sort=amount:desc&limit=20&offset=0");
     transactionsService.listPage.mockResolvedValueOnce(
       buildPageResponse([
@@ -971,6 +975,7 @@ describe("App", () => {
       type: undefined,
       categoryId: undefined,
     });
+    await user.click(screen.getByRole("button", { name: "Filtros" }));
     expect(screen.getByLabelText("Ordenar por")).toHaveValue("amount:desc");
   });
 
@@ -1026,6 +1031,7 @@ describe("App", () => {
     expect(await screen.findByText("Pagina inicial")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Proxima" }));
     expect(await screen.findByText("Antes do sort")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Filtros" }));
     await user.selectOptions(screen.getByLabelText("Ordenar por"), "amount:desc");
 
     expect(await screen.findByText("Apos sort")).toBeInTheDocument();
@@ -1111,7 +1117,7 @@ describe("App", () => {
     render(<App />);
 
     expect(await screen.findByText("Antes da busca")).toBeInTheDocument();
-
+    await user.click(screen.getByRole("button", { name: "Filtros" }));
     await user.type(screen.getByLabelText("Buscar"), "padaria");
     await user.click(screen.getByRole("button", { name: "Aplicar" }));
 
@@ -1147,7 +1153,7 @@ describe("App", () => {
     render(<App />);
 
     expect(await screen.findByText("Lista inicial")).toBeInTheDocument();
-
+    await user.click(screen.getByRole("button", { name: "Filtros" }));
     const searchInput = screen.getByLabelText("Buscar");
     const initialCallCount = transactionsService.listPage.mock.calls.length;
 
@@ -1257,6 +1263,7 @@ describe("App", () => {
     render(<App />);
 
     expect(await screen.findByText("Antes do preset")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Filtros" }));
     expect(screen.getByRole("button", { name: "Este mes" })).toHaveAttribute("aria-pressed", "false");
     await user.click(screen.getByRole("button", { name: "Este mes" }));
 
@@ -1411,6 +1418,7 @@ describe("App", () => {
     render(<App />);
 
     expect(await screen.findByText("Sem filtros ativos")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Filtros" }));
     expect(screen.getByRole("button", { name: "Este mes" })).toBeInTheDocument();
     expect(screen.queryByText(/Filtros ativos \(\d+\)/)).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Limpar tudo" })).not.toBeInTheDocument();
@@ -2236,6 +2244,7 @@ describe("App", () => {
     expect(await screen.findByText("Saida p2")).toBeInTheDocument();
     expect(screen.getByText("Pagina 2 de 2")).toBeInTheDocument();
 
+    await user.click(screen.getByRole("button", { name: "Filtros" }));
     await user.click(screen.getByRole("button", { name: "Filtrar entradas" }));
 
     expect(await screen.findByText("Entrada filtrada")).toBeInTheDocument();
@@ -2595,6 +2604,7 @@ describe("App", () => {
       render(<App />);
 
       await screen.findByText("Resumo financeiro");
+      await user.click(screen.getByRole("button", { name: "Filtros" }));
       await user.selectOptions(screen.getByLabelText("Periodo"), "Personalizado");
       fireEvent.change(screen.getByLabelText("Data inicial"), {
         target: { value: "2026-02-01" },

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -533,7 +533,6 @@ const App = ({
     setCustomEndDate,
     isFiltersPanelOpen,
     setIsFiltersPanelOpen,
-    isMobileFiltersPanel,
     filtersPanelRef,
     searchInputRef,
     periodRange,
@@ -1434,7 +1433,7 @@ const App = ({
     () => getCurrentMonthRange(new Date(`${todayISO}T00:00:00`)),
     [todayISO],
   );
-  const isFiltersContentVisible = !isMobileFiltersPanel || isFiltersPanelOpen;
+  const isFiltersContentVisible = isFiltersPanelOpen;
   const shouldShowPresets = !hasActiveFilters;
   const hasMonthlySummaryData =
     monthlySummary.income > 0 ||
@@ -1602,21 +1601,14 @@ const App = ({
             <div className="flex items-start justify-between gap-3 rounded border border-gray-200 bg-gray-50 px-3 py-2">
               <h2 className="text-base font-semibold text-gray-100">Resumo financeiro</h2>
               <div className="flex items-center gap-2">
-                {!hasActiveFilters && !isMobileFiltersPanel ? (
-                  <span className="rounded-full border border-gray-300 bg-white px-2 py-1 text-xs font-semibold text-gray-600">
-                    Sem filtros ativos
-                  </span>
-                ) : null}
-                {isMobileFiltersPanel ? (
-                  <button
-                    type="button"
-                    onClick={() => setIsFiltersPanelOpen(!isFiltersPanelOpen)}
-                    aria-expanded={isFiltersPanelOpen}
-                    className="whitespace-nowrap rounded border border-gray-300 bg-white px-2.5 py-1 text-xs font-semibold text-gray-700 hover:bg-gray-100"
-                  >
-                    {isFiltersPanelOpen ? "Ocultar" : "Filtros"}
-                  </button>
-                ) : null}
+                <button
+                  type="button"
+                  onClick={() => setIsFiltersPanelOpen(!isFiltersPanelOpen)}
+                  aria-expanded={isFiltersPanelOpen}
+                  className="whitespace-nowrap rounded border border-gray-300 bg-white px-2.5 py-1 text-xs font-semibold text-gray-700 hover:bg-gray-100"
+                >
+                  {isFiltersPanelOpen ? "Ocultar" : "Filtros"}
+                </button>
               </div>
             </div>
 


### PR DESCRIPTION
## Problem

The filter panel was always expanded on desktop (≥ 640 px), occupying ~200 px of
vertical space on every page load even when the user has no intention of filtering.

## Fix

| | Before | After |
|---|---|---|
| Desktop initial state | Always open | Collapsed (closed) |
| Mobile initial state | Collapsed | Collapsed (unchanged) |
| Toggle button | Mobile only | Both mobile and desktop |
| Auto-open with active filters | Mobile + initial URL | Initial URL only |
| "Editar filtros" link | Opens panel on mobile only | Opens panel on all viewports |

### Files changed
- **`useFilters.ts`** — initial state: `hasInitialActiveFilters()` (was `!isCompact || hasInitial`);
  resize handler no longer forces open on desktop;
  `handleEditFilters` always opens panel and scrolls (removed `isMobileFiltersPanel` guard).
- **`App.tsx`** — `isFiltersContentVisible = isFiltersPanelOpen` (viewport-agnostic);
  toggle button rendered unconditionally; "Sem filtros ativos" static badge removed.
- **`App.test.jsx`** — 11 tests updated to open the panel before accessing filter controls.

## Test plan
- [ ] Desktop: load app → filter panel collapsed → click "Filtros" → panel expands
- [ ] Desktop: reload with `?q=foo` in URL → panel auto-opens
- [ ] Mobile (< 640 px): existing behavior unchanged
- [ ] "Editar filtros" chip link opens panel and focuses search input

## Quality
- **112/112** web tests pass
- Lint clean