### PR TITLE
feat(web): apply semantic color tokens to inner content (PR-N8)

### DIFF
--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -134,13 +134,13 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
       role="presentation"
     >
       <div
-        className="w-full max-w-4xl rounded-lg bg-white p-4 sm:p-6"
+        className="w-full max-w-4xl rounded-lg bg-cf-surface p-4 sm:p-6"
         role="dialog"
         aria-modal="true"
         aria-labelledby="import-csv-modal-title"
       >
         <div className="mb-4 flex items-center justify-between">
-          <h2 id="import-csv-modal-title" className="text-lg font-semibold text-gray-800">
+          <h2 id="import-csv-modal-title" className="text-lg font-semibold text-cf-text-primary">
             Importar CSV
           </h2>
           <button
@@ -153,12 +153,12 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
           </button>
         </div>
 
-        <p className="mb-4 text-sm text-gray-600">
+        <p className="mb-4 text-sm text-cf-text-secondary">
           Envie um CSV para pre-visualizar as linhas validas e confirmar a importacao.
         </p>
 
-        <div className="rounded border border-gray-300 bg-white p-3">
-          <label htmlFor="csv-file-input" className="mb-1 block text-sm font-medium text-gray-700">
+        <div className="rounded border border-cf-border bg-cf-surface p-3">
+          <label htmlFor="csv-file-input" className="mb-1 block text-sm font-medium text-cf-text-primary">
             Arquivo CSV
           </label>
           <input
@@ -173,7 +173,7 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
               setErrorMessage("");
               setSuccessMessage("");
             }}
-            className="block w-full text-sm text-gray-700 file:mr-3 file:rounded file:border file:border-gray-300 file:bg-gray-100 file:px-3 file:py-1 file:text-sm file:font-semibold file:text-gray-700 hover:file:bg-gray-200"
+            className="block w-full text-sm text-cf-text-primary file:mr-3 file:rounded file:border file:border-cf-border file:bg-cf-bg-subtle file:px-3 file:py-1 file:text-sm file:font-semibold file:text-cf-text-primary hover:file:bg-cf-border"
           />
         </div>
 
@@ -190,14 +190,14 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
             type="button"
             onClick={handleCommit}
             disabled={!hasValidRows || isDryRunning || isCommitting}
-            className="rounded border border-gray-300 bg-white px-3 py-1.5 text-sm font-semibold text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60"
+            className="rounded border border-cf-border bg-cf-surface px-3 py-1.5 text-sm font-semibold text-cf-text-primary hover:bg-cf-bg-subtle disabled:cursor-not-allowed disabled:opacity-60"
           >
             {isCommitting ? "Importando..." : "Importar"}
           </button>
           <button
             type="button"
             onClick={onClose}
-            className="rounded border border-gray-300 bg-gray-100 px-3 py-1.5 text-sm font-semibold text-gray-700"
+            className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-1.5 text-sm font-semibold text-cf-text-secondary"
           >
             Fechar
           </button>
@@ -218,59 +218,59 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
         {dryRunResult ? (
           <div className="mt-4 space-y-3">
             <div className="grid gap-2 sm:grid-cols-5">
-              <div className="rounded border border-gray-300 bg-gray-400 px-3 py-2">
-                <p className="text-xs font-medium uppercase text-gray-600">Total</p>
-                <p className="text-sm font-semibold text-gray-800">{dryRunResult.summary.totalRows}</p>
+              <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2">
+                <p className="text-xs font-medium uppercase text-cf-text-secondary">Total</p>
+                <p className="text-sm font-semibold text-cf-text-primary">{dryRunResult.summary.totalRows}</p>
               </div>
-              <div className="rounded border border-gray-300 bg-gray-400 px-3 py-2">
-                <p className="text-xs font-medium uppercase text-gray-600">Validas</p>
-                <p className="text-sm font-semibold text-gray-800">{dryRunResult.summary.validRows}</p>
+              <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2">
+                <p className="text-xs font-medium uppercase text-cf-text-secondary">Validas</p>
+                <p className="text-sm font-semibold text-cf-text-primary">{dryRunResult.summary.validRows}</p>
               </div>
-              <div className="rounded border border-gray-300 bg-gray-400 px-3 py-2">
-                <p className="text-xs font-medium uppercase text-gray-600">Invalidas</p>
-                <p className="text-sm font-semibold text-gray-800">{dryRunResult.summary.invalidRows}</p>
+              <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2">
+                <p className="text-xs font-medium uppercase text-cf-text-secondary">Invalidas</p>
+                <p className="text-sm font-semibold text-cf-text-primary">{dryRunResult.summary.invalidRows}</p>
               </div>
-              <div className="rounded border border-gray-300 bg-gray-400 px-3 py-2">
-                <p className="text-xs font-medium uppercase text-gray-600">Entradas</p>
-                <p className="text-sm font-semibold text-gray-800">
+              <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2">
+                <p className="text-xs font-medium uppercase text-cf-text-secondary">Entradas</p>
+                <p className="text-sm font-semibold text-cf-text-primary">
                   {formatCurrency(dryRunResult.summary.income)}
                 </p>
               </div>
-              <div className="rounded border border-gray-300 bg-gray-400 px-3 py-2">
-                <p className="text-xs font-medium uppercase text-gray-600">Saidas</p>
-                <p className="text-sm font-semibold text-gray-800">
+              <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2">
+                <p className="text-xs font-medium uppercase text-cf-text-secondary">Saidas</p>
+                <p className="text-sm font-semibold text-cf-text-primary">
                   {formatCurrency(dryRunResult.summary.expense)}
                 </p>
               </div>
             </div>
 
-            <p className="text-xs text-gray-600">
+            <p className="text-xs text-cf-text-secondary">
               Sessao expira em: {dryRunResult.expiresAt || "nao informado"}
             </p>
 
             {dryRunResult.rows.length === 0 ? (
-              <div className="rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-600">
+              <div className="rounded border border-cf-border bg-cf-surface px-3 py-2 text-sm text-cf-text-secondary">
                 Sem linhas para pre-visualizar.
               </div>
             ) : (
-              <div className="max-h-80 overflow-auto rounded border border-gray-300">
+              <div className="max-h-80 overflow-auto rounded border border-cf-border">
                 <table className="min-w-full border-collapse text-left text-xs">
-                  <thead className="bg-gray-400">
+                  <thead className="bg-cf-bg-subtle">
                     <tr>
-                      <th className="border-b border-gray-300 px-2 py-2 text-gray-700">Linha</th>
-                      <th className="border-b border-gray-300 px-2 py-2 text-gray-700">Status</th>
-                      <th className="border-b border-gray-300 px-2 py-2 text-gray-700">Descricao</th>
-                      <th className="border-b border-gray-300 px-2 py-2 text-gray-700">Valor</th>
-                      <th className="border-b border-gray-300 px-2 py-2 text-gray-700">Data</th>
-                      <th className="border-b border-gray-300 px-2 py-2 text-gray-700">Categoria</th>
-                      <th className="border-b border-gray-300 px-2 py-2 text-gray-700">Erros</th>
+                      <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Linha</th>
+                      <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Status</th>
+                      <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Descricao</th>
+                      <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Valor</th>
+                      <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Data</th>
+                      <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Categoria</th>
+                      <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Erros</th>
                     </tr>
                   </thead>
                   <tbody>
                     {dryRunResult.rows.map((row) => (
                       <tr key={`import-row-${row.line}`} className="align-top">
-                        <td className="border-b border-gray-300 px-2 py-2 text-gray-700">{row.line}</td>
-                        <td className="border-b border-gray-300 px-2 py-2">
+                        <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">{row.line}</td>
+                        <td className="border-b border-cf-border px-2 py-2">
                           <span
                             className={`rounded px-2 py-0.5 font-semibold ${
                               row.status === "valid"
@@ -281,17 +281,17 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
                             {row.status === "valid" ? "Valida" : "Invalida"}
                           </span>
                         </td>
-                        <td className="border-b border-gray-300 px-2 py-2 text-gray-700">
+                        <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
                           {row.raw.description || "-"}
                         </td>
-                        <td className="border-b border-gray-300 px-2 py-2 text-gray-700">
+                        <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
                           {row.raw.value || "-"}
                         </td>
-                        <td className="border-b border-gray-300 px-2 py-2 text-gray-700">{row.raw.date || "-"}</td>
-                        <td className="border-b border-gray-300 px-2 py-2 text-gray-700">
+                        <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">{row.raw.date || "-"}</td>
+                        <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
                           {row.raw.category || "Sem categoria"}
                         </td>
-                        <td className="border-b border-gray-300 px-2 py-2 text-gray-700">
+                        <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
                           {row.errors.length > 0
                             ? row.errors.map((error) => error.message).join(" | ")
                             : "-"}

--- a/apps/web/src/components/ImportHistoryModal.jsx
+++ b/apps/web/src/components/ImportHistoryModal.jsx
@@ -159,13 +159,13 @@ const ImportHistoryModal = ({ isOpen, onClose }) => {
       role="presentation"
     >
       <div
-        className="w-full max-w-5xl rounded-lg bg-white p-4 sm:p-6"
+        className="w-full max-w-5xl rounded-lg bg-cf-surface p-4 sm:p-6"
         role="dialog"
         aria-modal="true"
         aria-labelledby="import-history-modal-title"
       >
         <div className="mb-4 flex items-center justify-between">
-          <h2 id="import-history-modal-title" className="text-lg font-semibold text-gray-800">
+          <h2 id="import-history-modal-title" className="text-lg font-semibold text-cf-text-primary">
             Historico de imports
           </h2>
           <button
@@ -193,57 +193,57 @@ const ImportHistoryModal = ({ isOpen, onClose }) => {
         ) : null}
 
         {isLoading ? (
-          <div className="rounded border border-gray-300 bg-white px-3 py-3 text-sm text-gray-600">
+          <div className="rounded border border-cf-border bg-cf-surface px-3 py-3 text-sm text-cf-text-secondary">
             Carregando historico...
           </div>
         ) : null}
 
         {!isLoading && !errorMessage && rowsWithStatus.length === 0 ? (
-          <div className="rounded border border-gray-300 bg-white px-3 py-3 text-sm text-gray-600">
+          <div className="rounded border border-cf-border bg-cf-surface px-3 py-3 text-sm text-cf-text-secondary">
             Sem imports para exibir.
           </div>
         ) : null}
 
         {!isLoading && !errorMessage && rowsWithStatus.length > 0 ? (
           <div className="space-y-3">
-            <div className="text-xs text-gray-600">
+            <div className="text-xs text-cf-text-secondary">
               Mostrando {rangeStart}-{rangeEnd}
             </div>
-            <div className="max-h-96 overflow-auto rounded border border-gray-300">
+            <div className="max-h-96 overflow-auto rounded border border-cf-border">
               <table className="min-w-full border-collapse text-left text-xs">
-                <thead className="bg-gray-400">
+                <thead className="bg-cf-bg-subtle">
                   <tr>
-                    <th className="border-b border-gray-300 px-2 py-2 text-gray-700">Data</th>
-                    <th className="border-b border-gray-300 px-2 py-2 text-gray-700">Status</th>
-                    <th className="border-b border-gray-300 px-2 py-2 text-gray-700">
+                    <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Data</th>
+                    <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Status</th>
+                    <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
                       Validas / Invalidas
                     </th>
-                    <th className="border-b border-gray-300 px-2 py-2 text-gray-700">Importadas</th>
-                    <th className="border-b border-gray-300 px-2 py-2 text-gray-700">Entradas</th>
-                    <th className="border-b border-gray-300 px-2 py-2 text-gray-700">Saidas</th>
+                    <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Importadas</th>
+                    <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Entradas</th>
+                    <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Saidas</th>
                   </tr>
                 </thead>
                 <tbody>
                   {rowsWithStatus.map((item) => (
                     <tr key={item.id} className="align-top">
-                      <td className="border-b border-gray-300 px-2 py-2 text-gray-700">
+                      <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
                         {formatDateTime(item.createdAt)}
                       </td>
-                      <td className="border-b border-gray-300 px-2 py-2">
+                      <td className="border-b border-cf-border px-2 py-2">
                         <span className={`rounded px-2 py-0.5 font-semibold ${item.status.className}`}>
                           {item.status.label}
                         </span>
                       </td>
-                      <td className="border-b border-gray-300 px-2 py-2 text-gray-700">
+                      <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
                         {item.summary.validRows} / {item.summary.invalidRows}
                       </td>
-                      <td className="border-b border-gray-300 px-2 py-2 text-gray-700">
+                      <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
                         {item.summary.imported}
                       </td>
-                      <td className="border-b border-gray-300 px-2 py-2 text-gray-700">
+                      <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
                         {formatCurrency(item.summary.income)}
                       </td>
-                      <td className="border-b border-gray-300 px-2 py-2 text-gray-700">
+                      <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
                         {formatCurrency(item.summary.expense)}
                       </td>
                     </tr>
@@ -256,7 +256,7 @@ const ImportHistoryModal = ({ isOpen, onClose }) => {
                 type="button"
                 onClick={handlePreviousPage}
                 disabled={!hasPreviousPage || isLoading}
-                className="rounded border border-gray-300 bg-white px-3 py-1.5 text-sm font-semibold text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60"
+                className="rounded border border-cf-border bg-cf-surface px-3 py-1.5 text-sm font-semibold text-cf-text-primary hover:bg-cf-bg-subtle disabled:cursor-not-allowed disabled:opacity-60"
               >
                 Anterior
               </button>
@@ -264,7 +264,7 @@ const ImportHistoryModal = ({ isOpen, onClose }) => {
                 type="button"
                 onClick={handleNextPage}
                 disabled={!hasNextPage || isLoading}
-                className="rounded border border-gray-300 bg-white px-3 py-1.5 text-sm font-semibold text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60"
+                className="rounded border border-cf-border bg-cf-surface px-3 py-1.5 text-sm font-semibold text-cf-text-primary hover:bg-cf-bg-subtle disabled:cursor-not-allowed disabled:opacity-60"
               >
                 Proxima
               </button>
@@ -276,7 +276,7 @@ const ImportHistoryModal = ({ isOpen, onClose }) => {
           <button
             type="button"
             onClick={onClose}
-            className="rounded border border-gray-300 bg-gray-100 px-3 py-1.5 text-sm font-semibold text-gray-700"
+            className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-1.5 text-sm font-semibold text-cf-text-secondary"
           >
             Fechar
           </button>

--- a/apps/web/src/components/TransactionChart.jsx
+++ b/apps/web/src/components/TransactionChart.jsx
@@ -19,9 +19,9 @@ const CustomTooltip = ({ active, payload, label }) => {
   const value = Number(payload[0].value || 0);
 
   return (
-    <div className="rounded border border-gray-300 bg-white px-3 py-2 text-xs shadow-sm">
-      <p className="font-semibold text-gray-900">{label}</p>
-      <p className="text-gray-700">{formatCurrency(value)}</p>
+    <div className="rounded border border-cf-border bg-cf-surface px-3 py-2 text-xs shadow-sm">
+      <p className="font-semibold text-cf-text-primary">{label}</p>
+      <p className="text-cf-text-secondary">{formatCurrency(value)}</p>
     </div>
   );
 };
@@ -47,15 +47,15 @@ const TransactionChart = ({ data }) => {
 
   if (!hasAnyValue) {
     return (
-      <div className="rounded border border-brand-1 bg-gray-500 p-4 text-center text-sm text-gray-100">
+      <div className="rounded border border-cf-border bg-cf-surface p-4 text-center text-sm text-cf-text-primary">
         Sem dados suficientes para exibir o grafico no periodo selecionado.
       </div>
     );
   }
 
   return (
-    <div className="rounded border border-brand-1 bg-white p-4">
-      <h3 className="mb-3 text-sm font-semibold text-gray-100">
+    <div className="rounded border border-cf-border bg-cf-surface p-4">
+      <h3 className="mb-3 text-sm font-semibold text-cf-text-primary">
         Receita x Despesa no periodo
       </h3>
       <div className="h-64 w-full">

--- a/apps/web/src/components/TransactionList.jsx
+++ b/apps/web/src/components/TransactionList.jsx
@@ -18,21 +18,21 @@ const TransactionList = ({ transactions, onDelete, onEdit }) => {
       {transactions.map((transaction) => (
         <div
           key={transaction.id}
-          className="my-2 flex w-full min-w-0 flex-col items-start gap-2 rounded border border-brand-1 bg-gray-mode p-3.5 sm:flex-row sm:items-center sm:justify-between"
+          className="my-2 flex w-full min-w-0 flex-col items-start gap-2 rounded border border-brand-1 bg-cf-surface p-3.5 sm:flex-row sm:items-center sm:justify-between"
         >
           <div className="flex min-w-0 flex-1 flex-col">
-            <span className="break-words text-sm font-medium text-gray-100">
+            <span className="break-words text-sm font-medium text-cf-text-primary">
               {transaction.description || "Sem descricao"}
             </span>
-            <span className="text-base font-medium text-gray-100">
+            <span className="text-base font-medium text-cf-text-primary">
               {formatValue(transaction.value)}
             </span>
-            <span className="text-xs text-gray-200">{formatDate(transaction.date)}</span>
-            <span className="break-words text-xs text-gray-200">
+            <span className="text-xs text-cf-text-secondary">{formatDate(transaction.date)}</span>
+            <span className="break-words text-xs text-cf-text-secondary">
               Categoria: {transaction.categoryName || "Sem categoria"}
             </span>
             {transaction.notes ? (
-              <span className="break-words text-xs text-gray-200">{transaction.notes}</span>
+              <span className="break-words text-xs text-cf-text-secondary">{transaction.notes}</span>
             ) : null}
           </div>
 
@@ -41,7 +41,7 @@ const TransactionList = ({ transactions, onDelete, onEdit }) => {
               className={`whitespace-nowrap rounded px-3 py-1 text-sm font-medium ${
                 transaction.type === CATEGORY_ENTRY
                   ? "bg-brand-3 text-brand-1"
-                  : "bg-gray-400 text-gray-100"
+                  : "bg-cf-bg-subtle text-cf-text-primary"
               }`}
             >
               {transaction.type}
@@ -49,7 +49,7 @@ const TransactionList = ({ transactions, onDelete, onEdit }) => {
             <button
               type="button"
               onClick={() => onEdit(transaction)}
-              className="whitespace-nowrap rounded border border-gray-300 px-2 py-1 text-xs font-semibold text-gray-200 transition-colors hover:border-gray-200 hover:text-gray-100"
+              className="whitespace-nowrap rounded border border-cf-border px-2 py-1 text-xs font-semibold text-cf-text-secondary transition-colors hover:border-cf-border-input hover:text-cf-text-primary"
               aria-label={`Editar transacao ${transaction.id}`}
             >
               Editar
@@ -57,7 +57,7 @@ const TransactionList = ({ transactions, onDelete, onEdit }) => {
             <button
               type="button"
               onClick={() => onDelete(transaction.id)}
-              className="whitespace-nowrap rounded border border-gray-300 px-2 py-1 text-xs font-semibold text-gray-200 transition-colors hover:border-gray-200 hover:text-gray-100"
+              className="whitespace-nowrap rounded border border-cf-border px-2 py-1 text-xs font-semibold text-cf-text-secondary transition-colors hover:border-cf-border-input hover:text-cf-text-primary"
               aria-label={`Excluir transacao ${transaction.id}`}
             >
               Excluir

--- a/apps/web/src/components/TrendChart.tsx
+++ b/apps/web/src/components/TrendChart.tsx
@@ -68,8 +68,8 @@ const CustomTooltip = ({ active, payload, label, deltaMap }: CustomTooltipProps)
   const deltas = label && deltaMap ? deltaMap.get(label) : undefined;
 
   return (
-    <div className="rounded border border-gray-300 bg-white px-3 py-2 text-xs shadow-sm">
-      <p className="mb-1 font-semibold text-gray-900">{formatMonthLabel(String(label || ""))}</p>
+    <div className="rounded border border-cf-border bg-cf-surface px-3 py-2 text-xs shadow-sm">
+      <p className="mb-1 font-semibold text-cf-text-primary">{formatMonthLabel(String(label || ""))}</p>
       {payload.map((entry) => {
         const delta =
           deltas && entry.dataKey && entry.dataKey in deltas
@@ -105,7 +105,7 @@ const TrendChart = ({ data, onMonthClick, selectedMonth }: TrendChartProps) => {
 
   if (!hasAnyValue) {
     return (
-      <div className="rounded border border-brand-1 bg-gray-500 p-4 text-center text-sm text-gray-100">
+      <div className="rounded border border-cf-border bg-cf-surface p-4 text-center text-sm text-cf-text-primary">
         Sem dados suficientes para exibir a evolucao historica.
       </div>
     );
@@ -117,11 +117,11 @@ const TrendChart = ({ data, onMonthClick, selectedMonth }: TrendChartProps) => {
     : false;
 
   return (
-    <div className="rounded border border-brand-1 bg-white p-4">
-      <h3 className="mb-3 text-sm font-semibold text-gray-100">
+    <div className="rounded border border-cf-border bg-cf-surface p-4">
+      <h3 className="mb-3 text-sm font-semibold text-cf-text-primary">
         Evolucao (ultimos 6 meses)
         {onMonthClick && (
-          <span className="ml-2 text-xs font-normal text-gray-200">
+          <span className="ml-2 text-xs font-normal text-cf-text-secondary">
             — clique em um mes para navegar
           </span>
         )}

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -1621,15 +1621,15 @@ const App = ({
 
       <main className="mx-auto mt-8 w-full max-w-6xl space-y-6 px-4 sm:mt-10 sm:px-6">
         <section ref={filtersPanelRef}>
-          <div className="space-y-4 rounded border border-gray-300 bg-white p-4">
-            <div className="flex items-start justify-between gap-3 rounded border border-gray-200 bg-gray-50 px-3 py-2">
-              <h2 className="text-base font-semibold text-gray-100">Resumo financeiro</h2>
+          <div className="space-y-4 rounded border border-cf-border bg-cf-surface p-4">
+            <div className="flex items-start justify-between gap-3 rounded border border-cf-border bg-cf-bg-subtle px-3 py-2">
+              <h2 className="text-base font-semibold text-cf-text-primary">Resumo financeiro</h2>
               <div className="flex items-center gap-2">
                 <button
                   type="button"
                   onClick={() => setIsFiltersPanelOpen(!isFiltersPanelOpen)}
                   aria-expanded={isFiltersPanelOpen}
-                  className="whitespace-nowrap rounded border border-gray-300 bg-white px-2.5 py-1 text-xs font-semibold text-gray-700 hover:bg-gray-100"
+                  className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                 >
                   {isFiltersPanelOpen ? "Ocultar" : "Filtros"}
                 </button>
@@ -1637,22 +1637,22 @@ const App = ({
             </div>
 
             {hasActiveFilters && appliedChips.length > 0 ? (
-              <div className="w-full max-w-full space-y-2 overflow-hidden rounded border border-gray-200 bg-gray-50 p-2">
+              <div className="w-full max-w-full space-y-2 overflow-hidden rounded border border-cf-border bg-cf-bg-subtle p-2">
                 <div className="flex flex-wrap items-center justify-between gap-2">
-                  <span className="text-xs font-semibold text-gray-700">
+                  <span className="text-xs font-semibold text-cf-text-primary">
                     Filtros ativos ({activeFiltersCount})
                   </span>
                   <div className="flex flex-wrap items-center gap-2">
                     <button
                       type="button"
                       onClick={handleEditFilters}
-                      className="rounded border border-gray-300 bg-white px-2 py-1 text-xs font-semibold text-gray-700 hover:bg-gray-100"
+                      className="rounded border border-cf-border bg-cf-surface px-2 py-1 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                     >
                       Editar filtros
                     </button>
                     <button
                       type="button"
-                      className="rounded border border-gray-300 bg-white px-2 py-1 text-xs font-semibold text-gray-700 hover:bg-gray-100"
+                      className="rounded border border-cf-border bg-cf-surface px-2 py-1 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                       onClick={() => applyFilterPreset("clear")}
                     >
                       Limpar tudo
@@ -1697,7 +1697,7 @@ const App = ({
 
             {isFiltersContentVisible ? (
               <div className="space-y-4">
-                <div className="space-y-3 rounded border border-gray-200 bg-gray-50 p-3">
+                <div className="space-y-3 rounded border border-cf-border bg-cf-bg-subtle p-3">
                   {shouldShowPresets ? (
                     <div className="flex flex-wrap items-center gap-1.5">
                       {visibleFilterPresets.map((preset) => (
@@ -1709,7 +1709,7 @@ const App = ({
                           className={`min-w-[88px] rounded border px-3 py-1.5 text-xs font-semibold transition-colors ${
                             isPresetActive(preset.id)
                               ? "border-brand-1 bg-brand-3 text-brand-1"
-                              : "border-gray-300 bg-white text-gray-900 hover:bg-gray-100"
+                              : "border-cf-border bg-cf-surface text-cf-text-primary hover:bg-cf-bg-subtle"
                           }`}
                         >
                           {preset.label}
@@ -1718,7 +1718,7 @@ const App = ({
                     </div>
                   ) : null}
                   <div className="flex flex-col gap-1.5">
-                    <span className="text-[11px] font-semibold uppercase tracking-wide text-gray-200">
+                    <span className="text-[11px] font-semibold uppercase tracking-wide text-cf-text-secondary">
                       Tipo
                     </span>
                     <div className="flex flex-wrap items-center gap-1.5">
@@ -1736,7 +1736,7 @@ const App = ({
                             className={`min-w-[84px] rounded border px-3 py-1.5 text-xs font-semibold transition-colors ${
                               active
                                 ? "border-brand-1 bg-brand-3 text-brand-1"
-                                : "border-gray-300 bg-white text-gray-200"
+                                : "border-cf-border bg-cf-surface text-cf-text-secondary"
                             }`}
                           >
                             {FILTER_BUTTON_LABELS[category]}
@@ -1747,10 +1747,10 @@ const App = ({
                   </div>
                 </div>
 
-                <div className="rounded border border-gray-200 bg-white p-3">
+                <div className="rounded border border-cf-border bg-cf-surface p-3">
             <label
               htmlFor="periodo"
-              className="mb-2 block text-sm font-medium text-gray-100"
+              className="mb-2 block text-sm font-medium text-cf-text-primary"
             >
               Periodo
             </label>
@@ -1767,7 +1767,7 @@ const App = ({
                   setCustomEndDate("");
                 }
               }}
-              className="w-full rounded border border-gray-400 px-3 py-2 text-sm text-gray-200"
+              className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-2 text-sm text-cf-text-secondary"
             >
               {PERIOD_OPTIONS.map((period) => (
                 <option key={period} value={period}>
@@ -1779,7 +1779,7 @@ const App = ({
             <div className="mt-3">
               <label
                 htmlFor="categoria-filtro"
-                className="mb-1 block text-xs font-medium text-gray-100"
+                className="mb-1 block text-xs font-medium text-cf-text-primary"
               >
                 Categoria
               </label>
@@ -1790,7 +1790,7 @@ const App = ({
                   setSelectedTransactionCategoryId(event.target.value);
                   setCurrentOffset(DEFAULT_OFFSET);
                 }}
-                className="w-full rounded border border-gray-400 px-3 py-2 text-sm text-gray-200"
+                className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-2 text-sm text-cf-text-secondary"
               >
                 <option value="">Todas</option>
                 {categories.map((categoryOption) => (
@@ -1804,7 +1804,7 @@ const App = ({
             <div className="mt-3">
               <label
                 htmlFor="ordenacao-transacoes"
-                className="mb-1 block text-xs font-medium text-gray-100"
+                className="mb-1 block text-xs font-medium text-cf-text-primary"
               >
                 Ordenar por
               </label>
@@ -1815,7 +1815,7 @@ const App = ({
                   setSelectedSort(normalizeSortOption(event.target.value));
                   setCurrentOffset(DEFAULT_OFFSET);
                 }}
-                className="w-full rounded border border-gray-400 px-3 py-2 text-sm text-gray-200"
+                className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-2 text-sm text-cf-text-secondary"
               >
                 {SORT_OPTIONS.map((sortOption) => (
                   <option key={sortOption.value} value={sortOption.value}>
@@ -1826,7 +1826,7 @@ const App = ({
             </div>
 
             <div className="mt-3">
-              <label htmlFor="busca-transacoes" className="mb-1 block text-xs font-medium text-gray-100">
+              <label htmlFor="busca-transacoes" className="mb-1 block text-xs font-medium text-cf-text-primary">
                 Buscar
               </label>
               <form onSubmit={handleApplyQueryFilter} className="flex gap-2">
@@ -1838,11 +1838,11 @@ const App = ({
                   onChange={(event) => setQueryInput(event.target.value)}
                   onKeyDown={handleQueryInputKeyDown}
                   placeholder="Descricao ou observacoes"
-                  className="w-full rounded border border-gray-400 px-3 py-2 text-sm text-gray-200"
+                  className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-2 text-sm text-cf-text-secondary"
                 />
                 <button
                   type="submit"
-                  className="rounded border border-gray-300 bg-white px-3 py-2 text-sm font-semibold text-gray-100 hover:bg-gray-400"
+                  className="rounded border border-cf-border bg-cf-surface px-3 py-2 text-sm font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                 >
                   Aplicar
                 </button>
@@ -1854,7 +1854,7 @@ const App = ({
                       <div>
                         <label
                           htmlFor="data-inicial"
-                          className="mb-1 block text-xs font-medium text-gray-100"
+                          className="mb-1 block text-xs font-medium text-cf-text-primary"
                         >
                           Data inicial
                         </label>
@@ -1866,13 +1866,13 @@ const App = ({
                             setCustomStartDate(event.target.value);
                             setCurrentOffset(DEFAULT_OFFSET);
                           }}
-                          className="w-full rounded border border-gray-400 px-3 py-2 text-sm text-gray-200"
+                          className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-2 text-sm text-cf-text-secondary"
                         />
                       </div>
                       <div>
                         <label
                           htmlFor="data-final"
-                          className="mb-1 block text-xs font-medium text-gray-100"
+                          className="mb-1 block text-xs font-medium text-cf-text-primary"
                         >
                           Data final
                         </label>
@@ -1884,7 +1884,7 @@ const App = ({
                             setCustomEndDate(event.target.value);
                             setCurrentOffset(DEFAULT_OFFSET);
                           }}
-                          className="w-full rounded border border-gray-400 px-3 py-2 text-sm text-gray-200"
+                          className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-2 text-sm text-cf-text-secondary"
                         />
                       </div>
                     </div>
@@ -1898,13 +1898,13 @@ const App = ({
         <div className="space-y-6">
           <section ref={summarySectionRef}>
             <div className="mb-2 flex items-center justify-between gap-2">
-          <h3 className="text-sm font-medium text-gray-100">Resumo mensal</h3>
+          <h3 className="text-sm font-medium text-cf-text-primary">Resumo mensal</h3>
           <input
             type="month"
             aria-label="Mes do resumo"
             value={selectedSummaryMonth}
             onChange={(event) => setSelectedSummaryMonth(event.target.value)}
-            className="rounded border border-gray-300 bg-white px-2 py-1 text-sm text-gray-100"
+            className="rounded border border-cf-border bg-cf-surface px-2 py-1 text-sm text-cf-text-primary"
           />
             </div>
             {summaryError ? (
@@ -1924,9 +1924,9 @@ const App = ({
               </div>
             ) : null}
             <div className="grid gap-3 sm:grid-cols-3">
-          <div className="rounded border border-brand-1 bg-gray-400 px-4 py-3.5">
-            <p className="text-xs font-medium uppercase text-gray-200">Saldo</p>
-            <p className="text-base font-medium text-gray-100">
+          <div className="rounded border border-brand-1 bg-cf-bg-subtle px-4 py-3.5">
+            <p className="text-xs font-medium uppercase text-cf-text-secondary">Saldo</p>
+            <p className="text-base font-medium text-cf-text-primary">
               {isLoadingSummary ? "Carregando..." : formatCurrency(monthlySummary.balance)}
             </p>
             <p
@@ -1950,9 +1950,9 @@ const App = ({
                     } ${formatSignedPercentage(monthOverMonthMetrics.balance.deltaPercent)} (${formatSignedCurrency(monthOverMonthMetrics.balance.delta)})`}
             </p>
           </div>
-          <div className="rounded border border-brand-1 bg-gray-400 px-4 py-3.5">
-            <p className="text-xs font-medium uppercase text-gray-200">Entradas</p>
-            <p className="text-base font-medium text-gray-100">
+          <div className="rounded border border-brand-1 bg-cf-bg-subtle px-4 py-3.5">
+            <p className="text-xs font-medium uppercase text-cf-text-secondary">Entradas</p>
+            <p className="text-base font-medium text-cf-text-primary">
               {isLoadingSummary ? "Carregando..." : formatCurrency(monthlySummary.income)}
             </p>
             <p
@@ -1976,9 +1976,9 @@ const App = ({
                     } ${formatSignedPercentage(monthOverMonthMetrics.income.deltaPercent)} (${formatSignedCurrency(monthOverMonthMetrics.income.delta)})`}
             </p>
           </div>
-          <div className="rounded border border-brand-1 bg-gray-400 px-4 py-3.5">
-            <p className="text-xs font-medium uppercase text-gray-200">Saidas</p>
-            <p className="text-base font-medium text-gray-100">
+          <div className="rounded border border-brand-1 bg-cf-bg-subtle px-4 py-3.5">
+            <p className="text-xs font-medium uppercase text-cf-text-secondary">Saidas</p>
+            <p className="text-base font-medium text-cf-text-primary">
               {isLoadingSummary ? "Carregando..." : formatCurrency(monthlySummary.expense)}
             </p>
             <p
@@ -2004,27 +2004,27 @@ const App = ({
           </div>
             </div>
             {!isLoadingSummary && !summaryError && momError ? (
-              <div className="mt-2 rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-600">
+              <div className="mt-2 rounded border border-cf-border bg-cf-surface px-3 py-2 text-sm text-cf-text-secondary">
                 {momError}
               </div>
             ) : null}
             {!isLoadingSummary && !summaryError && !hasMonthlySummaryData ? (
-              <div className="mt-2 rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-600">
+              <div className="mt-2 rounded border border-cf-border bg-cf-surface px-3 py-2 text-sm text-cf-text-secondary">
                 Sem dados para o mes selecionado.
               </div>
             ) : null}
             {!isLoadingSummary &&
             !summaryError &&
             summaryByCategoryExpenses.length > 0 ? (
-              <div className="mt-3 rounded border border-gray-300 bg-white p-3">
-                <h4 className="text-xs font-semibold uppercase tracking-wide text-gray-600">
+              <div className="mt-3 rounded border border-cf-border bg-cf-surface p-3">
+                <h4 className="text-xs font-semibold uppercase tracking-wide text-cf-text-secondary">
                   Despesas por categoria
                 </h4>
                 <ul className="mt-2 space-y-1.5">
                   {summaryByCategoryExpenses.map((categoryItem) => (
                     <li
                       key={`${categoryItem.categoryId ?? "uncategorized"}-${categoryItem.categoryName}`}
-                      className="flex items-center justify-between gap-3 text-sm text-gray-700"
+                      className="flex items-center justify-between gap-3 text-sm text-cf-text-primary"
                     >
                       <span className="break-words">{categoryItem.categoryName}</span>
                       <span className="whitespace-nowrap font-semibold">
@@ -2037,11 +2037,11 @@ const App = ({
             ) : null}
             {!isLoadingSummary && !summaryError && !momError ? (
               <div
-                className="mt-3 rounded border border-gray-300 bg-white p-3"
+                className="mt-3 rounded border border-cf-border bg-cf-surface p-3"
                 role="region"
                 aria-label="Top variacoes por categoria"
               >
-                <h4 className="text-xs font-semibold uppercase tracking-wide text-gray-600">
+                <h4 className="text-xs font-semibold uppercase tracking-wide text-cf-text-secondary">
                   Top variacoes por categoria
                 </h4>
                 {topCategoryMovers.length > 0 ? (
@@ -2050,10 +2050,10 @@ const App = ({
                       <li
                         key={`category-mover-${item.categoryId ?? item.categoryName}`}
                         data-testid="category-mover-item"
-                        className="rounded border border-gray-200 bg-gray-50 px-2.5 py-2 text-sm"
+                        className="rounded border border-cf-border bg-cf-bg-subtle px-2.5 py-2 text-sm"
                       >
                         <div className="flex items-center justify-between gap-2">
-                          <p className="font-semibold text-gray-900">{item.categoryName}</p>
+                          <p className="font-semibold text-cf-text-primary">{item.categoryName}</p>
                           <span
                             className={`text-xs font-semibold ${MOM_TONE_CLASSNAMES[item.tone]}`}
                           >
@@ -2065,7 +2065,7 @@ const App = ({
                             type="button"
                             aria-label={`Ver transacoes categoria: ${item.categoryName}`}
                             onClick={() => handleViewCategoryMoverTransactions(item.categoryId)}
-                            className="rounded border border-gray-300 bg-white px-2 py-1 text-xs font-semibold text-gray-800 hover:bg-gray-100"
+                            className="rounded border border-cf-border bg-cf-surface px-2 py-1 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                           >
                             Ver transacoes
                           </button>
@@ -2074,7 +2074,7 @@ const App = ({
                     ))}
                   </ul>
                 ) : (
-                  <p className="mt-2 text-sm text-gray-600">
+                  <p className="mt-2 text-sm text-cf-text-secondary">
                     Sem variacoes por categoria para o comparativo do mes.
                   </p>
                 )}
@@ -2083,17 +2083,17 @@ const App = ({
           </section>
 
       <section>
-        <div className="rounded border border-gray-300 bg-white p-3">
+        <div className="rounded border border-cf-border bg-cf-surface p-3">
           <div className="mb-2 flex items-center justify-between gap-2">
             <div>
-              <h3 className="text-sm font-medium text-gray-100">Metas do mes</h3>
-              <span className="text-xs text-gray-200">{selectedSummaryMonth}</span>
+              <h3 className="text-sm font-medium text-cf-text-primary">Metas do mes</h3>
+              <span className="text-xs text-cf-text-secondary">{selectedSummaryMonth}</span>
             </div>
             <button
               type="button"
               onClick={openCreateBudgetModal}
               disabled={!canCreateBudget}
-              className="rounded border border-gray-300 bg-white px-3 py-1 text-xs font-semibold text-gray-900 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60"
+              className="rounded border border-cf-border bg-cf-surface px-3 py-1 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle disabled:cursor-not-allowed disabled:opacity-60"
             >
               + Nova meta
             </button>
@@ -2152,17 +2152,17 @@ const App = ({
                   <li
                     key={`budget-alert-${budget.id}`}
                     data-testid="budget-alert-item"
-                    className="rounded border border-amber-200 bg-white px-3 py-2 text-sm text-gray-800"
+                    className="rounded border border-amber-200 bg-cf-surface px-3 py-2 text-sm text-cf-text-primary"
                   >
                     <div className="mb-1 flex items-center justify-between gap-2">
-                      <p className="font-semibold text-gray-900">{budget.categoryName}</p>
+                      <p className="font-semibold text-cf-text-primary">{budget.categoryName}</p>
                       <span
                         className={`rounded-full border px-2 py-0.5 text-xs font-semibold ${BUDGET_STATUS_BADGE_CLASSNAMES[budget.status]}`}
                       >
                         {BUDGET_STATUS_LABELS[budget.status]}
                       </span>
                     </div>
-                    <p className="text-xs text-gray-700">
+                    <p className="text-xs text-cf-text-secondary">
                       Uso: {formatPercentage(budget.percentage)} ({formatCurrency(budget.actual)} de{" "}
                       {formatCurrency(budget.budget)})
                     </p>
@@ -2171,7 +2171,7 @@ const App = ({
                         type="button"
                         aria-label={`Ver transacoes: ${budget.categoryName}`}
                         onClick={() => handleViewBudgetTransactions(budget)}
-                        className="rounded border border-gray-300 bg-white px-2 py-1 text-xs font-semibold text-gray-800 hover:bg-gray-100"
+                        className="rounded border border-cf-border bg-cf-surface px-2 py-1 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                       >
                         Ver transacoes
                       </button>
@@ -2194,20 +2194,20 @@ const App = ({
               {Array.from({ length: 3 }).map((_unusedValue, index) => (
                 <div
                   key={`budgets-skeleton-${index + 1}`}
-                  className="h-16 animate-pulse rounded border border-gray-300 bg-gray-100"
+                  className="h-16 animate-pulse rounded border border-cf-border bg-cf-bg-subtle"
                 />
               ))}
               <span className="sr-only">Carregando metas do mes...</span>
             </div>
           ) : null}
           {!isLoadingBudgets && !budgetsError && !hasMonthlyBudgetsData ? (
-            <div className="rounded border border-gray-300 bg-gray-50 px-3 py-2 text-sm text-gray-600">
+            <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2 text-sm text-cf-text-secondary">
               <p>Nenhuma meta cadastrada para o mes selecionado.</p>
               <button
                 type="button"
                 onClick={openCreateBudgetModal}
                 disabled={!canCreateBudget}
-                className="mt-2 rounded border border-gray-300 bg-white px-3 py-1 text-xs font-semibold text-gray-900 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60"
+                className="mt-2 rounded border border-cf-border bg-cf-surface px-3 py-1 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle disabled:cursor-not-allowed disabled:opacity-60"
               >
                 Criar meta
               </button>
@@ -2225,24 +2225,24 @@ const App = ({
                 return (
                   <li
                     key={budget.id}
-                    className="rounded border border-gray-300 bg-gray-50 px-3 py-2 text-sm text-gray-800"
+                    className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2 text-sm text-cf-text-primary"
                   >
                     <div className="mb-2 flex items-center justify-between gap-2">
-                      <p className="font-semibold text-gray-900">{budget.categoryName}</p>
+                      <p className="font-semibold text-cf-text-primary">{budget.categoryName}</p>
                       <span
                         className={`rounded-full border px-2 py-0.5 text-xs font-semibold ${BUDGET_STATUS_BADGE_CLASSNAMES[safeStatus]}`}
                       >
                         {BUDGET_STATUS_LABELS[safeStatus]}
                       </span>
                     </div>
-                    <div className="mb-2 h-2 w-full rounded-full bg-gray-200">
+                    <div className="mb-2 h-2 w-full rounded-full bg-cf-border">
                       <div
                         className={`h-2 rounded-full ${BUDGET_STATUS_BAR_CLASSNAMES[safeStatus]}`}
                         style={{ width: progressWidth }}
                         title={safeStatus === "exceeded" ? "Acima de 100%" : undefined}
                       />
                     </div>
-                    <div className="grid gap-1 text-xs text-gray-700 sm:grid-cols-2">
+                    <div className="grid gap-1 text-xs text-cf-text-secondary sm:grid-cols-2">
                       <span>Orcado: {formatCurrency(budget.budget)}</span>
                       <span>Realizado: {formatCurrency(budget.actual)}</span>
                       <span>Restante: {formatCurrency(budget.remaining)}</span>
@@ -2253,7 +2253,7 @@ const App = ({
                         type="button"
                         aria-label={`Editar meta: ${budget.categoryName}`}
                         onClick={() => openEditBudgetModal(budget)}
-                        className="rounded border border-gray-300 bg-white px-2 py-1 text-xs font-semibold text-gray-800 hover:bg-gray-100"
+                        className="rounded border border-cf-border bg-cf-surface px-2 py-1 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                       >
                         Editar
                       </button>
@@ -2277,7 +2277,7 @@ const App = ({
       <section>
         <Suspense
           fallback={
-            <div className="rounded border border-brand-1 bg-gray-500 p-4 text-sm text-gray-100">
+            <div className="rounded border border-cf-border bg-cf-surface p-4 text-sm text-cf-text-primary">
               Carregando grafico...
             </div>
           }
@@ -2288,22 +2288,22 @@ const App = ({
 
       <section>
         {trendError ? (
-          <div className="rounded border border-brand-1 bg-gray-500 p-4 text-center text-sm text-gray-100">
+          <div className="rounded border border-cf-border bg-cf-surface p-4 text-center text-sm text-cf-text-primary">
             {trendError}
           </div>
         ) : isLoadingTrend ? (
           <div
-            className="rounded border border-brand-1 bg-gray-500 p-4"
+            className="rounded border border-cf-border bg-cf-surface p-4"
             role="status"
             aria-live="polite"
           >
-            <div className="h-64 animate-pulse rounded bg-gray-400" />
+            <div className="h-64 animate-pulse rounded bg-cf-bg-subtle" />
             <span className="sr-only">Carregando evolucao...</span>
           </div>
         ) : (
           <Suspense
             fallback={
-              <div className="rounded border border-brand-1 bg-gray-500 p-4 text-sm text-gray-100">
+              <div className="rounded border border-cf-border bg-cf-surface p-4 text-sm text-cf-text-primary">
                 Carregando evolucao...
               </div>
             }
@@ -2317,10 +2317,10 @@ const App = ({
         )}
       </section>
 
-      <section ref={listSectionRef} className="rounded border border-brand-1 bg-gray-500 px-4 py-3.5">
+      <section ref={listSectionRef} className="rounded border border-cf-border bg-cf-surface px-4 py-3.5">
         {requestError ? (
           <div className="p-4 text-center">
-            <p className="text-sm font-medium text-red-300">{requestError}</p>
+            <p className="text-sm font-medium text-red-600">{requestError}</p>
             <button
               onClick={loadTransactions}
               className="mt-2 font-medium text-brand-1 hover:text-brand-2"
@@ -2333,19 +2333,19 @@ const App = ({
             {Array.from({ length: 4 }).map((_, index) => (
               <div
                 key={`transactions-skeleton-${index + 1}`}
-                className="h-20 animate-pulse rounded border border-gray-300 bg-gray-400"
+                className="h-20 animate-pulse rounded border border-cf-border bg-cf-bg-subtle"
               />
             ))}
             <span className="sr-only">Carregando transacoes...</span>
           </div>
         ) : filteredTransactions.length === 0 ? (
           hasActiveFilters ? (
-            <div className="p-4 text-center text-gray-100">
+            <div className="p-4 text-center text-cf-text-primary">
               Nenhum valor encontrado para os filtros selecionados.
             </div>
           ) : (
             <div className="p-4 text-center">
-              <p className="text-gray-100">Nenhum valor cadastrado.</p>
+              <p className="text-cf-text-primary">Nenhum valor cadastrado.</p>
               <button
                 onClick={openCreateModal}
                 className="font-medium text-brand-1 hover:text-brand-2"
@@ -2363,7 +2363,7 @@ const App = ({
         )}
 
         {!requestError && !isLoadingTransactions ? (
-          <div className="mt-2 border-t border-gray-300 px-2 pt-3 text-sm text-gray-100">
+          <div className="mt-2 border-t border-cf-border px-2 pt-3 text-sm text-cf-text-primary">
             <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
               <span>
                 Mostrando {rangeStart}-{rangeEnd} de {paginationMeta.total}
@@ -2374,7 +2374,7 @@ const App = ({
                   aria-label="Itens por pagina"
                   value={pageSize}
                   onChange={(event) => handlePageSizeChange(event.target.value)}
-                  className="rounded border border-gray-300 bg-white px-2 py-1 text-sm text-gray-100"
+                  className="rounded border border-cf-border bg-cf-surface px-2 py-1 text-sm text-cf-text-primary"
                 >
                   {PAGE_SIZE_OPTIONS.map((option) => (
                     <option key={option} value={option}>
@@ -2390,7 +2390,7 @@ const App = ({
                   type="button"
                   onClick={handleFirstPage}
                   disabled={currentPage <= 1}
-                  className="rounded border border-gray-300 px-3 py-1 font-semibold text-gray-100 hover:bg-gray-400 disabled:cursor-not-allowed disabled:opacity-60"
+                  className="rounded border border-cf-border px-3 py-1 font-semibold text-cf-text-primary hover:bg-cf-bg-subtle disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   Primeira
                 </button>
@@ -2402,7 +2402,7 @@ const App = ({
                 type="button"
                 onClick={handlePreviousPage}
                 disabled={currentPage <= 1}
-                className="rounded border border-gray-300 px-3 py-1 font-semibold text-gray-100 hover:bg-gray-400 disabled:cursor-not-allowed disabled:opacity-60"
+                className="rounded border border-cf-border px-3 py-1 font-semibold text-cf-text-primary hover:bg-cf-bg-subtle disabled:cursor-not-allowed disabled:opacity-60"
               >
                 Anterior
               </button>
@@ -2413,7 +2413,7 @@ const App = ({
                 type="button"
                 onClick={handleNextPage}
                 disabled={currentPage >= paginationMeta.totalPages}
-                className="rounded border border-gray-300 px-3 py-1 font-semibold text-gray-100 hover:bg-gray-400 disabled:cursor-not-allowed disabled:opacity-60"
+                className="rounded border border-cf-border px-3 py-1 font-semibold text-cf-text-primary hover:bg-cf-bg-subtle disabled:cursor-not-allowed disabled:opacity-60"
               >
                 Proxima
               </button>
@@ -2423,7 +2423,7 @@ const App = ({
                   type="button"
                   onClick={handleLastPage}
                   disabled={currentPage >= paginationMeta.totalPages}
-                  className="rounded border border-gray-300 px-3 py-1 font-semibold text-gray-100 hover:bg-gray-400 disabled:cursor-not-allowed disabled:opacity-60"
+                  className="rounded border border-cf-border px-3 py-1 font-semibold text-cf-text-primary hover:bg-cf-bg-subtle disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   Ultima
                 </button>
@@ -2438,9 +2438,9 @@ const App = ({
       </main>
 
       {undoState ? (
-        <div className="fixed bottom-4 left-1/2 z-40 w-[calc(100%-2rem)] max-w-500 -translate-x-1/2 rounded border border-brand-1 bg-white px-4 py-3 shadow-lg">
+        <div className="fixed bottom-4 left-1/2 z-40 w-[calc(100%-2rem)] max-w-500 -translate-x-1/2 rounded border border-brand-1 bg-cf-surface px-4 py-3 shadow-lg">
           <div className="flex items-center justify-between gap-3">
-            <p className="text-sm text-gray-100">Transacao removida.</p>
+            <p className="text-sm text-cf-text-primary">Transacao removida.</p>
             <button
               type="button"
               onClick={restoreDeletedTransaction}
@@ -2458,14 +2458,14 @@ const App = ({
             role="dialog"
             aria-modal="true"
             aria-labelledby="budget-modal-title"
-            className="w-full max-w-sm rounded bg-white p-4 shadow-lg"
+            className="w-full max-w-sm rounded bg-cf-surface p-4 shadow-lg"
           >
-            <h3 id="budget-modal-title" className="text-base font-semibold text-gray-900">
+            <h3 id="budget-modal-title" className="text-base font-semibold text-cf-text-primary">
               Meta do mes
             </h3>
-            <p className="mt-1 text-xs text-gray-600">Mes selecionado: {selectedSummaryMonth}</p>
+            <p className="mt-1 text-xs text-cf-text-secondary">Mes selecionado: {selectedSummaryMonth}</p>
             {editingBudget ? (
-              <div className="mt-2 rounded border border-gray-200 bg-gray-50 px-2 py-1 text-xs text-gray-700">
+              <div className="mt-2 rounded border border-cf-border bg-cf-bg-subtle px-2 py-1 text-xs text-cf-text-secondary">
                 <p>
                   Editando: <strong>{editingBudget.categoryName}</strong>
                 </p>
@@ -2481,7 +2481,7 @@ const App = ({
 
             <div className="mt-3 space-y-3">
               <div>
-                <label htmlFor="budget-category" className="mb-1 block text-xs font-medium text-gray-900">
+                <label htmlFor="budget-category" className="mb-1 block text-xs font-medium text-cf-text-primary">
                   Categoria da meta
                 </label>
                 <select
@@ -2494,7 +2494,7 @@ const App = ({
                     }))
                   }
                   disabled={isSavingBudget || Boolean(editingBudget)}
-                  className="w-full rounded border border-gray-400 px-3 py-2 text-sm text-gray-900 disabled:bg-gray-100 disabled:text-gray-500"
+                  className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-2 text-sm text-cf-text-primary disabled:bg-cf-bg-subtle disabled:text-cf-text-secondary"
                 >
                   <option value="">Selecione...</option>
                   {categories.map((categoryOption) => (
@@ -2506,7 +2506,7 @@ const App = ({
               </div>
 
               <div>
-                <label htmlFor="budget-amount" className="mb-1 block text-xs font-medium text-gray-900">
+                <label htmlFor="budget-amount" className="mb-1 block text-xs font-medium text-cf-text-primary">
                   Valor da meta
                 </label>
                 <input
@@ -2522,7 +2522,7 @@ const App = ({
                     }))
                   }
                   disabled={isSavingBudget}
-                  className="w-full rounded border border-gray-400 px-3 py-2 text-sm text-gray-900 disabled:bg-gray-100 disabled:text-gray-500"
+                  className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-2 text-sm text-cf-text-primary disabled:bg-cf-bg-subtle disabled:text-cf-text-secondary"
                 />
               </div>
             </div>
@@ -2532,7 +2532,7 @@ const App = ({
                 type="button"
                 onClick={closeBudgetModal}
                 disabled={isSavingBudget}
-                className="rounded border border-gray-300 px-3 py-1.5 text-sm font-semibold text-gray-700 disabled:cursor-not-allowed disabled:opacity-60"
+                className="rounded border border-cf-border px-3 py-1.5 text-sm font-semibold text-cf-text-secondary disabled:cursor-not-allowed disabled:opacity-60"
               >
                 Cancelar
               </button>
@@ -2551,16 +2551,16 @@ const App = ({
 
       {pendingDeleteTransactionId ? (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-gray-100 bg-opacity-50 p-4">
-          <div className="w-full max-w-sm rounded bg-white p-4 shadow-lg">
-            <h3 className="text-base font-semibold text-gray-100">Confirmar exclusao</h3>
-            <p className="mt-2 text-sm text-gray-200">
+          <div className="w-full max-w-sm rounded bg-cf-surface p-4 shadow-lg">
+            <h3 className="text-base font-semibold text-cf-text-primary">Confirmar exclusao</h3>
+            <p className="mt-2 text-sm text-cf-text-secondary">
               Deseja realmente excluir esta transacao?
             </p>
             <div className="mt-4 flex justify-end gap-2">
               <button
                 type="button"
                 onClick={closeDeleteDialog}
-                className="rounded border border-gray-300 px-3 py-1.5 text-sm font-semibold text-gray-200"
+                className="rounded border border-cf-border px-3 py-1.5 text-sm font-semibold text-cf-text-secondary"
               >
                 Cancelar
               </button>

--- a/apps/web/src/pages/CategoriesSettings.tsx
+++ b/apps/web/src/pages/CategoriesSettings.tsx
@@ -201,13 +201,13 @@ const CategoriesSettings = ({
   };
 
   return (
-    <div className="min-h-screen bg-gray-500 py-6">
+    <div className="min-h-screen bg-cf-bg-page py-6">
       <main className="mx-auto w-full max-w-4xl space-y-4 px-4 sm:px-6">
-        <section className="rounded border border-gray-300 bg-white p-4">
+        <section className="rounded border border-cf-border bg-cf-surface p-4">
           <div className="flex flex-wrap items-start justify-between gap-3">
             <div>
-              <h1 className="text-xl font-semibold text-gray-100">Settings - Categorias</h1>
-              <p className="mt-1 text-sm text-gray-200">
+              <h1 className="text-xl font-semibold text-cf-text-primary">Settings - Categorias</h1>
+              <p className="mt-1 text-sm text-cf-text-secondary">
                 Gerencie categorias ativas e removidas para os lancamentos.
               </p>
             </div>
@@ -215,7 +215,7 @@ const CategoriesSettings = ({
               <button
                 type="button"
                 onClick={onBack}
-                className="rounded border border-gray-300 bg-white px-3 py-1.5 text-xs font-semibold text-gray-100 hover:bg-gray-400"
+                className="rounded border border-cf-border bg-cf-surface px-3 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
               >
                 Voltar ao dashboard
               </button>
@@ -223,7 +223,7 @@ const CategoriesSettings = ({
                 <button
                   type="button"
                   onClick={onLogout}
-                  className="rounded border border-gray-300 bg-white px-3 py-1.5 text-xs font-semibold text-gray-100 hover:bg-gray-400"
+                  className="rounded border border-cf-border bg-cf-surface px-3 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                 >
                   Sair
                 </button>
@@ -231,8 +231,8 @@ const CategoriesSettings = ({
             </div>
           </div>
 
-          <div className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded border border-gray-200 bg-gray-50 px-3 py-2">
-            <label className="inline-flex cursor-pointer items-center gap-2 text-sm text-gray-700">
+          <div className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded border border-cf-border bg-cf-bg-subtle px-3 py-2">
+            <label className="inline-flex cursor-pointer items-center gap-2 text-sm text-cf-text-primary">
               <input
                 type="checkbox"
                 checked={includeDeleted}
@@ -280,7 +280,7 @@ const CategoriesSettings = ({
               {Array.from({ length: 4 }).map((_, index) => (
                 <div
                   key={`categories-skeleton-${index + 1}`}
-                  className="h-12 animate-pulse rounded border border-gray-300 bg-gray-100"
+                  className="h-12 animate-pulse rounded border border-cf-border bg-cf-bg-subtle"
                 />
               ))}
               <span className="sr-only">Carregando categorias...</span>
@@ -288,7 +288,7 @@ const CategoriesSettings = ({
           ) : null}
 
           {!isLoadingCategories && categories.length === 0 ? (
-            <div className="mt-3 rounded border border-gray-300 bg-gray-50 px-3 py-3 text-sm text-gray-700">
+            <div className="mt-3 rounded border border-cf-border bg-cf-bg-subtle px-3 py-3 text-sm text-cf-text-secondary">
               Nenhuma categoria encontrada para o filtro atual.
             </div>
           ) : null}
@@ -301,11 +301,11 @@ const CategoriesSettings = ({
                 return (
                   <li
                     key={category.id}
-                    className="flex flex-wrap items-center justify-between gap-3 rounded border border-gray-300 bg-white px-3 py-2"
+                    className="flex flex-wrap items-center justify-between gap-3 rounded border border-cf-border bg-cf-surface px-3 py-2"
                   >
                     <div className="min-w-0">
-                      <p className="break-words text-sm font-semibold text-gray-900">{category.name}</p>
-                      <p className="text-xs text-gray-200">
+                      <p className="break-words text-sm font-semibold text-cf-text-primary">{category.name}</p>
+                      <p className="text-xs text-cf-text-secondary">
                         {isDeleted ? "Removida" : "Ativa"}
                       </p>
                     </div>
@@ -324,7 +324,7 @@ const CategoriesSettings = ({
                           <button
                             type="button"
                             onClick={() => openRenameCategoryModal(category)}
-                            className="rounded border border-gray-300 bg-white px-2 py-1 text-xs font-semibold text-gray-700 hover:bg-gray-100"
+                            className="rounded border border-cf-border bg-cf-surface px-2 py-1 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                           >
                             Renomear
                           </button>
@@ -352,9 +352,9 @@ const CategoriesSettings = ({
             role="dialog"
             aria-modal="true"
             aria-labelledby="category-modal-title"
-            className="w-full max-w-sm rounded bg-white p-4 shadow-lg"
+            className="w-full max-w-sm rounded bg-cf-surface p-4 shadow-lg"
           >
-            <h2 id="category-modal-title" className="text-base font-semibold text-gray-900">
+            <h2 id="category-modal-title" className="text-base font-semibold text-cf-text-primary">
               {editingCategory ? "Renomear categoria" : "Nova categoria"}
             </h2>
 
@@ -369,7 +369,7 @@ const CategoriesSettings = ({
 
             <form onSubmit={handleSubmitCategory} className="mt-3 space-y-3">
               <div>
-                <label htmlFor="category-name" className="mb-1 block text-xs font-medium text-gray-900">
+                <label htmlFor="category-name" className="mb-1 block text-xs font-medium text-cf-text-primary">
                   Nome
                 </label>
                 <input
@@ -381,7 +381,7 @@ const CategoriesSettings = ({
                     setCategoryModalErrorMessage("");
                   }}
                   placeholder="Ex.: Alimentacao"
-                  className="w-full rounded border border-gray-400 px-3 py-2 text-sm text-gray-900"
+                  className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-2 text-sm text-cf-text-primary"
                 />
               </div>
 
@@ -390,7 +390,7 @@ const CategoriesSettings = ({
                   type="button"
                   onClick={closeCategoryModal}
                   disabled={isSavingCategory}
-                  className="rounded border border-gray-300 px-3 py-1.5 text-sm font-semibold text-gray-700 disabled:cursor-not-allowed disabled:opacity-60"
+                  className="rounded border border-cf-border px-3 py-1.5 text-sm font-semibold text-cf-text-secondary disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   Cancelar
                 </button>


### PR DESCRIPTION
## Summary

Apply semantic `cf-*` color tokens to inner web content (N8), continuing the N7 token rollout.

### Migrated files
- `apps/web/src/pages/App.tsx`
- `apps/web/src/components/TransactionList.jsx`
- `apps/web/src/components/TransactionChart.jsx`
- `apps/web/src/components/TrendChart.tsx`
- `apps/web/src/components/ImportCsvModal.jsx`
- `apps/web/src/components/ImportHistoryModal.jsx`
- `apps/web/src/pages/CategoriesSettings.tsx`

### Included fixes
- Budget/category skeleton surfaces: `bg-gray-100` -> `bg-cf-bg-subtle` (avoids near-black fallback)
- Transaction list error text: `text-red-300` -> `text-red-600` (contrast improvement)

## Validation
- [x] `npm -w apps/web run lint`
- [x] `npm -w apps/web test -- --run` (112/112)

## Notes
- Color/token migration only; no API/schema changes.
- Scope focused on inner content (shell/login/modal were migrated in N7).