### PR TITLE
fix(web): semantic green/red colors for Entrada/Saída type indicators

### DIFF
--- a/apps/web/src/components/Modal.jsx
+++ b/apps/web/src/components/Modal.jsx
@@ -251,7 +251,7 @@ const Modal = ({
                 type="button"
                 className={`rounded border px-3.5 py-1 text-sm font-semibold transition-colors ${
                   transactionType === CATEGORY_ENTRY
-                    ? "border-brand-1 bg-brand-3 text-brand-1"
+                    ? "border-green-500 bg-green-50 text-green-700"
                     : "border-cf-border bg-cf-surface text-cf-text-secondary"
                 }`}
                 onClick={() => {
@@ -265,7 +265,7 @@ const Modal = ({
                 type="button"
                 className={`rounded border px-3.5 py-1 text-sm font-semibold transition-colors ${
                   transactionType === CATEGORY_EXIT
-                    ? "border-brand-1 bg-brand-3 text-brand-1"
+                    ? "border-red-500 bg-red-50 text-red-700"
                     : "border-cf-border bg-cf-surface text-cf-text-secondary"
                 }`}
                 onClick={() => {

--- a/apps/web/src/components/TransactionList.jsx
+++ b/apps/web/src/components/TransactionList.jsx
@@ -39,8 +39,8 @@ const TransactionList = ({ transactions, onDelete, onEdit }) => {
             <span
               className={`whitespace-nowrap rounded px-3 py-1 text-sm font-medium ${
                 transaction.type === CATEGORY_ENTRY
-                  ? "bg-brand-3 text-brand-1"
-                  : "bg-cf-bg-subtle text-cf-text-primary"
+                  ? "bg-green-100 text-green-700"
+                  : "bg-red-100 text-red-700"
               }`}
             >
               {transaction.type}


### PR DESCRIPTION
## Summary

Removes brand purple from financial type semantics. Purple is now reserved exclusively for brand CTAs and active UI states (buttons, nav chips).

| Location | Before | After |
|---|---|---|
| Modal toggle — Entrada active | `bg-brand-3 text-brand-1` (purple) | `bg-green-50 text-green-700` (green) |
| Modal toggle — Saída active | `bg-brand-3 text-brand-1` (purple) | `bg-red-50 text-red-700` (red) |
| TransactionList badge — Entrada | `bg-brand-3 text-brand-1` (purple) | `bg-green-100 text-green-700` (green) |
| TransactionList badge — Saída | `bg-cf-bg-subtle text-cf-text-primary` (gray) | `bg-red-100 text-red-700` (red) |

Consistent with the existing budget status color pattern (`bg-green-50 text-green-700` / `bg-red-50 text-red-700`).

## Test plan

- [x] `npm -w apps/web run typecheck` → 0 errors
- [x] `npm -w apps/web run lint` → 0 warnings
- [x] `npm -w apps/web test -- --run` → 115/115 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)