### PR TITLE
feat(billing): add POST /billing/portal for Stripe Customer Portal

### DIFF
--- a/apps/api/src/billing-portal.test.js
+++ b/apps/api/src/billing-portal.test.js
@@ -1,0 +1,149 @@
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import app from "./app.js";
+import { clearDbClientForTests, dbQuery } from "./db/index.js";
+import { resetLoginProtectionState } from "./middlewares/login-protection.middleware.js";
+import {
+  resetImportRateLimiterState,
+  resetWriteRateLimiterState,
+} from "./middlewares/rate-limit.middleware.js";
+import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
+import { makeProUser, registerAndLogin, setupTestDb } from "./test-helpers.js";
+
+const { mockPortalCreate } = vi.hoisted(() => ({
+  mockPortalCreate: vi.fn(),
+}));
+
+vi.mock("stripe", () => ({
+  default: vi.fn().mockImplementation(() => ({
+    billingPortal: { sessions: { create: mockPortalCreate } },
+  })),
+}));
+
+describe("billing portal", () => {
+  beforeAll(async () => {
+    await setupTestDb();
+    process.env.STRIPE_SECRET_KEY = "sk_test_mock_controlfinance";
+    process.env.STRIPE_PORTAL_RETURN_URL = "https://app.test/billing";
+  });
+
+  afterAll(async () => {
+    await clearDbClientForTests();
+    delete process.env.STRIPE_SECRET_KEY;
+    delete process.env.STRIPE_PORTAL_RETURN_URL;
+  });
+
+  beforeEach(async () => {
+    resetLoginProtectionState();
+    resetImportRateLimiterState();
+    resetWriteRateLimiterState();
+    resetHttpMetricsForTests();
+    await dbQuery("DELETE FROM subscriptions");
+    await dbQuery("DELETE FROM transactions");
+    await dbQuery("DELETE FROM users");
+    mockPortalCreate.mockReset();
+    mockPortalCreate.mockResolvedValue({ url: "https://billing.stripe.com/portal/test-session-001" });
+  });
+
+  it("retorna 401 sem token", async () => {
+    const response = await request(app).post("/billing/portal");
+    expect(response.status).toBe(401);
+  });
+
+  it("retorna 422 quando usuario nao possui stripe_customer_id", async () => {
+    const email = "portal-no-customer@controlfinance.dev";
+    const token = await registerAndLogin(email);
+    // subscription sem stripe_customer_id
+    await makeProUser(email);
+
+    const response = await request(app)
+      .post("/billing/portal")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(422);
+    expect(response.body.message).toBe("Nenhuma assinatura encontrada para este usuario.");
+    expect(mockPortalCreate).not.toHaveBeenCalled();
+  });
+
+  it("retorna 422 quando usuario nao possui assinatura", async () => {
+    const token = await registerAndLogin("portal-free@controlfinance.dev");
+
+    const response = await request(app)
+      .post("/billing/portal")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(422);
+    expect(response.body.message).toBe("Nenhuma assinatura encontrada para este usuario.");
+    expect(mockPortalCreate).not.toHaveBeenCalled();
+  });
+
+  it("retorna 200 com url para usuario com stripe_customer_id", async () => {
+    const email = "portal-ok@controlfinance.dev";
+    const token = await registerAndLogin(email);
+    await makeProUser(email);
+    const userResult = await dbQuery(`SELECT id FROM users WHERE email = $1`, [email]);
+    const userId = userResult.rows[0].id;
+    await dbQuery(
+      `UPDATE subscriptions SET stripe_customer_id = 'cus_test_abc123' WHERE user_id = $1`,
+      [userId],
+    );
+
+    const response = await request(app)
+      .post("/billing/portal")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.url).toBe("https://billing.stripe.com/portal/test-session-001");
+  });
+
+  it("passa customer e return_url corretos para Stripe", async () => {
+    const email = "portal-args@controlfinance.dev";
+    const token = await registerAndLogin(email);
+    await makeProUser(email);
+    const userResult = await dbQuery(`SELECT id FROM users WHERE email = $1`, [email]);
+    const userId = userResult.rows[0].id;
+    await dbQuery(
+      `UPDATE subscriptions SET stripe_customer_id = 'cus_test_xyz789' WHERE user_id = $1`,
+      [userId],
+    );
+
+    await request(app)
+      .post("/billing/portal")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(mockPortalCreate).toHaveBeenCalledOnce();
+    const args = mockPortalCreate.mock.calls[0][0];
+    expect(args.customer).toBe("cus_test_xyz789");
+    expect(args.return_url).toBe("https://app.test/billing");
+  });
+
+  it("retorna 500 se STRIPE_SECRET_KEY nao configurado", async () => {
+    const saved = process.env.STRIPE_SECRET_KEY;
+    delete process.env.STRIPE_SECRET_KEY;
+    try {
+      const token = await registerAndLogin("portal-no-key@controlfinance.dev");
+      const response = await request(app)
+        .post("/billing/portal")
+        .set("Authorization", `Bearer ${token}`);
+      expect(response.status).toBe(500);
+      expect(mockPortalCreate).not.toHaveBeenCalled();
+    } finally {
+      process.env.STRIPE_SECRET_KEY = saved;
+    }
+  });
+
+  it("retorna 500 se STRIPE_PORTAL_RETURN_URL nao configurado", async () => {
+    const saved = process.env.STRIPE_PORTAL_RETURN_URL;
+    delete process.env.STRIPE_PORTAL_RETURN_URL;
+    try {
+      const token = await registerAndLogin("portal-no-url@controlfinance.dev");
+      const response = await request(app)
+        .post("/billing/portal")
+        .set("Authorization", `Bearer ${token}`);
+      expect(response.status).toBe(500);
+      expect(mockPortalCreate).not.toHaveBeenCalled();
+    } finally {
+      process.env.STRIPE_PORTAL_RETURN_URL = saved;
+    }
+  });
+});

--- a/apps/api/src/routes/billing.routes.js
+++ b/apps/api/src/routes/billing.routes.js
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { authMiddleware } from "../middlewares/auth.middleware.js";
 import { getSubscriptionSummaryForUser } from "../services/billing.service.js";
 import { createCheckoutSession } from "../services/stripe-checkout.service.js";
+import { createPortalSession } from "../services/stripe-portal.service.js";
 
 const router = Router();
 
@@ -23,6 +24,15 @@ router.post("/checkout", async (req, res, next) => {
       userEmail: req.user.email,
     });
     res.status(201).json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post("/portal", async (req, res, next) => {
+  try {
+    const result = await createPortalSession({ userId: req.user.id });
+    res.status(200).json(result);
   } catch (error) {
     next(error);
   }

--- a/apps/api/src/services/stripe-portal.service.js
+++ b/apps/api/src/services/stripe-portal.service.js
@@ -1,0 +1,39 @@
+import Stripe from "stripe";
+import { dbQuery } from "../db/index.js";
+
+const createError = (status, message) => {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+};
+
+export const createPortalSession = async ({ userId }) => {
+  const secretKey = process.env.STRIPE_SECRET_KEY;
+  if (!secretKey) throw createError(500, "Stripe secret key not configured.");
+
+  const returnUrl = process.env.STRIPE_PORTAL_RETURN_URL;
+  if (!returnUrl) throw createError(500, "Portal return URL not configured.");
+
+  const result = await dbQuery(
+    `SELECT stripe_customer_id FROM subscriptions
+      WHERE user_id = $1 AND stripe_customer_id IS NOT NULL
+      ORDER BY created_at DESC
+      LIMIT 1`,
+    [userId],
+  );
+
+  if (result.rows.length === 0) {
+    throw createError(422, "Nenhuma assinatura encontrada para este usuario.");
+  }
+
+  const stripeCustomerId = result.rows[0].stripe_customer_id;
+
+  const stripe = new Stripe(secretKey, { apiVersion: "2026-01-28.clover" });
+
+  const session = await stripe.billingPortal.sessions.create({
+    customer: stripeCustomerId,
+    return_url: returnUrl,
+  });
+
+  return { url: session.url };
+};


### PR DESCRIPTION
## Summary

- Adds \`stripe-portal.service.js\` — looks up \`stripe_customer_id\` from \`subscriptions\` table, calls \`stripe.billingPortal.sessions.create\`, returns \`{ url }\`
- Adds \`POST /billing/portal\` route to \`billing.routes.js\` (inherits \`authMiddleware\` from \`router.use\`)
- Returns 422 when no subscription with a \`stripe_customer_id\` exists for the user
- Returns 500 when \`STRIPE_SECRET_KEY\` or \`STRIPE_PORTAL_RETURN_URL\` env vars are missing

## Test plan

- [x] 401 — unauthenticated request rejected
- [x] 422 — user has subscription but no \`stripe_customer_id\`
- [x] 422 — user has no subscription at all
- [x] 200 — happy path returns portal URL
- [x] Arg verification — correct \`customer\` and \`return_url\` passed to Stripe
- [x] 500 — missing \`STRIPE_SECRET_KEY\`
- [x] 500 — missing \`STRIPE_PORTAL_RETURN_URL\`
- [x] Lint: 0 warnings
- [x] Tests: 180/180 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)