### PR TITLE
feat(api): salary engine + salary_profiles migration (PR-SAL1)

### DIFF
--- a/apps/api/src/db/migrations/019_create_salary_profiles.sql
+++ b/apps/api/src/db/migrations/019_create_salary_profiles.sql
@@ -1,0 +1,12 @@
+CREATE TABLE salary_profiles (
+  id           SERIAL PRIMARY KEY,
+  user_id      INTEGER        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  gross_salary NUMERIC(12,2)  NOT NULL CHECK (gross_salary > 0),
+  dependents   SMALLINT       NOT NULL DEFAULT 0 CHECK (dependents >= 0),
+  payment_day  SMALLINT       NOT NULL DEFAULT 5 CHECK (payment_day BETWEEN 1 AND 31),
+  created_at   TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+  UNIQUE (user_id)
+);
+
+CREATE INDEX idx_salary_profiles_user ON salary_profiles(user_id);

--- a/apps/api/src/domain/salary/inss.tables.js
+++ b/apps/api/src/domain/salary/inss.tables.js
@@ -1,0 +1,27 @@
+/**
+ * INSS contribution tables — progressive brackets per year.
+ * Source: RFB / MPS portarias. Add a new key when rates change.
+ *
+ * Each bracket: { upTo, rate }
+ *   upTo  = upper limit of the range (Infinity for the last band)
+ *   rate  = decimal (e.g. 0.075 = 7.5 %)
+ *
+ * Calculation is progressive (each layer is taxed at its own rate),
+ * matching the regra progressiva vigente from Jan 2023 onward.
+ */
+
+/** @type {Record<number, Array<{upTo: number, rate: number}>>} */
+export const INSS_BRACKETS = {
+  2026: [
+    { upTo: 1621.0,   rate: 0.075 },
+    { upTo: 2902.84,  rate: 0.09  },
+    { upTo: 4354.27,  rate: 0.12  },
+    { upTo: 8475.55,  rate: 0.14  },
+    { upTo: Infinity, rate: 0.14  }, // teto — capped at max contribution
+  ],
+};
+
+/** Maximum INSS monthly contribution ceiling per year (teto). */
+export const INSS_CEILING = {
+  2026: 988.09, // derived: progressive calc on teto salarial R$8.475,55
+};

--- a/apps/api/src/domain/salary/irrf.tables.js
+++ b/apps/api/src/domain/salary/irrf.tables.js
@@ -1,0 +1,28 @@
+/**
+ * IRRF withholding tables — progressive brackets per year.
+ * Source: RFB Instrução Normativa. Add a new key when rates change.
+ *
+ * Each bracket: { upTo, rate, deduction }
+ *   upTo      = upper limit of the range (Infinity for the last band)
+ *   rate      = decimal
+ *   deduction = fixed deduction amount applied to the bracket (tabela prática)
+ *
+ * Dependent deduction: fixed monthly value subtracted from the IRRF base
+ * before looking up the bracket.
+ */
+
+/** @type {Record<number, Array<{upTo: number, rate: number, deduction: number}>>} */
+export const IRRF_BRACKETS = {
+  2026: [
+    { upTo: 2428.80,  rate: 0,     deduction: 0      },
+    { upTo: 2826.65,  rate: 0.075, deduction: 182.16 },
+    { upTo: 3751.05,  rate: 0.15,  deduction: 394.16 },
+    { upTo: 4664.68,  rate: 0.225, deduction: 675.49 },
+    { upTo: Infinity, rate: 0.275, deduction: 908.73 },
+  ],
+};
+
+/** Monthly IRRF deduction per dependent (R$). */
+export const IRRF_DEPENDENT_DEDUCTION = {
+  2026: 189.59,
+};

--- a/apps/api/src/domain/salary/salary.calculator.js
+++ b/apps/api/src/domain/salary/salary.calculator.js
@@ -1,0 +1,105 @@
+import { INSS_BRACKETS, INSS_CEILING } from "./inss.tables.js";
+import {
+  IRRF_BRACKETS,
+  IRRF_DEPENDENT_DEDUCTION,
+} from "./irrf.tables.js";
+
+/**
+ * Calculate progressive INSS contribution.
+ * @param {number} gross
+ * @param {number} year
+ * @returns {number}
+ */
+function calcInss(gross, year) {
+  const brackets = INSS_BRACKETS[year];
+  if (!brackets) throw new Error(`INSS table not found for year ${year}`);
+
+  const ceiling = INSS_CEILING[year];
+
+  let contribution = 0;
+  let prev = 0;
+
+  for (const { upTo, rate } of brackets) {
+    const top = Math.min(gross, upTo === Infinity ? gross : upTo);
+    if (top <= prev) break;
+    contribution += (top - prev) * rate;
+    prev = top;
+    if (gross <= upTo) break;
+  }
+
+  return Math.min(contribution, ceiling);
+}
+
+/**
+ * Calculate monthly IRRF withholding using tabela prática progressiva.
+ * @param {number} irrfBase  gross minus INSS, minus dependent deductions
+ * @param {number} year
+ * @returns {number}
+ */
+function calcIrrf(irrfBase, year) {
+  const brackets = IRRF_BRACKETS[year];
+  if (!brackets) throw new Error(`IRRF table not found for year ${year}`);
+
+  for (const { upTo, rate, deduction } of brackets) {
+    if (irrfBase <= upTo) {
+      return Math.max(0, irrfBase * rate - deduction);
+    }
+  }
+  return 0;
+}
+
+/**
+ * Calculate net salary after INSS and IRRF (simplified modelo padrão).
+ *
+ * @param {object} params
+ * @param {number} params.grossSalary     Bruto mensal em R$
+ * @param {number} [params.dependents]    Número de dependentes (default 0)
+ * @param {number} [params.effectiveYear] Ano de referência para as tabelas (default 2025)
+ * @returns {{
+ *   grossMonthly: number,
+ *   inssMonthly: number,
+ *   irrfMonthly: number,
+ *   netMonthly: number,
+ *   netAnnual: number,
+ *   taxAnnual: number,
+ * }}
+ */
+export function calculateNetSalary({
+  grossSalary,
+  dependents = 0,
+  effectiveYear = 2026,
+}) {
+  if (typeof grossSalary !== "number" || grossSalary <= 0) {
+    throw new Error("grossSalary must be a positive number");
+  }
+  if (!Number.isInteger(dependents) || dependents < 0) {
+    throw new Error("dependents must be a non-negative integer");
+  }
+
+  // Round monthly values before deriving annual totals to keep
+  // netAnnual == netMonthly * 12 and taxAnnual == (inss + irrf) * 12.
+  const inssMonthly = round2(calcInss(grossSalary, effectiveYear));
+
+  const dependentDeduction =
+    (IRRF_DEPENDENT_DEDUCTION[effectiveYear] ?? 0) * dependents;
+  const irrfBase = Math.max(0, grossSalary - inssMonthly - dependentDeduction);
+  const irrfMonthly = round2(calcIrrf(irrfBase, effectiveYear));
+
+  const netMonthly  = round2(grossSalary - inssMonthly - irrfMonthly);
+  const netAnnual   = round2(netMonthly * 12);
+  const taxAnnual   = round2((inssMonthly + irrfMonthly) * 12);
+
+  return {
+    grossMonthly: round2(grossSalary),
+    inssMonthly,
+    irrfMonthly,
+    netMonthly,
+    netAnnual,
+    taxAnnual,
+  };
+}
+
+/** Round to 2 decimal places (centavos). */
+function round2(v) {
+  return Math.round(v * 100) / 100;
+}

--- a/apps/api/src/domain/salary/salary.calculator.test.js
+++ b/apps/api/src/domain/salary/salary.calculator.test.js
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+import { calculateNetSalary } from "./salary.calculator.js";
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+/** Compute expected INSS manually for 2026 progressive brackets. */
+function expectedInss2026(gross) {
+  const brackets = [
+    { upTo: 1621.0,  rate: 0.075 },
+    { upTo: 2902.84, rate: 0.09  },
+    { upTo: 4354.27, rate: 0.12  },
+    { upTo: 8475.55, rate: 0.14  },
+  ];
+  const ceiling = 988.09;
+  let total = 0;
+  let prev = 0;
+  for (const { upTo, rate } of brackets) {
+    const top = Math.min(gross, upTo);
+    if (top <= prev) break;
+    total += (top - prev) * rate;
+    prev = top;
+    if (gross <= upTo) break;
+  }
+  return Math.min(Math.round(total * 100) / 100, ceiling);
+}
+
+// ─── calculateNetSalary — validation ────────────────────────────────────────
+
+describe("calculateNetSalary — input validation", () => {
+  it("lança erro se grossSalary não é número", () => {
+    expect(() => calculateNetSalary({ grossSalary: "3000" })).toThrow();
+  });
+
+  it("lança erro se grossSalary é zero", () => {
+    expect(() => calculateNetSalary({ grossSalary: 0 })).toThrow();
+  });
+
+  it("lança erro se grossSalary é negativo", () => {
+    expect(() => calculateNetSalary({ grossSalary: -500 })).toThrow();
+  });
+
+  it("lança erro se dependents não é inteiro", () => {
+    expect(() =>
+      calculateNetSalary({ grossSalary: 3000, dependents: 1.5 })
+    ).toThrow();
+  });
+
+  it("lança erro se dependents é negativo", () => {
+    expect(() =>
+      calculateNetSalary({ grossSalary: 3000, dependents: -1 })
+    ).toThrow();
+  });
+
+  it("lança erro se ano não tem tabela INSS", () => {
+    expect(() =>
+      calculateNetSalary({ grossSalary: 3000, effectiveYear: 1990 })
+    ).toThrow(/INSS table not found/);
+  });
+});
+
+// ─── calculateNetSalary — shape ──────────────────────────────────────────────
+
+describe("calculateNetSalary — shape do retorno", () => {
+  it("retorna todos os campos esperados", () => {
+    const result = calculateNetSalary({ grossSalary: 3000 });
+    expect(result).toHaveProperty("grossMonthly");
+    expect(result).toHaveProperty("inssMonthly");
+    expect(result).toHaveProperty("irrfMonthly");
+    expect(result).toHaveProperty("netMonthly");
+    expect(result).toHaveProperty("netAnnual");
+    expect(result).toHaveProperty("taxAnnual");
+  });
+
+  it("grossMonthly == grossSalary passado", () => {
+    const result = calculateNetSalary({ grossSalary: 4500 });
+    expect(result.grossMonthly).toBe(4500);
+  });
+
+  it("netMonthly == grossMonthly - inssMonthly - irrfMonthly", () => {
+    const result = calculateNetSalary({ grossSalary: 5000 });
+    const expected =
+      Math.round(
+        (result.grossMonthly - result.inssMonthly - result.irrfMonthly) * 100
+      ) / 100;
+    expect(result.netMonthly).toBe(expected);
+  });
+
+  it("netAnnual == netMonthly * 12", () => {
+    const result = calculateNetSalary({ grossSalary: 5000 });
+    expect(result.netAnnual).toBe(Math.round(result.netMonthly * 12 * 100) / 100);
+  });
+
+  it("taxAnnual == (inssMonthly + irrfMonthly) * 12", () => {
+    const result = calculateNetSalary({ grossSalary: 5000 });
+    const expected =
+      Math.round((result.inssMonthly + result.irrfMonthly) * 12 * 100) / 100;
+    expect(result.taxAnnual).toBe(expected);
+  });
+});
+
+// ─── INSS — brackets 2026 ───────────────────────────────────────────────────
+
+describe("INSS 2026 — cálculo progressivo", () => {
+  it("R$1.621 — alíquota única 7,5%", () => {
+    const result = calculateNetSalary({ grossSalary: 1621 });
+    // 1621 × 7.5% = 121.575 → 121.58
+    expect(result.inssMonthly).toBe(Math.round(1621 * 0.075 * 100) / 100);
+  });
+
+  it("R$2.000 — duas faixas", () => {
+    const result = calculateNetSalary({ grossSalary: 2000 });
+    expect(result.inssMonthly).toBe(expectedInss2026(2000));
+  });
+
+  it("R$3.000 — três faixas", () => {
+    const result = calculateNetSalary({ grossSalary: 3000 });
+    expect(result.inssMonthly).toBe(expectedInss2026(3000));
+  });
+
+  it("R$5.000 — quatro faixas", () => {
+    const result = calculateNetSalary({ grossSalary: 5000 });
+    expect(result.inssMonthly).toBe(expectedInss2026(5000));
+  });
+
+  it("acima do teto R$8.475,55 — capped em R$988,09", () => {
+    const result = calculateNetSalary({ grossSalary: 15000 });
+    expect(result.inssMonthly).toBe(988.09);
+  });
+
+  it("exatamente no teto R$8.475,55 — máximo R$988,09", () => {
+    const result = calculateNetSalary({ grossSalary: 8475.55 });
+    expect(result.inssMonthly).toBe(988.09);
+  });
+});
+
+// ─── IRRF — isento / tributado 2026 ─────────────────────────────────────────
+
+describe("IRRF 2026 — isento e tributado", () => {
+  it("R$1.621 — IRRF isento (base < R$2.428,80)", () => {
+    const result = calculateNetSalary({ grossSalary: 1621 });
+    // base IRRF = 1621 − 121.58 = 1499.42 < 2428.80 → isento
+    expect(result.irrfMonthly).toBe(0);
+  });
+
+  it("R$2.500 — base próxima ao limite → isento ou 7,5%", () => {
+    const result = calculateNetSalary({ grossSalary: 2500 });
+    const inss = expectedInss2026(2500);
+    const base = Math.round((2500 - inss) * 100) / 100;
+    if (base <= 2428.8) {
+      expect(result.irrfMonthly).toBe(0);
+    } else {
+      expect(result.irrfMonthly).toBeGreaterThan(0);
+    }
+  });
+
+  it("R$3.000 — IRRF na faixa 7,5% ou 15%", () => {
+    const result = calculateNetSalary({ grossSalary: 3000 });
+    expect(result.irrfMonthly).toBeGreaterThan(0);
+  });
+
+  it("R$5.000 — IRRF positivo", () => {
+    const result = calculateNetSalary({ grossSalary: 5000 });
+    expect(result.irrfMonthly).toBeGreaterThan(0);
+  });
+
+  it("R$15.000 — IRRF na faixa máxima 27,5%", () => {
+    const result = calculateNetSalary({ grossSalary: 15000 });
+    const inss = 988.09; // teto
+    const base = Math.round((15000 - inss) * 100) / 100;
+    // faixa > 4664.68 → 27.5% − 908.73
+    const expectedIrrf = Math.round((base * 0.275 - 908.73) * 100) / 100;
+    expect(result.irrfMonthly).toBe(expectedIrrf);
+  });
+});
+
+// ─── Dependentes ─────────────────────────────────────────────────────────────
+
+describe("dedução por dependentes", () => {
+  it("0 dependentes == sem dedução de dependentes", () => {
+    const sem = calculateNetSalary({ grossSalary: 4000, dependents: 0 });
+    const com = calculateNetSalary({ grossSalary: 4000, dependents: 0 });
+    expect(sem.irrfMonthly).toBe(com.irrfMonthly);
+  });
+
+  it("1 dependente reduz IRRF em relação a 0 dependentes", () => {
+    const sem = calculateNetSalary({ grossSalary: 4000, dependents: 0 });
+    const com = calculateNetSalary({ grossSalary: 4000, dependents: 1 });
+    expect(com.irrfMonthly).toBeLessThanOrEqual(sem.irrfMonthly);
+  });
+
+  it("2 dependentes reduz IRRF mais do que 1 dependente", () => {
+    const um = calculateNetSalary({ grossSalary: 4000, dependents: 1 });
+    const dois = calculateNetSalary({ grossSalary: 4000, dependents: 2 });
+    expect(dois.irrfMonthly).toBeLessThanOrEqual(um.irrfMonthly);
+  });
+
+  it("dependentes não afetam o cálculo de INSS", () => {
+    const sem = calculateNetSalary({ grossSalary: 4000, dependents: 0 });
+    const com = calculateNetSalary({ grossSalary: 4000, dependents: 3 });
+    expect(com.inssMonthly).toBe(sem.inssMonthly);
+  });
+
+  it("IRRF nunca fica negativo com muitos dependentes", () => {
+    const result = calculateNetSalary({ grossSalary: 2500, dependents: 10 });
+    expect(result.irrfMonthly).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ─── effectiveYear — default ──────────────────────────────────────────────────
+
+describe("effectiveYear", () => {
+  it("sem effectiveYear usa 2026 por padrão", () => {
+    const a = calculateNetSalary({ grossSalary: 3000 });
+    const b = calculateNetSalary({ grossSalary: 3000, effectiveYear: 2026 });
+    expect(a).toEqual(b);
+  });
+});


### PR DESCRIPTION
## What
- Migration `019_create_salary_profiles.sql` — one salary profile per user (`UNIQUE user_id`), stores `gross_salary`, `dependents`, `payment_day`
- `domain/salary/inss.tables.js` — 2026 progressive INSS brackets + ceiling R\$988,09
- `domain/salary/irrf.tables.js` — 2026 IRRF tabela prática + dependent deduction R\$189,59
- `domain/salary/salary.calculator.js` — pure `calculateNetSalary()`, returns `grossMonthly / inssMonthly / irrfMonthly / netMonthly / netAnnual / taxAnnual`

## Why
CLT salary net calculation (INSS progressivo + IRRF simplificado) needed as an isolated, testable engine before exposing endpoints in PR-SAL2. `effectiveYear` defaults to **2026** (MVP fixed year — new key added to tables when rates change, no migration needed).

## Notes
- INSS ceiling R\$988,09 derived from progressive calc over 2026 salary ceiling R\$8.475,55
- Monthly values rounded before annual multiplication to keep `netAnnual == netMonthly × 12` exactly
- No routes in this PR — that's PR-SAL2

## Tests
- 28 unit tests (salary domain) — all passing
- 327/327 full API suite — no regression
- ESLint: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)