### PR TITLE
feat(web): billing settings page — plan card, subscribe & manage portal

### DIFF
--- a/apps/web/src/AppRoutes.tsx
+++ b/apps/web/src/AppRoutes.tsx
@@ -1,5 +1,6 @@
 import { Navigate, Route, Routes, useNavigate } from "react-router-dom";
 import App from "./pages/App";
+import BillingSettings from "./pages/BillingSettings";
 import CategoriesSettings from "./pages/CategoriesSettings";
 import Login from "./pages/Login";
 import ProtectedRoute from "./routers/ProtectedRoute";
@@ -18,10 +19,15 @@ const Dashboard = () => {
     navigate("/app/settings/categories");
   };
 
+  const handleOpenBillingSettings = () => {
+    navigate("/app/settings/billing");
+  };
+
   return (
     <App
       onLogout={handleLogout}
       onOpenCategoriesSettings={handleOpenCategoriesSettings}
+      onOpenBillingSettings={handleOpenBillingSettings}
     />
   );
 };
@@ -40,6 +46,22 @@ const CategoriesSettingsRoute = () => {
   };
 
   return <CategoriesSettings onBack={handleBack} onLogout={handleLogout} />;
+};
+
+const BillingSettingsRoute = () => {
+  const navigate = useNavigate();
+  const { logout } = useAuth();
+
+  const handleBack = () => {
+    navigate("/app");
+  };
+
+  const handleLogout = () => {
+    logout();
+    navigate("/", { replace: true });
+  };
+
+  return <BillingSettings onBack={handleBack} onLogout={handleLogout} />;
 };
 
 const RootRedirect = () => {
@@ -65,6 +87,14 @@ const AppRoutes = () => {
         element={
           <ProtectedRoute>
             <CategoriesSettingsRoute />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/app/settings/billing"
+        element={
+          <ProtectedRoute>
+            <BillingSettingsRoute />
           </ProtectedRoute>
         }
       />

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -101,6 +101,7 @@ interface ApiLikeError {
 interface AppProps {
   onLogout?: () => void;
   onOpenCategoriesSettings?: () => void;
+  onOpenBillingSettings?: () => void;
 }
 
 const PERIOD_OPTIONS = [
@@ -441,6 +442,7 @@ const calculateMonthOverMonthMetric = (
 const App = ({
   onLogout = undefined,
   onOpenCategoriesSettings = undefined,
+  onOpenBillingSettings = undefined,
 }: AppProps): JSX.Element => {
   const initialFilterState = useMemo(() => getInitialFilterState(), []);
   const initialPaginationState = useMemo(() => getInitialPaginationState(), []);
@@ -1349,6 +1351,11 @@ const App = ({
     onOpenCategoriesSettings?.();
   };
 
+  const handleOpenBillingSettings = () => {
+    closeMobileActionsMenu();
+    onOpenBillingSettings?.();
+  };
+
   const handleLogoutFromActionsMenu = () => {
     closeMobileActionsMenu();
     onLogout?.();
@@ -1534,6 +1541,16 @@ const App = ({
                         Categorias
                       </button>
                     ) : null}
+                    {onOpenBillingSettings ? (
+                      <button
+                        type="button"
+                        role="menuitem"
+                        onClick={handleOpenBillingSettings}
+                        className="rounded px-2 py-2 text-left text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
+                      >
+                        Assinatura
+                      </button>
+                    ) : null}
                     <button
                       type="button"
                       role="menuitem"
@@ -1605,6 +1622,15 @@ const App = ({
                     className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                   >
                     Categorias
+                  </button>
+                ) : null}
+                {onOpenBillingSettings ? (
+                  <button
+                    type="button"
+                    onClick={handleOpenBillingSettings}
+                    className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
+                  >
+                    Assinatura
                   </button>
                 ) : null}
               </div>

--- a/apps/web/src/pages/BillingSettings.tsx
+++ b/apps/web/src/pages/BillingSettings.tsx
@@ -1,0 +1,253 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  billingService,
+  type SubscriptionSummary,
+} from "../services/billing.service";
+
+interface ApiLikeError {
+  response?: {
+    data?: {
+      message?: string;
+    };
+    status?: number;
+  };
+  message?: string;
+}
+
+const getApiErrorMessage = (error: unknown, fallbackMessage: string): string => {
+  const normalizedError = error as ApiLikeError;
+  return (
+    normalizedError?.response?.data?.message ||
+    normalizedError?.message ||
+    fallbackMessage
+  );
+};
+
+const formatDate = (isoString: string | null | undefined): string => {
+  if (!isoString) return "";
+  const date = new Date(isoString);
+  if (isNaN(date.getTime())) return "";
+  return date.toLocaleDateString("pt-BR");
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  active: "Ativo",
+  trialing: "Em teste",
+  past_due: "Pagamento pendente",
+  canceled: "Cancelado",
+  unpaid: "Nao pago",
+};
+
+const STATUS_CLASSES: Record<string, string> = {
+  active: "border-green-200 bg-green-50 text-green-700",
+  trialing: "border-blue-200 bg-blue-50 text-blue-700",
+  past_due: "border-amber-200 bg-amber-50 text-amber-700",
+  canceled: "border-gray-200 bg-gray-50 text-gray-600",
+  unpaid: "border-red-200 bg-red-50 text-red-700",
+};
+
+interface BillingSettingsProps {
+  onBack?: () => void;
+  onLogout?: () => void;
+}
+
+const BillingSettings = ({
+  onBack = undefined,
+  onLogout = undefined,
+}: BillingSettingsProps): JSX.Element => {
+  const [summary, setSummary] = useState<SubscriptionSummary | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [isActionLoading, setIsActionLoading] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const loadSubscription = useCallback(async () => {
+    setIsLoading(true);
+    setLoadError(null);
+    try {
+      const data = await billingService.getSubscription();
+      setSummary(data);
+    } catch (error) {
+      setLoadError(
+        getApiErrorMessage(error, "Nao foi possivel carregar os dados da assinatura."),
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadSubscription();
+  }, [loadSubscription]);
+
+  const handleSubscribe = async () => {
+    setIsActionLoading(true);
+    setActionError(null);
+    try {
+      const { url } = await billingService.createCheckout();
+      window.location.href = url;
+    } catch (error) {
+      setActionError(
+        getApiErrorMessage(error, "Nao foi possivel iniciar o checkout. Tente novamente."),
+      );
+      setIsActionLoading(false);
+    }
+  };
+
+  const handleManage = async () => {
+    setIsActionLoading(true);
+    setActionError(null);
+    try {
+      const { url } = await billingService.createPortal();
+      window.location.href = url;
+    } catch (error) {
+      const status = (error as ApiLikeError)?.response?.status;
+      if (status === 422) {
+        setActionError(
+          "Portal de gerenciamento indisponivel. Entre em contato com o suporte.",
+        );
+      } else {
+        setActionError(
+          getApiErrorMessage(error, "Nao foi possivel abrir o portal. Tente novamente."),
+        );
+      }
+      setIsActionLoading(false);
+    }
+  };
+
+  const isPro = Boolean(summary?.subscription);
+  const statusKey = summary?.subscription?.status ?? "";
+  const statusLabel = STATUS_LABELS[statusKey] ?? "";
+  const statusClass = STATUS_CLASSES[statusKey] ?? "";
+  const periodEnd = summary?.subscription?.currentPeriodEnd;
+  const cancelAtPeriodEnd = summary?.subscription?.cancelAtPeriodEnd;
+
+  return (
+    <div className="min-h-screen bg-cf-bg-page py-6">
+      <main className="mx-auto w-full max-w-4xl space-y-4 px-4 sm:px-6">
+        <section className="rounded border border-cf-border bg-cf-surface p-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h1 className="text-xl font-semibold text-cf-text-primary">
+                Settings - Assinatura
+              </h1>
+              <p className="mt-1 text-sm text-cf-text-secondary">
+                Gerencie seu plano e assinatura.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                onClick={onBack}
+                className="rounded border border-cf-border bg-cf-surface px-3 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
+              >
+                Voltar ao dashboard
+              </button>
+              {onLogout ? (
+                <button
+                  type="button"
+                  onClick={onLogout}
+                  className="rounded border border-cf-border bg-cf-surface px-3 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
+                >
+                  Sair
+                </button>
+              ) : null}
+            </div>
+          </div>
+
+          {isLoading ? (
+            <div className="mt-4 space-y-3" role="status" aria-live="polite">
+              <div className="h-20 animate-pulse rounded border border-cf-border bg-cf-bg-subtle" />
+              <span className="sr-only">Carregando dados da assinatura...</span>
+            </div>
+          ) : null}
+
+          {!isLoading && loadError ? (
+            <div
+              className="mt-4 flex items-center justify-between gap-3 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+              role="alert"
+            >
+              <span>{loadError}</span>
+              <button
+                type="button"
+                onClick={loadSubscription}
+                className="rounded border border-red-300 px-2 py-1 text-xs font-semibold text-red-700 hover:bg-red-100"
+              >
+                Tentar novamente
+              </button>
+            </div>
+          ) : null}
+
+          {!isLoading && !loadError && summary ? (
+            <div className="mt-4 space-y-4">
+              {/* Plan card */}
+              <div className="rounded border border-cf-border bg-cf-bg-subtle p-4">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-cf-text-secondary">
+                      Plano atual
+                    </p>
+                    <p className="mt-0.5 text-lg font-bold text-cf-text-primary">
+                      {summary.displayName}
+                    </p>
+                    {isPro && statusLabel ? (
+                      <span
+                        className={`mt-1 inline-block rounded border px-2 py-0.5 text-xs font-semibold ${statusClass}`}
+                      >
+                        {statusLabel}
+                      </span>
+                    ) : null}
+                    {!isPro ? (
+                      <span className="mt-1 inline-block rounded border border-cf-border px-2 py-0.5 text-xs font-semibold text-cf-text-secondary">
+                        Gratuito
+                      </span>
+                    ) : null}
+                  </div>
+
+                  {!isPro ? (
+                    <button
+                      type="button"
+                      onClick={handleSubscribe}
+                      disabled={isActionLoading}
+                      className="rounded bg-brand-1 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-2 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {isActionLoading ? "Aguarde..." : "Assinar PRO"}
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={handleManage}
+                      disabled={isActionLoading}
+                      className="rounded border border-cf-border bg-cf-surface px-4 py-2 text-sm font-semibold text-cf-text-primary hover:bg-cf-bg-subtle disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {isActionLoading ? "Aguarde..." : "Gerenciar assinatura"}
+                    </button>
+                  )}
+                </div>
+
+                {isPro && periodEnd ? (
+                  <p className="mt-3 text-xs text-cf-text-secondary">
+                    {cancelAtPeriodEnd
+                      ? `Cancela em: ${formatDate(periodEnd)}`
+                      : `Renovacao em: ${formatDate(periodEnd)}`}
+                  </p>
+                ) : null}
+              </div>
+
+              {actionError ? (
+                <div
+                  className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+                  role="alert"
+                >
+                  {actionError}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default BillingSettings;

--- a/apps/web/src/services/billing.service.ts
+++ b/apps/web/src/services/billing.service.ts
@@ -1,0 +1,31 @@
+import { api } from "./api";
+
+export interface SubscriptionDetail {
+  status: string;
+  currentPeriodEnd: string | null;
+  cancelAtPeriodEnd: boolean;
+}
+
+export interface SubscriptionSummary {
+  plan: string;
+  displayName: string;
+  features: Record<string, unknown>;
+  subscription: SubscriptionDetail | null;
+}
+
+export const billingService = {
+  getSubscription: async (): Promise<SubscriptionSummary> => {
+    const { data } = await api.get<SubscriptionSummary>("/billing/subscription");
+    return data;
+  },
+
+  createCheckout: async (): Promise<{ url: string }> => {
+    const { data } = await api.post<{ url: string }>("/billing/checkout");
+    return data;
+  },
+
+  createPortal: async (): Promise<{ url: string }> => {
+    const { data } = await api.post<{ url: string }>("/billing/portal");
+    return data;
+  },
+};


### PR DESCRIPTION
## Summary

- Adds `billing.service.ts` with typed wrappers for `GET /billing/subscription`, `POST /billing/checkout` and `POST /billing/portal`
- Adds `BillingSettings.tsx` page: loading skeleton, plan card with status badge and period-end display, **"Assinar PRO"** button (free plan) and **"Gerenciar assinatura"** button (active subscription) — both redirect to Stripe URLs on success
- Adds `/app/settings/billing` route to `AppRoutes.tsx` (same pattern as `/app/settings/categories`)
- Adds **"Assinatura"** button to `App.tsx` header — mobile dropdown and desktop bar — via new `onOpenBillingSettings` prop

## Behaviour

| State | CTA shown | Action |
|---|---|---|
| Free plan | "Assinar PRO" | POST /billing/checkout → redirect |
| Active subscription | "Gerenciar assinatura" | POST /billing/portal → redirect |
| Portal 422 | Error message | "Portal indisponivel. Contato suporte." |
| Load error | Error + retry button | Retry getSubscription() |

## Test plan

- [x] Lint: 0 warnings
- [x] Typecheck: clean
- [x] Tests: 115/115 pass (no test coupling to new page — service calls are mocked at axios level)
- [ ] Smoke (manual): navigate to `/app/settings/billing`, confirm plan card renders, "Assinar PRO" initiates checkout redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)