### PR TITLE
feat(web): security settings page — password change, Google link

### DIFF
--- a/apps/web/src/AppRoutes.tsx
+++ b/apps/web/src/AppRoutes.tsx
@@ -4,6 +4,7 @@ import BillingSettings from "./pages/BillingSettings";
 import CategoriesSettings from "./pages/CategoriesSettings";
 import Login from "./pages/Login";
 import ProfileSettings from "./pages/ProfileSettings";
+import SecuritySettings from "./pages/SecuritySettings";
 import ProtectedRoute from "./routers/ProtectedRoute";
 import { useAuth } from "./hooks/useAuth";
 
@@ -28,12 +29,17 @@ const Dashboard = () => {
     navigate("/app/settings/profile");
   };
 
+  const handleOpenSecuritySettings = () => {
+    navigate("/app/settings/security");
+  };
+
   return (
     <App
       onLogout={handleLogout}
       onOpenCategoriesSettings={handleOpenCategoriesSettings}
       onOpenBillingSettings={handleOpenBillingSettings}
       onOpenProfileSettings={handleOpenProfileSettings}
+      onOpenSecuritySettings={handleOpenSecuritySettings}
     />
   );
 };
@@ -86,6 +92,22 @@ const ProfileSettingsRoute = () => {
   return <ProfileSettings onBack={handleBack} onLogout={handleLogout} />;
 };
 
+const SecuritySettingsRoute = () => {
+  const navigate = useNavigate();
+  const { logout } = useAuth();
+
+  const handleBack = () => {
+    navigate("/app");
+  };
+
+  const handleLogout = () => {
+    logout();
+    navigate("/", { replace: true });
+  };
+
+  return <SecuritySettings onBack={handleBack} onLogout={handleLogout} />;
+};
+
 const RootRedirect = () => {
   const { isAuthenticated } = useAuth();
 
@@ -125,6 +147,14 @@ const AppRoutes = () => {
         element={
           <ProtectedRoute>
             <ProfileSettingsRoute />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/app/settings/security"
+        element={
+          <ProtectedRoute>
+            <SecuritySettingsRoute />
           </ProtectedRoute>
         }
       />

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -103,6 +103,7 @@ interface AppProps {
   onOpenCategoriesSettings?: () => void;
   onOpenBillingSettings?: () => void;
   onOpenProfileSettings?: () => void;
+  onOpenSecuritySettings?: () => void;
 }
 
 const PERIOD_OPTIONS = [
@@ -445,6 +446,7 @@ const App = ({
   onOpenCategoriesSettings = undefined,
   onOpenBillingSettings = undefined,
   onOpenProfileSettings = undefined,
+  onOpenSecuritySettings = undefined,
 }: AppProps): JSX.Element => {
   const initialFilterState = useMemo(() => getInitialFilterState(), []);
   const initialPaginationState = useMemo(() => getInitialPaginationState(), []);
@@ -1363,6 +1365,11 @@ const App = ({
     onOpenProfileSettings?.();
   };
 
+  const handleOpenSecuritySettings = () => {
+    closeMobileActionsMenu();
+    onOpenSecuritySettings?.();
+  };
+
   const handleLogoutFromActionsMenu = () => {
     closeMobileActionsMenu();
     onLogout?.();
@@ -1568,6 +1575,16 @@ const App = ({
                         Perfil
                       </button>
                     ) : null}
+                    {onOpenSecuritySettings ? (
+                      <button
+                        type="button"
+                        role="menuitem"
+                        onClick={handleOpenSecuritySettings}
+                        className="rounded px-2 py-2 text-left text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
+                      >
+                        Seguranca
+                      </button>
+                    ) : null}
                     <button
                       type="button"
                       role="menuitem"
@@ -1657,6 +1674,15 @@ const App = ({
                     className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                   >
                     Perfil
+                  </button>
+                ) : null}
+                {onOpenSecuritySettings ? (
+                  <button
+                    type="button"
+                    onClick={handleOpenSecuritySettings}
+                    className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
+                  >
+                    Seguranca
                   </button>
                 ) : null}
               </div>

--- a/apps/web/src/pages/SecuritySettings.tsx
+++ b/apps/web/src/pages/SecuritySettings.tsx
@@ -1,0 +1,350 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { FormEvent } from "react";
+import { GoogleLogin } from "@react-oauth/google";
+import { profileService } from "../services/profile.service";
+import { securityService } from "../services/security.service";
+
+interface ApiLikeError {
+  response?: {
+    data?: { message?: string };
+    status?: number;
+  };
+  message?: string;
+}
+
+const getApiErrorMessage = (error: unknown, fallback: string): string => {
+  const e = error as ApiLikeError;
+  return e?.response?.data?.message || e?.message || fallback;
+};
+
+const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d).{8,}$/;
+
+interface SecuritySettingsProps {
+  onBack?: () => void;
+  onLogout?: () => void;
+}
+
+const SecuritySettings = ({
+  onBack = undefined,
+  onLogout = undefined,
+}: SecuritySettingsProps): JSX.Element => {
+  // Account state from GET /me
+  const [hasPassword, setHasPassword] = useState<boolean>(true);
+  const [linkedProviders, setLinkedProviders] = useState<string[]>([]);
+  const [isLoadingAccount, setIsLoadingAccount] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  // Password form state
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [isSavingPassword, setIsSavingPassword] = useState(false);
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [passwordSuccess, setPasswordSuccess] = useState(false);
+  const passwordTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Google link state
+  const [isLinkingGoogle, setIsLinkingGoogle] = useState(false);
+  const [googleError, setGoogleError] = useState<string | null>(null);
+  const [googleSuccess, setGoogleSuccess] = useState(false);
+
+  const loadAccountInfo = useCallback(async () => {
+    setIsLoadingAccount(true);
+    setLoadError(null);
+    try {
+      const me = await profileService.getMe();
+      // hasPassword defaults to true (conservative) if field not yet returned by API
+      setHasPassword(me.hasPassword !== false);
+      setLinkedProviders(me.linkedProviders ?? []);
+    } catch (error) {
+      setLoadError(getApiErrorMessage(error, "Nao foi possivel carregar as informacoes da conta."));
+    } finally {
+      setIsLoadingAccount(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadAccountInfo();
+    return () => {
+      if (passwordTimerRef.current) clearTimeout(passwordTimerRef.current);
+    };
+  }, [loadAccountInfo]);
+
+  const handlePasswordSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setPasswordError(null);
+    setPasswordSuccess(false);
+
+    if (!PASSWORD_REGEX.test(newPassword)) {
+      setPasswordError("Senha fraca: use no minimo 8 caracteres com letras e numeros.");
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      setPasswordError("As senhas nao coincidem.");
+      return;
+    }
+
+    setIsSavingPassword(true);
+    try {
+      await securityService.changePassword({
+        ...(hasPassword ? { currentPassword } : {}),
+        newPassword,
+      });
+      setPasswordSuccess(true);
+      setCurrentPassword("");
+      setNewPassword("");
+      setConfirmPassword("");
+      // After setting a password, user now has one
+      setHasPassword(true);
+      passwordTimerRef.current = setTimeout(() => setPasswordSuccess(false), 4000);
+    } catch (error) {
+      setPasswordError(
+        getApiErrorMessage(error, "Nao foi possivel alterar a senha. Tente novamente."),
+      );
+    } finally {
+      setIsSavingPassword(false);
+    }
+  };
+
+  const handleGoogleSuccess = async (credential: string) => {
+    setIsLinkingGoogle(true);
+    setGoogleError(null);
+    setGoogleSuccess(false);
+    try {
+      await securityService.linkGoogle(credential);
+      setGoogleSuccess(true);
+      setLinkedProviders((prev) => (prev.includes("google") ? prev : [...prev, "google"]));
+    } catch (error) {
+      setGoogleError(
+        getApiErrorMessage(error, "Nao foi possivel vincular a conta Google. Tente novamente."),
+      );
+    } finally {
+      setIsLinkingGoogle(false);
+    }
+  };
+
+  const isGoogleLinked = linkedProviders.includes("google");
+
+  return (
+    <div className="min-h-screen bg-cf-bg-page py-6">
+      <main className="mx-auto w-full max-w-4xl space-y-4 px-4 sm:px-6">
+        <section className="rounded border border-cf-border bg-cf-surface p-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h1 className="text-xl font-semibold text-cf-text-primary">Settings - Seguranca</h1>
+              <p className="mt-1 text-sm text-cf-text-secondary">
+                Gerencie sua senha e metodos de acesso vinculados.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                onClick={onBack}
+                className="rounded border border-cf-border bg-cf-surface px-3 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
+              >
+                Voltar ao dashboard
+              </button>
+              {onLogout ? (
+                <button
+                  type="button"
+                  onClick={onLogout}
+                  className="rounded border border-cf-border bg-cf-surface px-3 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
+                >
+                  Sair
+                </button>
+              ) : null}
+            </div>
+          </div>
+
+          {isLoadingAccount ? (
+            <div className="mt-4 space-y-3" role="status" aria-live="polite">
+              <div className="h-10 animate-pulse rounded border border-cf-border bg-cf-bg-subtle" />
+              <div className="h-10 animate-pulse rounded border border-cf-border bg-cf-bg-subtle" />
+              <span className="sr-only">Carregando informacoes de seguranca...</span>
+            </div>
+          ) : null}
+
+          {!isLoadingAccount && loadError ? (
+            <div
+              className="mt-4 flex items-center justify-between gap-3 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+              role="alert"
+            >
+              <span>{loadError}</span>
+              <button
+                type="button"
+                onClick={loadAccountInfo}
+                className="rounded border border-red-300 px-2 py-1 text-xs font-semibold text-red-700 hover:bg-red-100"
+              >
+                Tentar novamente
+              </button>
+            </div>
+          ) : null}
+
+          {!isLoadingAccount && !loadError ? (
+            <div className="mt-4 space-y-6">
+              {/* ── Password section ── */}
+              <div className="rounded border border-cf-border bg-cf-bg-subtle p-4">
+                <h2 className="text-sm font-semibold text-cf-text-primary">
+                  {hasPassword ? "Alterar senha" : "Definir senha"}
+                </h2>
+                {!hasPassword ? (
+                  <p className="mt-1 text-xs text-cf-text-secondary">
+                    Sua conta usa somente o Google para acesso. Defina uma senha para tambem poder
+                    entrar com email e senha.
+                  </p>
+                ) : null}
+
+                <form onSubmit={handlePasswordSubmit} noValidate className="mt-3 space-y-3">
+                  {hasPassword ? (
+                    <div>
+                      <label
+                        htmlFor="current_password"
+                        className="block text-sm font-semibold text-cf-text-primary"
+                      >
+                        Senha atual
+                      </label>
+                      <input
+                        id="current_password"
+                        type="password"
+                        value={currentPassword}
+                        onChange={(e) => setCurrentPassword(e.target.value)}
+                        autoComplete="current-password"
+                        required
+                        className="mt-1 w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary focus:outline-none focus:ring-1 focus:ring-brand-1"
+                      />
+                    </div>
+                  ) : null}
+
+                  <div>
+                    <label
+                      htmlFor="new_password"
+                      className="block text-sm font-semibold text-cf-text-primary"
+                    >
+                      Nova senha
+                    </label>
+                    <input
+                      id="new_password"
+                      type="password"
+                      value={newPassword}
+                      onChange={(e) => setNewPassword(e.target.value)}
+                      autoComplete="new-password"
+                      required
+                      className="mt-1 w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary focus:outline-none focus:ring-1 focus:ring-brand-1"
+                    />
+                    <p className="mt-0.5 text-xs text-cf-text-secondary">
+                      Minimo 8 caracteres com letras e numeros.
+                    </p>
+                  </div>
+
+                  <div>
+                    <label
+                      htmlFor="confirm_password"
+                      className="block text-sm font-semibold text-cf-text-primary"
+                    >
+                      Confirmar nova senha
+                    </label>
+                    <input
+                      id="confirm_password"
+                      type="password"
+                      value={confirmPassword}
+                      onChange={(e) => setConfirmPassword(e.target.value)}
+                      autoComplete="new-password"
+                      required
+                      className="mt-1 w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary focus:outline-none focus:ring-1 focus:ring-brand-1"
+                    />
+                  </div>
+
+                  {passwordError ? (
+                    <div
+                      className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+                      role="alert"
+                    >
+                      {passwordError}
+                    </div>
+                  ) : null}
+
+                  {passwordSuccess ? (
+                    <div
+                      className="rounded border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700"
+                      role="status"
+                      aria-live="polite"
+                    >
+                      Senha alterada com sucesso.
+                    </div>
+                  ) : null}
+
+                  <div className="flex justify-end">
+                    <button
+                      type="submit"
+                      disabled={isSavingPassword}
+                      className="rounded bg-brand-1 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-2 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {isSavingPassword
+                        ? "Salvando..."
+                        : hasPassword
+                          ? "Alterar senha"
+                          : "Definir senha"}
+                    </button>
+                  </div>
+                </form>
+              </div>
+
+              {/* ── Google link section ── */}
+              <div className="rounded border border-cf-border bg-cf-bg-subtle p-4">
+                <h2 className="text-sm font-semibold text-cf-text-primary">Acesso com Google</h2>
+
+                {isGoogleLinked ? (
+                  <div className="mt-3 flex items-center gap-2">
+                    <span className="inline-flex items-center gap-1.5 rounded border border-green-200 bg-green-50 px-3 py-1.5 text-sm font-semibold text-green-700">
+                      <span aria-hidden="true">✓</span> Google vinculado
+                    </span>
+                  </div>
+                ) : (
+                  <div className="mt-3 space-y-2">
+                    <p className="text-xs text-cf-text-secondary">
+                      Vincule sua conta Google para entrar sem senha.
+                    </p>
+                    {isLinkingGoogle ? (
+                      <p className="text-sm text-cf-text-secondary">Vinculando...</p>
+                    ) : (
+                      <GoogleLogin
+                        onSuccess={(credentialResponse) => {
+                          const idToken = credentialResponse.credential;
+                          if (!idToken) return;
+                          void handleGoogleSuccess(idToken);
+                        }}
+                        onError={() => {
+                          setGoogleError("Falha ao autenticar com Google. Tente novamente.");
+                        }}
+                      />
+                    )}
+                    {googleError ? (
+                      <div
+                        className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+                        role="alert"
+                      >
+                        {googleError}
+                      </div>
+                    ) : null}
+                    {googleSuccess ? (
+                      <div
+                        className="rounded border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700"
+                        role="status"
+                        aria-live="polite"
+                      >
+                        Conta Google vinculada com sucesso.
+                      </div>
+                    ) : null}
+                  </div>
+                )}
+              </div>
+            </div>
+          ) : null}
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default SecuritySettings;

--- a/apps/web/src/services/profile.service.ts
+++ b/apps/web/src/services/profile.service.ts
@@ -11,6 +11,8 @@ export interface MeResponse {
   id: number;
   name: string;
   email: string;
+  hasPassword?: boolean;
+  linkedProviders?: string[];
   profile: UserProfile | null;
 }
 

--- a/apps/web/src/services/security.service.ts
+++ b/apps/web/src/services/security.service.ts
@@ -1,0 +1,16 @@
+import { api } from "./api";
+
+export interface ChangePasswordPayload {
+  currentPassword?: string;
+  newPassword: string;
+}
+
+export const securityService = {
+  changePassword: async (payload: ChangePasswordPayload): Promise<void> => {
+    await api.patch("/auth/password", payload);
+  },
+
+  linkGoogle: async (idToken: string): Promise<void> => {
+    await api.post("/auth/google/link", { idToken });
+  },
+};


### PR DESCRIPTION
## Summary
- Add SecuritySettings page at /app/settings/security (change/set password, link Google account)
- Loads hasPassword + linkedProviders from GET /me; conservative defaults when API field absent
- Password section: shows current-password field only when user already has one
- Google section: shows linked badge if already linked; otherwise renders GoogleLogin button
- Optimistic state updates on success; 4s auto-dismiss success banner
- Add security.service.ts with changePassword and linkGoogle methods
- Extend MeResponse interface with optional hasPassword? and linkedProviders?
- Wire /app/settings/security route + Seguranca nav button (mobile + desktop)

## Test plan
- [x] npm -w apps/web run lint — 0 warnings
- [x] npm -w apps/web run typecheck — no errors
- [x] npm -w apps/web test --run — 115/115 pass
- [ ] Smoke: password-only user sees Senha atual field + Google link button
- [ ] Smoke: Google-only user (hasPassword: false) sees only Nova senha (no current-password field)
- [ ] Smoke: user with Google linked sees linked badge instead of login button
- [ ] Smoke: Seguranca button visible in header and mobile menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)