### PR TITLE
fix(web): improve contrast for WCAG AA compliance

### DIFF
--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -146,7 +146,7 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
           <button
             type="button"
             onClick={onClose}
-            className="text-gray-500 transition-colors hover:text-gray-700"
+            className="text-gray-200 transition-colors hover:text-gray-100"
             aria-label="Fechar modal de importacao CSV"
           >
             X

--- a/apps/web/src/components/ImportHistoryModal.jsx
+++ b/apps/web/src/components/ImportHistoryModal.jsx
@@ -172,7 +172,7 @@ const ImportHistoryModal = ({ isOpen, onClose }) => {
             ref={closeButtonRef}
             type="button"
             onClick={onClose}
-            className="text-gray-500 transition-colors hover:text-gray-700"
+            className="text-gray-200 transition-colors hover:text-gray-100"
             aria-label="Fechar modal de historico de imports"
           >
             X

--- a/apps/web/src/components/TrendChart.tsx
+++ b/apps/web/src/components/TrendChart.tsx
@@ -121,7 +121,7 @@ const TrendChart = ({ data, onMonthClick, selectedMonth }: TrendChartProps) => {
       <h3 className="mb-3 text-sm font-semibold text-gray-100">
         Evolucao (ultimos 6 meses)
         {onMonthClick && (
-          <span className="ml-2 text-xs font-normal text-gray-300">
+          <span className="ml-2 text-xs font-normal text-gray-200">
             — clique em um mes para navegar
           </span>
         )}

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -1652,7 +1652,7 @@ const App = ({
                           <button
                             type="button"
                             aria-label={`Remover filtro: ${chip.removeLabel}`}
-                            className="inline-flex h-5 w-5 items-center justify-center rounded-full text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-brand-1 focus:ring-offset-1"
+                            className="inline-flex h-5 w-5 items-center justify-center rounded-full text-gray-200 transition-colors hover:bg-gray-400 hover:text-gray-100 focus:outline-none focus:ring-2 focus:ring-brand-1 focus:ring-offset-1"
                             onClick={() => handleRemoveAppliedChip(chip.id)}
                           >
                             <svg

--- a/apps/web/src/pages/CategoriesSettings.tsx
+++ b/apps/web/src/pages/CategoriesSettings.tsx
@@ -305,7 +305,7 @@ const CategoriesSettings = ({
                   >
                     <div className="min-w-0">
                       <p className="break-words text-sm font-semibold text-gray-900">{category.name}</p>
-                      <p className="text-xs text-gray-500">
+                      <p className="text-xs text-gray-200">
                         {isDeleted ? "Removida" : "Ativa"}
                       </p>
                     </div>


### PR DESCRIPTION
## Summary

- TrendChart.tsx: hint text 	ext-gray-300 (#ADB5BD, 2.05:1) → 	ext-gray-200 (#495057, 8.2:1)
- App.tsx: chip remove-button base color 	ext-gray-500 (#F1F3F5, ~1.05:1) → 	ext-gray-200; hover pair adjusted to gray-400/gray-100
- ImportCsvModal.jsx: close button 	ext-gray-500 → 	ext-gray-200; hover gray-100
- ImportHistoryModal.jsx: close button 	ext-gray-500 → 	ext-gray-200; hover gray-100
- CategoriesSettings.tsx: status label 	ext-gray-500 → 	ext-gray-200

All five changes are color-only — no layout, spacing, or structure touched.

## Test plan

- [x] 
pm -w apps/web run lint — 0 warnings/errors
- [x] 
pm -w apps/web test -- --run — 112/112 pass
- [ ] Visual smoke: verify hint text, chip ✕, modal close buttons and category status label are legible on white backgrounds
