### PR TITLE
feat(web): Recharts dark mode for axis, grid and legend (PR-N10)

### DIFF
--- a/apps/web/src/components/TransactionChart.jsx
+++ b/apps/web/src/components/TransactionChart.jsx
@@ -1,3 +1,4 @@
+import { useContext } from "react";
 import PropTypes from "prop-types";
 import {
   Bar,
@@ -8,6 +9,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
+import { ThemeContext } from "../context/theme-context";
 
 const formatCurrency = (value) => `R$ ${value.toFixed(2)}`;
 
@@ -43,6 +45,11 @@ CustomTooltip.defaultProps = {
 };
 
 const TransactionChart = ({ data }) => {
+  const themeCtx = useContext(ThemeContext);
+  const isDark = themeCtx?.theme === "dark";
+  const axisStroke = isDark ? "#94A3B8" : "#495057";
+  const gridStroke = isDark ? "#334155" : "#ADB5BD";
+
   const hasAnyValue = data.some((item) => item.total > 0);
 
   if (!hasAnyValue) {
@@ -61,9 +68,9 @@ const TransactionChart = ({ data }) => {
       <div className="h-64 w-full">
         <ResponsiveContainer>
           <BarChart data={data} margin={{ top: 8, right: 8, left: 8, bottom: 8 }}>
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="name" stroke="#495057" />
-            <YAxis stroke="#495057" width={90} tickFormatter={formatCurrency} />
+            <CartesianGrid strokeDasharray="3 3" stroke={gridStroke} />
+            <XAxis dataKey="name" stroke={axisStroke} />
+            <YAxis stroke={axisStroke} width={90} tickFormatter={formatCurrency} />
             <Tooltip content={<CustomTooltip />} />
             <Bar dataKey="total" fill="#6741D9" radius={[6, 6, 0, 0]} />
           </BarChart>

--- a/apps/web/src/components/TrendChart.tsx
+++ b/apps/web/src/components/TrendChart.tsx
@@ -1,3 +1,4 @@
+import { useContext } from "react";
 import {
   CartesianGrid,
   Legend,
@@ -10,6 +11,7 @@ import {
   YAxis,
 } from "recharts";
 import type { TrendPoint } from "../services/analytics.service";
+import { ThemeContext } from "../context/theme-context";
 
 const formatCurrency = (value: number) => `R$ ${Number(value || 0).toFixed(2)}`;
 
@@ -99,6 +101,12 @@ interface TrendChartProps {
 }
 
 const TrendChart = ({ data, onMonthClick, selectedMonth }: TrendChartProps) => {
+  const themeCtx = useContext(ThemeContext);
+  const isDark = themeCtx?.theme === "dark";
+  const axisStroke = isDark ? "#94A3B8" : "#495057";
+  const gridStroke = isDark ? "#334155" : "#ADB5BD";
+  const legendColor = isDark ? "#F1F5F9" : "#212529";
+
   const hasAnyValue = data.some(
     (point) => point.income > 0 || point.expense > 0 || point.balance !== 0,
   );
@@ -139,11 +147,11 @@ const TrendChart = ({ data, onMonthClick, selectedMonth }: TrendChartProps) => {
           }}
           className={onMonthClick ? "cursor-pointer" : undefined}
         >
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="month" stroke="#495057" tickFormatter={formatMonthLabel} />
-            <YAxis stroke="#495057" width={90} tickFormatter={formatCurrency} />
+            <CartesianGrid strokeDasharray="3 3" stroke={gridStroke} />
+            <XAxis dataKey="month" stroke={axisStroke} tickFormatter={formatMonthLabel} />
+            <YAxis stroke={axisStroke} width={90} tickFormatter={formatCurrency} />
             <Tooltip content={<CustomTooltip deltaMap={deltaMap} />} />
-            <Legend />
+            <Legend wrapperStyle={{ color: legendColor }} />
             {isSelectedInRange && (
               <ReferenceLine
                 x={selectedMonth}


### PR DESCRIPTION
## Summary
- Adds dark-mode aware Recharts colors for axes, grid and legend
- Uses `ThemeContext` via `useContext` with null-safety (`themeCtx?.theme === dark`) so charts gracefully fall back to light mode outside `ThemeProvider`
- Keeps data-series colors unchanged (intentional):
  - green `#16a34a`
  - red `#dc2626`
  - brand purple `#6741D9`

## Color mapping
| Prop | Light | Dark |
|---|---|---|
| `XAxis` / `YAxis` `stroke` | `#495057` | `#94A3B8` |
| `CartesianGrid` `stroke` | `#ADB5BD` | `#334155` |
| `Legend` `wrapperStyle.color` | `#212529` | `#F1F5F9` |

## Validation
- [x] `npm -w apps/web run lint`
- [x] `npm -w apps/web test -- --run` (114/114)
- [ ] Manual smoke in both themes (charts readability)

## Notes
- Scope is visual-only for chart infrastructure (no API/schema/behavior changes)