### PR TITLE
feat(web): add dark mode infrastructure (PR-N6)

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -13,6 +13,15 @@
       content="financas, controle financeiro, dinheiro, economia"
     />
     <title>Control Finance</title>
+    <script>
+      (function () {
+        var stored = localStorage.getItem('cf-theme');
+        var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (stored === 'dark' || (!stored && prefersDark)) {
+          document.documentElement.classList.add('dark');
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/src/context/ThemeProvider.tsx
+++ b/apps/web/src/context/ThemeProvider.tsx
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useState } from "react";
+import type { ReactNode } from "react";
+import { ThemeContext } from "./theme-context";
+import type { Theme } from "./theme-context";
+
+const STORAGE_KEY = "cf-theme";
+
+const getInitialTheme = (): Theme => {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === "dark" || stored === "light") return stored;
+    if (typeof window !== "undefined" && window.matchMedia) {
+      return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    }
+  } catch {
+    // localStorage ou matchMedia indisponivel (ex: testes)
+  }
+  return "light";
+};
+
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+export const ThemeProvider = ({ children }: ThemeProviderProps) => {
+  const [theme, setTheme] = useState<Theme>(getInitialTheme);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === "dark") {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+    try {
+      localStorage.setItem(STORAGE_KEY, theme);
+    } catch {
+      // ignore
+    }
+  }, [theme]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((prev) => (prev === "dark" ? "light" : "dark"));
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};

--- a/apps/web/src/context/theme-context.ts
+++ b/apps/web/src/context/theme-context.ts
@@ -1,0 +1,10 @@
+import { createContext } from "react";
+
+export type Theme = "light" | "dark";
+
+export interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+export const ThemeContext = createContext<ThemeContextValue | null>(null);

--- a/apps/web/src/hooks/useTheme.ts
+++ b/apps/web/src/hooks/useTheme.ts
@@ -1,0 +1,10 @@
+import { useContext } from "react";
+import { ThemeContext } from "../context/theme-context";
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme deve ser usado dentro de ThemeProvider.");
+  }
+  return context;
+};

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import AppRoutes from "./AppRoutes";
 import { AuthProvider } from "./context/AuthContext";
+import { ThemeProvider } from "./context/ThemeProvider";
 import "./index.css";
 
 const rootElement = document.getElementById("root");
@@ -14,9 +15,11 @@ if (!rootElement) {
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <BrowserRouter>
-      <AuthProvider>
-        <AppRoutes />
-      </AuthProvider>
+      <ThemeProvider>
+        <AuthProvider>
+          <AppRoutes />
+        </AuthProvider>
+      </ThemeProvider>
     </BrowserRouter>
   </React.StrictMode>,
 );

--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -6,6 +6,10 @@ import { CATEGORY_ENTRY, CATEGORY_EXIT } from "../components/DatabaseUtils";
 import { transactionsService } from "../services/transactions.service";
 import { analyticsService } from "../services/analytics.service";
 
+vi.mock("../hooks/useTheme", () => ({
+  useTheme: () => ({ theme: "light", toggleTheme: vi.fn() }),
+}));
+
 vi.mock("../components/TransactionChart", () => ({
   default: () => <div data-testid="transaction-chart" />,
 }));

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -38,6 +38,7 @@ import {
   normalizeSortOption,
   isSelectedPeriod,
 } from "../features/filters/useFilters";
+import { useTheme } from "../hooks/useTheme";
 
 const TransactionChart = lazy(() => import("../components/TransactionChart"));
 const TrendChart = lazy(() => import("../components/TrendChart"));
@@ -514,6 +515,8 @@ const App = ({
   }, []);
 
   const onPaginationReset = useCallback(() => setCurrentOffset(DEFAULT_OFFSET), []);
+
+  const { theme, toggleTheme } = useTheme();
 
   const {
     selectedCategory,
@@ -1466,8 +1469,8 @@ const App = ({
   );
 
   return (
-    <div className="App min-h-screen bg-white pb-10">
-      <header className="w-full bg-gray-500 py-3 shadow-md sm:py-4">
+    <div className="App min-h-screen bg-white pb-10 dark:bg-gray-900">
+      <header className="w-full bg-gray-500 py-3 shadow-md sm:py-4 dark:bg-gray-800">
         <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 sm:px-6 lg:flex-row lg:items-center lg:justify-between">
           <h1 className="text-4xl font-semibold">
             <span className="text-brand-1">Control</span>
@@ -1531,6 +1534,14 @@ const App = ({
                         Categorias
                       </button>
                     ) : null}
+                    <button
+                      type="button"
+                      role="menuitem"
+                      onClick={toggleTheme}
+                      className="rounded px-2 py-2 text-left text-xs font-semibold text-gray-900 hover:bg-gray-100"
+                    >
+                      {theme === "dark" ? "☀ Claro" : "☾ Escuro"}
+                    </button>
                     {onLogout ? (
                       <>
                         <div className="my-1 h-px bg-gray-200" role="separator" />
@@ -1549,6 +1560,14 @@ const App = ({
               </div>
             ) : (
               <div className="flex min-w-0 items-center gap-1 rounded border border-gray-300 bg-white/70 p-1 sm:gap-2">
+                <button
+                  type="button"
+                  onClick={toggleTheme}
+                  aria-label={theme === "dark" ? "Mudar para tema claro" : "Mudar para tema escuro"}
+                  className="whitespace-nowrap rounded border border-gray-300 bg-white px-2.5 py-1.5 text-xs font-semibold text-gray-100 hover:bg-gray-400"
+                >
+                  {theme === "dark" ? "☀ Claro" : "☾ Escuro"}
+                </button>
                 {onLogout ? (
                   <button
                     onClick={onLogout}

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: ["./index.html",
   "./src/**/*.{js,jsx,ts,tsx}",],
   theme: {


### PR DESCRIPTION
﻿## Summary

- `ThemeContext` + `ThemeProvider` seguindo o mesmo padrão do `AuthContext`
- `useTheme` hook com error guard
- `darkMode: 'class'` no `tailwind.config.js`
- Script anti-FOUC inline no `index.html` (aplica `dark` no `<html>` antes do React montar — sem flash branco)
- `ThemeProvider` envolve o app em `main.tsx`
- Toggle "☾ Escuro" / "☀ Claro" no header — desktop (barra de ações) + mobile (menu "Acoes")
- Smoke visual: `dark:bg-gray-900` no root, `dark:bg-gray-800` no header
- `useTheme` mockado em `App.test.jsx` (visual-only, não requer ThemeProvider nos testes)

## Test plan

- [x] `npm -w apps/web run lint` — 0 warnings
- [x] `npm -w apps/web test -- --run` — 112/112 pass
- [ ] Smoke: clicar toggle → header escurece, fundo escurece, `<html class="dark">` no DevTools
- [ ] Recarregar em dark mode → sem flash branco
- [ ] Aba anônima → respeita `prefers-color-scheme` do sistema
