### PR TITLE
feat(api): smart trial window with payday extension

### DIFF
--- a/apps/api/src/db/migrations/014_add_trial_ends_at.sql
+++ b/apps/api/src/db/migrations/014_add_trial_ends_at.sql
@@ -1,0 +1,11 @@
+-- Add trial_ends_at to users; new users get 14 days from signup.
+-- Existing rows are backfilled using their created_at for historical accuracy.
+-- The application sets trial_ends_at explicitly on INSERT (no column DEFAULT needed).
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS trial_ends_at TIMESTAMPTZ;
+
+UPDATE users
+SET trial_ends_at = created_at + INTERVAL '14 days'
+WHERE trial_ends_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_users_trial_ends_at ON users (trial_ends_at);

--- a/apps/api/src/me.test.js
+++ b/apps/api/src/me.test.js
@@ -54,6 +54,45 @@ describe("GET /me", () => {
     expect(response.body.profile).toBeNull();
   });
 
+  it("retorna trialEndsAt como ISO string e trialExpired false para usuario recem registrado", async () => {
+    const token = await registerAndLogin("me-trial-active@test.dev");
+
+    const response = await request(app)
+      .get("/me")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    expect(typeof response.body.trialEndsAt).toBe("string");
+    expect(response.body.trialExpired).toBe(false);
+
+    // trialEndsAt should be roughly 14 days from now (± 60s tolerance)
+    const trialEnd = new Date(response.body.trialEndsAt);
+    const expectedEnd = new Date(Date.now() + 14 * 24 * 60 * 60 * 1000);
+    expect(Math.abs(trialEnd.getTime() - expectedEnd.getTime())).toBeLessThan(60_000);
+  });
+
+  it("retorna trialExpired true para usuario com trial vencido", async () => {
+    const token = await registerAndLogin("me-trial-expired@test.dev");
+    const userResult = await dbQuery(
+      `SELECT id FROM users WHERE email = $1`,
+      ["me-trial-expired@test.dev"],
+    );
+    const userId = userResult.rows[0].id;
+
+    // Force trial to have expired in the past
+    await dbQuery(
+      `UPDATE users SET trial_ends_at = NOW() - INTERVAL '1 day' WHERE id = $1`,
+      [userId],
+    );
+
+    const response = await request(app)
+      .get("/me")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.trialExpired).toBe(true);
+  });
+
   it("retorna hasPassword false para usuario Google-only (sem password_hash)", async () => {
     const email = "me-google-only@test.dev";
     const userResult = await dbQuery(
@@ -271,5 +310,59 @@ describe("PATCH /me/profile", () => {
 
     expect(response.status).toBe(200);
     expect(response.body.avatarUrl).toBeNull();
+  });
+
+  it("atualiza trial_ends_at ao configurar payday (MAX entre created_at+14d e proximo payday)", async () => {
+    const token = await registerAndLogin("patch-payday-trial@test.dev");
+    const userResult = await dbQuery(
+      `SELECT id, created_at FROM users WHERE email = $1`,
+      ["patch-payday-trial@test.dev"],
+    );
+    const { id: userId, created_at: createdAt } = userResult.rows[0];
+
+    // Use payday = 31 (always upcoming — day 31 never passes for standard months)
+    await request(app)
+      .patch("/me/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ payday: 31 });
+
+    const updatedUser = await dbQuery(
+      `SELECT trial_ends_at FROM users WHERE id = $1`,
+      [userId],
+    );
+    const trialEndsAt = new Date(updatedUser.rows[0].trial_ends_at);
+    const signupPlus14 = new Date(new Date(createdAt).getTime() + 14 * 24 * 60 * 60 * 1000);
+
+    // trial_ends_at must be >= created_at + 14 days (GREATEST guarantee)
+    expect(trialEndsAt.getTime()).toBeGreaterThanOrEqual(signupPlus14.getTime() - 1000);
+  });
+
+  it("nao altera trial_ends_at quando payday nao e enviado", async () => {
+    const token = await registerAndLogin("patch-no-payday@test.dev");
+    const userResult = await dbQuery(
+      `SELECT id FROM users WHERE email = $1`,
+      ["patch-no-payday@test.dev"],
+    );
+    const userId = userResult.rows[0].id;
+
+    // Record trial before update
+    const before = await dbQuery(
+      `SELECT trial_ends_at FROM users WHERE id = $1`,
+      [userId],
+    );
+
+    await request(app)
+      .patch("/me/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ display_name: "Apenas nome" });
+
+    const after = await dbQuery(
+      `SELECT trial_ends_at FROM users WHERE id = $1`,
+      [userId],
+    );
+
+    const beforeTs = new Date(before.rows[0].trial_ends_at).getTime();
+    const afterTs = new Date(after.rows[0].trial_ends_at).getTime();
+    expect(afterTs).toBe(beforeTs);
   });
 });

--- a/apps/api/src/services/auth.service.js
+++ b/apps/api/src/services/auth.service.js
@@ -74,15 +74,16 @@ export const registerUser = async ({ name = "", email, password }) => {
 
   const normalizedName = typeof name === "string" ? name.trim() : "";
   const passwordHash = await bcrypt.hash(normalizedPassword, 10);
+  const trialEndsAt = new Date(Date.now() + 14 * 24 * 60 * 60 * 1000);
 
   try {
     const result = await dbQuery(
       `
-        INSERT INTO users (name, email, password_hash)
-        VALUES ($1, $2, $3)
+        INSERT INTO users (name, email, password_hash, trial_ends_at)
+        VALUES ($1, $2, $3, $4)
         RETURNING id, name, email
       `,
-      [normalizedName, normalizedEmail, passwordHash],
+      [normalizedName, normalizedEmail, passwordHash, trialEndsAt.toISOString()],
     );
 
     return createAuthResult(result.rows[0]);
@@ -279,9 +280,10 @@ export const loginOrRegisterWithGoogle = async ({ idToken } = {}) => {
     user = userResult.rows[0];
   } else {
     // 3. New user — create without password
+    const googleTrialEndsAt = new Date(Date.now() + 14 * 24 * 60 * 60 * 1000);
     const newUserResult = await dbQuery(
-      `INSERT INTO users (name, email) VALUES ($1, $2) RETURNING id, name, email`,
-      [name, email],
+      `INSERT INTO users (name, email, trial_ends_at) VALUES ($1, $2, $3) RETURNING id, name, email`,
+      [name, email, googleTrialEndsAt.toISOString()],
     );
     user = newUserResult.rows[0];
   }

--- a/apps/api/src/services/profile.service.js
+++ b/apps/api/src/services/profile.service.js
@@ -71,11 +71,27 @@ const rowToProfile = (row) => ({
   avatarUrl: row.avatar_url ?? null,
 });
 
+// Returns ISO string for trial end date and whether trial has expired
+const extractTrialInfo = (user) => {
+  const trialEndsAt = user.trial_ends_at ? new Date(user.trial_ends_at).toISOString() : null;
+  const trialExpired = trialEndsAt ? new Date(trialEndsAt) <= new Date() : false;
+  return { trialEndsAt, trialExpired };
+};
+
+// Calculates the next occurrence of `payday` from `referenceDate`
+const calcNextPaydayDate = (payday, referenceDate = new Date()) => {
+  const day = referenceDate.getDate();
+  if (payday > day) {
+    return new Date(referenceDate.getFullYear(), referenceDate.getMonth(), payday);
+  }
+  return new Date(referenceDate.getFullYear(), referenceDate.getMonth() + 1, payday);
+};
+
 export const getMyProfile = async (userId) => {
   const normalizedUserId = normalizeUserId(userId);
 
   const userResult = await dbQuery(
-    `SELECT id, name, email, (password_hash IS NOT NULL) AS has_password
+    `SELECT id, name, email, (password_hash IS NOT NULL) AS has_password, trial_ends_at
      FROM users WHERE id = $1 LIMIT 1`,
     [normalizedUserId],
   );
@@ -85,6 +101,7 @@ export const getMyProfile = async (userId) => {
   }
 
   const user = userResult.rows[0];
+  const { trialEndsAt, trialExpired } = extractTrialInfo(user);
 
   const [profileResult, identitiesResult] = await Promise.all([
     dbQuery(
@@ -104,6 +121,8 @@ export const getMyProfile = async (userId) => {
     email: user.email,
     hasPassword: Boolean(user.has_password),
     linkedProviders: identitiesResult.rows.map((r) => r.provider),
+    trialEndsAt,
+    trialExpired,
     profile: profileResult.rows.length > 0 ? rowToProfile(profileResult.rows[0]) : null,
   };
 };
@@ -150,6 +169,23 @@ export const updateMyProfile = async (userId, payload = {}) => {
      DO UPDATE SET ${setClauses}`,
     [normalizedUserId, ...vals, now],
   );
+
+  // When payday is set, extend trial_ends_at = MAX(created_at + 14 days, next payday)
+  // so users always see at least one full pay cycle before trial expires.
+  if (normalizedPayday !== undefined && normalizedPayday !== null) {
+    const userRow = await dbQuery(
+      `SELECT created_at, trial_ends_at FROM users WHERE id = $1 LIMIT 1`,
+      [normalizedUserId],
+    );
+    const { created_at: createdAt } = userRow.rows[0];
+    const signupPlus14 = new Date(new Date(createdAt).getTime() + 14 * 24 * 60 * 60 * 1000);
+    const nextPayday = calcNextPaydayDate(normalizedPayday);
+    const newTrialEndsAt = signupPlus14 > nextPayday ? signupPlus14 : nextPayday;
+    await dbQuery(
+      `UPDATE users SET trial_ends_at = $2 WHERE id = $1`,
+      [normalizedUserId, newTrialEndsAt.toISOString()],
+    );
+  }
 
   const result = await dbQuery(
     `SELECT display_name, salary_monthly, payday, avatar_url

--- a/apps/web/src/services/profile.service.ts
+++ b/apps/web/src/services/profile.service.ts
@@ -13,6 +13,8 @@ export interface MeResponse {
   email: string;
   hasPassword?: boolean;
   linkedProviders?: string[];
+  trialEndsAt: string | null;
+  trialExpired: boolean;
   profile: UserProfile | null;
 }
 


### PR DESCRIPTION
## Summary
- Add migration `014_add_trial_ends_at.sql` to `users`.
- Backfill existing users with `created_at + 14 days`.
- Set `trial_ends_at` on new user creation in auth service (email/password and Google signup flow).
- Extend `GET /me` output via profile service with:
  - `trialEndsAt`
  - `trialExpired`
- On profile update with payday, recompute trial end with rule:
  - `max(created_at + 14 days, next payday)`

## Validation
- API tests passing on branch: 198/198
- API lint passing: 0 warnings