### PR TITLE
feat(web): show/hide password toggle (N9)

### DIFF
--- a/apps/web/src/pages/Login.test.jsx
+++ b/apps/web/src/pages/Login.test.jsx
@@ -76,6 +76,47 @@ describe("Login", () => {
     expect(authState.login).not.toHaveBeenCalled();
   });
 
+  it("alterna visibilidade da senha no modo login", async () => {
+    mockUseAuth.mockReturnValue(createAuthMockState());
+    const user = userEvent.setup();
+    renderLoginPage();
+
+    const input = screen.getByLabelText("Senha");
+    const toggle = screen.getByRole("button", { name: "Mostrar senha" });
+
+    expect(input).toHaveAttribute("type", "password");
+
+    await user.click(toggle);
+    expect(input).toHaveAttribute("type", "text");
+    expect(screen.getByRole("button", { name: "Ocultar senha" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Ocultar senha" }));
+    expect(input).toHaveAttribute("type", "password");
+  });
+
+  it("alterna visibilidade da senha no modo registro e reseta ao trocar de modo", async () => {
+    mockUseAuth.mockReturnValue(createAuthMockState());
+    const user = userEvent.setup();
+    renderLoginPage();
+
+    await user.click(screen.getByRole("button", { name: "Criar conta" }));
+
+    const senhaInput = screen.getByLabelText("Senha");
+    const confirmarInput = screen.getByLabelText("Confirmar senha");
+    const toggle = screen.getAllByRole("button", { name: "Mostrar senha" })[0];
+
+    expect(senhaInput).toHaveAttribute("type", "password");
+    expect(confirmarInput).toHaveAttribute("type", "password");
+
+    await user.click(toggle);
+    expect(senhaInput).toHaveAttribute("type", "text");
+    expect(confirmarInput).toHaveAttribute("type", "text");
+
+    // Trocar para login deve resetar showPassword
+    await user.click(screen.getByRole("button", { name: "Login" }));
+    expect(screen.getByLabelText("Senha")).toHaveAttribute("type", "password");
+  });
+
   it("realiza cadastro e login com senha valida", async () => {
     const authState = createAuthMockState();
     const user = userEvent.setup();

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -30,6 +30,7 @@ const Login = (): JSX.Element => {
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [localError, setLocalError] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
 
   useEffect(() => {
     if (isAuthenticated) {
@@ -45,6 +46,7 @@ const Login = (): JSX.Element => {
   const handleModeChange = (nextMode: AuthMode) => {
     setMode(nextMode);
     resetErrors();
+    setShowPassword(false);
 
     if (nextMode === "login") {
       setConfirmPassword("");
@@ -164,14 +166,33 @@ const Login = (): JSX.Element => {
             >
               Senha
             </label>
-            <input
-              id="senha"
-              type="password"
-              value={password}
-              onChange={(event) => setPassword(event.target.value)}
-              className="w-full rounded border border-cf-border-input px-3 py-2 text-sm text-cf-text-secondary"
-              autoComplete={mode === "register" ? "new-password" : "current-password"}
-            />
+            <div className="relative">
+              <input
+                id="senha"
+                type={showPassword ? "text" : "password"}
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                className="w-full rounded border border-cf-border-input px-3 py-2 pr-10 text-sm text-cf-text-secondary"
+                autoComplete={showPassword ? "off" : mode === "register" ? "new-password" : "current-password"}
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((prev) => !prev)}
+                className="absolute inset-y-0 right-0 flex items-center px-3 text-cf-text-secondary hover:text-cf-text-primary"
+                aria-label={showPassword ? "Ocultar senha" : "Mostrar senha"}
+              >
+                {showPassword ? (
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+                  </svg>
+                ) : (
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                  </svg>
+                )}
+              </button>
+            </div>
           </div>
 
           {mode === "register" ? (
@@ -182,14 +203,33 @@ const Login = (): JSX.Element => {
               >
                 Confirmar senha
               </label>
-              <input
-                id="confirmar-senha"
-                type="password"
-                value={confirmPassword}
-                onChange={(event) => setConfirmPassword(event.target.value)}
-                className="w-full rounded border border-cf-border-input px-3 py-2 text-sm text-cf-text-secondary"
-                autoComplete="new-password"
-              />
+              <div className="relative">
+                <input
+                  id="confirmar-senha"
+                  type={showPassword ? "text" : "password"}
+                  value={confirmPassword}
+                  onChange={(event) => setConfirmPassword(event.target.value)}
+                  className="w-full rounded border border-cf-border-input px-3 py-2 pr-10 text-sm text-cf-text-secondary"
+                  autoComplete={showPassword ? "off" : "new-password"}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((prev) => !prev)}
+                  className="absolute inset-y-0 right-0 flex items-center px-3 text-cf-text-secondary hover:text-cf-text-primary"
+                  aria-label={showPassword ? "Ocultar senha" : "Mostrar senha"}
+                >
+                  {showPassword ? (
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+                    </svg>
+                  ) : (
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                    </svg>
+                  )}
+                </button>
+              </div>
             </div>
           ) : null}
 


### PR DESCRIPTION
## Summary
- Adds show/hide toggle button to `senha` and `confirmar-senha` in `Login.tsx`
- Shared `showPassword` state: in register mode, one toggle reveals/hides both password fields
- Resets visibility to hidden when switching tabs (`Login` <-> `Criar conta`)
- Uses `autoComplete=off` only while revealed (`type=text`) to avoid browser/linter conflicts
- Uses inline SVG icons and existing semantic token classes (`text-cf-text-secondary` / `hover:text-cf-text-primary`)

## Validation
- [x] `npm -w apps/web run lint`
- [x] `npm -w apps/web test -- --run` (114/114)
- [x] Added tests in `Login.test.jsx` for toggle behavior and reset on mode switch

## Manual smoke
- [ ] Login mode: click eye -> reveal/hide password
- [ ] Register mode: toggle controls both password fields
- [ ] Switching tabs resets fields to hidden
- [ ] Dark mode icon contrast is acceptable