### PR TITLE
feat(web): desktop Conta dropdown, mobile nav reorder, dark mode + PT-BR fixes

### DIFF
--- a/apps/web/src/components/UpgradeModal.tsx
+++ b/apps/web/src/components/UpgradeModal.tsx
@@ -8,10 +8,10 @@ interface UpgradeModalProps {
 }
 
 const FEATURES = [
-  { label: "Budget tracking", free: "✓", pro: "✓" },
+  { label: "Controle de metas", free: "✓", pro: "✓" },
   { label: "Analytics (histórico)", free: "6 meses", pro: "24 meses" },
-  { label: "CSV Export", free: "—", pro: "✓" },
-  { label: "CSV Import", free: "—", pro: "✓" },
+  { label: "Exportar CSV", free: "—", pro: "✓" },
+  { label: "Importar CSV", free: "—", pro: "✓" },
 ];
 
 const UpgradeModal = ({ isOpen, reason, onClose }: UpgradeModalProps) => {

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -461,6 +461,9 @@ const App = ({
   const mobileActionsButtonRef = useRef<HTMLButtonElement | null>(null);
   const mobileActionsMenuRef = useRef<HTMLDivElement | null>(null);
   const firstMobileActionsItemRef = useRef<HTMLButtonElement | null>(null);
+  const contaButtonRef = useRef<HTMLButtonElement | null>(null);
+  const contaMenuRef = useRef<HTMLDivElement | null>(null);
+  const firstContaItemRef = useRef<HTMLButtonElement | null>(null);
   const [selectedSummaryMonth, setSelectedSummaryMonth] = useState(() => getInitialSummaryMonth());
   const [categories, setCategories] = useState<CategoryOption[]>([]);
   const [hasLoadedCategories, setHasLoadedCategories] = useState(false);
@@ -477,6 +480,7 @@ const App = ({
   const [isImportModalOpen, setImportModalOpen] = useState(false);
   const [isImportHistoryModalOpen, setImportHistoryModalOpen] = useState(false);
   const [isMobileActionsMenuOpen, setMobileActionsMenuOpen] = useState(false);
+  const [isContaMenuOpen, setContaMenuOpen] = useState(false);
   const [useMobileActionsMenu, setUseMobileActionsMenu] = useState(() =>
     isCompactHeaderActionsMode(),
   );
@@ -683,6 +687,42 @@ const App = ({
 
     focusFirstMenuItem();
   }, [isMobileActionsMenuOpen]);
+
+  // ─── Conta dropdown (desktop) ────────────────────────────────────────────────
+
+  useEffect(() => {
+    if (!isContaMenuOpen || typeof window === "undefined") return undefined;
+
+    const handleMouseDown = (event: MouseEvent) => {
+      const target = event.target as Node | null;
+      if (contaMenuRef.current?.contains(target) || contaButtonRef.current?.contains(target)) return;
+      setContaMenuOpen(false);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setContaMenuOpen(false);
+        contaButtonRef.current?.focus();
+      }
+    };
+
+    window.addEventListener("mousedown", handleMouseDown);
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("mousedown", handleMouseDown);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isContaMenuOpen]);
+
+  useEffect(() => {
+    if (!isContaMenuOpen) return;
+    const focus = () => firstContaItemRef.current?.focus();
+    if (typeof window !== "undefined" && typeof window.requestAnimationFrame === "function") {
+      window.requestAnimationFrame(focus);
+      return;
+    }
+    focus();
+  }, [isContaMenuOpen]);
 
   useEffect(() => {
     if (typeof window === "undefined") return undefined;
@@ -1542,6 +1582,29 @@ const App = ({
                     ref={mobileActionsMenuRef}
                     className="absolute right-0 top-full z-20 mt-1 flex w-44 flex-col gap-1 rounded border border-cf-border bg-cf-surface p-1 shadow-lg"
                   >
+                    {onOpenBills ? (
+                      <button
+                        type="button"
+                        role="menuitem"
+                        onClick={handleOpenBills}
+                        className="rounded px-2 py-2 text-left text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
+                      >
+                        Pendencias
+                      </button>
+                    ) : null}
+                    {onOpenCategoriesSettings ? (
+                      <button
+                        type="button"
+                        role="menuitem"
+                        onClick={handleOpenCategoriesSettings}
+                        className="rounded px-2 py-2 text-left text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
+                      >
+                        Categorias
+                      </button>
+                    ) : null}
+                    {(onOpenBills || onOpenCategoriesSettings) ? (
+                      <div className="my-1 h-px bg-cf-border" role="separator" />
+                    ) : null}
                     <button
                       type="button"
                       role="menuitem"
@@ -1568,24 +1631,17 @@ const App = ({
                     >
                       Historico de imports
                     </button>
-                    {onOpenBills ? (
-                      <button
-                        type="button"
-                        role="menuitem"
-                        onClick={handleOpenBills}
-                        className="rounded px-2 py-2 text-left text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
-                      >
-                        Pendencias
-                      </button>
+                    {(onOpenProfileSettings || onOpenBillingSettings || onOpenSecuritySettings) ? (
+                      <div className="my-1 h-px bg-cf-border" role="separator" />
                     ) : null}
-                    {onOpenCategoriesSettings ? (
+                    {onOpenProfileSettings ? (
                       <button
                         type="button"
                         role="menuitem"
-                        onClick={handleOpenCategoriesSettings}
+                        onClick={handleOpenProfileSettings}
                         className="rounded px-2 py-2 text-left text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                       >
-                        Categorias
+                        Perfil
                       </button>
                     ) : null}
                     {onOpenBillingSettings ? (
@@ -1596,16 +1652,6 @@ const App = ({
                         className="rounded px-2 py-2 text-left text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                       >
                         Assinatura
-                      </button>
-                    ) : null}
-                    {onOpenProfileSettings ? (
-                      <button
-                        type="button"
-                        role="menuitem"
-                        onClick={handleOpenProfileSettings}
-                        className="rounded px-2 py-2 text-left text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
-                      >
-                        Perfil
                       </button>
                     ) : null}
                     {onOpenSecuritySettings ? (
@@ -1652,14 +1698,6 @@ const App = ({
                 >
                   {theme === "dark" ? "☀ Claro" : "☾ Escuro"}
                 </button>
-                {onLogout ? (
-                  <button
-                    onClick={onLogout}
-                    className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
-                  >
-                    Sair
-                  </button>
-                ) : null}
                 <button
                   type="button"
                   onClick={handleExportCsv}
@@ -1700,32 +1738,75 @@ const App = ({
                     Categorias
                   </button>
                 ) : null}
-                {onOpenBillingSettings ? (
-                  <button
-                    type="button"
-                    onClick={handleOpenBillingSettings}
-                    className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
-                  >
-                    Assinatura
-                  </button>
-                ) : null}
-                {onOpenProfileSettings ? (
-                  <button
-                    type="button"
-                    onClick={handleOpenProfileSettings}
-                    className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
-                  >
-                    Perfil
-                  </button>
-                ) : null}
-                {onOpenSecuritySettings ? (
-                  <button
-                    type="button"
-                    onClick={handleOpenSecuritySettings}
-                    className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
-                  >
-                    Seguranca
-                  </button>
+                {(onOpenProfileSettings || onOpenBillingSettings || onOpenSecuritySettings || onLogout) ? (
+                  <div className="relative">
+                    <button
+                      type="button"
+                      ref={contaButtonRef}
+                      aria-haspopup="menu"
+                      aria-expanded={isContaMenuOpen ? "true" : "false"}
+                      onClick={() => setContaMenuOpen((v) => !v)}
+                      className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
+                    >
+                      Conta
+                    </button>
+                    {isContaMenuOpen ? (
+                      <div
+                        role="menu"
+                        aria-label="Conta"
+                        ref={contaMenuRef}
+                        className="absolute right-0 top-full z-20 mt-1 flex w-40 flex-col gap-1 rounded border border-cf-border bg-cf-surface p-1 shadow-lg"
+                      >
+                        {onOpenProfileSettings ? (
+                          <button
+                            type="button"
+                            role="menuitem"
+                            ref={firstContaItemRef}
+                            onClick={() => { setContaMenuOpen(false); onOpenProfileSettings(); }}
+                            className="rounded px-2 py-2 text-left text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
+                          >
+                            Perfil
+                          </button>
+                        ) : null}
+                        {onOpenBillingSettings ? (
+                          <button
+                            type="button"
+                            role="menuitem"
+                            ref={onOpenProfileSettings ? undefined : firstContaItemRef}
+                            onClick={() => { setContaMenuOpen(false); onOpenBillingSettings(); }}
+                            className="rounded px-2 py-2 text-left text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
+                          >
+                            Assinatura
+                          </button>
+                        ) : null}
+                        {onOpenSecuritySettings ? (
+                          <button
+                            type="button"
+                            role="menuitem"
+                            ref={!onOpenProfileSettings && !onOpenBillingSettings ? firstContaItemRef : undefined}
+                            onClick={() => { setContaMenuOpen(false); onOpenSecuritySettings(); }}
+                            className="rounded px-2 py-2 text-left text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
+                          >
+                            Seguranca
+                          </button>
+                        ) : null}
+                        {onLogout ? (
+                          <>
+                            <div className="my-1 h-px bg-cf-border" role="separator" />
+                            <button
+                              type="button"
+                              role="menuitem"
+                              ref={!onOpenProfileSettings && !onOpenBillingSettings && !onOpenSecuritySettings ? firstContaItemRef : undefined}
+                              onClick={() => { setContaMenuOpen(false); onLogout(); }}
+                              className="rounded px-2 py-2 text-left text-xs font-semibold text-red-700 hover:bg-red-50"
+                            >
+                              Sair
+                            </button>
+                          </>
+                        ) : null}
+                      </div>
+                    ) : null}
+                  </div>
                 ) : null}
               </div>
             )}

--- a/apps/web/src/pages/BillsPage.tsx
+++ b/apps/web/src/pages/BillsPage.tsx
@@ -251,7 +251,7 @@ const BillsPage = ({
   ];
 
   return (
-    <div className="min-h-screen bg-cf-bg px-4 py-6 sm:px-6">
+    <div className="min-h-screen bg-cf-bg-page px-4 py-6 sm:px-6">
       <div className="mx-auto max-w-2xl">
         {/* Header */}
         <div className="mb-6 flex items-center justify-between gap-4">


### PR DESCRIPTION
## Summary

- **BillsPage dark mode**: `bg-cf-bg` → `bg-cf-bg-page` (invalid Tailwind class was rendering white in dark mode)
- **UpgradeModal PT-BR**: translated 3 English feature labels (`Budget tracking`, `CSV Export`, `CSV Import`) to PT-BR
- **Desktop nav**: grouped Perfil / Assinatura / Segurança / Sair into a single **Conta** dropdown (click-outside + Escape + focus-first-item); standalone Sair button removed
- **Mobile Acoes menu**: reordered items into logical groups (nav shortcuts → CSV ops → account settings → theme → Sair)

## Test plan

- [x] 136/136 web tests pass
- [x] `vite build` zero errors
- [x] `eslint` zero warnings
- [ ] Dark mode: `/app/bills` background is dark (not white)
- [ ] Desktop: "Conta" button opens dropdown with Perfil / Assinatura / Segurança / Sair; click-outside and Escape close it
- [ ] Mobile (<640px): "Acoes" menu shows items in new logical order