### PR TITLE
feat(bills): installment batch creation (PR-B3B)

### DIFF
--- a/apps/api/src/bills.test.js
+++ b/apps/api/src/bills.test.js
@@ -429,6 +429,112 @@ describe("bills", () => {
     expectErrorResponseWithRequestId(res, 404, "Pendencia nao encontrada.");
   });
 
+  // ─── POST /bills/batch ───────────────────────────────────────────────────────
+
+  describe("POST /bills/batch", () => {
+    it("cria N parcelas atomicamente e retorna todas", async () => {
+      const token = await registerAndLogin("bills-batch-create@test.dev");
+
+      const bills = [
+        { title: "IPTU (1/3)", amount: 500, dueDate: FUTURE_DATE },
+        { title: "IPTU (2/3)", amount: 500, dueDate: toLocalDate(60) },
+        { title: "IPTU (3/3)", amount: 500, dueDate: toLocalDate(90) },
+      ];
+
+      const res = await request(app)
+        .post("/bills/batch")
+        .set("Authorization", `Bearer ${token}`)
+        .send({ bills });
+
+      expect(res.status).toBe(201);
+      expect(res.body.bills).toHaveLength(3);
+      expect(res.body.bills[0].title).toBe("IPTU (1/3)");
+      expect(res.body.bills[1].title).toBe("IPTU (2/3)");
+      expect(res.body.bills[2].title).toBe("IPTU (3/3)");
+      expect(res.body.bills[0].amount).toBe(500);
+
+      // Verify all 3 are persisted in DB
+      const listRes = await request(app)
+        .get("/bills")
+        .set("Authorization", `Bearer ${token}`);
+      expect(listRes.body.pagination.total).toBe(3);
+    });
+
+    it("retorna 400 se bills array tiver menos de 2 items", async () => {
+      const token = await registerAndLogin("bills-batch-min@test.dev");
+
+      const res = await request(app)
+        .post("/bills/batch")
+        .set("Authorization", `Bearer ${token}`)
+        .send({ bills: [{ title: "A", amount: 100, dueDate: FUTURE_DATE }] });
+
+      expectErrorResponseWithRequestId(res, 400, "Informe entre 2 e 24 parcelas.");
+    });
+
+    it("retorna 400 se bills array tiver mais de 24 items", async () => {
+      const token = await registerAndLogin("bills-batch-max@test.dev");
+
+      const bills = Array.from({ length: 25 }, (_, i) => ({
+        title: `P ${i + 1}`,
+        amount: 100,
+        dueDate: FUTURE_DATE,
+      }));
+
+      const res = await request(app)
+        .post("/bills/batch")
+        .set("Authorization", `Bearer ${token}`)
+        .send({ bills });
+
+      expectErrorResponseWithRequestId(res, 400, "Informe entre 2 e 24 parcelas.");
+    });
+
+    it("retorna 400 se qualquer parcela tiver campo invalido", async () => {
+      const token = await registerAndLogin("bills-batch-invalid@test.dev");
+
+      const res = await request(app)
+        .post("/bills/batch")
+        .set("Authorization", `Bearer ${token}`)
+        .send({
+          bills: [
+            { title: "Valida", amount: 100, dueDate: FUTURE_DATE },
+            { title: "", amount: 100, dueDate: FUTURE_DATE }, // title vazio
+          ],
+        });
+
+      expectErrorResponseWithRequestId(res, 400, "Titulo e obrigatorio.");
+    });
+
+    it("nao cria nenhuma bill se uma parcela for invalida (atomico)", async () => {
+      const token = await registerAndLogin("bills-batch-atomic@test.dev");
+
+      const res = await request(app)
+        .post("/bills/batch")
+        .set("Authorization", `Bearer ${token}`)
+        .send({
+          bills: [
+            { title: "Valida", amount: 100, dueDate: FUTURE_DATE },
+            { title: "Invalida", amount: -50, dueDate: FUTURE_DATE }, // amount invalido
+          ],
+        });
+
+      expect(res.status).toBe(400);
+
+      // DB deve estar vazio — nenhuma bill criada
+      const listRes = await request(app)
+        .get("/bills")
+        .set("Authorization", `Bearer ${token}`);
+      expect(listRes.body.pagination.total).toBe(0);
+    });
+
+    it("retorna 401 sem token", async () => {
+      const res = await request(app)
+        .post("/bills/batch")
+        .send({ bills: [] });
+
+      expect(res.status).toBe(401);
+    });
+  });
+
   // ─── Rate limiting ───────────────────────────────────────────────────────────
 
   it("POST /bills aplica rate limit por usuario", async () => {

--- a/apps/api/src/routes/bills.routes.js
+++ b/apps/api/src/routes/bills.routes.js
@@ -3,6 +3,7 @@ import { authMiddleware } from "../middlewares/auth.middleware.js";
 import { billsWriteRateLimiter } from "../middlewares/rate-limit.middleware.js";
 import {
   createBillForUser,
+  createBillsBatchForUser,
   listBillsByUser,
   getBillsSummaryForUser,
   updateBillForUser,
@@ -40,6 +41,16 @@ router.post("/", billsWriteRateLimiter, async (req, res, next) => {
   try {
     const bill = await createBillForUser(req.user.id, req.body || {});
     res.status(201).json(bill);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /bills/batch — create N bills atomically (installments)
+router.post("/batch", billsWriteRateLimiter, async (req, res, next) => {
+  try {
+    const bills = await createBillsBatchForUser(req.user.id, req.body?.bills ?? []);
+    res.status(201).json({ bills });
   } catch (error) {
     next(error);
   }

--- a/apps/api/src/services/bills.service.js
+++ b/apps/api/src/services/bills.service.js
@@ -396,6 +396,45 @@ export const markBillAsPaidForUser = async (userId, billId, payload = {}) => {
 };
 
 /**
+ * Creates N bills atomically (all or nothing) in a single DB transaction.
+ * @param {number} userId
+ * @param {Array} payloads - validated before call, 2-24 items
+ * @returns {Promise<Array>}
+ */
+export const createBillsBatchForUser = async (userId, payloads) => {
+  const uid = normalizeUserId(userId);
+
+  if (!Array.isArray(payloads) || payloads.length < 2 || payloads.length > 24) {
+    throw createError(400, "Informe entre 2 e 24 parcelas.");
+  }
+
+  // Validate all payloads up-front (before transaction)
+  const normalized = payloads.map((p) => ({
+    title:          normalizeTitle(p.title),
+    amount:         normalizeAmount(p.amount),
+    dueDate:        normalizeDueDate(p.dueDate),
+    categoryId:     normalizeOptionalCategoryId(p.categoryId) ?? null,
+    notes:          normalizeOptionalText(p.notes, "Notas") ?? null,
+    provider:       normalizeOptionalText(p.provider, "Fornecedor") ?? null,
+    referenceMonth: normalizeOptionalReferenceMonth(p.referenceMonth) ?? null,
+  }));
+
+  return withDbTransaction(async (client) => {
+    const results = [];
+    for (const b of normalized) {
+      const { rows } = await client.query(
+        `INSERT INTO bills (user_id, title, amount, due_date, category_id, notes, provider, reference_month)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+         RETURNING *`,
+        [uid, b.title, b.amount, b.dueDate, b.categoryId, b.notes, b.provider, b.referenceMonth],
+      );
+      results.push(mapBillRow(rows[0]));
+    }
+    return results;
+  });
+};
+
+/**
  * Returns the sum and count of pending bills whose due_date <= endDate.
  * Used by the forecast engine to compute the adjusted projected balance.
  * @param {number} userId

--- a/apps/web/src/components/BillModal.tsx
+++ b/apps/web/src/components/BillModal.tsx
@@ -20,6 +20,19 @@ const formatAmountForInput = (value: number): string => {
   return value.toFixed(2).replace(".", ",");
 };
 
+const addMonthsClamped = (isoDate: string, n: number): string => {
+  const [y, m, d] = isoDate.split("-").map(Number);
+  const targetYear = y + Math.floor((m - 1 + n) / 12);
+  const targetMonth = ((m - 1 + n) % 12) + 1;
+  const lastDay = new Date(Date.UTC(targetYear, targetMonth, 0)).getUTCDate();
+  const clampedDay = Math.min(d, lastDay);
+  return [
+    targetYear,
+    String(targetMonth).padStart(2, "0"),
+    String(clampedDay).padStart(2, "0"),
+  ].join("-");
+};
+
 const BillModal = ({
   isOpen,
   onClose,
@@ -38,6 +51,8 @@ const BillModal = ({
   const [notes, setNotes] = useState("");
   const [isSaving, setIsSaving] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
+  const [showInstallments, setShowInstallments] = useState(false);
+  const [installmentCount, setInstallmentCount] = useState("2");
 
   // Reset form when modal opens/closes
   useEffect(() => {
@@ -61,6 +76,8 @@ const BillModal = ({
     }
     setErrorMessage("");
     setIsSaving(false);
+    setShowInstallments(false);
+    setInstallmentCount("2");
   }, [isOpen, initialBill]);
 
   // Escape key listener
@@ -99,22 +116,39 @@ const BillModal = ({
         return;
       }
 
-      const payload: CreateBillPayload = {
-        title: trimmedTitle,
-        amount: parsedAmount,
-        dueDate,
-        categoryId: categoryId ? Number(categoryId) : null,
-        provider: provider.trim() || null,
-        referenceMonth: referenceMonth.trim() || null,
-        notes: notes.trim() || null,
-      };
-
       setIsSaving(true);
       try {
-        const savedBill = isEditing && initialBill
-          ? await billsService.update(initialBill.id, payload)
-          : await billsService.create(payload);
-        onSaved(savedBill);
+        if (showInstallments && !isEditing) {
+          const n = Math.max(2, Math.min(24, parseInt(installmentCount, 10) || 2));
+          const bills: CreateBillPayload[] = Array.from({ length: n }, (_, i) => {
+            const installmentDueDate = addMonthsClamped(dueDate, i);
+            return {
+              title: `${trimmedTitle} (${i + 1}/${n})`,
+              amount: parsedAmount,
+              dueDate: installmentDueDate,
+              categoryId: categoryId ? Number(categoryId) : null,
+              provider: provider.trim() || null,
+              referenceMonth: installmentDueDate.slice(0, 7),
+              notes: notes.trim() || null,
+            };
+          });
+          const createdBills = await billsService.createBatch(bills);
+          onSaved(createdBills[0]);
+        } else {
+          const payload: CreateBillPayload = {
+            title: trimmedTitle,
+            amount: parsedAmount,
+            dueDate,
+            categoryId: categoryId ? Number(categoryId) : null,
+            provider: provider.trim() || null,
+            referenceMonth: referenceMonth.trim() || null,
+            notes: notes.trim() || null,
+          };
+          const savedBill = isEditing && initialBill
+            ? await billsService.update(initialBill.id, payload)
+            : await billsService.create(payload);
+          onSaved(savedBill);
+        }
       } catch (error) {
         const err = error as { response?: { data?: { message?: string } }; message?: string };
         setErrorMessage(
@@ -124,7 +158,7 @@ const BillModal = ({
         setIsSaving(false);
       }
     },
-    [title, amount, dueDate, categoryId, provider, referenceMonth, notes, isEditing, initialBill, onSaved],
+    [title, amount, dueDate, categoryId, provider, referenceMonth, notes, isEditing, initialBill, onSaved, showInstallments, installmentCount],
   );
 
   if (!isOpen) return null;
@@ -272,6 +306,40 @@ const BillModal = ({
             />
           </div>
 
+          {/* Installments */}
+          {!isEditing ? (
+            <div className="border-t border-cf-border pt-3">
+              <label className="flex cursor-pointer items-center gap-2 text-sm text-cf-text-primary">
+                <input
+                  type="checkbox"
+                  checked={showInstallments}
+                  onChange={(e) => setShowInstallments(e.target.checked)}
+                  disabled={isSaving}
+                  className="rounded"
+                />
+                Parcelar
+              </label>
+
+              {showInstallments ? (
+                <div className="mt-2 flex items-center gap-2">
+                  <input
+                    type="number"
+                    min={2}
+                    max={24}
+                    value={installmentCount}
+                    onChange={(e) => setInstallmentCount(e.target.value)}
+                    disabled={isSaving}
+                    aria-label="Numero de parcelas"
+                    className="w-16 rounded border border-cf-border-input px-2 py-1.5 text-sm text-cf-text-primary focus:outline-none focus:ring-1 focus:ring-brand-1 bg-cf-surface"
+                  />
+                  <span className="text-sm text-cf-text-secondary">
+                    parcelas mensais a partir de {dueDate || "—"}
+                  </span>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+
           {/* Error */}
           {errorMessage ? (
             <div
@@ -297,7 +365,11 @@ const BillModal = ({
               disabled={isSaving}
               className="rounded bg-brand-1 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-2 disabled:cursor-not-allowed disabled:opacity-60"
             >
-              {isSaving ? "Salvando..." : "Salvar"}
+              {isSaving
+                ? "Gerando..."
+                : showInstallments && !isEditing
+                ? `Gerar ${parseInt(installmentCount, 10) || 2} parcelas`
+                : "Salvar"}
             </button>
           </div>
         </form>

--- a/apps/web/src/pages/BillsPage.test.tsx
+++ b/apps/web/src/pages/BillsPage.test.tsx
@@ -13,6 +13,7 @@ vi.mock("../services/bills.service", () => ({
     getSummary: vi.fn(),
     list: vi.fn(),
     create: vi.fn(),
+    createBatch: vi.fn(),
     update: vi.fn(),
     remove: vi.fn(),
     markPaid: vi.fn(),
@@ -246,6 +247,61 @@ describe("BillsPage", () => {
       expect(billsService.list).toHaveBeenCalledWith(
         expect.objectContaining({ offset: 20 }),
       );
+    });
+  });
+
+  // ─── Parcelamento ─────────────────────────────────────────────────────────────
+
+  it("parcelamento cria N bills via createBatch com titulos corretos", async () => {
+    const user = userEvent.setup();
+    vi.mocked(billsService.createBatch).mockResolvedValue([
+      buildBill({ id: 10, title: "IPTU (1/3)" }),
+      buildBill({ id: 11, title: "IPTU (2/3)" }),
+      buildBill({ id: 12, title: "IPTU (3/3)" }),
+    ]);
+
+    renderPage();
+    await waitFor(() => expect(screen.getByText("Conta de Agua")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: /Nova pendencia/ }));
+    await user.type(screen.getByLabelText(/Titulo/), "IPTU");
+    await user.type(screen.getByLabelText(/Valor/), "500");
+    await user.click(screen.getByRole("checkbox", { name: /Parcelar/ }));
+
+    const countInput = screen.getByRole("spinbutton", { name: /parcelas/i });
+    await user.clear(countInput);
+    await user.type(countInput, "3");
+
+    await user.click(screen.getByRole("button", { name: "Gerar 3 parcelas" }));
+
+    await waitFor(() => {
+      expect(billsService.createBatch).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ title: "IPTU (1/3)" }),
+          expect.objectContaining({ title: "IPTU (2/3)" }),
+          expect.objectContaining({ title: "IPTU (3/3)" }),
+        ]),
+      );
+    });
+  });
+
+  it("erro no createBatch exibe mensagem de erro no modal", async () => {
+    const user = userEvent.setup();
+    vi.mocked(billsService.createBatch).mockRejectedValue(
+      new Error("Falha ao criar parcelas."),
+    );
+
+    renderPage();
+    await waitFor(() => expect(screen.getByText("Conta de Agua")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: /Nova pendencia/ }));
+    await user.type(screen.getByLabelText(/Titulo/), "IPTU");
+    await user.type(screen.getByLabelText(/Valor/), "500");
+    await user.click(screen.getByRole("checkbox", { name: /Parcelar/ }));
+    await user.click(screen.getByRole("button", { name: "Gerar 2 parcelas" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/services/bills.service.ts
+++ b/apps/web/src/services/bills.service.ts
@@ -46,6 +46,10 @@ export interface CreateBillPayload {
 
 export type UpdateBillPayload = Partial<CreateBillPayload>;
 
+export interface BillsBatchResult {
+  bills: unknown[];
+}
+
 export interface MarkPaidResult {
   bill: Bill;
   transaction: {
@@ -180,6 +184,11 @@ export const billsService = {
 
   remove: async (id: number): Promise<void> => {
     await api.delete(`/bills/${id}`);
+  },
+
+  createBatch: async (bills: CreateBillPayload[]): Promise<Bill[]> => {
+    const { data } = await api.post<BillsBatchResult>("/bills/batch", { bills });
+    return (data.bills as BillApiPayload[]).map(normalizeBill);
   },
 
   markPaid: async (id: number, opts: { paidAt?: string } = {}): Promise<MarkPaidResult> => {


### PR DESCRIPTION
## Summary

- `POST /bills/batch`: creates 2–24 bills atomically via `withDbTransaction` (all-or-nothing)
- `createBillsBatchForUser`: validates all payloads up-front before the transaction opens
- `BillModal`: new **Parcelar** toggle (hidden when editing) — checkbox reveals a count input (2–24); titles auto-suffixed as `Title (X/N)`; due dates computed via `addMonthsClamped`; `referenceMonth` derived automatically from each installment's due date
- `billsService.createBatch`: web client method posting to `/bills/batch` with `normalizeBill` mapping

## Tests

- **API** (6 new): happy path (3 parcelas persisted), min < 2, max > 24, invalid field, atomicity (0 bills on error), 401 without token → 30/30
- **Web** (2 new): `createBatch` called with correct titles, error displays `role="alert"` → 138/138
- Build + lint: clean

## Checklist

- [x] Atomic endpoint with validation before transaction
- [x] Date edge-case handled (Jan 31 → Feb 28 via `addMonthsClamped`)
- [x] Installment UI hidden in edit mode
- [x] Rate limiter reused (`billsWriteRateLimiter`)
- [x] All tests green, build clean, ESLint 0 warnings