### PR TITLE
feat(api): user profile — migration 013, GET /me, PATCH /me/profile

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -9,6 +9,7 @@ import budgetsRoutes from "./routes/budgets.routes.js";
 import analyticsRoutes from "./routes/analytics.routes.js";
 import transactionsRoutes from "./routes/transactions.routes.js";
 import billingRoutes from "./routes/billing.routes.js";
+import meRoutes from "./routes/me.routes.js";
 import stripeWebhooksRoutes from "./routes/stripe-webhooks.routes.js";
 import { notFoundHandler, errorHandler } from "./middlewares/error.middleware.js";
 import { requestIdMiddleware } from "./middlewares/request-id.middleware.js";
@@ -82,6 +83,7 @@ app.use("/budgets", budgetsRoutes);
 app.use("/analytics", analyticsRoutes);
 app.use("/transactions", transactionsRoutes);
 app.use("/billing", billingRoutes);
+app.use("/me", meRoutes);
 
 app.use(notFoundHandler);
 app.use(errorHandler);

--- a/apps/api/src/db/migrations/013_create_user_profiles.sql
+++ b/apps/api/src/db/migrations/013_create_user_profiles.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS user_profiles (
+  user_id        INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  display_name   TEXT,
+  salary_monthly NUMERIC(12, 2),
+  payday         SMALLINT,
+  avatar_url     TEXT,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_user_profiles_payday CHECK (payday IS NULL OR (payday >= 1 AND payday <= 31)),
+  CONSTRAINT chk_user_profiles_salary CHECK (salary_monthly IS NULL OR salary_monthly >= 0)
+);

--- a/apps/api/src/me.test.js
+++ b/apps/api/src/me.test.js
@@ -1,0 +1,243 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import request from "supertest";
+import app from "./app.js";
+import { clearDbClientForTests, dbQuery } from "./db/index.js";
+import {
+  setupTestDb,
+  registerAndLogin,
+  expectErrorResponseWithRequestId,
+} from "./test-helpers.js";
+import { resetLoginProtectionState } from "./middlewares/login-protection.middleware.js";
+import {
+  resetImportRateLimiterState,
+  resetWriteRateLimiterState,
+} from "./middlewares/rate-limit.middleware.js";
+import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
+
+describe("GET /me", () => {
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  afterAll(async () => {
+    await clearDbClientForTests();
+  });
+
+  beforeEach(async () => {
+    resetLoginProtectionState();
+    resetImportRateLimiterState();
+    resetWriteRateLimiterState();
+    resetHttpMetricsForTests();
+    await dbQuery("DELETE FROM user_profiles");
+    await dbQuery("DELETE FROM transactions");
+    await dbQuery("DELETE FROM user_identities");
+    await dbQuery("DELETE FROM users");
+  });
+
+  it("retorna 401 sem token", async () => {
+    const response = await request(app).get("/me");
+    expect(response.status).toBe(401);
+  });
+
+  it("retorna id, name, email e profile null para usuario sem perfil", async () => {
+    const token = await registerAndLogin("me-no-profile@test.dev");
+
+    const response = await request(app)
+      .get("/me")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    expect(typeof response.body.id).toBe("number");
+    expect(response.body.email).toBe("me-no-profile@test.dev");
+    expect(response.body.profile).toBeNull();
+  });
+
+  it("retorna profile preenchido quando usuario tem perfil", async () => {
+    const token = await registerAndLogin("me-with-profile@test.dev");
+    const userResult = await dbQuery(
+      `SELECT id FROM users WHERE email = $1`,
+      ["me-with-profile@test.dev"],
+    );
+    const userId = userResult.rows[0].id;
+
+    await dbQuery(
+      `INSERT INTO user_profiles (user_id, display_name, salary_monthly, payday, avatar_url)
+       VALUES ($1, 'Joao Silva', 5000.00, 5, 'https://example.com/avatar.jpg')`,
+      [userId],
+    );
+
+    const response = await request(app)
+      .get("/me")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.profile).toMatchObject({
+      displayName: "Joao Silva",
+      salaryMonthly: 5000,
+      payday: 5,
+      avatarUrl: "https://example.com/avatar.jpg",
+    });
+  });
+});
+
+describe("PATCH /me/profile", () => {
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  afterAll(async () => {
+    await clearDbClientForTests();
+  });
+
+  beforeEach(async () => {
+    resetLoginProtectionState();
+    resetImportRateLimiterState();
+    resetWriteRateLimiterState();
+    resetHttpMetricsForTests();
+    await dbQuery("DELETE FROM user_profiles");
+    await dbQuery("DELETE FROM transactions");
+    await dbQuery("DELETE FROM user_identities");
+    await dbQuery("DELETE FROM users");
+  });
+
+  it("retorna 401 sem token", async () => {
+    const response = await request(app)
+      .patch("/me/profile")
+      .send({ display_name: "Teste" });
+    expect(response.status).toBe(401);
+  });
+
+  it("cria perfil com todos os campos", async () => {
+    const token = await registerAndLogin("patch-all@test.dev");
+
+    const response = await request(app)
+      .patch("/me/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        display_name: "Maria Santos",
+        salary_monthly: 7500,
+        payday: 10,
+        avatar_url: "https://example.com/maria.jpg",
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      displayName: "Maria Santos",
+      salaryMonthly: 7500,
+      payday: 10,
+      avatarUrl: "https://example.com/maria.jpg",
+    });
+  });
+
+  it("atualiza parcialmente — so o campo enviado muda", async () => {
+    const token = await registerAndLogin("patch-partial@test.dev");
+
+    // Create initial profile
+    await request(app)
+      .patch("/me/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ display_name: "Original", salary_monthly: 3000, payday: 1 });
+
+    // Update only display_name
+    const response = await request(app)
+      .patch("/me/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ display_name: "Atualizado" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.displayName).toBe("Atualizado");
+    expect(response.body.salaryMonthly).toBe(3000);
+    expect(response.body.payday).toBe(1);
+  });
+
+  it("aceita display_name vazio como null", async () => {
+    const token = await registerAndLogin("patch-empty-name@test.dev");
+
+    await request(app)
+      .patch("/me/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ display_name: "  " });
+
+    const getResponse = await request(app)
+      .get("/me")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(getResponse.body.profile.displayName).toBeNull();
+  });
+
+  it("retorna 400 para payday invalido (zero)", async () => {
+    const token = await registerAndLogin("patch-payday-zero@test.dev");
+
+    const response = await request(app)
+      .patch("/me/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ payday: 0 });
+
+    expectErrorResponseWithRequestId(response, 400, "payday deve ser um inteiro entre 1 e 31.");
+  });
+
+  it("retorna 400 para payday invalido (32)", async () => {
+    const token = await registerAndLogin("patch-payday-32@test.dev");
+
+    const response = await request(app)
+      .patch("/me/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ payday: 32 });
+
+    expectErrorResponseWithRequestId(response, 400, "payday deve ser um inteiro entre 1 e 31.");
+  });
+
+  it("retorna 400 para salary_monthly negativo", async () => {
+    const token = await registerAndLogin("patch-salary-neg@test.dev");
+
+    const response = await request(app)
+      .patch("/me/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ salary_monthly: -100 });
+
+    expectErrorResponseWithRequestId(response, 400, "salary_monthly nao pode ser negativo.");
+  });
+
+  it("retorna 400 para avatar_url sem https://", async () => {
+    const token = await registerAndLogin("patch-avatar-http@test.dev");
+
+    const response = await request(app)
+      .patch("/me/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ avatar_url: "http://example.com/img.jpg" });
+
+    expectErrorResponseWithRequestId(response, 400, "avatar_url deve comecar com https://.");
+  });
+
+  it("retorna 400 quando nenhum campo valido enviado", async () => {
+    const token = await registerAndLogin("patch-empty@test.dev");
+
+    const response = await request(app)
+      .patch("/me/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({});
+
+    expectErrorResponseWithRequestId(
+      response,
+      400,
+      "Nenhum campo valido enviado para atualizacao.",
+    );
+  });
+
+  it("aceita avatar_url null para limpar o campo", async () => {
+    const token = await registerAndLogin("patch-avatar-null@test.dev");
+
+    await request(app)
+      .patch("/me/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ avatar_url: "https://example.com/old.jpg" });
+
+    const response = await request(app)
+      .patch("/me/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ avatar_url: null });
+
+    expect(response.status).toBe(200);
+    expect(response.body.avatarUrl).toBeNull();
+  });
+});

--- a/apps/api/src/routes/me.routes.js
+++ b/apps/api/src/routes/me.routes.js
@@ -1,0 +1,27 @@
+import { Router } from "express";
+import { authMiddleware } from "../middlewares/auth.middleware.js";
+import { getMyProfile, updateMyProfile } from "../services/profile.service.js";
+
+const router = Router();
+
+router.use(authMiddleware);
+
+router.get("/", async (req, res, next) => {
+  try {
+    const result = await getMyProfile(req.user.id);
+    res.status(200).json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.patch("/profile", async (req, res, next) => {
+  try {
+    const profile = await updateMyProfile(req.user.id, req.body ?? {});
+    res.status(200).json(profile);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/apps/api/src/services/profile.service.js
+++ b/apps/api/src/services/profile.service.js
@@ -1,0 +1,152 @@
+import { dbQuery } from "../db/index.js";
+
+const createError = (status, message) => {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+};
+
+const normalizeUserId = (value) => {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw createError(401, "Usuario nao autenticado.");
+  }
+  return parsed;
+};
+
+// Returns undefined → field was not sent (skip update)
+// Returns null     → field was explicitly set to null (clear)
+// Returns value    → set to that value
+
+const normalizeDisplayName = (value) => {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (typeof value !== "string") throw createError(400, "display_name deve ser texto.");
+  const trimmed = value.trim();
+  if (trimmed.length > 100) throw createError(400, "display_name deve ter no maximo 100 caracteres.");
+  return trimmed || null;
+};
+
+const normalizeSalaryMonthly = (value) => {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  const n = Number(value);
+  if (!Number.isFinite(n)) throw createError(400, "salary_monthly deve ser um numero.");
+  if (n < 0) throw createError(400, "salary_monthly nao pode ser negativo.");
+  return n;
+};
+
+const normalizePayday = (value) => {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 1 || n > 31) {
+    throw createError(400, "payday deve ser um inteiro entre 1 e 31.");
+  }
+  return n;
+};
+
+const normalizeAvatarUrl = (value) => {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (typeof value !== "string") throw createError(400, "avatar_url deve ser texto.");
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (!trimmed.startsWith("https://")) {
+    throw createError(400, "avatar_url deve comecar com https://.");
+  }
+  if (trimmed.length > 2048) {
+    throw createError(400, "avatar_url deve ter no maximo 2048 caracteres.");
+  }
+  return trimmed;
+};
+
+const rowToProfile = (row) => ({
+  displayName: row.display_name ?? null,
+  salaryMonthly:
+    row.salary_monthly !== null && row.salary_monthly !== undefined
+      ? Number(row.salary_monthly)
+      : null,
+  payday: row.payday !== null && row.payday !== undefined ? Number(row.payday) : null,
+  avatarUrl: row.avatar_url ?? null,
+});
+
+export const getMyProfile = async (userId) => {
+  const normalizedUserId = normalizeUserId(userId);
+
+  const userResult = await dbQuery(
+    `SELECT id, name, email FROM users WHERE id = $1 LIMIT 1`,
+    [normalizedUserId],
+  );
+
+  if (userResult.rows.length === 0) {
+    throw createError(404, "Usuario nao encontrado.");
+  }
+
+  const user = userResult.rows[0];
+
+  const profileResult = await dbQuery(
+    `SELECT display_name, salary_monthly, payday, avatar_url
+     FROM user_profiles WHERE user_id = $1 LIMIT 1`,
+    [normalizedUserId],
+  );
+
+  return {
+    id: Number(user.id),
+    name: user.name,
+    email: user.email,
+    profile: profileResult.rows.length > 0 ? rowToProfile(profileResult.rows[0]) : null,
+  };
+};
+
+export const updateMyProfile = async (userId, payload = {}) => {
+  const normalizedUserId = normalizeUserId(userId);
+
+  // Normalize only fields that were explicitly sent (undefined = not sent)
+  const updates = {};
+
+  const displayName = normalizeDisplayName(payload.display_name);
+  if (displayName !== undefined) updates.display_name = displayName;
+
+  const salaryMonthly = normalizeSalaryMonthly(payload.salary_monthly);
+  if (salaryMonthly !== undefined) updates.salary_monthly = salaryMonthly;
+
+  const normalizedPayday = normalizePayday(payload.payday);
+  if (normalizedPayday !== undefined) updates.payday = normalizedPayday;
+
+  const avatarUrl = normalizeAvatarUrl(payload.avatar_url);
+  if (avatarUrl !== undefined) updates.avatar_url = avatarUrl;
+
+  if (Object.keys(updates).length === 0) {
+    throw createError(400, "Nenhum campo valido enviado para atualizacao.");
+  }
+
+  const cols = Object.keys(updates);
+  const vals = Object.values(updates);
+  const now = new Date().toISOString();
+
+  // $1 = userId, $2..$N = field values, $N+1 = now
+  const nowIdx = vals.length + 2;
+  const insertColsSql = ["user_id", ...cols, "updated_at"].join(", ");
+  const insertPlaceholders = ["$1", ...cols.map((_, i) => `$${i + 2}`), `$${nowIdx}`].join(", ");
+  const setClauses = [
+    ...cols.map((col, i) => `${col} = $${i + 2}`),
+    `updated_at = $${nowIdx}`,
+  ].join(", ");
+
+  await dbQuery(
+    `INSERT INTO user_profiles (${insertColsSql})
+     VALUES (${insertPlaceholders})
+     ON CONFLICT (user_id)
+     DO UPDATE SET ${setClauses}`,
+    [normalizedUserId, ...vals, now],
+  );
+
+  const result = await dbQuery(
+    `SELECT display_name, salary_monthly, payday, avatar_url
+     FROM user_profiles WHERE user_id = $1 LIMIT 1`,
+    [normalizedUserId],
+  );
+
+  return rowToProfile(result.rows[0]);
+};


### PR DESCRIPTION
## Summary

- **Migration 013** — \`user_profiles\` table: \`user_id\` (PK, FK → users ON DELETE CASCADE), \`display_name\`, \`salary_monthly NUMERIC(12,2)\`, \`payday SMALLINT\`, \`avatar_url\`, \`created_at\`, \`updated_at\`. CHECK constraints enforce \`payday IN [1,31]\` and \`salary_monthly >= 0\`.
- **\`profile.service.js\`** — \`getMyProfile\`: returns \`{ id, name, email, profile | null }\`; \`updateMyProfile\`: partial upsert via \`INSERT … ON CONFLICT DO UPDATE\`, distinguishing \`null\` (explicit clear) from \`undefined\` (field not sent)
- **\`me.routes.js\`** — \`GET /me\` and \`PATCH /me/profile\`, both authenticated via \`authMiddleware\`. Mounted at \`/me\` in \`app.js\`

## Validation rules

| Field | Rule |
|---|---|
| \`display_name\` | string, trimmed, max 100 chars; empty string → null |
| \`salary_monthly\` | number ≥ 0; null clears |
| \`payday\` | integer 1–31; null clears |
| \`avatar_url\` | must start with \`https://\`, max 2048 chars; null clears |

## Test plan (13 tests)

- [x] \`GET /me\` — 401 unauthenticated
- [x] \`GET /me\` — returns \`profile: null\` for user without profile row
- [x] \`GET /me\` — returns full profile when row exists
- [x] \`PATCH /me/profile\` — 401 unauthenticated
- [x] Creates profile with all fields
- [x] Partial update: only sent field changes, others preserved
- [x] Empty string display_name → stored as null
- [x] 400 payday = 0 (below range)
- [x] 400 payday = 32 (above range)
- [x] 400 salary_monthly negative
- [x] 400 avatar_url with http:// (must be https://)
- [x] 400 empty payload (no valid fields)
- [x] \`avatar_url: null\` explicitly clears the field (200)
- [x] Lint: 0 warnings. Tests: 193/193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)