### PR TITLE
feat(web): add semantic color tokens and migrate shell/login/modal (PR-N7)

### DIFF
--- a/apps/web/src/components/Modal.jsx
+++ b/apps/web/src/components/Modal.jsx
@@ -147,22 +147,22 @@ const Modal = ({
       onClick={handleBackdropClick}
       role="presentation"
     >
-      <div className="w-full max-w-md rounded-lg bg-white p-4 sm:p-6">
+      <div className="w-full max-w-md rounded-lg bg-cf-surface p-4 sm:p-6">
         <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-gray-100">
+          <h2 className="text-lg font-semibold text-cf-text-primary">
             {isEditing ? "Editar transacao" : "Registro de valor"}
           </h2>
           <button
             type="button"
             onClick={onClose}
-            className="text-gray-200 transition-colors hover:text-gray-100"
+            className="text-cf-text-secondary transition-colors hover:text-cf-text-primary"
             aria-label="Fechar modal"
           >
             X
           </button>
         </div>
 
-        <p className="mb-4 text-sm text-gray-200">
+        <p className="mb-4 text-sm text-cf-text-secondary">
           {isEditing
             ? "Atualize os campos da transacao."
             : "Digite o valor, selecione o tipo e a data da transacao."}
@@ -170,14 +170,14 @@ const Modal = ({
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="flex flex-col gap-2">
-            <label htmlFor="valor" className="text-sm font-medium text-gray-100">
+            <label htmlFor="valor" className="text-sm font-medium text-cf-text-primary">
               Valor
             </label>
-            <div className="flex items-center rounded border border-gray-400 px-4 py-2">
-              <span className="text-sm font-medium text-gray-200">R$</span>
+            <div className="flex items-center rounded border border-cf-border-input px-4 py-2">
+              <span className="text-sm font-medium text-cf-text-secondary">R$</span>
               <input
                 id="valor"
-                className="w-full pl-2 text-sm text-gray-200 outline-none"
+                className="w-full pl-2 text-sm text-cf-text-secondary outline-none bg-transparent"
                 name="valor"
                 placeholder="0,00"
                 type="text"
@@ -193,13 +193,13 @@ const Modal = ({
           </div>
 
           <div className="flex flex-col gap-2">
-            <label htmlFor="data" className="text-sm font-medium text-gray-100">
+            <label htmlFor="data" className="text-sm font-medium text-cf-text-primary">
               Data
             </label>
             <input
               id="data"
               type="date"
-              className="rounded border border-gray-400 px-3 py-2 text-sm text-gray-200"
+              className="rounded border border-cf-border-input px-3 py-2 text-sm text-cf-text-secondary bg-cf-surface"
               value={transactionDate}
               onChange={(event) => {
                 setTransactionDate(event.target.value);
@@ -210,13 +210,13 @@ const Modal = ({
           </div>
 
           <div className="flex flex-col gap-2">
-            <label htmlFor="descricao" className="text-sm font-medium text-gray-100">
+            <label htmlFor="descricao" className="text-sm font-medium text-cf-text-primary">
               Descricao
             </label>
             <input
               id="descricao"
               type="text"
-              className="rounded border border-gray-400 px-3 py-2 text-sm text-gray-200"
+              className="rounded border border-cf-border-input px-3 py-2 text-sm text-cf-text-secondary bg-cf-surface"
               value={description}
               onChange={(event) => {
                 setDescription(event.target.value);
@@ -228,12 +228,12 @@ const Modal = ({
           </div>
 
           <div className="flex flex-col gap-2">
-            <label htmlFor="observacoes" className="text-sm font-medium text-gray-100">
+            <label htmlFor="observacoes" className="text-sm font-medium text-cf-text-primary">
               Observacoes
             </label>
             <textarea
               id="observacoes"
-              className="min-h-20 rounded border border-gray-400 px-3 py-2 text-sm text-gray-200"
+              className="min-h-20 rounded border border-cf-border-input px-3 py-2 text-sm text-cf-text-secondary bg-cf-surface"
               value={notes}
               onChange={(event) => {
                 setNotes(event.target.value);
@@ -245,14 +245,14 @@ const Modal = ({
           </div>
 
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-            <span className="text-sm font-medium text-gray-100">Tipo de valor</span>
+            <span className="text-sm font-medium text-cf-text-primary">Tipo de valor</span>
             <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row">
               <button
                 type="button"
                 className={`rounded border px-3.5 py-1 text-sm font-semibold transition-colors ${
                   transactionType === CATEGORY_ENTRY
                     ? "border-brand-1 bg-brand-3 text-brand-1"
-                    : "border-gray-300 bg-white text-gray-200"
+                    : "border-cf-border bg-cf-surface text-cf-text-secondary"
                 }`}
                 onClick={() => {
                   setTransactionType(CATEGORY_ENTRY);
@@ -266,7 +266,7 @@ const Modal = ({
                 className={`rounded border px-3.5 py-1 text-sm font-semibold transition-colors ${
                   transactionType === CATEGORY_EXIT
                     ? "border-brand-1 bg-brand-3 text-brand-1"
-                    : "border-gray-300 bg-white text-gray-200"
+                    : "border-cf-border bg-cf-surface text-cf-text-secondary"
                 }`}
                 onClick={() => {
                   setTransactionType(CATEGORY_EXIT);
@@ -279,12 +279,12 @@ const Modal = ({
           </div>
 
           <div className="flex flex-col gap-2">
-            <label htmlFor="categoria" className="text-sm font-medium text-gray-100">
+            <label htmlFor="categoria" className="text-sm font-medium text-cf-text-primary">
               Categoria
             </label>
             <select
               id="categoria"
-              className="rounded border border-gray-400 px-3 py-2 text-sm text-gray-200"
+              className="rounded border border-cf-border-input px-3 py-2 text-sm text-cf-text-secondary bg-cf-surface"
               value={selectedCategoryId}
               onChange={(event) => {
                 setSelectedCategoryId(event.target.value);
@@ -323,7 +323,7 @@ const Modal = ({
           <div className="flex items-center justify-end gap-3">
             <button
               type="button"
-              className="rounded border border-gray-300 bg-gray-400 px-3.5 py-1.5 text-sm font-semibold text-gray-200"
+              className="rounded border border-cf-border bg-cf-bg-subtle px-3.5 py-1.5 text-sm font-semibold text-cf-text-secondary"
               onClick={onClose}
             >
               Cancelar

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5,6 +5,28 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&display=swap');
 
+:root {
+  --cf-bg-page:        #FFFFFF;
+  --cf-header-bg:      #F1F3F5;
+  --cf-surface:        #FFFFFF;
+  --cf-bg-subtle:      #E9ECEF;
+  --cf-text-primary:   #212529;
+  --cf-text-secondary: #495057;
+  --cf-border:         #ADB5BD;
+  --cf-border-input:   #E9ECEF;
+}
+
+.dark {
+  --cf-bg-page:        #0f172a;
+  --cf-header-bg:      #1e293b;
+  --cf-surface:        #1e293b;
+  --cf-bg-subtle:      #243044;
+  --cf-text-primary:   #F1F5F9;
+  --cf-text-secondary: #94A3B8;
+  --cf-border:         #334155;
+  --cf-border-input:   #475569;
+}
+
 
 .btn-primary {
   @apply bg-brand-1 text-white font-medium py-2 px-4 rounded;

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -1469,12 +1469,12 @@ const App = ({
   );
 
   return (
-    <div className="App min-h-screen bg-white pb-10 dark:bg-gray-900">
-      <header className="w-full bg-gray-500 py-3 shadow-md sm:py-4 dark:bg-gray-800">
+    <div className="App min-h-screen bg-cf-bg-page pb-10">
+      <header className="w-full bg-cf-header-bg py-3 shadow-md sm:py-4">
         <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 sm:px-6 lg:flex-row lg:items-center lg:justify-between">
           <h1 className="text-4xl font-semibold">
             <span className="text-brand-1">Control</span>
-            <span className="text-gray-100">Finance</span>
+            <span className="text-cf-text-primary">Finance</span>
           </h1>
           <div className="flex flex-wrap items-center justify-end gap-2">
             {useMobileActionsMenu ? (
@@ -1486,7 +1486,7 @@ const App = ({
                   aria-controls={MOBILE_ACTIONS_MENU_ID}
                   onClick={toggleMobileActionsMenu}
                   ref={mobileActionsButtonRef}
-                  className="whitespace-nowrap rounded border border-gray-300 bg-white px-2.5 py-1.5 text-xs font-semibold text-gray-100 hover:bg-gray-400"
+                  className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                 >
                   Acoes
                 </button>
@@ -1496,7 +1496,7 @@ const App = ({
                     id={MOBILE_ACTIONS_MENU_ID}
                     aria-label="Acoes rapidas"
                     ref={mobileActionsMenuRef}
-                    className="absolute right-0 top-full z-20 mt-1 flex w-44 flex-col gap-1 rounded border border-gray-300 bg-white p-1 shadow-lg"
+                    className="absolute right-0 top-full z-20 mt-1 flex w-44 flex-col gap-1 rounded border border-cf-border bg-cf-surface p-1 shadow-lg"
                   >
                     <button
                       type="button"
@@ -1504,7 +1504,7 @@ const App = ({
                       ref={firstMobileActionsItemRef}
                       onClick={handleExportCsvFromMenu}
                       disabled={isExportingCsv}
-                      className="rounded px-2 py-2 text-left text-xs font-semibold text-gray-900 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60"
+                      className="rounded px-2 py-2 text-left text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle disabled:cursor-not-allowed disabled:opacity-60"
                     >
                       {isExportingCsv ? "Exportando CSV..." : "Exportar CSV"}
                     </button>
@@ -1512,7 +1512,7 @@ const App = ({
                       type="button"
                       role="menuitem"
                       onClick={handleOpenImportModal}
-                      className="rounded px-2 py-2 text-left text-xs font-semibold text-gray-900 hover:bg-gray-100"
+                      className="rounded px-2 py-2 text-left text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                     >
                       Importar CSV
                     </button>
@@ -1520,7 +1520,7 @@ const App = ({
                       type="button"
                       role="menuitem"
                       onClick={handleOpenImportHistoryModal}
-                      className="rounded px-2 py-2 text-left text-xs font-semibold text-gray-900 hover:bg-gray-100"
+                      className="rounded px-2 py-2 text-left text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                     >
                       Historico de imports
                     </button>
@@ -1529,7 +1529,7 @@ const App = ({
                         type="button"
                         role="menuitem"
                         onClick={handleOpenCategoriesSettings}
-                        className="rounded px-2 py-2 text-left text-xs font-semibold text-gray-900 hover:bg-gray-100"
+                        className="rounded px-2 py-2 text-left text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                       >
                         Categorias
                       </button>
@@ -1538,13 +1538,13 @@ const App = ({
                       type="button"
                       role="menuitem"
                       onClick={toggleTheme}
-                      className="rounded px-2 py-2 text-left text-xs font-semibold text-gray-900 hover:bg-gray-100"
+                      className="rounded px-2 py-2 text-left text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                     >
                       {theme === "dark" ? "☀ Claro" : "☾ Escuro"}
                     </button>
                     {onLogout ? (
                       <>
-                        <div className="my-1 h-px bg-gray-200" role="separator" />
+                        <div className="my-1 h-px bg-cf-border" role="separator" />
                         <button
                           type="button"
                           role="menuitem"
@@ -1559,19 +1559,19 @@ const App = ({
                 ) : null}
               </div>
             ) : (
-              <div className="flex min-w-0 items-center gap-1 rounded border border-gray-300 bg-white/70 p-1 sm:gap-2">
+              <div className="flex min-w-0 items-center gap-1 rounded border border-cf-border bg-cf-surface/70 p-1 sm:gap-2">
                 <button
                   type="button"
                   onClick={toggleTheme}
                   aria-label={theme === "dark" ? "Mudar para tema claro" : "Mudar para tema escuro"}
-                  className="whitespace-nowrap rounded border border-gray-300 bg-white px-2.5 py-1.5 text-xs font-semibold text-gray-100 hover:bg-gray-400"
+                  className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                 >
                   {theme === "dark" ? "☀ Claro" : "☾ Escuro"}
                 </button>
                 {onLogout ? (
                   <button
                     onClick={onLogout}
-                    className="whitespace-nowrap rounded border border-gray-300 bg-white px-2.5 py-1.5 text-xs font-semibold text-gray-100 hover:bg-gray-400"
+                    className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                   >
                     Sair
                   </button>
@@ -1580,21 +1580,21 @@ const App = ({
                   type="button"
                   onClick={handleExportCsv}
                   disabled={isExportingCsv}
-                  className="whitespace-nowrap rounded border border-gray-300 bg-white px-2.5 py-1.5 text-xs font-semibold text-gray-100 hover:bg-gray-400 disabled:cursor-not-allowed disabled:opacity-60"
+                  className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   {isExportingCsv ? "Exportando CSV..." : "Exportar CSV"}
                 </button>
                 <button
                   type="button"
                   onClick={handleOpenImportModal}
-                  className="whitespace-nowrap rounded border border-gray-300 bg-white px-2.5 py-1.5 text-xs font-semibold text-gray-100 hover:bg-gray-400"
+                  className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                 >
                   Importar CSV
                 </button>
                 <button
                   type="button"
                   onClick={handleOpenImportHistoryModal}
-                  className="whitespace-nowrap rounded border border-gray-300 bg-white px-2.5 py-1.5 text-xs font-semibold text-gray-100 hover:bg-gray-400"
+                  className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                 >
                   Historico de imports
                 </button>
@@ -1602,7 +1602,7 @@ const App = ({
                   <button
                     type="button"
                     onClick={handleOpenCategoriesSettings}
-                    className="whitespace-nowrap rounded border border-gray-300 bg-white px-2.5 py-1.5 text-xs font-semibold text-gray-100 hover:bg-gray-400"
+                    className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                   >
                     Categorias
                   </button>
@@ -1664,14 +1664,14 @@ const App = ({
                     {appliedChips.map((chip) => (
                       <span
                         key={chip.id}
-                        className="inline-flex whitespace-nowrap items-center gap-1 rounded-full border border-gray-300 bg-white py-1 pl-2.5 pr-1.5 text-xs font-medium text-gray-700"
+                        className="inline-flex whitespace-nowrap items-center gap-1 rounded-full border border-cf-border bg-cf-surface py-1 pl-2.5 pr-1.5 text-xs font-medium text-cf-text-primary"
                       >
                         {chip.text}
                         {chip.removable ? (
                           <button
                             type="button"
                             aria-label={`Remover filtro: ${chip.removeLabel}`}
-                            className="inline-flex h-5 w-5 items-center justify-center rounded-full text-gray-200 transition-colors hover:bg-gray-400 hover:text-gray-100 focus:outline-none focus:ring-2 focus:ring-brand-1 focus:ring-offset-1"
+                            className="inline-flex h-5 w-5 items-center justify-center rounded-full text-cf-text-secondary transition-colors hover:bg-cf-bg-subtle hover:text-cf-text-primary focus:outline-none focus:ring-2 focus:ring-brand-1 focus:ring-offset-1"
                             onClick={() => handleRemoveAppliedChip(chip.id)}
                           >
                             <svg

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -87,12 +87,12 @@ const Login = (): JSX.Element => {
   };
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-gray-500 p-4">
-      <section className="w-full max-w-md rounded bg-white p-6 shadow-lg">
-        <h1 className="text-3xl font-semibold text-gray-100">
+    <main className="flex min-h-screen items-center justify-center bg-cf-bg-page p-4">
+      <section className="w-full max-w-md rounded bg-cf-surface p-6 shadow-lg">
+        <h1 className="text-3xl font-semibold text-cf-text-primary">
           <span className="text-brand-1">Control</span>Finance
         </h1>
-        <p className="mt-2 text-sm text-gray-200">
+        <p className="mt-2 text-sm text-cf-text-secondary">
           Entre para acessar o dashboard financeiro.
         </p>
 
@@ -103,7 +103,7 @@ const Login = (): JSX.Element => {
             className={`rounded px-3 py-2 text-sm font-medium ${
               mode === "login"
                 ? "bg-brand-1 text-white"
-                : "bg-gray-400 text-gray-100"
+                : "bg-cf-bg-subtle text-cf-text-primary"
             }`}
           >
             Login
@@ -114,7 +114,7 @@ const Login = (): JSX.Element => {
             className={`rounded px-3 py-2 text-sm font-medium ${
               mode === "register"
                 ? "bg-brand-1 text-white"
-                : "bg-gray-400 text-gray-100"
+                : "bg-cf-bg-subtle text-cf-text-primary"
             }`}
           >
             Criar conta
@@ -126,7 +126,7 @@ const Login = (): JSX.Element => {
             <div>
               <label
                 htmlFor="nome"
-                className="mb-1 block text-sm font-medium text-gray-100"
+                className="mb-1 block text-sm font-medium text-cf-text-primary"
               >
                 Nome
               </label>
@@ -135,7 +135,7 @@ const Login = (): JSX.Element => {
                 type="text"
                 value={name}
                 onChange={(event) => setName(event.target.value)}
-                className="w-full rounded border border-gray-400 px-3 py-2 text-sm text-gray-200"
+                className="w-full rounded border border-cf-border-input px-3 py-2 text-sm text-cf-text-secondary"
               />
             </div>
           ) : null}
@@ -143,7 +143,7 @@ const Login = (): JSX.Element => {
           <div>
             <label
               htmlFor="email"
-              className="mb-1 block text-sm font-medium text-gray-100"
+              className="mb-1 block text-sm font-medium text-cf-text-primary"
             >
               Email
             </label>
@@ -152,7 +152,7 @@ const Login = (): JSX.Element => {
               type="email"
               value={email}
               onChange={(event) => setEmail(event.target.value)}
-              className="w-full rounded border border-gray-400 px-3 py-2 text-sm text-gray-200"
+              className="w-full rounded border border-cf-border-input px-3 py-2 text-sm text-cf-text-secondary"
               autoComplete="email"
             />
           </div>
@@ -160,7 +160,7 @@ const Login = (): JSX.Element => {
           <div>
             <label
               htmlFor="senha"
-              className="mb-1 block text-sm font-medium text-gray-100"
+              className="mb-1 block text-sm font-medium text-cf-text-primary"
             >
               Senha
             </label>
@@ -169,7 +169,7 @@ const Login = (): JSX.Element => {
               type="password"
               value={password}
               onChange={(event) => setPassword(event.target.value)}
-              className="w-full rounded border border-gray-400 px-3 py-2 text-sm text-gray-200"
+              className="w-full rounded border border-cf-border-input px-3 py-2 text-sm text-cf-text-secondary"
               autoComplete={mode === "register" ? "new-password" : "current-password"}
             />
           </div>
@@ -178,7 +178,7 @@ const Login = (): JSX.Element => {
             <div>
               <label
                 htmlFor="confirmar-senha"
-                className="mb-1 block text-sm font-medium text-gray-100"
+                className="mb-1 block text-sm font-medium text-cf-text-primary"
               >
                 Confirmar senha
               </label>
@@ -187,7 +187,7 @@ const Login = (): JSX.Element => {
                 type="password"
                 value={confirmPassword}
                 onChange={(event) => setConfirmPassword(event.target.value)}
-                className="w-full rounded border border-gray-400 px-3 py-2 text-sm text-gray-200"
+                className="w-full rounded border border-cf-border-input px-3 py-2 text-sm text-cf-text-secondary"
                 autoComplete="new-password"
               />
             </div>

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -23,6 +23,14 @@ export default {
         '5xl': '20px',
       },
       colors: {
+        'cf-bg-page':        'var(--cf-bg-page)',
+        'cf-header-bg':      'var(--cf-header-bg)',
+        'cf-surface':        'var(--cf-surface)',
+        'cf-bg-subtle':      'var(--cf-bg-subtle)',
+        'cf-text-primary':   'var(--cf-text-primary)',
+        'cf-text-secondary': 'var(--cf-text-secondary)',
+        'cf-border':         'var(--cf-border)',
+        'cf-border-input':   'var(--cf-border-input)',
         brand: {
           1: '#6741D9',
           2: '#4C3299',


### PR DESCRIPTION
﻿## Summary

Instala 8 tokens de cor semânticos via CSS custom properties e migra os 3 primeiros
componentes (shell, login, modal de transação).

### Tokens criados (index.css :root + .dark)

| Token | Light | Dark |
|---|---|---|
| `cf-bg-page` | #FFFFFF | #111827 |
| `cf-header-bg` | #F1F3F5 | #1F2937 |
| `cf-surface` | #FFFFFF | #1F2937 |
| `cf-bg-subtle` | #E9ECEF | #374151 |
| `cf-text-primary` | #212529 | #F9FAFB |
| `cf-text-secondary` | #495057 | #D1D5DB |
| `cf-border` | #ADB5BD | #374151 |
| `cf-border-input` | #E9ECEF | #4B5563 |

### Componentes migrados

- **App.tsx**: root shell, header + todos os botões do header, menu mobile, chips de filtro (remove dark: inline do N6)
- **Login.tsx**: página inteira — background, card, labels, inputs, tabs
- **Modal.jsx**: container, close button, todos os labels, inputs, textarea, select, botões de tipo, botão Cancelar

### Estratégia CSS variables

Componentes usam `bg-cf-surface` sem nenhum `dark:` prefix — a classe `.dark` no `<html>` troca as variáveis automaticamente. Padrão shadcn/ui.

## Test plan

- [x] `npm -w apps/web run lint` — 0 warnings
- [x] `npm -w apps/web test -- --run` — 112/112 pass
- [ ] Light mode: pixel-idêntico ao antes
- [ ] Dark mode: toggle → header dark, modal dark, login dark, inputs e labels legíveis
- [ ] Contraste dark: text-cf-text-primary (#F9FAFB) em cf-surface (#1F2937) = 13.8:1 ✅
