### PR TITLE
feat(api): income sources with fixed deductions (PR-INSS1)

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -13,6 +13,7 @@ import meRoutes from "./routes/me.routes.js";
 import forecastRoutes from "./routes/forecast.routes.js";
 import stripeWebhooksRoutes from "./routes/stripe-webhooks.routes.js";
 import billsRoutes from "./routes/bills.routes.js";
+import incomeSourcesRoutes from "./routes/income-sources.routes.js";
 import { notFoundHandler, errorHandler } from "./middlewares/error.middleware.js";
 import { requestIdMiddleware } from "./middlewares/request-id.middleware.js";
 import { requestLoggingMiddleware } from "./middlewares/request-logging.middleware.js";
@@ -88,6 +89,7 @@ app.use("/billing", billingRoutes);
 app.use("/me", meRoutes);
 app.use("/forecasts", forecastRoutes);
 app.use("/bills", billsRoutes);
+app.use("/income-sources", incomeSourcesRoutes);
 
 app.use(notFoundHandler);
 app.use(errorHandler);

--- a/apps/api/src/db/migrations/018_create_income_sources.sql
+++ b/apps/api/src/db/migrations/018_create_income_sources.sql
@@ -1,0 +1,54 @@
+CREATE TABLE income_sources (
+  id               SERIAL PRIMARY KEY,
+  user_id          INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name             TEXT NOT NULL,
+  category_id      INT REFERENCES categories(id) ON DELETE SET NULL,
+  default_day      SMALLINT CHECK (default_day BETWEEN 1 AND 31),
+  notes            TEXT,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_income_sources_user_id ON income_sources(user_id);
+
+CREATE TABLE income_deductions (
+  id               SERIAL PRIMARY KEY,
+  income_source_id INT NOT NULL REFERENCES income_sources(id) ON DELETE CASCADE,
+  label            TEXT NOT NULL,
+  amount           NUMERIC(12,2) NOT NULL CHECK (amount >= 0),
+  is_variable      BOOLEAN NOT NULL DEFAULT FALSE,
+  is_active        BOOLEAN NOT NULL DEFAULT TRUE,
+  sort_order       SMALLINT NOT NULL DEFAULT 0,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_income_deductions_source ON income_deductions(income_source_id);
+
+CREATE TABLE income_statements (
+  id                     SERIAL PRIMARY KEY,
+  income_source_id       INT NOT NULL REFERENCES income_sources(id) ON DELETE CASCADE,
+  reference_month        CHAR(7) NOT NULL,
+  net_amount             NUMERIC(12,2) NOT NULL CHECK (net_amount > 0),
+  total_deductions       NUMERIC(12,2) NOT NULL DEFAULT 0 CHECK (total_deductions >= 0),
+  payment_date           DATE,
+  status                 TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'posted')),
+  posted_transaction_id  INT REFERENCES transactions(id) ON DELETE SET NULL,
+  created_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at             TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX uidx_income_statements_source_month
+  ON income_statements(income_source_id, reference_month);
+
+CREATE INDEX idx_income_statements_source ON income_statements(income_source_id);
+
+CREATE TABLE income_statement_deductions (
+  id           SERIAL PRIMARY KEY,
+  statement_id INT NOT NULL REFERENCES income_statements(id) ON DELETE CASCADE,
+  label        TEXT NOT NULL,
+  amount       NUMERIC(12,2) NOT NULL CHECK (amount >= 0),
+  is_variable  BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+CREATE INDEX idx_income_stmt_deductions ON income_statement_deductions(statement_id);

--- a/apps/api/src/income-sources.test.js
+++ b/apps/api/src/income-sources.test.js
@@ -1,0 +1,604 @@
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import app from "./app.js";
+import { clearDbClientForTests, dbQuery } from "./db/index.js";
+import { resetLoginProtectionState } from "./middlewares/login-protection.middleware.js";
+import {
+  resetImportRateLimiterState,
+  resetWriteRateLimiterState,
+} from "./middlewares/rate-limit.middleware.js";
+import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
+import {
+  expectErrorResponseWithRequestId,
+  registerAndLogin,
+  setupTestDb,
+} from "./test-helpers.js";
+
+describe("income-sources", () => {
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  afterAll(async () => {
+    await clearDbClientForTests();
+  });
+
+  beforeEach(async () => {
+    resetLoginProtectionState();
+    resetImportRateLimiterState();
+    resetWriteRateLimiterState();
+    resetHttpMetricsForTests();
+    await dbQuery("DELETE FROM income_statement_deductions");
+    await dbQuery("DELETE FROM income_statements");
+    await dbQuery("DELETE FROM income_deductions");
+    await dbQuery("DELETE FROM income_sources");
+    await dbQuery("DELETE FROM transactions");
+    await dbQuery("DELETE FROM categories");
+    await dbQuery("DELETE FROM users");
+  });
+
+  // ─── Auth ─────────────────────────────────────────────────────────────────────
+
+  it("GET /income-sources bloqueia sem token", async () => {
+    const res = await request(app).get("/income-sources");
+    expect(res.status).toBe(401);
+  });
+
+  // ─── Create source ────────────────────────────────────────────────────────────
+
+  it("POST /income-sources cria fonte de renda com nome", async () => {
+    const token = await registerAndLogin("inss-create@test.dev");
+
+    const res = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Pensao INSS" });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      name: "Pensao INSS",
+      categoryId: null,
+      defaultDay: null,
+      notes: null,
+    });
+    expect(Number.isInteger(res.body.id)).toBe(true);
+    expect(typeof res.body.createdAt).toBe("string");
+  });
+
+  it("POST /income-sources cria com campos opcionais", async () => {
+    const token = await registerAndLogin("inss-create-full@test.dev");
+
+    const catRes = await request(app)
+      .post("/categories")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Rendimentos" });
+    const categoryId = catRes.body.id;
+
+    const res = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Salario", categoryId, defaultDay: 5, notes: "CLT" });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ name: "Salario", categoryId, defaultDay: 5, notes: "CLT" });
+  });
+
+  it("POST /income-sources retorna 400 quando nome esta vazio", async () => {
+    const token = await registerAndLogin("inss-val-name@test.dev");
+
+    const res = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "   " });
+
+    expectErrorResponseWithRequestId(res, 400, "Nome da fonte de renda e obrigatorio.");
+  });
+
+  // ─── List sources ─────────────────────────────────────────────────────────────
+
+  it("GET /income-sources retorna lista com descontos ativos", async () => {
+    const token = await registerAndLogin("inss-list@test.dev");
+
+    const srcRes = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Pensao" });
+    const sourceId = srcRes.body.id;
+
+    await request(app)
+      .post(`/income-sources/${sourceId}/deductions`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ label: "Emprestimo", amount: 300 });
+
+    const res = await request(app)
+      .get("/income-sources")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.sources)).toBe(true);
+    expect(res.body.sources).toHaveLength(1);
+    expect(res.body.sources[0].name).toBe("Pensao");
+    expect(Array.isArray(res.body.sources[0].deductions)).toBe(true);
+    expect(res.body.sources[0].deductions).toHaveLength(1);
+    expect(res.body.sources[0].deductions[0].label).toBe("Emprestimo");
+  });
+
+  it("GET /income-sources retorna lista vazia quando nao ha fontes", async () => {
+    const token = await registerAndLogin("inss-list-empty@test.dev");
+
+    const res = await request(app)
+      .get("/income-sources")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.sources).toHaveLength(0);
+  });
+
+  it("GET /income-sources isola fontes entre usuarios", async () => {
+    const token1 = await registerAndLogin("inss-iso-1@test.dev");
+    const token2 = await registerAndLogin("inss-iso-2@test.dev");
+
+    await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token1}`)
+      .send({ name: "Fonte user1" });
+
+    const res = await request(app)
+      .get("/income-sources")
+      .set("Authorization", `Bearer ${token2}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.sources).toHaveLength(0);
+  });
+
+  // ─── Update source ────────────────────────────────────────────────────────────
+
+  it("PATCH /income-sources/:id atualiza nome", async () => {
+    const token = await registerAndLogin("inss-upd@test.dev");
+
+    const srcRes = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Original" });
+    const sourceId = srcRes.body.id;
+
+    const res = await request(app)
+      .patch(`/income-sources/${sourceId}`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Atualizada" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ id: sourceId, name: "Atualizada" });
+  });
+
+  it("PATCH /income-sources/:id retorna 404 para fonte de outro usuario", async () => {
+    const token1 = await registerAndLogin("inss-upd-iso-1@test.dev");
+    const token2 = await registerAndLogin("inss-upd-iso-2@test.dev");
+
+    const srcRes = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token1}`)
+      .send({ name: "Alheia" });
+    const sourceId = srcRes.body.id;
+
+    const res = await request(app)
+      .patch(`/income-sources/${sourceId}`)
+      .set("Authorization", `Bearer ${token2}`)
+      .send({ name: "Hackeado" });
+
+    expect(res.status).toBe(404);
+  });
+
+  // ─── Delete source ────────────────────────────────────────────────────────────
+
+  it("DELETE /income-sources/:id remove a fonte", async () => {
+    const token = await registerAndLogin("inss-del@test.dev");
+
+    const srcRes = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Remover" });
+    const sourceId = srcRes.body.id;
+
+    const deleteRes = await request(app)
+      .delete(`/income-sources/${sourceId}`)
+      .set("Authorization", `Bearer ${token}`);
+    expect(deleteRes.status).toBe(204);
+
+    const listRes = await request(app)
+      .get("/income-sources")
+      .set("Authorization", `Bearer ${token}`);
+    expect(listRes.body.sources).toHaveLength(0);
+  });
+
+  it("DELETE /income-sources/:id retorna 404 para fonte de outro usuario", async () => {
+    const token1 = await registerAndLogin("inss-del-iso-1@test.dev");
+    const token2 = await registerAndLogin("inss-del-iso-2@test.dev");
+
+    const srcRes = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token1}`)
+      .send({ name: "Alheia" });
+    const sourceId = srcRes.body.id;
+
+    const res = await request(app)
+      .delete(`/income-sources/${sourceId}`)
+      .set("Authorization", `Bearer ${token2}`);
+    expect(res.status).toBe(404);
+  });
+
+  // ─── Deductions ────────────────────────────────────────────────────────────────
+
+  it("POST /income-sources/:id/deductions adiciona desconto fixo", async () => {
+    const token = await registerAndLogin("inss-ded-fixed@test.dev");
+
+    const srcRes = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Pensao" });
+    const sourceId = srcRes.body.id;
+
+    const res = await request(app)
+      .post(`/income-sources/${sourceId}/deductions`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ label: "Emprestimo Caixa", amount: 450.32 });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      label: "Emprestimo Caixa",
+      amount: 450.32,
+      isVariable: false,
+      isActive: true,
+    });
+    expect(Number.isInteger(res.body.id)).toBe(true);
+  });
+
+  it("POST /income-sources/:id/deductions adiciona desconto variavel", async () => {
+    const token = await registerAndLogin("inss-ded-var@test.dev");
+
+    const srcRes = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Pensao" });
+    const sourceId = srcRes.body.id;
+
+    const res = await request(app)
+      .post(`/income-sources/${sourceId}/deductions`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ label: "Cartao Consignado", amount: 200, isVariable: true });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ label: "Cartao Consignado", isVariable: true });
+  });
+
+  it("POST /income-sources/:id/deductions retorna 400 para valor negativo", async () => {
+    const token = await registerAndLogin("inss-ded-neg@test.dev");
+
+    const srcRes = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Pensao" });
+    const sourceId = srcRes.body.id;
+
+    const res = await request(app)
+      .post(`/income-sources/${sourceId}/deductions`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ label: "Invalido", amount: -50 });
+
+    expectErrorResponseWithRequestId(res, 400, "Valor do desconto deve ser maior ou igual a zero.");
+  });
+
+  it("PATCH /income-sources/deductions/:id atualiza valor", async () => {
+    const token = await registerAndLogin("inss-ded-upd@test.dev");
+
+    const srcRes = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Pensao" });
+    const sourceId = srcRes.body.id;
+
+    const dedRes = await request(app)
+      .post(`/income-sources/${sourceId}/deductions`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ label: "Emprestimo", amount: 300 });
+    const deductionId = dedRes.body.id;
+
+    const res = await request(app)
+      .patch(`/income-sources/deductions/${deductionId}`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ amount: 350 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ id: deductionId, amount: 350 });
+  });
+
+  it("PATCH /income-sources/deductions/:id retorna 404 para desconto de outro usuario", async () => {
+    const token1 = await registerAndLogin("inss-ded-upd-iso-1@test.dev");
+    const token2 = await registerAndLogin("inss-ded-upd-iso-2@test.dev");
+
+    const srcRes = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token1}`)
+      .send({ name: "Pensao" });
+    const sourceId = srcRes.body.id;
+
+    const dedRes = await request(app)
+      .post(`/income-sources/${sourceId}/deductions`)
+      .set("Authorization", `Bearer ${token1}`)
+      .send({ label: "Emprestimo", amount: 300 });
+    const deductionId = dedRes.body.id;
+
+    const res = await request(app)
+      .patch(`/income-sources/deductions/${deductionId}`)
+      .set("Authorization", `Bearer ${token2}`)
+      .send({ amount: 999 });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("DELETE /income-sources/deductions/:id remove desconto", async () => {
+    const token = await registerAndLogin("inss-ded-del@test.dev");
+
+    const srcRes = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Pensao" });
+    const sourceId = srcRes.body.id;
+
+    const dedRes = await request(app)
+      .post(`/income-sources/${sourceId}/deductions`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ label: "Remover", amount: 100 });
+    const deductionId = dedRes.body.id;
+
+    const delRes = await request(app)
+      .delete(`/income-sources/deductions/${deductionId}`)
+      .set("Authorization", `Bearer ${token}`);
+    expect(delRes.status).toBe(204);
+
+    const listRes = await request(app)
+      .get("/income-sources")
+      .set("Authorization", `Bearer ${token}`);
+    expect(listRes.body.sources[0].deductions).toHaveLength(0);
+  });
+
+  it("DELETE /income-sources/deductions/:id retorna 404 para desconto de outro usuario", async () => {
+    const token1 = await registerAndLogin("inss-ded-del-iso-1@test.dev");
+    const token2 = await registerAndLogin("inss-ded-del-iso-2@test.dev");
+
+    const srcRes = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token1}`)
+      .send({ name: "Pensao" });
+    const sourceId = srcRes.body.id;
+
+    const dedRes = await request(app)
+      .post(`/income-sources/${sourceId}/deductions`)
+      .set("Authorization", `Bearer ${token1}`)
+      .send({ label: "Alheia", amount: 100 });
+    const deductionId = dedRes.body.id;
+
+    const res = await request(app)
+      .delete(`/income-sources/deductions/${deductionId}`)
+      .set("Authorization", `Bearer ${token2}`);
+    expect(res.status).toBe(404);
+  });
+
+  // ─── Statements ───────────────────────────────────────────────────────────────
+
+  it("POST /income-sources/:id/statements cria rascunho e clona descontos", async () => {
+    const token = await registerAndLogin("inss-stmt-create@test.dev");
+
+    const srcRes = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Pensao INSS" });
+    const sourceId = srcRes.body.id;
+
+    await request(app)
+      .post(`/income-sources/${sourceId}/deductions`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ label: "Emprestimo 1", amount: 300 });
+    await request(app)
+      .post(`/income-sources/${sourceId}/deductions`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ label: "Cartao", amount: 200, isVariable: true });
+
+    const res = await request(app)
+      .post(`/income-sources/${sourceId}/statements`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ referenceMonth: "2026-02", netAmount: 2803.52 });
+
+    expect(res.status).toBe(201);
+    expect(res.body.statement).toMatchObject({
+      referenceMonth: "2026-02",
+      netAmount: 2803.52,
+      totalDeductions: 500,
+      status: "draft",
+    });
+    expect(Array.isArray(res.body.deductions)).toBe(true);
+    expect(res.body.deductions).toHaveLength(2);
+    expect(res.body.deductions[0].label).toBe("Emprestimo 1");
+    expect(res.body.deductions[1].label).toBe("Cartao");
+  });
+
+  it("POST /income-sources/:id/statements retorna 409 para mes duplicado", async () => {
+    const token = await registerAndLogin("inss-stmt-dup@test.dev");
+
+    const srcRes = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Pensao" });
+    const sourceId = srcRes.body.id;
+
+    await request(app)
+      .post(`/income-sources/${sourceId}/statements`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ referenceMonth: "2026-01", netAmount: 2500 });
+
+    const res = await request(app)
+      .post(`/income-sources/${sourceId}/statements`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ referenceMonth: "2026-01", netAmount: 2500 });
+
+    expectErrorResponseWithRequestId(res, 409, "Ja existe um extrato para 2026-01.");
+  });
+
+  it("POST /income-sources/:id/statements retorna 400 para mes invalido", async () => {
+    const token = await registerAndLogin("inss-stmt-badmonth@test.dev");
+
+    const srcRes = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Pensao" });
+    const sourceId = srcRes.body.id;
+
+    const res = await request(app)
+      .post(`/income-sources/${sourceId}/statements`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ referenceMonth: "2026-13", netAmount: 2500 });
+
+    expectErrorResponseWithRequestId(res, 400, "Mes de referencia invalido. Use o formato YYYY-MM.");
+  });
+
+  it("PATCH /income-sources/statements/:id atualiza valor liquido", async () => {
+    const token = await registerAndLogin("inss-stmt-upd@test.dev");
+
+    const srcRes = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Pensao" });
+    const sourceId = srcRes.body.id;
+
+    const stmtRes = await request(app)
+      .post(`/income-sources/${sourceId}/statements`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ referenceMonth: "2026-02", netAmount: 2500 });
+    const statementId = stmtRes.body.statement.id;
+
+    const res = await request(app)
+      .patch(`/income-sources/statements/${statementId}`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ netAmount: 2803.52 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.statement).toMatchObject({ id: statementId, netAmount: 2803.52 });
+  });
+
+  it("PATCH /income-sources/statements/:id retorna 400 se ja lancado", async () => {
+    const token = await registerAndLogin("inss-stmt-upd-posted@test.dev");
+
+    const srcRes = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Pensao" });
+    const sourceId = srcRes.body.id;
+
+    const stmtRes = await request(app)
+      .post(`/income-sources/${sourceId}/statements`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ referenceMonth: "2026-02", netAmount: 2500 });
+    const statementId = stmtRes.body.statement.id;
+
+    await request(app)
+      .post(`/income-sources/statements/${statementId}/post`)
+      .set("Authorization", `Bearer ${token}`);
+
+    const res = await request(app)
+      .patch(`/income-sources/statements/${statementId}`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ netAmount: 999 });
+
+    expectErrorResponseWithRequestId(res, 400, "Extrato ja lancado. Nao e possivel editar.");
+  });
+
+  it("POST /income-sources/statements/:id/post cria transacao Entrada e marca lancado", async () => {
+    const token = await registerAndLogin("inss-post@test.dev");
+
+    const srcRes = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Pensao INSS" });
+    const sourceId = srcRes.body.id;
+
+    const stmtRes = await request(app)
+      .post(`/income-sources/${sourceId}/statements`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ referenceMonth: "2026-02", netAmount: 2803.52 });
+    const statementId = stmtRes.body.statement.id;
+
+    const res = await request(app)
+      .post(`/income-sources/statements/${statementId}/post`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.statement).toMatchObject({ id: statementId, status: "posted" });
+    expect(Number.isInteger(res.body.statement.postedTransactionId)).toBe(true);
+    expect(res.body.transaction).toMatchObject({
+      type: "Entrada",
+      value: 2803.52,
+      description: "Pensao INSS – 2026-02",
+    });
+
+    // Transaction appears in list
+    const txRes = await request(app)
+      .get("/transactions")
+      .set("Authorization", `Bearer ${token}`);
+    expect(txRes.body.data.some((tx) => tx.description === "Pensao INSS – 2026-02")).toBe(true);
+  });
+
+  it("POST /income-sources/statements/:id/post herda category_id da fonte", async () => {
+    const token = await registerAndLogin("inss-post-cat@test.dev");
+
+    const catRes = await request(app)
+      .post("/categories")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Rendimentos" });
+    const categoryId = catRes.body.id;
+
+    const srcRes = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Pensao", categoryId });
+    const sourceId = srcRes.body.id;
+
+    const stmtRes = await request(app)
+      .post(`/income-sources/${sourceId}/statements`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ referenceMonth: "2026-02", netAmount: 2500 });
+    const statementId = stmtRes.body.statement.id;
+
+    const res = await request(app)
+      .post(`/income-sources/statements/${statementId}/post`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.transaction.categoryId).toBe(categoryId);
+  });
+
+  it("POST /income-sources/statements/:id/post retorna 409 ao relançar", async () => {
+    const token = await registerAndLogin("inss-post-dup@test.dev");
+
+    const srcRes = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Pensao" });
+    const sourceId = srcRes.body.id;
+
+    const stmtRes = await request(app)
+      .post(`/income-sources/${sourceId}/statements`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ referenceMonth: "2026-02", netAmount: 2500 });
+    const statementId = stmtRes.body.statement.id;
+
+    await request(app)
+      .post(`/income-sources/statements/${statementId}/post`)
+      .set("Authorization", `Bearer ${token}`);
+
+    const res = await request(app)
+      .post(`/income-sources/statements/${statementId}/post`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expectErrorResponseWithRequestId(res, 409, "Extrato ja foi lancado.");
+  });
+});

--- a/apps/api/src/middlewares/rate-limit.middleware.js
+++ b/apps/api/src/middlewares/rate-limit.middleware.js
@@ -87,6 +87,7 @@ export const transactionsWriteRateLimiter = createUserWriteRateLimiter("transact
 export const categoriesWriteRateLimiter = createUserWriteRateLimiter("categories-write");
 export const budgetsWriteRateLimiter = createUserWriteRateLimiter("budgets-write");
 export const billsWriteRateLimiter = createUserWriteRateLimiter("bills-write");
+export const incomeSourcesWriteRateLimiter = createUserWriteRateLimiter("income-sources-write");
 
 export const resetImportRateLimiterState = () => {
   if (importRateLimiter?.store?.resetAll) {
@@ -100,6 +101,7 @@ export const resetWriteRateLimiterState = () => {
     categoriesWriteRateLimiter,
     budgetsWriteRateLimiter,
     billsWriteRateLimiter,
+    incomeSourcesWriteRateLimiter,
   ].forEach((limiter) => {
     if (limiter?.store?.resetAll) {
       limiter.store.resetAll();

--- a/apps/api/src/routes/income-sources.routes.js
+++ b/apps/api/src/routes/income-sources.routes.js
@@ -1,0 +1,149 @@
+import { Router } from "express";
+import { authMiddleware } from "../middlewares/auth.middleware.js";
+import { incomeSourcesWriteRateLimiter } from "../middlewares/rate-limit.middleware.js";
+import {
+  createIncomeSourceForUser,
+  listIncomeSourcesForUser,
+  updateIncomeSourceForUser,
+  deleteIncomeSourceForUser,
+  createDeductionForSource,
+  updateDeductionForSource,
+  deleteDeductionForSource,
+  createStatementDraftForSource,
+  getStatementWithDeductions,
+  updateStatementForSource,
+  postStatementForSource,
+  listStatementsForSource,
+} from "../services/income-sources.service.js";
+
+const router = Router();
+
+router.use(authMiddleware);
+
+// ─── Income Sources ────────────────────────────────────────────────────────────
+
+router.get("/", async (req, res, next) => {
+  try {
+    const sources = await listIncomeSourcesForUser(req.user.id);
+    res.status(200).json({ sources });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post("/", incomeSourcesWriteRateLimiter, async (req, res, next) => {
+  try {
+    const source = await createIncomeSourceForUser(req.user.id, req.body || {});
+    res.status(201).json(source);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.patch("/:id", incomeSourcesWriteRateLimiter, async (req, res, next) => {
+  try {
+    const source = await updateIncomeSourceForUser(req.user.id, req.params.id, req.body || {});
+    res.status(200).json(source);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.delete("/:id", incomeSourcesWriteRateLimiter, async (req, res, next) => {
+  try {
+    await deleteIncomeSourceForUser(req.user.id, req.params.id);
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+// ─── Deductions ────────────────────────────────────────────────────────────────
+
+router.post("/:id/deductions", incomeSourcesWriteRateLimiter, async (req, res, next) => {
+  try {
+    const deduction = await createDeductionForSource(req.user.id, req.params.id, req.body || {});
+    res.status(201).json(deduction);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.patch("/deductions/:deductionId", incomeSourcesWriteRateLimiter, async (req, res, next) => {
+  try {
+    const deduction = await updateDeductionForSource(
+      req.user.id,
+      req.params.deductionId,
+      req.body || {},
+    );
+    res.status(200).json(deduction);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.delete("/deductions/:deductionId", incomeSourcesWriteRateLimiter, async (req, res, next) => {
+  try {
+    await deleteDeductionForSource(req.user.id, req.params.deductionId);
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+// ─── Statements ────────────────────────────────────────────────────────────────
+
+router.get("/:id/statements", async (req, res, next) => {
+  try {
+    const statements = await listStatementsForSource(req.user.id, req.params.id);
+    res.status(200).json({ statements });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post("/:id/statements", incomeSourcesWriteRateLimiter, async (req, res, next) => {
+  try {
+    const result = await createStatementDraftForSource(req.user.id, req.params.id, req.body || {});
+    res.status(201).json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get("/statements/:statementId", async (req, res, next) => {
+  try {
+    const result = await getStatementWithDeductions(req.user.id, req.params.statementId);
+    res.status(200).json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.patch("/statements/:statementId", incomeSourcesWriteRateLimiter, async (req, res, next) => {
+  try {
+    const result = await updateStatementForSource(
+      req.user.id,
+      req.params.statementId,
+      req.body || {},
+    );
+    res.status(200).json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post(
+  "/statements/:statementId/post",
+  incomeSourcesWriteRateLimiter,
+  async (req, res, next) => {
+    try {
+      const result = await postStatementForSource(req.user.id, req.params.statementId);
+      res.status(200).json(result);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+export default router;

--- a/apps/api/src/services/income-sources.service.js
+++ b/apps/api/src/services/income-sources.service.js
@@ -1,0 +1,638 @@
+import { dbQuery, withDbTransaction } from "../db/index.js";
+import { TRANSACTION_TYPE_ENTRY } from "../constants/transaction-types.js";
+
+const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+const ISO_MONTH_REGEX = /^\d{4}-(0[1-9]|1[0-2])$/;
+const NAME_MAX_LENGTH = 200;
+const LABEL_MAX_LENGTH = 200;
+const NOTES_MAX_LENGTH = 1000;
+
+const createError = (status, message) => {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+};
+
+const toISODate = (value = new Date()) => {
+  const date = new Date(value);
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+const toISODateTime = (value) => {
+  if (typeof value === "string") return value;
+  return new Date(value).toISOString();
+};
+
+const isValidISODate = (value) => {
+  if (typeof value !== "string" || !ISO_DATE_REGEX.test(value)) return false;
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(parsed.getTime());
+};
+
+const toMoney = (value) => Number(Number(value || 0).toFixed(2));
+
+// ─── Normalization ─────────────────────────────────────────────────────────────
+
+const normalizeUserId = (value) => {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw createError(401, "Usuario nao autenticado.");
+  }
+  return parsed;
+};
+
+const normalizeSourceId = (value) => {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw createError(400, "ID de fonte de renda invalido.");
+  }
+  return parsed;
+};
+
+const normalizeDeductionId = (value) => {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw createError(400, "ID de desconto invalido.");
+  }
+  return parsed;
+};
+
+const normalizeStatementId = (value) => {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw createError(400, "ID de extrato invalido.");
+  }
+  return parsed;
+};
+
+const normalizeSourceName = (value) => {
+  if (typeof value !== "string" || !value.trim()) {
+    throw createError(400, "Nome da fonte de renda e obrigatorio.");
+  }
+  const trimmed = value.trim();
+  if (trimmed.length > NAME_MAX_LENGTH) {
+    throw createError(400, `Nome deve ter no maximo ${NAME_MAX_LENGTH} caracteres.`);
+  }
+  return trimmed;
+};
+
+const normalizeDeductionLabel = (value) => {
+  if (typeof value !== "string" || !value.trim()) {
+    throw createError(400, "Rotulo do desconto e obrigatorio.");
+  }
+  const trimmed = value.trim();
+  if (trimmed.length > LABEL_MAX_LENGTH) {
+    throw createError(400, `Rotulo deve ter no maximo ${LABEL_MAX_LENGTH} caracteres.`);
+  }
+  return trimmed;
+};
+
+const normalizeDeductionAmount = (value) => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw createError(400, "Valor do desconto deve ser maior ou igual a zero.");
+  }
+  return toMoney(parsed);
+};
+
+const normalizeNetAmount = (value) => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw createError(400, "Valor liquido deve ser maior que zero.");
+  }
+  return toMoney(parsed);
+};
+
+const normalizeReferenceMonth = (value) => {
+  if (typeof value !== "string" || !ISO_MONTH_REGEX.test(value)) {
+    throw createError(400, "Mes de referencia invalido. Use o formato YYYY-MM.");
+  }
+  return value;
+};
+
+const normalizePaymentDate = (value) => {
+  if (value == null || value === "") return null;
+  if (typeof value !== "string" || !isValidISODate(value)) {
+    throw createError(400, "Data de pagamento invalida.");
+  }
+  return value;
+};
+
+const normalizeOptionalCategoryId = (value) => {
+  if (value == null || value === "") return null;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw createError(400, "ID de categoria invalido.");
+  }
+  return parsed;
+};
+
+const normalizeOptionalDefaultDay = (value) => {
+  if (value == null || value === "") return null;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 31) {
+    throw createError(400, "Dia padrao deve ser entre 1 e 31.");
+  }
+  return parsed;
+};
+
+const normalizeOptionalNotes = (value) => {
+  if (value == null || value === "") return null;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (trimmed.length > NOTES_MAX_LENGTH) {
+    throw createError(400, `Notas deve ter no maximo ${NOTES_MAX_LENGTH} caracteres.`);
+  }
+  return trimmed;
+};
+
+// ─── Row mappers ───────────────────────────────────────────────────────────────
+
+const mapSourceRow = (row) => ({
+  id: Number(row.id),
+  userId: Number(row.user_id),
+  name: String(row.name),
+  categoryId: row.category_id != null ? Number(row.category_id) : null,
+  defaultDay: row.default_day != null ? Number(row.default_day) : null,
+  notes: row.notes != null ? String(row.notes) : null,
+  createdAt: toISODateTime(row.created_at),
+  updatedAt: toISODateTime(row.updated_at),
+});
+
+const mapDeductionRow = (row) => ({
+  id: Number(row.id),
+  incomeSourceId: Number(row.income_source_id),
+  label: String(row.label),
+  amount: toMoney(row.amount),
+  isVariable: Boolean(row.is_variable),
+  isActive: Boolean(row.is_active),
+  sortOrder: Number(row.sort_order),
+  createdAt: toISODateTime(row.created_at),
+  updatedAt: toISODateTime(row.updated_at),
+});
+
+const mapStatementRow = (row) => ({
+  id: Number(row.id),
+  incomeSourceId: Number(row.income_source_id),
+  referenceMonth: String(row.reference_month),
+  netAmount: toMoney(row.net_amount),
+  totalDeductions: toMoney(row.total_deductions),
+  paymentDate: row.payment_date != null ? toISODate(row.payment_date) : null,
+  status: String(row.status),
+  postedTransactionId: row.posted_transaction_id != null ? Number(row.posted_transaction_id) : null,
+  createdAt: toISODateTime(row.created_at),
+  updatedAt: toISODateTime(row.updated_at),
+});
+
+const mapStatementDeductionRow = (row) => ({
+  id: Number(row.id),
+  statementId: Number(row.statement_id),
+  label: String(row.label),
+  amount: toMoney(row.amount),
+  isVariable: Boolean(row.is_variable),
+});
+
+const mapTransactionRow = (row) => ({
+  id: Number(row.id),
+  type: String(row.type),
+  value: toMoney(row.value),
+  date: toISODate(row.date),
+  description: row.description != null ? String(row.description) : null,
+  categoryId: row.category_id != null ? Number(row.category_id) : null,
+});
+
+// ─── Income Sources ────────────────────────────────────────────────────────────
+
+export const createIncomeSourceForUser = async (userId, payload) => {
+  const uid = normalizeUserId(userId);
+  const name = normalizeSourceName(payload.name);
+  const categoryId = normalizeOptionalCategoryId(payload.categoryId);
+  const defaultDay = normalizeOptionalDefaultDay(payload.defaultDay);
+  const notes = normalizeOptionalNotes(payload.notes);
+
+  const { rows } = await dbQuery(
+    `INSERT INTO income_sources (user_id, name, category_id, default_day, notes)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING *`,
+    [uid, name, categoryId, defaultDay, notes],
+  );
+  return mapSourceRow(rows[0]);
+};
+
+export const listIncomeSourcesForUser = async (userId) => {
+  const uid = normalizeUserId(userId);
+
+  const { rows: sourceRows } = await dbQuery(
+    `SELECT * FROM income_sources WHERE user_id = $1 ORDER BY created_at ASC`,
+    [uid],
+  );
+
+  if (sourceRows.length === 0) return [];
+
+  const { rows: deductionRows } = await dbQuery(
+    `SELECT d.* FROM income_deductions d
+     JOIN income_sources s ON s.id = d.income_source_id
+     WHERE s.user_id = $1 AND d.is_active = TRUE
+     ORDER BY d.sort_order ASC, d.id ASC`,
+    [uid],
+  );
+
+  const deductionsBySource = {};
+  for (const row of deductionRows) {
+    const sid = Number(row.income_source_id);
+    if (!deductionsBySource[sid]) deductionsBySource[sid] = [];
+    deductionsBySource[sid].push(mapDeductionRow(row));
+  }
+
+  return sourceRows.map((row) => ({
+    ...mapSourceRow(row),
+    deductions: deductionsBySource[Number(row.id)] ?? [],
+  }));
+};
+
+export const updateIncomeSourceForUser = async (userId, sourceId, payload) => {
+  const uid = normalizeUserId(userId);
+  const sid = normalizeSourceId(sourceId);
+
+  const setClauses = [];
+  const params = [];
+
+  if (payload.name !== undefined) {
+    params.push(normalizeSourceName(payload.name));
+    setClauses.push(`name = $${params.length}`);
+  }
+  if (payload.categoryId !== undefined) {
+    params.push(normalizeOptionalCategoryId(payload.categoryId));
+    setClauses.push(`category_id = $${params.length}`);
+  }
+  if (payload.defaultDay !== undefined) {
+    params.push(normalizeOptionalDefaultDay(payload.defaultDay));
+    setClauses.push(`default_day = $${params.length}`);
+  }
+  if (payload.notes !== undefined) {
+    params.push(normalizeOptionalNotes(payload.notes));
+    setClauses.push(`notes = $${params.length}`);
+  }
+
+  if (setClauses.length === 0) {
+    const { rows } = await dbQuery(
+      `SELECT * FROM income_sources WHERE id = $1 AND user_id = $2`,
+      [sid, uid],
+    );
+    if (!rows[0]) throw createError(404, "Fonte de renda nao encontrada.");
+    return mapSourceRow(rows[0]);
+  }
+
+  setClauses.push(`updated_at = NOW()`);
+  params.push(sid, uid);
+
+  const { rows } = await dbQuery(
+    `UPDATE income_sources SET ${setClauses.join(", ")}
+     WHERE id = $${params.length - 1} AND user_id = $${params.length}
+     RETURNING *`,
+    params,
+  );
+
+  if (!rows[0]) throw createError(404, "Fonte de renda nao encontrada.");
+  return mapSourceRow(rows[0]);
+};
+
+export const deleteIncomeSourceForUser = async (userId, sourceId) => {
+  const uid = normalizeUserId(userId);
+  const sid = normalizeSourceId(sourceId);
+
+  const { rows } = await dbQuery(
+    `DELETE FROM income_sources WHERE id = $1 AND user_id = $2 RETURNING id`,
+    [sid, uid],
+  );
+  if (!rows[0]) throw createError(404, "Fonte de renda nao encontrada.");
+  return { id: Number(rows[0].id) };
+};
+
+// ─── Deductions ────────────────────────────────────────────────────────────────
+
+const requireSourceOwnership = async (uid, sourceId) => {
+  const { rows } = await dbQuery(
+    `SELECT id FROM income_sources WHERE id = $1 AND user_id = $2`,
+    [sourceId, uid],
+  );
+  if (!rows[0]) throw createError(404, "Fonte de renda nao encontrada.");
+};
+
+const requireDeductionOwnership = async (uid, deductionId) => {
+  const { rows } = await dbQuery(
+    `SELECT d.id FROM income_deductions d
+     JOIN income_sources s ON s.id = d.income_source_id
+     WHERE d.id = $1 AND s.user_id = $2`,
+    [deductionId, uid],
+  );
+  if (!rows[0]) throw createError(404, "Desconto nao encontrado.");
+};
+
+export const createDeductionForSource = async (userId, sourceId, payload) => {
+  const uid = normalizeUserId(userId);
+  const sid = normalizeSourceId(sourceId);
+
+  await requireSourceOwnership(uid, sid);
+
+  const label = normalizeDeductionLabel(payload.label);
+  const amount = normalizeDeductionAmount(payload.amount);
+  const isVariable = Boolean(payload.isVariable);
+  const sortOrder = payload.sortOrder != null ? Number(payload.sortOrder) : 0;
+
+  const { rows } = await dbQuery(
+    `INSERT INTO income_deductions
+       (income_source_id, label, amount, is_variable, sort_order)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING *`,
+    [sid, label, amount, isVariable, sortOrder],
+  );
+  return mapDeductionRow(rows[0]);
+};
+
+export const updateDeductionForSource = async (userId, deductionId, payload) => {
+  const uid = normalizeUserId(userId);
+  const did = normalizeDeductionId(deductionId);
+
+  await requireDeductionOwnership(uid, did);
+
+  const setClauses = [];
+  const params = [];
+
+  if (payload.label !== undefined) {
+    params.push(normalizeDeductionLabel(payload.label));
+    setClauses.push(`label = $${params.length}`);
+  }
+  if (payload.amount !== undefined) {
+    params.push(normalizeDeductionAmount(payload.amount));
+    setClauses.push(`amount = $${params.length}`);
+  }
+  if (payload.isVariable !== undefined) {
+    params.push(Boolean(payload.isVariable));
+    setClauses.push(`is_variable = $${params.length}`);
+  }
+  if (payload.isActive !== undefined) {
+    params.push(Boolean(payload.isActive));
+    setClauses.push(`is_active = $${params.length}`);
+  }
+  if (payload.sortOrder !== undefined) {
+    params.push(Number(payload.sortOrder));
+    setClauses.push(`sort_order = $${params.length}`);
+  }
+
+  if (setClauses.length === 0) {
+    const { rows } = await dbQuery(`SELECT * FROM income_deductions WHERE id = $1`, [did]);
+    return mapDeductionRow(rows[0]);
+  }
+
+  setClauses.push(`updated_at = NOW()`);
+  params.push(did);
+
+  const { rows } = await dbQuery(
+    `UPDATE income_deductions SET ${setClauses.join(", ")}
+     WHERE id = $${params.length}
+     RETURNING *`,
+    params,
+  );
+  return mapDeductionRow(rows[0]);
+};
+
+export const deleteDeductionForSource = async (userId, deductionId) => {
+  const uid = normalizeUserId(userId);
+  const did = normalizeDeductionId(deductionId);
+
+  await requireDeductionOwnership(uid, did);
+
+  await dbQuery(`DELETE FROM income_deductions WHERE id = $1`, [did]);
+  return { id: did };
+};
+
+// ─── Statements ────────────────────────────────────────────────────────────────
+
+const requireStatementOwnership = async (uid, statementId) => {
+  const { rows } = await dbQuery(
+    `SELECT st.id, st.status FROM income_statements st
+     JOIN income_sources s ON s.id = st.income_source_id
+     WHERE st.id = $1 AND s.user_id = $2`,
+    [statementId, uid],
+  );
+  if (!rows[0]) throw createError(404, "Extrato nao encontrado.");
+  return rows[0];
+};
+
+export const createStatementDraftForSource = async (userId, sourceId, payload) => {
+  const uid = normalizeUserId(userId);
+  const sid = normalizeSourceId(sourceId);
+
+  await requireSourceOwnership(uid, sid);
+
+  const referenceMonth = normalizeReferenceMonth(payload.referenceMonth);
+  const netAmount = normalizeNetAmount(payload.netAmount);
+  const paymentDate = normalizePaymentDate(payload.paymentDate ?? null);
+
+  return withDbTransaction(async (client) => {
+    // Fetch active deductions to clone
+    const { rows: deductionRows } = await client.query(
+      `SELECT * FROM income_deductions
+       WHERE income_source_id = $1 AND is_active = TRUE
+       ORDER BY sort_order ASC, id ASC`,
+      [sid],
+    );
+
+    const totalDeductions = deductionRows.reduce(
+      (sum, row) => sum + toMoney(row.amount),
+      0,
+    );
+
+    // Create statement (409 if unique constraint fires)
+    let stmtRow;
+    try {
+      const { rows } = await client.query(
+        `INSERT INTO income_statements
+           (income_source_id, reference_month, net_amount, total_deductions, payment_date)
+         VALUES ($1, $2, $3, $4, $5)
+         RETURNING *`,
+        [sid, referenceMonth, netAmount, toMoney(totalDeductions), paymentDate],
+      );
+      stmtRow = rows[0];
+    } catch (err) {
+      if (err.code === "23505") {
+        throw createError(409, `Ja existe um extrato para ${referenceMonth}.`);
+      }
+      throw err;
+    }
+
+    // Clone active deductions as snapshot
+    const snapshotDeductions = [];
+    for (const d of deductionRows) {
+      const { rows } = await client.query(
+        `INSERT INTO income_statement_deductions
+           (statement_id, label, amount, is_variable)
+         VALUES ($1, $2, $3, $4)
+         RETURNING *`,
+        [stmtRow.id, d.label, d.amount, d.is_variable],
+      );
+      snapshotDeductions.push(mapStatementDeductionRow(rows[0]));
+    }
+
+    return {
+      statement: mapStatementRow(stmtRow),
+      deductions: snapshotDeductions,
+    };
+  });
+};
+
+export const getStatementWithDeductions = async (userId, statementId) => {
+  const uid = normalizeUserId(userId);
+  const stid = normalizeStatementId(statementId);
+
+  await requireStatementOwnership(uid, stid);
+
+  const [{ rows: stmtRows }, { rows: dedRows }] = await Promise.all([
+    dbQuery(`SELECT * FROM income_statements WHERE id = $1`, [stid]),
+    dbQuery(
+      `SELECT * FROM income_statement_deductions WHERE statement_id = $1 ORDER BY id ASC`,
+      [stid],
+    ),
+  ]);
+
+  return {
+    statement: mapStatementRow(stmtRows[0]),
+    deductions: dedRows.map(mapStatementDeductionRow),
+  };
+};
+
+export const updateStatementForSource = async (userId, statementId, payload) => {
+  const uid = normalizeUserId(userId);
+  const stid = normalizeStatementId(statementId);
+
+  const existing = await requireStatementOwnership(uid, stid);
+  if (existing.status === "posted") {
+    throw createError(400, "Extrato ja lancado. Nao e possivel editar.");
+  }
+
+  const setClauses = [];
+  const params = [];
+
+  if (payload.netAmount !== undefined) {
+    params.push(normalizeNetAmount(payload.netAmount));
+    setClauses.push(`net_amount = $${params.length}`);
+  }
+  if (payload.paymentDate !== undefined) {
+    params.push(normalizePaymentDate(payload.paymentDate));
+    setClauses.push(`payment_date = $${params.length}`);
+  }
+
+  // Update individual snapshot deduction amounts
+  if (Array.isArray(payload.deductions)) {
+    for (const { id, amount } of payload.deductions) {
+      const did = normalizeDeductionId(id);
+      const amt = normalizeDeductionAmount(amount);
+      await dbQuery(
+        `UPDATE income_statement_deductions SET amount = $1 WHERE id = $2 AND statement_id = $3`,
+        [amt, did, stid],
+      );
+    }
+
+    // Recompute total_deductions from snapshot
+    const { rows: dedRows } = await dbQuery(
+      `SELECT amount FROM income_statement_deductions WHERE statement_id = $1`,
+      [stid],
+    );
+    const newTotal = dedRows.reduce((sum, r) => sum + toMoney(r.amount), 0);
+    params.push(toMoney(newTotal));
+    setClauses.push(`total_deductions = $${params.length}`);
+  }
+
+  if (setClauses.length === 0) {
+    return getStatementWithDeductions(uid, stid);
+  }
+
+  setClauses.push(`updated_at = NOW()`);
+  params.push(stid);
+
+  await dbQuery(
+    `UPDATE income_statements SET ${setClauses.join(", ")} WHERE id = $${params.length}`,
+    params,
+  );
+
+  return getStatementWithDeductions(uid, stid);
+};
+
+export const postStatementForSource = async (userId, statementId) => {
+  const uid = normalizeUserId(userId);
+  const stid = normalizeStatementId(statementId);
+
+  return withDbTransaction(async (client) => {
+    // Fetch statement + source (for category_id and name)
+    const { rows: stmtRows } = await client.query(
+      `SELECT st.*, s.name AS source_name, s.category_id AS source_category_id
+       FROM income_statements st
+       JOIN income_sources s ON s.id = st.income_source_id
+       WHERE st.id = $1 AND s.user_id = $2`,
+      [stid, uid],
+    );
+
+    if (!stmtRows[0]) throw createError(404, "Extrato nao encontrado.");
+    const stmt = stmtRows[0];
+
+    if (stmt.status === "posted") {
+      throw createError(409, "Extrato ja foi lancado.");
+    }
+
+    const paymentDate = stmt.payment_date != null
+      ? toISODate(stmt.payment_date)
+      : toISODate();
+
+    const description = `${stmt.source_name} – ${stmt.reference_month}`;
+
+    // Create income transaction
+    const { rows: txRows } = await client.query(
+      `INSERT INTO transactions (user_id, type, value, date, description, category_id)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING *`,
+      [
+        uid,
+        TRANSACTION_TYPE_ENTRY,
+        toMoney(stmt.net_amount),
+        paymentDate,
+        description,
+        stmt.source_category_id ?? null,
+      ],
+    );
+
+    // Mark statement as posted
+    const { rows: updatedStmt } = await client.query(
+      `UPDATE income_statements
+       SET status = 'posted', posted_transaction_id = $1, updated_at = NOW()
+       WHERE id = $2
+       RETURNING *`,
+      [txRows[0].id, stid],
+    );
+
+    return {
+      statement: mapStatementRow(updatedStmt[0]),
+      transaction: mapTransactionRow(txRows[0]),
+    };
+  });
+};
+
+export const listStatementsForSource = async (userId, sourceId) => {
+  const uid = normalizeUserId(userId);
+  const sid = normalizeSourceId(sourceId);
+
+  await requireSourceOwnership(uid, sid);
+
+  const { rows } = await dbQuery(
+    `SELECT * FROM income_statements
+     WHERE income_source_id = $1
+     ORDER BY reference_month DESC`,
+    [sid],
+  );
+
+  return rows.map(mapStatementRow);
+};


### PR DESCRIPTION
## Summary

- Migration 018: 4 new tables — `income_sources`, `income_deductions`, `income_statements`, `income_statement_deductions`
- Service layer: CRUD for sources + deductions; draft statement creation clones active deductions as immutable snapshot; `postStatementForSource` atomically inserts an `Entrada` transaction (inheriting `category_id` from the source) and marks the statement posted
- 12 REST endpoints under `/income-sources`, all behind `authMiddleware`; `incomeSourcesWriteRateLimiter` on all write routes
- 22 tests: create/list/update/delete sources; add/edit/delete deductions; draft creation + deduction cloning; duplicate-month 409; invalid-month 400; PATCH blocked on posted statement; `postStatement` creates transaction with correct `categoryId`; re-post 409

## Test plan

- [x] `npm -w apps/api test -- --run` → 299/299
- [x] `npm -w apps/api run lint` → 0 warnings