### PR TITLE
feat(auth): link accounts — PATCH /auth/password + POST /auth/google/link

### DIFF
--- a/apps/api/src/auth.link.test.js
+++ b/apps/api/src/auth.link.test.js
@@ -1,0 +1,130 @@
+import { vi, describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import request from "supertest";
+import app from "./app.js";
+import { clearDbClientForTests, dbQuery } from "./db/index.js";
+import {
+  setupTestDb,
+  registerAndLogin,
+  expectErrorResponseWithRequestId,
+} from "./test-helpers.js";
+import { resetLoginProtectionState } from "./middlewares/login-protection.middleware.js";
+import {
+  resetImportRateLimiterState,
+  resetWriteRateLimiterState,
+} from "./middlewares/rate-limit.middleware.js";
+import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
+
+const GOOGLE_SUB = "google-sub-link-test";
+const GOOGLE_EMAIL = "googlelink@test.dev";
+const GOOGLE_NAME = "Link Test User";
+
+vi.mock("google-auth-library", () => ({
+  OAuth2Client: vi.fn().mockImplementation(() => ({
+    verifyIdToken: vi.fn().mockResolvedValue({
+      getPayload: () => ({
+        sub: GOOGLE_SUB,
+        email: GOOGLE_EMAIL,
+        name: GOOGLE_NAME,
+      }),
+    }),
+  })),
+}));
+
+describe("POST /auth/google/link", () => {
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  afterAll(async () => {
+    await clearDbClientForTests();
+  });
+
+  beforeEach(async () => {
+    resetLoginProtectionState();
+    resetImportRateLimiterState();
+    resetWriteRateLimiterState();
+    resetHttpMetricsForTests();
+    await dbQuery("DELETE FROM transactions");
+    await dbQuery("DELETE FROM user_identities");
+    await dbQuery("DELETE FROM users");
+  });
+
+  it("retorna 401 quando nao autenticado", async () => {
+    const response = await request(app)
+      .post("/auth/google/link")
+      .send({ idToken: "any-token" });
+
+    expect(response.status).toBe(401);
+  });
+
+  it("vincula identidade Google a conta com senha existente", async () => {
+    const token = await registerAndLogin("user@test.dev", "Senha123");
+
+    const response = await request(app)
+      .post("/auth/google/link")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ idToken: "valid-google-token" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Conta Google vinculada com sucesso.");
+
+    // Subsequent Google login must resolve to same account
+    const googleLogin = await request(app)
+      .post("/auth/google")
+      .send({ idToken: "valid-google-token" });
+
+    expect(googleLogin.status).toBe(200);
+    expect(googleLogin.body.user.email).toBe("user@test.dev");
+  });
+
+  it("retorna 200 (idempotente) quando identidade Google ja esta vinculada ao mesmo usuario", async () => {
+    const token = await registerAndLogin("user@test.dev", "Senha123");
+
+    // First link
+    await request(app)
+      .post("/auth/google/link")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ idToken: "valid-google-token" });
+
+    // Second link — same identity, same user
+    const response = await request(app)
+      .post("/auth/google/link")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ idToken: "valid-google-token" });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("retorna 409 quando identidade Google ja esta vinculada a outro usuario", async () => {
+    // First user claims the Google identity
+    const tokenA = await registerAndLogin("usera@test.dev", "Senha123");
+    await request(app)
+      .post("/auth/google/link")
+      .set("Authorization", `Bearer ${tokenA}`)
+      .send({ idToken: "valid-google-token" });
+
+    // Second user tries to link the same Google identity
+    const tokenB = await registerAndLogin("userb@test.dev", "Senha123");
+    const response = await request(app)
+      .post("/auth/google/link")
+      .set("Authorization", `Bearer ${tokenB}`)
+      .send({ idToken: "valid-google-token" });
+
+    expectErrorResponseWithRequestId(
+      response,
+      409,
+      "Esta conta Google ja esta vinculada a outro usuario.",
+    );
+  });
+
+  it("retorna 400 quando idToken esta ausente", async () => {
+    const token = await registerAndLogin("user@test.dev", "Senha123");
+
+    const response = await request(app)
+      .post("/auth/google/link")
+      .set("Authorization", `Bearer ${token}`)
+      .send({});
+
+    expectErrorResponseWithRequestId(response, 400, "Token Google ausente ou invalido.");
+  });
+});

--- a/apps/api/src/auth.password.test.js
+++ b/apps/api/src/auth.password.test.js
@@ -1,0 +1,143 @@
+import { vi, describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import request from "supertest";
+import app from "./app.js";
+import { clearDbClientForTests, dbQuery } from "./db/index.js";
+import {
+  setupTestDb,
+  registerAndLogin,
+  expectErrorResponseWithRequestId,
+} from "./test-helpers.js";
+import { resetLoginProtectionState } from "./middlewares/login-protection.middleware.js";
+import {
+  resetImportRateLimiterState,
+  resetWriteRateLimiterState,
+} from "./middlewares/rate-limit.middleware.js";
+import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
+
+const GOOGLE_ONLY_EMAIL = "googleonly@passwordtest.dev";
+const GOOGLE_ONLY_SUB = "google-sub-password-test";
+
+vi.mock("google-auth-library", () => ({
+  OAuth2Client: vi.fn().mockImplementation(() => ({
+    verifyIdToken: vi.fn().mockResolvedValue({
+      getPayload: () => ({
+        sub: GOOGLE_ONLY_SUB,
+        email: GOOGLE_ONLY_EMAIL,
+        name: "Google Only User",
+      }),
+    }),
+  })),
+}));
+
+describe("PATCH /auth/password", () => {
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  afterAll(async () => {
+    await clearDbClientForTests();
+  });
+
+  beforeEach(async () => {
+    resetLoginProtectionState();
+    resetImportRateLimiterState();
+    resetWriteRateLimiterState();
+    resetHttpMetricsForTests();
+    await dbQuery("DELETE FROM transactions");
+    await dbQuery("DELETE FROM user_identities");
+    await dbQuery("DELETE FROM users");
+  });
+
+  it("retorna 401 quando nao autenticado", async () => {
+    const response = await request(app)
+      .patch("/auth/password")
+      .send({ newPassword: "Senha123" });
+
+    expect(response.status).toBe(401);
+  });
+
+  it("usuario com senha pode alterar com currentPassword correto", async () => {
+    const token = await registerAndLogin("user@test.dev", "Senha123");
+
+    const response = await request(app)
+      .patch("/auth/password")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ currentPassword: "Senha123", newPassword: "NovaSenha456" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Senha atualizada com sucesso.");
+
+    // Confirm new password works for login
+    const loginResponse = await request(app)
+      .post("/auth/login")
+      .send({ email: "user@test.dev", password: "NovaSenha456" });
+    expect(loginResponse.status).toBe(200);
+  });
+
+  it("retorna 400 quando currentPassword ausente para usuario com senha", async () => {
+    const token = await registerAndLogin("user@test.dev", "Senha123");
+
+    const response = await request(app)
+      .patch("/auth/password")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ newPassword: "NovaSenha456" });
+
+    expectErrorResponseWithRequestId(response, 400, "Senha atual e obrigatoria.");
+  });
+
+  it("retorna 401 quando currentPassword incorreto", async () => {
+    const token = await registerAndLogin("user@test.dev", "Senha123");
+
+    const response = await request(app)
+      .patch("/auth/password")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ currentPassword: "SenhaErrada", newPassword: "NovaSenha456" });
+
+    expectErrorResponseWithRequestId(response, 401, "Senha atual incorreta.");
+  });
+
+  it("retorna 400 quando newPassword e fraca", async () => {
+    const token = await registerAndLogin("user@test.dev", "Senha123");
+
+    const response = await request(app)
+      .patch("/auth/password")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ currentPassword: "Senha123", newPassword: "fraca" });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("retorna 400 quando newPassword ausente", async () => {
+    const token = await registerAndLogin("user@test.dev", "Senha123");
+
+    const response = await request(app)
+      .patch("/auth/password")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ currentPassword: "Senha123" });
+
+    expectErrorResponseWithRequestId(response, 400, "Nova senha e obrigatoria.");
+  });
+
+  it("usuario Google-only pode definir senha sem currentPassword", async () => {
+    // Create Google-only user via POST /auth/google
+    const googleResponse = await request(app)
+      .post("/auth/google")
+      .send({ idToken: "valid-google-token" });
+    expect(googleResponse.status).toBe(200);
+    const { token } = googleResponse.body;
+
+    const response = await request(app)
+      .patch("/auth/password")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ newPassword: "NovaSenha789" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Senha atualizada com sucesso.");
+
+    // Confirm password login now works for this account
+    const loginResponse = await request(app)
+      .post("/auth/login")
+      .send({ email: GOOGLE_ONLY_EMAIL, password: "NovaSenha789" });
+    expect(loginResponse.status).toBe(200);
+  });
+});

--- a/apps/api/src/routes/auth.routes.js
+++ b/apps/api/src/routes/auth.routes.js
@@ -1,5 +1,11 @@
 import { Router } from "express";
-import { loginUser, registerUser, loginOrRegisterWithGoogle } from "../services/auth.service.js";
+import {
+  loginUser,
+  registerUser,
+  loginOrRegisterWithGoogle,
+  setUserPassword,
+  linkGoogleIdentity,
+} from "../services/auth.service.js";
 import { authMiddleware } from "../middlewares/auth.middleware.js";
 import {
   bruteForceLoginGuard,
@@ -39,6 +45,31 @@ router.post("/google", async (req, res, next) => {
   try {
     const authResult = await loginOrRegisterWithGoogle(req.body || {});
     res.status(200).json(authResult);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.patch("/password", authMiddleware, async (req, res, next) => {
+  try {
+    await setUserPassword({
+      userId: req.user.id,
+      currentPassword: req.body?.currentPassword,
+      newPassword: req.body?.newPassword,
+    });
+    res.status(200).json({ message: "Senha atualizada com sucesso." });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post("/google/link", authMiddleware, async (req, res, next) => {
+  try {
+    await linkGoogleIdentity({
+      userId: req.user.id,
+      idToken: req.body?.idToken,
+    });
+    res.status(200).json({ message: "Conta Google vinculada com sucesso." });
   } catch (error) {
     next(error);
   }


### PR DESCRIPTION
## Summary

Completes the OAuth account bridge — users can now connect password and Google login to the same account.

**`PATCH /auth/password`** (authenticated)
- Google-only users (no `password_hash`): set password without `currentPassword` — enables email+password login after
- Users with existing password: require correct `currentPassword` before updating
- Validates new password strength (same regex as register)

**`POST /auth/google/link`** (authenticated)
- Verifies Google ID token, inserts into `user_identities`
- Idempotent: same identity + same user → 200
- 409 if Google identity already claimed by a different account

## Test plan

- [x] `auth.password.test.js` — 7 tests (unauthenticated, change password, missing/wrong currentPassword, weak/missing newPassword, Google-only set)
- [x] `auth.link.test.js` — 5 tests (unauthenticated, link, idempotent, 409 conflict, missing token)
- [x] `npm -w apps/api run lint` → 0 warnings
- [x] `npm -w apps/api test -- --run` → **173/173 pass** (15 test files)

## Out of scope

Web UI for account management (profile/settings page) — deferred to a follow-up PR after PR-L and PR-M.

🤖 Generated with [Claude Code](https://claude.com/claude-code)