### PR TITLE
feat(forecast): integrate pending bills into projected balance (v1.28.0)

### DIFF
--- a/apps/api/src/forecast.test.js
+++ b/apps/api/src/forecast.test.js
@@ -301,3 +301,163 @@ describe("computeForecast — flip detection (deterministic)", () => {
     expect(typeof result.projectedBalance).toBe("number");
   });
 });
+
+// ─── Forecast + Bills integration ────────────────────────────────────────────
+
+// Helpers for real current-month boundaries (HTTP tests use real `now`)
+const _now = new Date();
+const CURRENT_MONTH_END = new Date(Date.UTC(_now.getUTCFullYear(), _now.getUTCMonth() + 1, 0))
+  .toISOString()
+  .slice(0, 10);
+const CURRENT_MONTH_START = new Date(Date.UTC(_now.getUTCFullYear(), _now.getUTCMonth(), 1))
+  .toISOString()
+  .slice(0, 10);
+// A date well beyond the current month to test exclusion
+const NEXT_MONTH_DATE = new Date(Date.UTC(_now.getUTCFullYear(), _now.getUTCMonth() + 1, 15))
+  .toISOString()
+  .slice(0, 10);
+
+describe("forecast — bills integration", () => {
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await clearDbClientForTests(); });
+  beforeEach(async () => {
+    resetLoginProtectionState();
+    resetImportRateLimiterState();
+    resetWriteRateLimiterState();
+    resetHttpMetricsForTests();
+    await dbQuery("DELETE FROM user_forecasts");
+    await dbQuery("DELETE FROM user_profiles");
+    await dbQuery("DELETE FROM transactions");
+    await dbQuery("DELETE FROM bills");
+    await dbQuery("DELETE FROM user_identities");
+    await dbQuery("DELETE FROM users");
+  });
+
+  it("recompute inclui bill pendente do mes na projecao ajustada", async () => {
+    const token = await registerAndLogin("fc-bills-pending@test.dev");
+
+    await request(app)
+      .post("/bills")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ title: "Aluguel", amount: 1200, dueDate: CURRENT_MONTH_END });
+
+    const res = await request(app)
+      .post("/forecasts/recompute")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.billsPendingTotal).toBe(1200);
+    expect(res.body.billsPendingCount).toBe(1);
+    expect(res.body.adjustedProjectedBalance).toBe(
+      Number((res.body.projectedBalance - 1200).toFixed(2)),
+    );
+  });
+
+  it("recompute com bill paga nao afeta projecao ajustada", async () => {
+    const token = await registerAndLogin("fc-bills-paid@test.dev");
+
+    const createRes = await request(app)
+      .post("/bills")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ title: "Luz", amount: 200, dueDate: CURRENT_MONTH_END });
+    const billId = createRes.body.id;
+
+    await request(app)
+      .patch(`/bills/${billId}/mark-paid`)
+      .set("Authorization", `Bearer ${token}`);
+
+    const res = await request(app)
+      .post("/forecasts/recompute")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.billsPendingTotal).toBe(0);
+    expect(res.body.billsPendingCount).toBe(0);
+    expect(res.body.adjustedProjectedBalance).toBe(res.body.projectedBalance);
+  });
+
+  it("bill vencida ainda pendente e incluida na projecao", async () => {
+    const token = await registerAndLogin("fc-bills-overdue@test.dev");
+
+    await request(app)
+      .post("/bills")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ title: "Internet", amount: 99.9, dueDate: CURRENT_MONTH_START });
+
+    const res = await request(app)
+      .post("/forecasts/recompute")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.billsPendingTotal).toBeGreaterThan(0);
+    expect(res.body.billsPendingCount).toBe(1);
+  });
+
+  it("bill de proximo mes nao afeta projecao ajustada do mes atual", async () => {
+    const token = await registerAndLogin("fc-bills-nextmonth@test.dev");
+
+    await request(app)
+      .post("/bills")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ title: "IPTU", amount: 500, dueDate: NEXT_MONTH_DATE });
+
+    const res = await request(app)
+      .post("/forecasts/recompute")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.billsPendingTotal).toBe(0);
+    expect(res.body.billsPendingCount).toBe(0);
+    expect(res.body.adjustedProjectedBalance).toBe(res.body.projectedBalance);
+  });
+
+  it("GET /forecasts/current enriquece com bills em tempo real", async () => {
+    const token = await registerAndLogin("fc-bills-realtime@test.dev");
+
+    // Recompute without bills — stored projectedBalance has no bills
+    await request(app)
+      .post("/forecasts/recompute")
+      .set("Authorization", `Bearer ${token}`);
+
+    // Add bill AFTER recompute
+    await request(app)
+      .post("/bills")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ title: "Agua", amount: 80, dueDate: CURRENT_MONTH_END });
+
+    // GET /current should reflect the fresh bill even without recompute
+    const res = await request(app)
+      .get("/forecasts/current")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.billsPendingTotal).toBe(80);
+    expect(res.body.billsPendingCount).toBe(1);
+    expect(res.body.adjustedProjectedBalance).toBe(
+      Number((res.body.projectedBalance - 80).toFixed(2)),
+    );
+  });
+
+  it("recompute com multiplas bills soma corretamente", async () => {
+    const token = await registerAndLogin("fc-bills-multi@test.dev");
+
+    await request(app).post("/bills").set("Authorization", `Bearer ${token}`)
+      .send({ title: "Aluguel", amount: 1200, dueDate: CURRENT_MONTH_END });
+    await request(app).post("/bills").set("Authorization", `Bearer ${token}`)
+      .send({ title: "Luz", amount: 150.5, dueDate: CURRENT_MONTH_END });
+    await request(app).post("/bills").set("Authorization", `Bearer ${token}`)
+      .send({ title: "Internet", amount: 99.9, dueDate: CURRENT_MONTH_END });
+
+    const res = await request(app)
+      .post("/forecasts/recompute")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.billsPendingCount).toBe(3);
+    expect(res.body.billsPendingTotal).toBeCloseTo(1450.4, 1);
+    expect(res.body.adjustedProjectedBalance).toBeCloseTo(
+      res.body.projectedBalance - 1450.4,
+      1,
+    );
+  });
+});

--- a/apps/api/src/services/bills.service.js
+++ b/apps/api/src/services/bills.service.js
@@ -394,3 +394,26 @@ export const markBillAsPaidForUser = async (userId, billId, payload = {}) => {
     };
   });
 };
+
+/**
+ * Returns the sum and count of pending bills whose due_date <= endDate.
+ * Used by the forecast engine to compute the adjusted projected balance.
+ * @param {number} userId
+ * @param {string} endDate - ISO date string "YYYY-MM-DD"
+ */
+export const getPendingBillsDueByDate = async (userId, endDate) => {
+  const uid = normalizeUserId(userId);
+  const { rows } = await dbQuery(
+    `SELECT COALESCE(SUM(amount), 0)::float AS bills_total,
+            COUNT(*)::int                   AS bills_count
+     FROM bills
+     WHERE user_id  = $1
+       AND status   = 'pending'
+       AND due_date <= $2`,
+    [uid, endDate],
+  );
+  return {
+    billsTotal: rows[0].bills_total,
+    billsCount: rows[0].bills_count,
+  };
+};

--- a/apps/api/src/services/forecast.service.js
+++ b/apps/api/src/services/forecast.service.js
@@ -1,4 +1,5 @@
 import { dbQuery } from "../db/index.js";
+import { getPendingBillsDueByDate } from "./bills.service.js";
 
 const ENGINE_VERSION = "v1";
 
@@ -166,6 +167,10 @@ export const computeForecast = async (userId, { now = new Date() } = {}) => {
     [uid, mStart, ENGINE_VERSION, pb, salaryMonthly, spendingToDate.toFixed(2), da, daysRemaining, flipDetected, flipDirection],
   );
 
+  const monthEnd = monthEndStr(now);
+  const { billsTotal, billsCount } = await getPendingBillsDueByDate(uid, monthEnd);
+  const adjustedProjectedBalance = Number((pb - billsTotal).toFixed(2));
+
   return {
     month: mStart.slice(0, 7),
     engineVersion: ENGINE_VERSION,
@@ -177,6 +182,9 @@ export const computeForecast = async (userId, { now = new Date() } = {}) => {
     flipDetected,
     flipDirection,
     generatedAt: new Date().toISOString(),
+    billsPendingTotal: Number(billsTotal.toFixed(2)),
+    billsPendingCount: billsCount,
+    adjustedProjectedBalance,
   };
 };
 
@@ -193,5 +201,12 @@ export const getLatestForecast = async (userId, { now = new Date() } = {}) => {
   );
 
   if (result.rows.length === 0) return null;
-  return rowToForecast(result.rows[0]);
+
+  const forecast = rowToForecast(result.rows[0]);
+  const monthEnd = monthEndStr(now);
+  const { billsTotal, billsCount } = await getPendingBillsDueByDate(uid, monthEnd);
+  forecast.billsPendingTotal = Number(billsTotal.toFixed(2));
+  forecast.billsPendingCount = billsCount;
+  forecast.adjustedProjectedBalance = Number((forecast.projectedBalance - billsTotal).toFixed(2));
+  return forecast;
 };

--- a/apps/web/src/components/ForecastCard.tsx
+++ b/apps/web/src/components/ForecastCard.tsx
@@ -217,19 +217,27 @@ const ForecastCard = ({
         <>
           <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
             <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
-              <p className="text-xs font-medium uppercase text-cf-text-secondary">Projecao fim do mes</p>
+              <p className="text-xs font-medium uppercase text-cf-text-secondary">Projecao ajustada</p>
               <p
                 className={`mt-1 text-lg font-bold ${
-                  forecast.projectedBalance < 0 ? "text-red-600" : "text-cf-text-primary"
+                  forecast.adjustedProjectedBalance < 0 ? "text-red-600" : "text-cf-text-primary"
                 }`}
               >
-                {formatCurrency(forecast.projectedBalance)}
+                {formatCurrency(forecast.adjustedProjectedBalance)}
               </p>
               {forecast.incomeExpected !== null ? (
                 <p className="mt-0.5 text-xs text-cf-text-secondary">
                   Salario esperado: {formatCurrency(forecast.incomeExpected)}
                 </p>
               ) : null}
+              {forecast.billsPendingCount > 0 ? (
+                <p className="mt-0.5 text-xs text-amber-600">
+                  {forecast.billsPendingCount}{" "}
+                  {forecast.billsPendingCount === 1 ? "pendencia incluida" : "pendencias incluidas"}
+                </p>
+              ) : (
+                <p className="mt-0.5 text-xs text-cf-text-secondary">Sem pendencias este mes</p>
+              )}
             </div>
 
             <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
@@ -251,11 +259,19 @@ const ForecastCard = ({
             </div>
 
             <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
-              <p className="text-xs font-medium uppercase text-cf-text-secondary">Projecao de gasto</p>
-              <p className="mt-1 text-base font-semibold text-cf-text-primary">
-                {formatCurrency(forecast.dailyAvgSpending * forecast.daysRemaining)}
+              <p className="text-xs font-medium uppercase text-cf-text-secondary">Pendencias do mes</p>
+              <p
+                className={`mt-1 text-base font-semibold ${
+                  forecast.billsPendingCount > 0 ? "text-amber-600" : "text-cf-text-primary"
+                }`}
+              >
+                {formatCurrency(forecast.billsPendingTotal)}
               </p>
-              <p className="mt-0.5 text-xs text-cf-text-secondary">nos proximos dias</p>
+              <p className="mt-0.5 text-xs text-cf-text-secondary">
+                {forecast.billsPendingCount > 0
+                  ? `${forecast.billsPendingCount} ${forecast.billsPendingCount === 1 ? "conta" : "contas"} este mes`
+                  : "Nenhuma pendencia"}
+              </p>
             </div>
           </div>
 

--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -280,6 +280,9 @@ describe("App", () => {
       flipDirection: null,
       engineVersion: "v1",
       incomeExpected: null,
+      billsPendingTotal: 0,
+      billsPendingCount: 0,
+      adjustedProjectedBalance: 1200,
     });
     profileService.getMe.mockResolvedValue({
       id: 1,

--- a/apps/web/src/services/forecast.service.ts
+++ b/apps/web/src/services/forecast.service.ts
@@ -10,6 +10,9 @@ export interface Forecast {
   flipDirection: "pos_to_neg" | "neg_to_pos" | null;
   engineVersion: string;
   incomeExpected: number | null;
+  billsPendingTotal: number;
+  billsPendingCount: number;
+  adjustedProjectedBalance: number;
 }
 
 export const forecastService = {


### PR DESCRIPTION
### Context

The current forecast calculates `projectedBalance` using only transaction history (daily spending average). Pending bills — known future obligations with due dates — were completely ignored, making the projection overly optimistic.

This PR enriches the forecast response with bills data, giving users a realistic view of their end-of-month balance.

---

### What was delivered

**API (`apps/api`)**

* New `getPendingBillsDueByDate(userId, endDate)` in `bills.service.js`
  * Queries pending bills with `due_date <= monthEnd`
  * Includes both overdue (still unpaid) and future bills due this month
* Both `computeForecast` and `getLatestForecast` now enrich their response with:
  * `billsPendingTotal` — sum of pending bills due by month-end (always fresh, not stored in DB)
  * `billsPendingCount` — count
  * `adjustedProjectedBalance` — `projectedBalance - billsPendingTotal`
* 6 new integration tests in `forecast.test.js`

**Web (`apps/web`)**

* `Forecast` interface updated with the 3 new fields
* `ForecastCard` active state:
  * **Card 1**: Now shows `adjustedProjectedBalance` ("Projeção ajustada") with a subtext showing pending count (amber) or "Sem pendências este mês"
  * **Card 4**: Replaced "Projeção de gasto" with **"Pendências do mês"** showing `billsPendingTotal` in amber when > 0
* `App.test.jsx` `beforeEach` mock updated with the new fields

---

### Main files

**Modified**
* `apps/api/src/services/bills.service.js`
* `apps/api/src/services/forecast.service.js`
* `apps/api/src/forecast.test.js`
* `apps/web/src/services/forecast.service.ts`
* `apps/web/src/components/ForecastCard.tsx`
* `apps/web/src/pages/App.test.jsx`

---

### Tests / Quality

* ✅ API tests: **267/267** passing (6 new integration tests)
* ✅ Web tests: **136/136** passing
* ✅ Build: clean
* ✅ Lint: clean

---

### Manual smoke

1. Create 2 pending bills (e.g. R$ 200 + R$ 350) due this month
2. Click "Atualizar" on ForecastCard → Card 1 shows `projectedBalance - 550`, card 4 shows R$ 550 in amber
3. Mark 1 bill as paid → refresh → card 4 drops to R$ 200
4. `GET /forecasts/current` without recomputing after adding a new bill → `billsPendingTotal` updates in real time

---

### Checklist

* [x] API tests passing (267/267)
* [x] Web tests passing (136/136)
* [x] Build OK
* [x] Lint OK
* [x] No DB migration needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)