### PR TITLE
feat(web): profile settings page — avatar, form, /app/settings/profile

### DIFF
--- a/apps/web/src/AppRoutes.tsx
+++ b/apps/web/src/AppRoutes.tsx
@@ -3,6 +3,7 @@ import App from "./pages/App";
 import BillingSettings from "./pages/BillingSettings";
 import CategoriesSettings from "./pages/CategoriesSettings";
 import Login from "./pages/Login";
+import ProfileSettings from "./pages/ProfileSettings";
 import ProtectedRoute from "./routers/ProtectedRoute";
 import { useAuth } from "./hooks/useAuth";
 
@@ -23,11 +24,16 @@ const Dashboard = () => {
     navigate("/app/settings/billing");
   };
 
+  const handleOpenProfileSettings = () => {
+    navigate("/app/settings/profile");
+  };
+
   return (
     <App
       onLogout={handleLogout}
       onOpenCategoriesSettings={handleOpenCategoriesSettings}
       onOpenBillingSettings={handleOpenBillingSettings}
+      onOpenProfileSettings={handleOpenProfileSettings}
     />
   );
 };
@@ -64,6 +70,22 @@ const BillingSettingsRoute = () => {
   return <BillingSettings onBack={handleBack} onLogout={handleLogout} />;
 };
 
+const ProfileSettingsRoute = () => {
+  const navigate = useNavigate();
+  const { logout } = useAuth();
+
+  const handleBack = () => {
+    navigate("/app");
+  };
+
+  const handleLogout = () => {
+    logout();
+    navigate("/", { replace: true });
+  };
+
+  return <ProfileSettings onBack={handleBack} onLogout={handleLogout} />;
+};
+
 const RootRedirect = () => {
   const { isAuthenticated } = useAuth();
 
@@ -95,6 +117,14 @@ const AppRoutes = () => {
         element={
           <ProtectedRoute>
             <BillingSettingsRoute />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/app/settings/profile"
+        element={
+          <ProtectedRoute>
+            <ProfileSettingsRoute />
           </ProtectedRoute>
         }
       />

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -102,6 +102,7 @@ interface AppProps {
   onLogout?: () => void;
   onOpenCategoriesSettings?: () => void;
   onOpenBillingSettings?: () => void;
+  onOpenProfileSettings?: () => void;
 }
 
 const PERIOD_OPTIONS = [
@@ -443,6 +444,7 @@ const App = ({
   onLogout = undefined,
   onOpenCategoriesSettings = undefined,
   onOpenBillingSettings = undefined,
+  onOpenProfileSettings = undefined,
 }: AppProps): JSX.Element => {
   const initialFilterState = useMemo(() => getInitialFilterState(), []);
   const initialPaginationState = useMemo(() => getInitialPaginationState(), []);
@@ -1356,6 +1358,11 @@ const App = ({
     onOpenBillingSettings?.();
   };
 
+  const handleOpenProfileSettings = () => {
+    closeMobileActionsMenu();
+    onOpenProfileSettings?.();
+  };
+
   const handleLogoutFromActionsMenu = () => {
     closeMobileActionsMenu();
     onLogout?.();
@@ -1551,6 +1558,16 @@ const App = ({
                         Assinatura
                       </button>
                     ) : null}
+                    {onOpenProfileSettings ? (
+                      <button
+                        type="button"
+                        role="menuitem"
+                        onClick={handleOpenProfileSettings}
+                        className="rounded px-2 py-2 text-left text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
+                      >
+                        Perfil
+                      </button>
+                    ) : null}
                     <button
                       type="button"
                       role="menuitem"
@@ -1631,6 +1648,15 @@ const App = ({
                     className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                   >
                     Assinatura
+                  </button>
+                ) : null}
+                {onOpenProfileSettings ? (
+                  <button
+                    type="button"
+                    onClick={handleOpenProfileSettings}
+                    className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
+                  >
+                    Perfil
                   </button>
                 ) : null}
               </div>

--- a/apps/web/src/pages/ProfileSettings.tsx
+++ b/apps/web/src/pages/ProfileSettings.tsx
@@ -1,0 +1,336 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { FormEvent } from "react";
+import { profileService, type UserProfile } from "../services/profile.service";
+
+interface ApiLikeError {
+  response?: {
+    data?: { message?: string };
+    status?: number;
+  };
+  message?: string;
+}
+
+const getApiErrorMessage = (error: unknown, fallback: string): string => {
+  const e = error as ApiLikeError;
+  return e?.response?.data?.message || e?.message || fallback;
+};
+
+const getInitials = (displayName: string | null, email: string): string => {
+  const trimmed = displayName?.trim();
+  if (trimmed) return trimmed[0].toUpperCase();
+  return email[0]?.toUpperCase() ?? "?";
+};
+
+interface AvatarProps {
+  avatarUrl: string;
+  displayName: string;
+  email: string;
+}
+
+const Avatar = ({ avatarUrl, displayName, email }: AvatarProps): JSX.Element => {
+  const [imgError, setImgError] = useState(false);
+  const initials = getInitials(displayName || null, email);
+  const showImage = avatarUrl.startsWith("https://") && !imgError;
+
+  useEffect(() => {
+    setImgError(false);
+  }, [avatarUrl]);
+
+  if (showImage) {
+    return (
+      <img
+        src={avatarUrl}
+        alt="Avatar"
+        className="h-16 w-16 rounded-full object-cover"
+        onError={() => setImgError(true)}
+      />
+    );
+  }
+
+  return (
+    <div className="flex h-16 w-16 items-center justify-center rounded-full bg-brand-1 text-xl font-bold text-white">
+      {initials}
+    </div>
+  );
+};
+
+interface ProfileSettingsProps {
+  onBack?: () => void;
+  onLogout?: () => void;
+}
+
+const ProfileSettings = ({
+  onBack = undefined,
+  onLogout = undefined,
+}: ProfileSettingsProps): JSX.Element => {
+  const [email, setEmail] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [salaryMonthly, setSalaryMonthly] = useState("");
+  const [payday, setPayday] = useState("");
+  const [avatarUrl, setAvatarUrl] = useState("");
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+
+  const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const loadProfile = useCallback(async () => {
+    setIsLoading(true);
+    setLoadError(null);
+    try {
+      const me = await profileService.getMe();
+      setEmail(me.email);
+      const p: UserProfile | null = me.profile;
+      setDisplayName(p?.displayName ?? "");
+      setSalaryMonthly(p?.salaryMonthly !== null && p?.salaryMonthly !== undefined
+        ? String(p.salaryMonthly)
+        : "");
+      setPayday(p?.payday !== null && p?.payday !== undefined ? String(p.payday) : "");
+      setAvatarUrl(p?.avatarUrl ?? "");
+    } catch (error) {
+      setLoadError(getApiErrorMessage(error, "Nao foi possivel carregar o perfil."));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadProfile();
+    return () => {
+      if (successTimerRef.current) clearTimeout(successTimerRef.current);
+    };
+  }, [loadProfile]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setIsSaving(true);
+    setSaveError(null);
+    setSaveSuccess(false);
+
+    const salaryNum = salaryMonthly.trim() ? Number(salaryMonthly) : null;
+    const paydayNum = payday.trim() ? Number(payday) : null;
+
+    try {
+      await profileService.updateProfile({
+        display_name: displayName.trim() || null,
+        salary_monthly: salaryNum,
+        payday: paydayNum,
+        avatar_url: avatarUrl.trim() || null,
+      });
+      setSaveSuccess(true);
+      successTimerRef.current = setTimeout(() => setSaveSuccess(false), 4000);
+    } catch (error) {
+      setSaveError(getApiErrorMessage(error, "Nao foi possivel salvar o perfil. Tente novamente."));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const avatarPreview = avatarUrl.trim();
+
+  return (
+    <div className="min-h-screen bg-cf-bg-page py-6">
+      <main className="mx-auto w-full max-w-4xl space-y-4 px-4 sm:px-6">
+        <section className="rounded border border-cf-border bg-cf-surface p-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h1 className="text-xl font-semibold text-cf-text-primary">Settings - Perfil</h1>
+              <p className="mt-1 text-sm text-cf-text-secondary">
+                Personalize seu nome, salario e preferencias de conta.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                onClick={onBack}
+                className="rounded border border-cf-border bg-cf-surface px-3 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
+              >
+                Voltar ao dashboard
+              </button>
+              {onLogout ? (
+                <button
+                  type="button"
+                  onClick={onLogout}
+                  className="rounded border border-cf-border bg-cf-surface px-3 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
+                >
+                  Sair
+                </button>
+              ) : null}
+            </div>
+          </div>
+
+          {isLoading ? (
+            <div className="mt-4 space-y-3" role="status" aria-live="polite">
+              <div className="h-16 animate-pulse rounded border border-cf-border bg-cf-bg-subtle" />
+              <div className="h-10 animate-pulse rounded border border-cf-border bg-cf-bg-subtle" />
+              <div className="h-10 animate-pulse rounded border border-cf-border bg-cf-bg-subtle" />
+              <span className="sr-only">Carregando perfil...</span>
+            </div>
+          ) : null}
+
+          {!isLoading && loadError ? (
+            <div
+              className="mt-4 flex items-center justify-between gap-3 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+              role="alert"
+            >
+              <span>{loadError}</span>
+              <button
+                type="button"
+                onClick={loadProfile}
+                className="rounded border border-red-300 px-2 py-1 text-xs font-semibold text-red-700 hover:bg-red-100"
+              >
+                Tentar novamente
+              </button>
+            </div>
+          ) : null}
+
+          {!isLoading && !loadError ? (
+            <form onSubmit={handleSubmit} noValidate className="mt-4 space-y-4">
+              {/* Avatar preview */}
+              <div className="flex items-center gap-4">
+                <Avatar
+                  avatarUrl={avatarPreview}
+                  displayName={displayName}
+                  email={email}
+                />
+                <div className="min-w-0 flex-1">
+                  <label
+                    htmlFor="avatar_url"
+                    className="block text-sm font-semibold text-cf-text-primary"
+                  >
+                    URL do avatar
+                  </label>
+                  <input
+                    id="avatar_url"
+                    type="url"
+                    value={avatarUrl}
+                    onChange={(e) => setAvatarUrl(e.target.value)}
+                    placeholder="https://..."
+                    className="mt-1 w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
+                  />
+                  <p className="mt-0.5 text-xs text-cf-text-secondary">
+                    Deve comecar com https://. Deixe vazio para usar as iniciais.
+                  </p>
+                </div>
+              </div>
+
+              {/* Display name */}
+              <div>
+                <label
+                  htmlFor="display_name"
+                  className="block text-sm font-semibold text-cf-text-primary"
+                >
+                  Nome exibido
+                </label>
+                <input
+                  id="display_name"
+                  type="text"
+                  value={displayName}
+                  onChange={(e) => setDisplayName(e.target.value)}
+                  maxLength={100}
+                  placeholder="Como voce quer ser chamado"
+                  className="mt-1 w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
+                />
+              </div>
+
+              {/* Email (read-only) */}
+              <div>
+                <label
+                  htmlFor="email"
+                  className="block text-sm font-semibold text-cf-text-primary"
+                >
+                  Email
+                </label>
+                <input
+                  id="email"
+                  type="email"
+                  value={email}
+                  readOnly
+                  className="mt-1 w-full rounded border border-cf-border bg-cf-bg-subtle px-3 py-1.5 text-sm text-cf-text-secondary"
+                />
+              </div>
+
+              {/* Salary + Payday row */}
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div>
+                  <label
+                    htmlFor="salary_monthly"
+                    className="block text-sm font-semibold text-cf-text-primary"
+                  >
+                    Salario mensal (R$)
+                  </label>
+                  <input
+                    id="salary_monthly"
+                    type="number"
+                    min="0"
+                    step="0.01"
+                    value={salaryMonthly}
+                    onChange={(e) => setSalaryMonthly(e.target.value)}
+                    placeholder="0,00"
+                    className="mt-1 w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
+                  />
+                </div>
+                <div>
+                  <label
+                    htmlFor="payday"
+                    className="block text-sm font-semibold text-cf-text-primary"
+                  >
+                    Dia do pagamento
+                  </label>
+                  <input
+                    id="payday"
+                    type="number"
+                    min="1"
+                    max="31"
+                    step="1"
+                    value={payday}
+                    onChange={(e) => setPayday(e.target.value)}
+                    placeholder="Ex: 5"
+                    className="mt-1 w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
+                  />
+                  <p className="mt-0.5 text-xs text-cf-text-secondary">Dia do mes (1 a 31)</p>
+                </div>
+              </div>
+
+              {/* Feedback */}
+              {saveError ? (
+                <div
+                  className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+                  role="alert"
+                >
+                  {saveError}
+                </div>
+              ) : null}
+
+              {saveSuccess ? (
+                <div
+                  className="rounded border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700"
+                  role="status"
+                  aria-live="polite"
+                >
+                  Perfil salvo com sucesso.
+                </div>
+              ) : null}
+
+              {/* Actions */}
+              <div className="flex justify-end">
+                <button
+                  type="submit"
+                  disabled={isSaving}
+                  className="rounded bg-brand-1 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-2 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isSaving ? "Salvando..." : "Salvar perfil"}
+                </button>
+              </div>
+            </form>
+          ) : null}
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default ProfileSettings;

--- a/apps/web/src/services/profile.service.ts
+++ b/apps/web/src/services/profile.service.ts
@@ -1,0 +1,34 @@
+import { api } from "./api";
+
+export interface UserProfile {
+  displayName: string | null;
+  salaryMonthly: number | null;
+  payday: number | null;
+  avatarUrl: string | null;
+}
+
+export interface MeResponse {
+  id: number;
+  name: string;
+  email: string;
+  profile: UserProfile | null;
+}
+
+export interface ProfileUpdatePayload {
+  display_name?: string | null;
+  salary_monthly?: number | null;
+  payday?: number | null;
+  avatar_url?: string | null;
+}
+
+export const profileService = {
+  getMe: async (): Promise<MeResponse> => {
+    const { data } = await api.get<MeResponse>("/me");
+    return data;
+  },
+
+  updateProfile: async (payload: ProfileUpdatePayload): Promise<UserProfile> => {
+    const { data } = await api.patch<UserProfile>("/me/profile", payload);
+    return data;
+  },
+};


### PR DESCRIPTION
## Summary

- Adds \`profile.service.ts\` with typed wrappers for \`GET /me\` and \`PATCH /me/profile\`
- Adds \`ProfileSettings.tsx\` page: avatar preview with \`img\` + initials fallback, form for display name / email (read-only) / salary / payday / avatar URL, loading skeleton, save error, success banner (auto-dismisses after 4s)
- Adds \`/app/settings/profile\` route to \`AppRoutes.tsx\` (same pattern as categories and billing)
- Adds **"Perfil"** button to \`App.tsx\` header — mobile dropdown and desktop bar — via \`onOpenProfileSettings\` prop

## ProfileSettings details

| Field | Input | Notes |
|---|---|---|
| Avatar URL | text / url | Preview with \`<img>\` + \`onError\` fallback to initials |
| Nome exibido | text, max 100 | Empty → null (clears) |
| Email | read-only | From \`GET /me\` |
| Salario mensal | number ≥ 0 | Empty → null |
| Dia do pagamento | number 1–31 | Empty → null |

## Test plan

- [x] Lint: 0 warnings
- [x] Typecheck: clean
- [x] Tests: 115/115 pass
- [ ] Smoke: navigate to \`/app/settings/profile\`, fill form, save, confirm persisted via reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)