### PR TITLE
fix(ci): strip UTF-8 BOM from package.json files

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,40 +1,40 @@
-﻿{
-    "name":  "@control-finance/api",
-    "private":  true,
-    "version":  "1.29.0",
-    "type":  "module",
-    "engines":  {
-                    "node":  "24.x"
-                },
-    "scripts":  {
-                    "dev":  "node --watch src/server.js",
-                    "start":  "node src/server.js",
-                    "build":  "node -e \"console.log(\u0027api build: no-op\u0027)\"",
-                    "db:migrate":  "node src/db/migrate.js",
-                    "db:backfill:categories-normalized":  "node src/db/backfill-categories-normalized.js",
-                    "db:seed":  "node src/db/seed.js",
-                    "lint":  "eslint src --max-warnings 0",
-                    "test":  "vitest run"
-                },
-    "dependencies":  {
-                         "bcryptjs":  "^2.4.3",
-                         "cors":  "^2.8.5",
-                         "csv-parse":  "^5.6.0",
-                         "dotenv":  "^16.4.5",
-                         "express":  "^4.21.2",
-                         "express-rate-limit":  "^8.2.1",
-                         "google-auth-library":  "^10.5.0",
-                         "jsonwebtoken":  "^9.0.2",
-                         "multer":  "^2.0.2",
-                         "nodemailer":  "^8.0.1",
-                         "pg":  "^8.16.3",
-                         "prom-client":  "^15.1.3",
-                         "stripe":  "^20.3.1"
-                     },
-    "devDependencies":  {
-                            "eslint":  "^8.57.1",
-                            "pg-mem":  "^3.0.5",
-                            "supertest":  "^7.1.4",
-                            "vitest":  "^3.2.4"
-                        }
+{
+  "name": "@control-finance/api",
+  "private": true,
+  "version": "1.29.0",
+  "type": "module",
+  "engines": {
+    "node": "24.x"
+  },
+  "scripts": {
+    "dev": "node --watch src/server.js",
+    "start": "node src/server.js",
+    "build": "node -e \"console.log('api build: no-op')\"",
+    "db:migrate": "node src/db/migrate.js",
+    "db:backfill:categories-normalized": "node src/db/backfill-categories-normalized.js",
+    "db:seed": "node src/db/seed.js",
+    "lint": "eslint src --max-warnings 0",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "cors": "^2.8.5",
+    "csv-parse": "^5.6.0",
+    "dotenv": "^16.4.5",
+    "express": "^4.21.2",
+    "express-rate-limit": "^8.2.1",
+    "google-auth-library": "^10.5.0",
+    "jsonwebtoken": "^9.0.2",
+    "multer": "^2.0.2",
+    "nodemailer": "^8.0.1",
+    "pg": "^8.16.3",
+    "prom-client": "^15.1.3",
+    "stripe": "^20.3.1"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.1",
+    "pg-mem": "^3.0.5",
+    "supertest": "^7.1.4",
+    "vitest": "^3.2.4"
+  }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,50 +1,50 @@
-﻿{
-    "name":  "@control-finance/web",
-    "private":  true,
-    "version":  "1.29.0",
-    "type":  "module",
-    "engines":  {
-                    "node":  "24.x"
-                },
-    "scripts":  {
-                    "dev":  "vite",
-                    "build":  "vite build",
-                    "lint":  "eslint . --ext js,jsx,ts,tsx --report-unused-disable-directives --max-warnings 0",
-                    "typecheck":  "tsc -p tsconfig.json --noEmit",
-                    "typecheck:auth":  "tsc -p tsconfig.auth.json --noEmit",
-                    "preview":  "vite preview",
-                    "test":  "vitest",
-                    "test:run":  "vitest run"
-                },
-    "dependencies":  {
-                         "@react-oauth/google":  "^0.13.4",
-                         "autoprefixer":  "^10.4.24",
-                         "axios":  "^1.8.4",
-                         "postcss":  "^8.5.6",
-                         "prop-types":  "^15.8.1",
-                         "react":  "^18.3.1",
-                         "react-dom":  "^18.3.1",
-                         "react-router-dom":  "^6.30.1",
-                         "recharts":  "^2.12.7",
-                         "tailwindcss":  "^3.4.19"
-                     },
-    "devDependencies":  {
-                            "@testing-library/jest-dom":  "^6.9.1",
-                            "@testing-library/react":  "^16.3.2",
-                            "@testing-library/user-event":  "^14.6.1",
-                            "@types/node":  "^25.2.3",
-                            "@types/react":  "^18.3.28",
-                            "@types/react-dom":  "^18.3.7",
-                            "@typescript-eslint/eslint-plugin":  "^8.47.0",
-                            "@typescript-eslint/parser":  "^8.47.0",
-                            "@vitejs/plugin-react":  "^5.1.4",
-                            "eslint":  "^8.57.1",
-                            "eslint-plugin-react":  "^7.37.5",
-                            "eslint-plugin-react-hooks":  "^4.6.2",
-                            "eslint-plugin-react-refresh":  "^0.4.26",
-                            "jsdom":  "^26.1.0",
-                            "typescript":  "^5.9.3",
-                            "vite":  "^7.3.1",
-                            "vitest":  "^3.2.4"
-                        }
+{
+  "name": "@control-finance/web",
+  "private": true,
+  "version": "1.29.0",
+  "type": "module",
+  "engines": {
+    "node": "24.x"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "lint": "eslint . --ext js,jsx,ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck:auth": "tsc -p tsconfig.auth.json --noEmit",
+    "preview": "vite preview",
+    "test": "vitest",
+    "test:run": "vitest run"
+  },
+  "dependencies": {
+    "@react-oauth/google": "^0.13.4",
+    "autoprefixer": "^10.4.24",
+    "axios": "^1.8.4",
+    "postcss": "^8.5.6",
+    "prop-types": "^15.8.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.30.1",
+    "recharts": "^2.12.7",
+    "tailwindcss": "^3.4.19"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/node": "^25.2.3",
+    "@types/react": "^18.3.28",
+    "@types/react-dom": "^18.3.7",
+    "@typescript-eslint/eslint-plugin": "^8.47.0",
+    "@typescript-eslint/parser": "^8.47.0",
+    "@vitejs/plugin-react": "^5.1.4",
+    "eslint": "^8.57.1",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^4.6.2",
+    "eslint-plugin-react-refresh": "^0.4.26",
+    "jsdom": "^26.1.0",
+    "typescript": "^5.9.3",
+    "vite": "^7.3.1",
+    "vitest": "^3.2.4"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,25 +1,25 @@
-﻿{
-    "name":  "control-finance-monorepo",
-    "private":  true,
-    "version":  "1.29.0",
-    "engines":  {
-                    "node":  "24.x"
-                },
-    "workspaces":  [
-                       "apps/web",
-                       "apps/api"
-                   ],
-    "scripts":  {
-                    "dev":  "concurrently \"npm -w apps/api run dev\" \"npm -w apps/web run dev\"",
-                    "lint":  "npm -w apps/web run lint \u0026\u0026 npm -w apps/api run lint",
-                    "typecheck:web":  "npm -w apps/web run typecheck",
-                    "typecheck":  "npm run typecheck:web",
-                    "test":  "npm -w apps/web run test:run \u0026\u0026 npm -w apps/api run test",
-                    "test:run":  "npm run test",
-                    "build":  "npm -w apps/web run build \u0026\u0026 npm -w apps/api run build",
-                    "preview":  "npm -w apps/web run preview"
-                },
-    "devDependencies":  {
-                            "concurrently":  "^9.2.1"
-                        }
+{
+  "name": "control-finance-monorepo",
+  "private": true,
+  "version": "1.29.0",
+  "engines": {
+    "node": "24.x"
+  },
+  "workspaces": [
+    "apps/web",
+    "apps/api"
+  ],
+  "scripts": {
+    "dev": "concurrently \"npm -w apps/api run dev\" \"npm -w apps/web run dev\"",
+    "lint": "npm -w apps/web run lint && npm -w apps/api run lint",
+    "typecheck:web": "npm -w apps/web run typecheck",
+    "typecheck": "npm run typecheck:web",
+    "test": "npm -w apps/web run test:run && npm -w apps/api run test",
+    "test:run": "npm run test",
+    "build": "npm -w apps/web run build && npm -w apps/api run build",
+    "preview": "npm -w apps/web run preview"
+  },
+  "devDependencies": {
+    "concurrently": "^9.2.1"
+  }
 }


### PR DESCRIPTION
PowerShell's \/\ wrote UTF-8 BOM (ef bb bf) into all three package.json files during the v1.29.0 release bump. Node.js and Linux CI runners reject BOM-prefixed JSON. Strips the BOM and rewrites as clean UTF-8.