### PR TITLE
chore(web): enable forceConsistentCasingInFileNames in tsconfig

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -16,6 +16,7 @@
     "noImplicitAny": true,
     "skipLibCheck": true,
     "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true,
     "types": [
       "vite/client"
     ]


### PR DESCRIPTION
Enables  in .

Prevents import casing mismatches that compile on Windows but silently break on case-sensitive Linux/Vercel deployments (e.g.,  vs ).

Lint: 0 warnings. Tests: 115/115 pass.