### PR TITLE
feat(web): intercept 402 responses and show Free vs Pro upgrade modal

### DIFF
--- a/apps/web/src/components/UpgradeModal.tsx
+++ b/apps/web/src/components/UpgradeModal.tsx
@@ -1,0 +1,105 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+interface UpgradeModalProps {
+  isOpen: boolean;
+  reason: string;
+  onClose: () => void;
+}
+
+const FEATURES = [
+  { label: "Budget tracking", free: "✓", pro: "✓" },
+  { label: "Analytics (histórico)", free: "6 meses", pro: "24 meses" },
+  { label: "CSV Export", free: "—", pro: "✓" },
+  { label: "CSV Import", free: "—", pro: "✓" },
+];
+
+const UpgradeModal = ({ isOpen, reason, onClose }: UpgradeModalProps) => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const isTrialExpired = reason.toLowerCase().includes("teste encerrado");
+  const title = isTrialExpired ? "Seu período de teste encerrou" : "Recurso disponível no plano Pro";
+
+  const handleUpgrade = () => {
+    onClose();
+    navigate("/app/settings/billing");
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-gray-100 bg-opacity-50 p-4"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="upgrade-modal-title"
+        className="w-full max-w-md rounded bg-cf-surface p-6 shadow-lg"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 id="upgrade-modal-title" className="text-base font-semibold text-cf-text-primary">
+          {title}
+        </h3>
+
+        {reason ? (
+          <p className="mt-1 text-sm text-cf-text-secondary">{reason}</p>
+        ) : null}
+
+        <div className="mt-4 overflow-hidden rounded border border-cf-border">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-cf-bg-subtle">
+                <th className="px-3 py-2 text-left font-medium text-cf-text-primary">Recurso</th>
+                <th className="px-3 py-2 text-center font-medium text-cf-text-secondary">Gratuito</th>
+                <th className="px-3 py-2 text-center font-medium text-brand-1">Pro</th>
+              </tr>
+            </thead>
+            <tbody>
+              {FEATURES.map((feature, index) => (
+                <tr key={feature.label} className={index % 2 === 0 ? "" : "bg-cf-bg-subtle"}>
+                  <td className="border-t border-cf-border px-3 py-2 text-cf-text-primary">{feature.label}</td>
+                  <td className="border-t border-cf-border px-3 py-2 text-center text-cf-text-secondary">{feature.free}</td>
+                  <td className="border-t border-cf-border px-3 py-2 text-center font-medium text-cf-text-primary">{feature.pro}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded border border-cf-border px-3 py-1.5 text-sm font-semibold text-cf-text-secondary hover:bg-cf-bg-subtle"
+          >
+            Fechar
+          </button>
+          <button
+            type="button"
+            onClick={handleUpgrade}
+            className="rounded bg-brand-1 px-3 py-1.5 text-sm font-semibold text-white hover:bg-brand-2"
+          >
+            Ativar plano Pro
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default UpgradeModal;

--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -12,6 +12,10 @@ vi.mock("../hooks/useTheme", () => ({
   useTheme: () => ({ theme: "light", toggleTheme: vi.fn() }),
 }));
 
+vi.mock("../components/UpgradeModal", () => ({
+  default: () => null,
+}));
+
 vi.mock("../components/TransactionChart", () => ({
   default: () => <div data-testid="transaction-chart" />,
 }));

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -2,6 +2,7 @@ import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } fro
 import Modal from "../components/Modal";
 import ImportCsvModal from "../components/ImportCsvModal";
 import ImportHistoryModal from "../components/ImportHistoryModal";
+import UpgradeModal from "../components/UpgradeModal";
 import ForecastCard from "../components/ForecastCard";
 import TransactionList from "../components/TransactionList";
 import {
@@ -28,6 +29,7 @@ import {
   normalizeTransactionDate,
 } from "../components/DatabaseUtils";
 import { analyticsService, type TrendPoint } from "../services/analytics.service";
+import { setPaymentRequiredHandler } from "../services/api";
 import {
   useFilters,
   type FilterState,
@@ -476,6 +478,8 @@ const App = ({
     isCompactHeaderActionsMode(),
   );
   const [isBudgetModalOpen, setBudgetModalOpen] = useState(false);
+  const [isUpgradeModalOpen, setUpgradeModalOpen] = useState(false);
+  const [upgradeModalReason, setUpgradeModalReason] = useState("");
   const [editingTransaction, setEditingTransaction] = useState<TransactionWithCategoryName | null>(null);
   const [editingBudget, setEditingBudget] = useState<MonthlyBudget | null>(null);
   const [budgetForm, setBudgetForm] = useState<BudgetFormState>(DEFAULT_BUDGET_FORM);
@@ -591,6 +595,16 @@ const App = ({
       if (budgetSuccessTimeoutRef.current) {
         clearTimeout(budgetSuccessTimeoutRef.current);
       }
+    };
+  }, []);
+
+  useEffect(() => {
+    setPaymentRequiredHandler((message: string) => {
+      setUpgradeModalReason(message);
+      setUpgradeModalOpen(true);
+    });
+    return () => {
+      setPaymentRequiredHandler(undefined);
     };
   }, []);
 
@@ -2670,6 +2684,12 @@ const App = ({
         categories={categories}
         hasLoadedCategories={hasLoadedCategories}
         initialTransaction={editingTransaction}
+      />
+
+      <UpgradeModal
+        isOpen={isUpgradeModalOpen}
+        reason={upgradeModalReason}
+        onClose={() => setUpgradeModalOpen(false)}
       />
 
       <ImportCsvModal

--- a/apps/web/src/services/api.test.js
+++ b/apps/web/src/services/api.test.js
@@ -8,6 +8,7 @@ import {
   resolveApiUrl,
   setStoredToken,
   setUnauthorizedHandler,
+  setPaymentRequiredHandler,
 } from "./api";
 
 var requestInterceptor;
@@ -43,6 +44,7 @@ describe("api service", () => {
   beforeEach(() => {
     window.localStorage.clear();
     setUnauthorizedHandler(undefined);
+    setPaymentRequiredHandler(undefined);
   });
 
   it("consulta o healthcheck da API", async () => {
@@ -150,5 +152,27 @@ describe("api service", () => {
 
     expect(getStoredToken()).toBe("");
     expect(onUnauthorized).not.toHaveBeenCalled();
+  });
+
+  it("chama paymentRequiredHandler com a mensagem quando status e 402", async () => {
+    const onPaymentRequired = vi.fn();
+    setPaymentRequiredHandler(onPaymentRequired);
+
+    await expect(
+      responseErrorInterceptor({
+        response: { status: 402, data: { message: "Periodo de teste encerrado." } },
+      }),
+    ).rejects.toBeTruthy();
+
+    expect(onPaymentRequired).toHaveBeenCalledWith("Periodo de teste encerrado.");
+  });
+
+  it("nao falha se paymentRequiredHandler nao estiver definido (status 402)", async () => {
+    await expect(
+      responseErrorInterceptor({
+        response: { status: 402, data: {} },
+      }),
+    ).rejects.toBeTruthy();
+    // nenhum erro de "is not a function"
   });
 });

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -12,6 +12,7 @@ type EnvConfig = {
 };
 
 type UnauthorizedHandler = (() => void) | undefined;
+type PaymentRequiredHandler = ((message: string) => void) | undefined;
 
 type ApiConfigurationError = Error & {
   code: "API_URL_NOT_CONFIGURED";
@@ -38,6 +39,7 @@ export const AUTH_TOKEN_STORAGE_KEY = "control_finance.auth_token";
 const REQUEST_ID_HEADER_NAME = "x-request-id";
 const isApiConfigured = Boolean(API_URL);
 let unauthorizedHandler: UnauthorizedHandler = undefined;
+let paymentRequiredHandler: PaymentRequiredHandler = undefined;
 
 const createApiConfigurationError = (): ApiConfigurationError => {
   const error = new Error(API_CONFIGURATION_ERROR_MESSAGE) as ApiConfigurationError;
@@ -163,6 +165,10 @@ export const setUnauthorizedHandler = (handler: UnauthorizedHandler) => {
   unauthorizedHandler = typeof handler === "function" ? handler : undefined;
 };
 
+export const setPaymentRequiredHandler = (handler: PaymentRequiredHandler) => {
+  paymentRequiredHandler = typeof handler === "function" ? handler : undefined;
+};
+
 export const api = axios.create({
   baseURL: API_URL || undefined,
   timeout: 8000,
@@ -205,6 +211,17 @@ api.interceptors.response.use(
 
       if (typeof unauthorizedHandler === "function") {
         unauthorizedHandler();
+      }
+    }
+
+    if (error?.response?.status === 402) {
+      const message: string =
+        typeof error?.response?.data?.message === "string"
+          ? error.response.data.message
+          : "";
+
+      if (typeof paymentRequiredHandler === "function") {
+        paymentRequiredHandler(message);
       }
     }
 


### PR DESCRIPTION
## Summary

- **api.ts**: adds `setPaymentRequiredHandler` export (same pattern as `setUnauthorizedHandler`); response interceptor now catches 402, extracts `error.response.data.message`, fires the handler — `Promise.reject` still propagates so component error states are unaffected
- **UpgradeModal.tsx** (new component): contextual headline (trial copy vs generic PRO copy), Free vs Pro comparison table matching real entitlements (`budget_tracking`, analytics 6 vs 24 months, `csv_export`, `csv_import`), Escape + backdrop close, `aria-modal`, CTA navigates to `/app/settings/billing`
- **App.tsx**: registers/cleans up the handler in `useEffect`, two `useState` for modal open state and reason string, renders `<UpgradeModal>` alongside the existing modal block
- **api.test.js**: two new tests for 402 interceptor (handler called with correct message, no crash when handler is undefined)
- **App.test.jsx**: mocks `UpgradeModal` (it calls `useNavigate`; App tests run without Router context)

## Test plan

- [ ] `npm -w apps/web run lint` → 0 warnings
- [ ] `npm -w apps/web test -- --run` → 117/117 pass
- [ ] Expire trial via SQL: `UPDATE users SET trial_ends_at = NOW() - INTERVAL '1 day' WHERE id = X`
- [ ] Hit Analytics tab → 402 → modal opens with headline + comparison table
- [ ] Click "Ativar plano Pro" → navigates to `/app/settings/billing`, modal closes
- [ ] Click outside modal or press Escape → modal closes, no navigation
- [ ] PRO user: analytics loads normally, modal never appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)