### PR TITLE
fix(web): centralize BRL currency formatting with Intl.NumberFormat

### DIFF
--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -1,13 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { transactionsService } from "../services/transactions.service";
+import { formatCurrency } from "../utils/formatCurrency";
 
 const getApiErrorMessage = (error, fallbackMessage) => {
   return error?.response?.data?.message || error?.message || fallbackMessage;
-};
-
-const formatCurrency = (value) => {
-  return `R$ ${(Number(value) || 0).toFixed(2)}`;
 };
 
 const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {

--- a/apps/web/src/components/ImportHistoryModal.jsx
+++ b/apps/web/src/components/ImportHistoryModal.jsx
@@ -1,15 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { transactionsService } from "../services/transactions.service";
+import { formatCurrency } from "../utils/formatCurrency";
 
 const DEFAULT_LIMIT = 20;
 
 const getApiErrorMessage = (error, fallbackMessage) => {
   return error?.response?.data?.message || error?.message || fallbackMessage;
-};
-
-const formatCurrency = (value) => {
-  return `R$ ${(Number(value) || 0).toFixed(2)}`;
 };
 
 const formatDateTime = (value) => {

--- a/apps/web/src/components/TransactionChart.jsx
+++ b/apps/web/src/components/TransactionChart.jsx
@@ -10,8 +10,7 @@ import {
   YAxis,
 } from "recharts";
 import { ThemeContext } from "../context/theme-context";
-
-const formatCurrency = (value) => `R$ ${value.toFixed(2)}`;
+import { formatCurrency } from "../utils/formatCurrency";
 
 const CustomTooltip = ({ active, payload, label }) => {
   if (!active || !payload || payload.length === 0) {

--- a/apps/web/src/components/TransactionList.jsx
+++ b/apps/web/src/components/TransactionList.jsx
@@ -1,7 +1,6 @@
 import PropTypes from "prop-types";
 import { CATEGORY_ENTRY } from "./DatabaseUtils";
-
-const formatValue = (value) => `R$ ${value.toFixed(2)}`;
+import { formatCurrency } from "../utils/formatCurrency";
 
 const formatDate = (value) => {
   const date = new Date(`${value}T00:00:00`);
@@ -25,7 +24,7 @@ const TransactionList = ({ transactions, onDelete, onEdit }) => {
               {transaction.description || "Sem descricao"}
             </span>
             <span className="text-base font-medium text-cf-text-primary">
-              {formatValue(transaction.value)}
+              {formatCurrency(transaction.value)}
             </span>
             <span className="text-xs text-cf-text-secondary">{formatDate(transaction.date)}</span>
             <span className="break-words text-xs text-cf-text-secondary">

--- a/apps/web/src/components/TrendChart.test.tsx
+++ b/apps/web/src/components/TrendChart.test.tsx
@@ -99,9 +99,9 @@ describe("TrendChart", () => {
   it("shows absolute values and month-over-month deltas in tooltip", () => {
     render(<TrendChart data={trendData} />);
 
-    expect(screen.getByText("Entradas: R$ 2000.00")).toBeInTheDocument();
-    expect(screen.getByText("+R$ 200.00", { exact: false })).toBeInTheDocument();
-    expect(screen.getByText("Saidas: R$ 700.00")).toBeInTheDocument();
-    expect(screen.getByText("+R$ 100.00", { exact: false })).toBeInTheDocument();
+    expect(screen.getByText("Entradas: R$ 2.000,00")).toBeInTheDocument();
+    expect(screen.getByText("+R$ 200,00", { exact: false })).toBeInTheDocument();
+    expect(screen.getByText("Saidas: R$ 700,00")).toBeInTheDocument();
+    expect(screen.getByText("+R$ 100,00", { exact: false })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/TrendChart.tsx
+++ b/apps/web/src/components/TrendChart.tsx
@@ -12,8 +12,7 @@ import {
 } from "recharts";
 import type { TrendPoint } from "../services/analytics.service";
 import { ThemeContext } from "../context/theme-context";
-
-const formatCurrency = (value: number) => `R$ ${Number(value || 0).toFixed(2)}`;
+import { formatCurrency } from "../utils/formatCurrency";
 
 const MONTH_NAMES_PT = ["Jan", "Fev", "Mar", "Abr", "Mai", "Jun", "Jul", "Ago", "Set", "Out", "Nov", "Dez"];
 

--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -284,9 +284,9 @@ describe("App", () => {
 
     render(<App />);
 
-    expect(await screen.findByText("R$ 1079.50")).toBeInTheDocument();
-    expect(screen.getByText("R$ 1500.00")).toBeInTheDocument();
-    expect(screen.getByText("R$ 420.50")).toBeInTheDocument();
+    expect(await screen.findByText("R$ 1.079,50")).toBeInTheDocument();
+    expect(screen.getByText("R$ 1.500,00")).toBeInTheDocument();
+    expect(screen.getByText("R$ 420,50")).toBeInTheDocument();
     expect(transactionsService.getMonthlySummary).toHaveBeenCalledWith(expect.any(String));
   });
 
@@ -324,10 +324,10 @@ describe("App", () => {
 
     render(<App />);
 
-    expect(await screen.findByText("R$ 1020.00")).toBeInTheDocument();
-    expect(screen.getByTestId("mom-income")).toHaveTextContent("MoM: ↑ +8.3% (+R$ 100.00)");
-    expect(screen.getByTestId("mom-balance")).toHaveTextContent("MoM: ↑ +13.3% (+R$ 120.00)");
-    expect(screen.getByTestId("mom-expense")).toHaveTextContent("MoM: ↓ -6.7% (-R$ 20.00)");
+    expect(await screen.findByText("R$ 1.020,00")).toBeInTheDocument();
+    expect(screen.getByTestId("mom-income")).toHaveTextContent("MoM: ↑ +8.3% (+R$ 100,00)");
+    expect(screen.getByTestId("mom-balance")).toHaveTextContent("MoM: ↑ +13.3% (+R$ 120,00)");
+    expect(screen.getByTestId("mom-expense")).toHaveTextContent("MoM: ↓ -6.7% (-R$ 20,00)");
     expect(screen.getByTestId("mom-expense")).toHaveClass("text-green-200");
   });
 
@@ -366,7 +366,7 @@ describe("App", () => {
     render(<App />);
 
     expect(await screen.findByTestId("mom-income")).toBeInTheDocument();
-    expect(screen.getByTestId("mom-income")).toHaveTextContent("MoM: ↑ — (+R$ 100.00)");
+    expect(screen.getByTestId("mom-income")).toHaveTextContent("MoM: ↑ — (+R$ 100,00)");
   });
 
   it("exibe loading de comparacao mensal enquanto os resumos sao carregados", async () => {
@@ -433,7 +433,7 @@ describe("App", () => {
 
     render(<App />);
 
-    expect(await screen.findByText("R$ 700.00")).toBeInTheDocument();
+    expect(await screen.findByText("R$ 700,00")).toBeInTheDocument();
     expect(await screen.findByText("Comparacao mensal indisponivel.")).toBeInTheDocument();
     expect(screen.getByTestId("mom-income")).toHaveTextContent("MoM: —");
     expect(screen.getByTestId("mom-balance")).toHaveTextContent("MoM: —");
@@ -563,9 +563,9 @@ describe("App", () => {
 
     expect((await screen.findAllByText("Alimentacao")).length).toBeGreaterThan(0);
     expect(screen.getAllByText("Proximo do limite").length).toBeGreaterThan(0);
-    expect(screen.getByText("Orcado: R$ 1000.00")).toBeInTheDocument();
-    expect(screen.getByText("Realizado: R$ 855.50")).toBeInTheDocument();
-    expect(screen.getByText("Restante: R$ 144.50")).toBeInTheDocument();
+    expect(screen.getByText("Orcado: R$ 1.000,00")).toBeInTheDocument();
+    expect(screen.getByText("Realizado: R$ 855,50")).toBeInTheDocument();
+    expect(screen.getByText("Restante: R$ 144,50")).toBeInTheDocument();
     expect(screen.getByText("Uso: 85.55%")).toBeInTheDocument();
     expect(transactionsService.getMonthlyBudgets).toHaveBeenCalledWith(expect.any(String));
   });
@@ -865,7 +865,7 @@ describe("App", () => {
       month: expect.any(String),
       amount: 900,
     });
-    expect(await screen.findByText("Orcado: R$ 900.00")).toBeInTheDocument();
+    expect(await screen.findByText("Orcado: R$ 900,00")).toBeInTheDocument();
   });
 
   it("exclui meta mensal e recarrega estado vazio", async () => {
@@ -1651,7 +1651,7 @@ describe("App", () => {
     await user.click(screen.getByRole("button", { name: "Tentar novamente" }));
 
     expect(await screen.findByTestId("mom-balance")).toBeInTheDocument();
-    expect(screen.getByText("R$ 700.00")).toBeInTheDocument();
+    expect(screen.getByText("R$ 700,00")).toBeInTheDocument();
     expect(screen.queryByText("Nao foi possivel carregar o resumo mensal.")).not.toBeInTheDocument();
   });
 

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -39,6 +39,7 @@ import {
   isSelectedPeriod,
 } from "../features/filters/useFilters";
 import { useTheme } from "../hooks/useTheme";
+import { formatCurrency } from "../utils/formatCurrency";
 
 const TransactionChart = lazy(() => import("../components/TransactionChart"));
 const TrendChart = lazy(() => import("../components/TrendChart"));
@@ -369,7 +370,6 @@ const getInitialPaginationState = (): PaginationState => {
   };
 };
 
-const formatCurrency = (value: number) => `R$ ${Number(value || 0).toFixed(2)}`;
 const formatPercentage = (value: number) => `${Number(value || 0).toFixed(2)}%`;
 const formatSignedCurrency = (value: number) => {
   if (value > 0) {

--- a/apps/web/src/utils/formatCurrency.ts
+++ b/apps/web/src/utils/formatCurrency.ts
@@ -1,0 +1,15 @@
+const brlFormatter = new Intl.NumberFormat("pt-BR", {
+  style: "currency",
+  currency: "BRL",
+});
+
+export const formatCurrency = (value: unknown): string => {
+  const n =
+    typeof value === "number"
+      ? value
+      : typeof value === "string"
+        ? Number(value)
+        : NaN;
+
+  return brlFormatter.format(Number.isFinite(n) ? n : 0);
+};


### PR DESCRIPTION
## Summary

- **Bug fix**: `R$ 1500.00` → `R$ 1.500,00` — correct pt-BR locale with thousands separator and comma decimal
- **Single source of truth**: new `src/utils/formatCurrency.ts` with a singleton `Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" })` instance
- **Removed duplication**: 6 inline implementations deleted (`TransactionList`, `TransactionChart`, `TrendChart`, `ImportHistoryModal`, `ImportCsvModal`, `App`)
- **Test assertions updated** to match correct locale output

## Out of scope

- Input masking in `Modal.jsx` (deferred to PR-U2)
- `formatPercentage` in `App.tsx` (different semantic — not currency)
- `toFixed(2)` in `transactions.service.ts` (numeric rounding — not display)

## Test plan

- [x] `npm -w apps/web run typecheck` → 0 errors
- [x] `npm -w apps/web run lint` → 0 warnings
- [x] `npm -w apps/web test -- --run` → 115/115 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)