### PR TITLE
fix(web): keep 'Sem categoria' last in category expense breakdown

### DIFF
--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -1062,7 +1062,12 @@ const App = ({
           expense: Number.isFinite(normalizedExpense) ? normalizedExpense : 0,
         };
       })
-      .filter((categoryItem) => categoryItem.expense > 0);
+      .filter((categoryItem) => categoryItem.expense > 0)
+      .sort((a, b) => {
+        if (a.categoryId === null && b.categoryId !== null) return 1;
+        if (b.categoryId === null && a.categoryId !== null) return -1;
+        return b.expense - a.expense;
+      });
   }, [monthlySummary.byCategory]);
 
   const monthOverMonthMetrics = useMemo(


### PR DESCRIPTION
## Problem

In the category expense breakdown, "Sem categoria" (uncategorized transactions)
could appear anywhere in the list — often at the top when its expense total was
highest. This made the breakdown confusing because "Sem categoria" is a catch-all
bucket, not a real category.

## Fix

Added a `.sort()` after `.filter()` in `summaryByCategoryExpenses` useMemo:

```ts
.sort((a, b) => {
  if (a.categoryId === null && b.categoryId !== null) return 1;
  if (b.categoryId === null && a.categoryId !== null) return -1;
  return b.expense - a.expense;
})
```

- Items with `categoryId === null` always sort to the bottom
- Categorized items remain ordered by `expense` descending

## Impact

- 1-line logic change in a single `useMemo` ([App.tsx:1065](apps/web/src/pages/App.tsx#L1065))
- No schema or API changes
- **112/112** web tests pass unchanged
- Lint clean