### PR TITLE
feat(api): paywall bypass allowlist + trial features for analytics

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -18,6 +18,10 @@ DB_SSL=false
 # Aceita lista separada por virgula (ex.: local + Vercel)
 # CORS_ORIGIN=http://localhost:5173,https://control-finance-react-tail-wind.vercel.app
 CORS_ORIGIN=http://localhost:5173
+# Paywall bypass -- DEV / STAGING ONLY. Ignored when NODE_ENV=production.
+# Set PAYWALL_BYPASS_ENABLED=true and list emails to grant full PRO access without a subscription.
+PAYWALL_BYPASS_ENABLED=false
+# PAYWALL_BYPASS_EMAILS=dev@example.com,qa@example.com
 # Login hardening
 AUTH_RATE_LIMIT_WINDOW_MS=900000
 AUTH_RATE_LIMIT_MAX_REQUESTS=20

--- a/apps/api/src/analytics.test.js
+++ b/apps/api/src/analytics.test.js
@@ -13,6 +13,7 @@ import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
 import {
   expectErrorResponseWithRequestId,
   getExpectedTrendMonths,
+  getUserIdByEmail,
   registerAndLogin,
   setupTestDb,
 } from "./test-helpers.js";
@@ -55,8 +56,11 @@ describe("analytics", () => {
     },
   );
 
-  it("GET /analytics/trend retorna 3 meses por padrao para usuario free (limite do plano)", async () => {
-    const token = await registerAndLogin("analytics-trend-default@controlfinance.dev");
+  it("GET /analytics/trend retorna 6 meses por padrao para usuario em trial ativo (limite do plano)", async () => {
+    const email = "analytics-trend-default@controlfinance.dev";
+    const token = await registerAndLogin(email);
+    // Active trial: TRIAL_FEATURES gives analytics_months_max=6, so default cap = min(6,6) = 6
+    await getUserIdByEmail(email); // ensure user exists
 
     const response = await request(app)
       .get("/analytics/trend")
@@ -64,8 +68,8 @@ describe("analytics", () => {
 
     expect(response.status).toBe(200);
     expect(Array.isArray(response.body)).toBe(true);
-    expect(response.body).toHaveLength(3);
-    expect(response.body.map((item) => item.month)).toEqual(getExpectedTrendMonths(3));
+    expect(response.body).toHaveLength(6);
+    expect(response.body.map((item) => item.month)).toEqual(getExpectedTrendMonths(6));
     response.body.forEach((item) => {
       expect(typeof item.month).toBe("string");
       expect(item.month).toMatch(/^\d{4}-\d{2}$/);

--- a/apps/api/src/billing.test.js
+++ b/apps/api/src/billing.test.js
@@ -10,6 +10,7 @@ import {
 import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
 import {
   expectErrorResponseWithRequestId,
+  getUserIdByEmail,
   makeProUser,
   registerAndLogin,
   setupTestDb,
@@ -93,8 +94,10 @@ describe("billing", () => {
     expectErrorResponseWithRequestId(response, 402, "Recurso disponivel apenas no plano Pro.");
   });
 
-  it("GET /analytics/trend retorna 3 meses para usuario free (limite do plano)", async () => {
-    const token = await registerAndLogin("billing-trend-free@controlfinance.dev");
+  it("GET /analytics/trend retorna 6 meses para usuario em trial ativo (limite do plano)", async () => {
+    const email = "billing-trend-free@controlfinance.dev";
+    const token = await registerAndLogin(email);
+    // Active trial: TRIAL_FEATURES gives analytics_months_max=6
 
     const response = await request(app)
       .get("/analytics/trend")
@@ -102,18 +105,21 @@ describe("billing", () => {
 
     expect(response.status).toBe(200);
     expect(Array.isArray(response.body)).toBe(true);
-    expect(response.body).toHaveLength(3);
+    expect(response.body).toHaveLength(6);
   });
 
-  it("GET /analytics/trend retorna 402 ao solicitar 6 meses com plano free", async () => {
-    const token = await registerAndLogin("billing-trend-exceeded@controlfinance.dev");
+  it("GET /analytics/trend retorna 402 para usuario com trial expirado (paywall)", async () => {
+    const email = "billing-trend-exceeded@controlfinance.dev";
+    const token = await registerAndLogin(email);
+    const userId = await getUserIdByEmail(email);
+    await dbQuery(`UPDATE users SET trial_ends_at = NOW() - INTERVAL '1 day' WHERE id = $1`, [userId]);
 
     const response = await request(app)
       .get("/analytics/trend")
       .query({ months: 6 })
       .set("Authorization", `Bearer ${token}`);
 
-    expectErrorResponseWithRequestId(response, 402, "Limite de historico excedido no plano gratuito.");
+    expectErrorResponseWithRequestId(response, 402, "Periodo de teste encerrado. Ative seu plano para continuar utilizando esta funcionalidade.");
   });
 
   it("usuario pro acessa dry-run normalmente", async () => {

--- a/apps/api/src/middlewares/entitlement.middleware.js
+++ b/apps/api/src/middlewares/entitlement.middleware.js
@@ -1,6 +1,38 @@
 import { dbQuery } from "../db/index.js";
 import { getActivePlanFeaturesForUser } from "../services/billing.service.js";
 
+// ---------------------------------------------------------------------------
+// Paywall bypass (dev / staging only)
+// ---------------------------------------------------------------------------
+
+const parseBypassEmails = () =>
+  (process.env.PAYWALL_BYPASS_EMAILS || "")
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+
+const isBypassEnabled = () => {
+  const enabled = (process.env.PAYWALL_BYPASS_ENABLED || "").toLowerCase();
+  const isProd = (process.env.NODE_ENV || "").toLowerCase() === "production";
+  if (isProd) return false;
+  return enabled === "true" || enabled === "1";
+};
+
+const canBypass = (userEmail) => {
+  if (!isBypassEnabled()) return false;
+  return parseBypassEmails().includes((userEmail || "").toLowerCase());
+};
+
+// Features granted to bypass users (equivalent to PRO).
+const BYPASS_FEATURES = {
+  csv_import: true,
+  csv_export: true,
+  analytics_months_max: 24,
+  budget_tracking: true,
+};
+
+// ---------------------------------------------------------------------------
+
 const createPaymentRequiredError = (message = "Recurso disponivel apenas no plano Pro.") => {
   const error = new Error(message);
   error.status = 402;
@@ -14,11 +46,19 @@ const TRIAL_EXPIRED_MESSAGE =
  * Middleware factory for boolean feature gates.
  * Returns 402 if the authenticated user's active plan has featureName === false.
  *
+ * Bypass: skipped entirely when PAYWALL_BYPASS_ENABLED=true (non-prod only)
+ * and the user's email is in PAYWALL_BYPASS_EMAILS.
+ *
  * Usage:
  *   router.post("/import/dry-run", requireFeature("csv_import"), handler)
  */
 export const requireFeature = (featureName) => async (req, res, next) => {
   try {
+    if (canBypass(req.user?.email)) {
+      req.log?.info?.({ event: "paywall.bypass", email: req.user.email, feature: featureName, requestId: req.requestId });
+      return next();
+    }
+
     const features = await getActivePlanFeaturesForUser(req.user.id);
 
     if (features[featureName] === false) {
@@ -35,12 +75,19 @@ export const requireFeature = (featureName) => async (req, res, next) => {
  * Middleware that attaches the user's full plan features to req.entitlements.
  * Used for numeric caps (e.g. analytics_months_max) where the route needs the value.
  *
+ * Bypass: sets req.entitlements to PRO-equivalent features (non-prod only).
+ *
  * Usage:
  *   router.get("/trend", attachEntitlements, handler)
  *   // then in handler: req.entitlements.analytics_months_max
  */
 export const attachEntitlements = async (req, res, next) => {
   try {
+    if (canBypass(req.user?.email)) {
+      req.entitlements = BYPASS_FEATURES;
+      return next();
+    }
+
     req.entitlements = await getActivePlanFeaturesForUser(req.user.id);
     return next();
   } catch (error) {
@@ -56,11 +103,19 @@ export const attachEntitlements = async (req, res, next) => {
  * It does NOT grant access to plan-specific features (csv_import, csv_export) —
  * those still require requireFeature().
  *
+ * Bypass: skipped entirely when PAYWALL_BYPASS_ENABLED=true (non-prod only)
+ * and the user's email is in PAYWALL_BYPASS_EMAILS.
+ *
  * Usage:
  *   router.post("/forecasts/recompute", requireActiveTrialOrPaidPlan, handler)
  */
 export const requireActiveTrialOrPaidPlan = async (req, res, next) => {
   try {
+    if (canBypass(req.user?.email)) {
+      req.log?.info?.({ event: "paywall.bypass", email: req.user.email, requestId: req.requestId });
+      return next();
+    }
+
     const userId = req.user.id;
 
     // Check for an active paid subscription

--- a/apps/api/src/paywall.test.js
+++ b/apps/api/src/paywall.test.js
@@ -22,7 +22,11 @@ import {
 } from "./middlewares/rate-limit.middleware.js";
 import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
 import { authMiddleware } from "./middlewares/auth.middleware.js";
-import { requireActiveTrialOrPaidPlan } from "./middlewares/entitlement.middleware.js";
+import {
+  requireActiveTrialOrPaidPlan,
+  requireFeature,
+  attachEntitlements,
+} from "./middlewares/entitlement.middleware.js";
 
 // Mount a minimal app just for testing this middleware
 const testApp = express();
@@ -32,6 +36,18 @@ testApp.get(
   authMiddleware,
   requireActiveTrialOrPaidPlan,
   (_req, res) => res.json({ ok: true }),
+);
+testApp.get(
+  "/feature-gated",
+  authMiddleware,
+  requireFeature("csv_import"),
+  (_req, res) => res.json({ ok: true }),
+);
+testApp.get(
+  "/entitlements",
+  authMiddleware,
+  attachEntitlements,
+  (req, res) => res.json(req.entitlements),
 );
 // eslint-disable-next-line no-unused-vars
 testApp.use((err, _req, res, next) => {
@@ -141,5 +157,101 @@ describe("requireActiveTrialOrPaidPlan", () => {
       .set("Authorization", `Bearer ${token}`);
 
     expect(res.status).toBe(402);
+  });
+});
+
+describe("paywall bypass (PAYWALL_BYPASS_ENABLED)", () => {
+  const BYPASS_EMAIL = "bypass-dev@test.dev";
+
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await clearDbClientForTests(); });
+  beforeEach(resetState);
+
+  it("bypass ignora paywall em requireActiveTrialOrPaidPlan (trial expirado)", async () => {
+    const token = await registerAndLogin(BYPASS_EMAIL);
+    const userId = await getUserIdByEmail(BYPASS_EMAIL);
+    await dbQuery(`UPDATE users SET trial_ends_at = NOW() - INTERVAL '1 day' WHERE id = $1`, [userId]);
+
+    const originalEnabled = process.env.PAYWALL_BYPASS_ENABLED;
+    const originalEmails  = process.env.PAYWALL_BYPASS_EMAILS;
+    process.env.PAYWALL_BYPASS_ENABLED = "true";
+    process.env.PAYWALL_BYPASS_EMAILS  = BYPASS_EMAIL;
+
+    try {
+      const res = await request(testApp)
+        .get("/trial-gated")
+        .set("Authorization", `Bearer ${token}`);
+      expect(res.status).toBe(200);
+    } finally {
+      process.env.PAYWALL_BYPASS_ENABLED = originalEnabled;
+      process.env.PAYWALL_BYPASS_EMAILS  = originalEmails;
+    }
+  });
+
+  it("bypass ignora paywall em requireFeature (csv_import bloqueado no plano free)", async () => {
+    const token = await registerAndLogin(BYPASS_EMAIL);
+    const userId = await getUserIdByEmail(BYPASS_EMAIL);
+    await dbQuery(`UPDATE users SET trial_ends_at = NOW() - INTERVAL '1 day' WHERE id = $1`, [userId]);
+
+    const originalEnabled = process.env.PAYWALL_BYPASS_ENABLED;
+    const originalEmails  = process.env.PAYWALL_BYPASS_EMAILS;
+    process.env.PAYWALL_BYPASS_ENABLED = "true";
+    process.env.PAYWALL_BYPASS_EMAILS  = BYPASS_EMAIL;
+
+    try {
+      const res = await request(testApp)
+        .get("/feature-gated")
+        .set("Authorization", `Bearer ${token}`);
+      expect(res.status).toBe(200);
+    } finally {
+      process.env.PAYWALL_BYPASS_ENABLED = originalEnabled;
+      process.env.PAYWALL_BYPASS_EMAILS  = originalEmails;
+    }
+  });
+
+  it("bypass em attachEntitlements retorna features PRO (analytics_months_max=24)", async () => {
+    const token = await registerAndLogin(BYPASS_EMAIL);
+
+    const originalEnabled = process.env.PAYWALL_BYPASS_ENABLED;
+    const originalEmails  = process.env.PAYWALL_BYPASS_EMAILS;
+    process.env.PAYWALL_BYPASS_ENABLED = "true";
+    process.env.PAYWALL_BYPASS_EMAILS  = BYPASS_EMAIL;
+
+    try {
+      const res = await request(testApp)
+        .get("/entitlements")
+        .set("Authorization", `Bearer ${token}`);
+      expect(res.status).toBe(200);
+      expect(res.body.csv_import).toBe(true);
+      expect(res.body.csv_export).toBe(true);
+      expect(res.body.analytics_months_max).toBe(24);
+    } finally {
+      process.env.PAYWALL_BYPASS_ENABLED = originalEnabled;
+      process.env.PAYWALL_BYPASS_EMAILS  = originalEmails;
+    }
+  });
+
+  it("bypass NAO se aplica quando NODE_ENV=production", async () => {
+    const token = await registerAndLogin(BYPASS_EMAIL);
+    const userId = await getUserIdByEmail(BYPASS_EMAIL);
+    await dbQuery(`UPDATE users SET trial_ends_at = NOW() - INTERVAL '1 day' WHERE id = $1`, [userId]);
+
+    const originalEnabled = process.env.PAYWALL_BYPASS_ENABLED;
+    const originalEmails  = process.env.PAYWALL_BYPASS_EMAILS;
+    const originalEnv     = process.env.NODE_ENV;
+    process.env.PAYWALL_BYPASS_ENABLED = "true";
+    process.env.PAYWALL_BYPASS_EMAILS  = BYPASS_EMAIL;
+    process.env.NODE_ENV = "production";
+
+    try {
+      const res = await request(testApp)
+        .get("/trial-gated")
+        .set("Authorization", `Bearer ${token}`);
+      expect(res.status).toBe(402);
+    } finally {
+      process.env.PAYWALL_BYPASS_ENABLED = originalEnabled;
+      process.env.PAYWALL_BYPASS_EMAILS  = originalEmails;
+      process.env.NODE_ENV = originalEnv;
+    }
   });
 });

--- a/apps/api/src/routes/analytics.routes.js
+++ b/apps/api/src/routes/analytics.routes.js
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { authMiddleware } from "../middlewares/auth.middleware.js";
-import { attachEntitlements } from "../middlewares/entitlement.middleware.js";
+import { attachEntitlements, requireActiveTrialOrPaidPlan } from "../middlewares/entitlement.middleware.js";
 import { getMonthlyTrendForUser } from "../services/analytics.service.js";
 
 const router = Router();
@@ -8,7 +8,7 @@ const router = Router();
 const DEFAULT_MONTHS = 6;
 const MAX_MONTHS = 24;
 
-router.use(authMiddleware);
+router.use(authMiddleware, requireActiveTrialOrPaidPlan);
 
 router.get("/trend", attachEntitlements, async (req, res, next) => {
   try {

--- a/apps/api/src/services/billing.service.js
+++ b/apps/api/src/services/billing.service.js
@@ -6,6 +6,15 @@ const createError = (status, message) => {
   return error;
 };
 
+// Features available during an active trial.
+// csv_import/export remain PRO-only; analytics cap is set to 6 months.
+const TRIAL_FEATURES = {
+  csv_import: false,
+  csv_export: false,
+  analytics_months_max: 6,
+  budget_tracking: true,
+};
+
 const normalizeUserId = (value) => {
   const parsed = Number(value);
 
@@ -37,6 +46,18 @@ export const getActivePlanFeaturesForUser = async (userId) => {
 
   if (subscriptionResult.rows.length > 0) {
     return subscriptionResult.rows[0].features;
+  }
+
+  // Check for an active trial
+  const trialResult = await dbQuery(
+    `SELECT trial_ends_at FROM users WHERE id = $1 LIMIT 1`,
+    [normalizedUserId],
+  );
+  const trialEndsAt =
+    trialResult.rows.length > 0 ? trialResult.rows[0].trial_ends_at : null;
+
+  if (trialEndsAt && new Date(trialEndsAt) > new Date()) {
+    return TRIAL_FEATURES;
   }
 
   const freePlanResult = await dbQuery(


### PR DESCRIPTION
## Summary

- **Paywall bypass allowlist** (dev/staging only):  +  env vars. Applied in , , and . Absolute production lock when . 4 new bypass tests.
- **Trial features for analytics**:  now returns  (, csv false) for active trial users instead of falling back to the free plan (cap 3).  now requires  at router level -- expired trial gets 402.
- **Test updates**:  +  updated to reflect new semantics (trial active = 6 months default, trial expired = 402 paywall).

## Test plan
- [ ] 237/237 API tests pass
- [ ]  + email in allowlist bypasses 402 in dev
- [ ] Same config with  still returns 402
- [ ] Active trial user can access  (200, 6 months)
- [ ] Expired trial user gets 402 on 

🤖 Generated with [Claude Code](https://claude.com/claude-code)