### PR TITLE
ops(smoke): print BaseUrl alongside DB target in Step 3 header

### DIFF
--- a/scripts/smoke-paywall-forecast.ps1
+++ b/scripts/smoke-paywall-forecast.ps1
@@ -237,6 +237,7 @@ if (-not $DbConnectionString) {
     $dbParsed  = $false
   }
 
+  Write-Host "API       : $BaseUrl" -ForegroundColor Yellow
   Write-Host "DB target : $dbDisplay" -ForegroundColor Yellow
   Write-Host "psql      : $PsqlPath" -ForegroundColor Yellow
 


### PR DESCRIPTION
Print the API BaseUrl alongside DB target before any SQL runs in Step 3.

Prevents the classic "expired prod DB while hitting staging API" accident -- both targets are visible in the same block.