### PR TITLE
feat(api): salary profile endpoints — GET + PUT /salary/profile (PR-SAL2)

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -14,6 +14,7 @@ import forecastRoutes from "./routes/forecast.routes.js";
 import stripeWebhooksRoutes from "./routes/stripe-webhooks.routes.js";
 import billsRoutes from "./routes/bills.routes.js";
 import incomeSourcesRoutes from "./routes/income-sources.routes.js";
+import salaryRoutes from "./routes/salary.routes.js";
 import { notFoundHandler, errorHandler } from "./middlewares/error.middleware.js";
 import { requestIdMiddleware } from "./middlewares/request-id.middleware.js";
 import { requestLoggingMiddleware } from "./middlewares/request-logging.middleware.js";
@@ -90,6 +91,7 @@ app.use("/me", meRoutes);
 app.use("/forecasts", forecastRoutes);
 app.use("/bills", billsRoutes);
 app.use("/income-sources", incomeSourcesRoutes);
+app.use("/salary", salaryRoutes);
 
 app.use(notFoundHandler);
 app.use(errorHandler);

--- a/apps/api/src/routes/salary.routes.js
+++ b/apps/api/src/routes/salary.routes.js
@@ -1,0 +1,30 @@
+import { Router } from "express";
+import { authMiddleware } from "../middlewares/auth.middleware.js";
+import {
+  getSalaryProfileForUser,
+  upsertSalaryProfileForUser,
+} from "../services/salary-profile.service.js";
+
+const router = Router();
+
+router.use(authMiddleware);
+
+router.get("/profile", async (req, res, next) => {
+  try {
+    const profile = await getSalaryProfileForUser(req.user.id);
+    res.status(200).json(profile);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.put("/profile", async (req, res, next) => {
+  try {
+    const profile = await upsertSalaryProfileForUser(req.user.id, req.body || {});
+    res.status(200).json(profile);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/apps/api/src/salary-profile.test.js
+++ b/apps/api/src/salary-profile.test.js
@@ -1,0 +1,312 @@
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import app from "./app.js";
+import { clearDbClientForTests, dbQuery } from "./db/index.js";
+import { resetLoginProtectionState } from "./middlewares/login-protection.middleware.js";
+import {
+  resetImportRateLimiterState,
+  resetWriteRateLimiterState,
+} from "./middlewares/rate-limit.middleware.js";
+import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
+import {
+  expectErrorResponseWithRequestId,
+  registerAndLogin,
+  setupTestDb,
+} from "./test-helpers.js";
+
+describe("salary-profile", () => {
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  afterAll(async () => {
+    await clearDbClientForTests();
+  });
+
+  beforeEach(async () => {
+    resetLoginProtectionState();
+    resetImportRateLimiterState();
+    resetWriteRateLimiterState();
+    resetHttpMetricsForTests();
+    await dbQuery("DELETE FROM salary_profiles");
+    await dbQuery("DELETE FROM users");
+  });
+
+  // ─── Auth ─────────────────────────────────────────────────────────────────
+
+  it("GET /salary/profile bloqueia sem token", async () => {
+    const res = await request(app).get("/salary/profile");
+    expect(res.status).toBe(401);
+  });
+
+  it("PUT /salary/profile bloqueia sem token", async () => {
+    const res = await request(app).put("/salary/profile").send({ gross_salary: 5000 });
+    expect(res.status).toBe(401);
+  });
+
+  // ─── GET — 404 quando não existe ─────────────────────────────────────────
+
+  it("GET /salary/profile retorna 404 quando usuario nao tem perfil", async () => {
+    const token = await registerAndLogin("sal-get-404@test.dev");
+    const res = await request(app)
+      .get("/salary/profile")
+      .set("Authorization", `Bearer ${token}`);
+    expectErrorResponseWithRequestId(res, 404, "Perfil salarial não encontrado.");
+  });
+
+  // ─── PUT — criação (upsert insert) ───────────────────────────────────────
+
+  it("PUT /salary/profile cria perfil com campos minimos", async () => {
+    const token = await registerAndLogin("sal-create@test.dev");
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      grossSalary: 5000,
+      dependents:  0,
+      paymentDay:  5,
+    });
+    expect(typeof res.body.id).toBe("number");
+    expect(res.body.calculation).toBeDefined();
+  });
+
+  it("PUT /salary/profile cria perfil com todos os campos", async () => {
+    const token = await registerAndLogin("sal-create-full@test.dev");
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 8000, dependents: 2, payment_day: 10 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      grossSalary: 8000,
+      dependents:  2,
+      paymentDay:  10,
+    });
+  });
+
+  // ─── PUT — atualização (upsert update) ───────────────────────────────────
+
+  it("PUT /salary/profile atualiza perfil existente", async () => {
+    const token = await registerAndLogin("sal-update@test.dev");
+
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000 });
+
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 7500, dependents: 1, payment_day: 15 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      grossSalary: 7500,
+      dependents:  1,
+      paymentDay:  15,
+    });
+  });
+
+  it("segundo upsert mantém mesmo id", async () => {
+    const token = await registerAndLogin("sal-same-id@test.dev");
+
+    const first = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000 });
+
+    const second = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 6000 });
+
+    expect(second.body.id).toBe(first.body.id);
+  });
+
+  // ─── GET — após criação ───────────────────────────────────────────────────
+
+  it("GET /salary/profile retorna perfil criado com calculo", async () => {
+    const token = await registerAndLogin("sal-get-ok@test.dev");
+
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000, dependents: 1 });
+
+    const res = await request(app)
+      .get("/salary/profile")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ grossSalary: 5000, dependents: 1 });
+    expect(res.body.calculation).toMatchObject({
+      grossMonthly: 5000,
+      inssMonthly:  expect.any(Number),
+      irrfMonthly:  expect.any(Number),
+      netMonthly:   expect.any(Number),
+      netAnnual:    expect.any(Number),
+      taxAnnual:    expect.any(Number),
+    });
+    expect(res.body.calculation.netMonthly).toBeGreaterThan(0);
+    expect(res.body.calculation.netMonthly).toBeLessThan(5000);
+  });
+
+  // ─── Cálculo — sanidade 2026 ──────────────────────────────────────────────
+
+  it("salario minimo 2026 R$1.621 — IRRF isento", async () => {
+    const token = await registerAndLogin("sal-minimo@test.dev");
+
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 1621 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.calculation.irrfMonthly).toBe(0);
+    expect(res.body.calculation.inssMonthly).toBe(
+      Math.round(1621 * 0.075 * 100) / 100,
+    );
+  });
+
+  it("effectiveYear nao aceito do client — calculo usa 2026", async () => {
+    const token = await registerAndLogin("sal-year@test.dev");
+
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000, effectiveYear: 2020 }); // client tenta passar ano
+
+    // campo desconhecido ignorado; calculo usa 2026 (default do motor)
+    expect(res.status).toBe(200);
+    expect(res.body.calculation.grossMonthly).toBe(5000);
+  });
+
+  // ─── Validação — gross_salary ─────────────────────────────────────────────
+
+  it("PUT sem gross_salary retorna 422", async () => {
+    const token = await registerAndLogin("sal-val-no-gross@test.dev");
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ dependents: 0 });
+    expectErrorResponseWithRequestId(res, 422, "gross_salary é obrigatório.");
+  });
+
+  it("PUT gross_salary = 0 retorna 422", async () => {
+    const token = await registerAndLogin("sal-val-zero@test.dev");
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 0 });
+    expectErrorResponseWithRequestId(res, 422, "gross_salary deve ser um número positivo.");
+  });
+
+  it("PUT gross_salary negativo retorna 422", async () => {
+    const token = await registerAndLogin("sal-val-neg@test.dev");
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: -500 });
+    expectErrorResponseWithRequestId(res, 422, "gross_salary deve ser um número positivo.");
+  });
+
+  it("PUT gross_salary string nao numerica retorna 422", async () => {
+    const token = await registerAndLogin("sal-val-str@test.dev");
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: "abc" });
+    expectErrorResponseWithRequestId(res, 422, "gross_salary deve ser um número positivo.");
+  });
+
+  // ─── Validação — dependents ───────────────────────────────────────────────
+
+  it("PUT dependents negativo retorna 422", async () => {
+    const token = await registerAndLogin("sal-val-dep-neg@test.dev");
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000, dependents: -1 });
+    expectErrorResponseWithRequestId(res, 422, "dependents deve ser um inteiro não negativo.");
+  });
+
+  it("PUT dependents fracionario retorna 422", async () => {
+    const token = await registerAndLogin("sal-val-dep-frac@test.dev");
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000, dependents: 1.5 });
+    expectErrorResponseWithRequestId(res, 422, "dependents deve ser um inteiro não negativo.");
+  });
+
+  // ─── Validação — payment_day ──────────────────────────────────────────────
+
+  it("PUT payment_day = 0 retorna 422", async () => {
+    const token = await registerAndLogin("sal-val-day-0@test.dev");
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000, payment_day: 0 });
+    expectErrorResponseWithRequestId(
+      res,
+      422,
+      "payment_day deve ser um inteiro entre 1 e 31.",
+    );
+  });
+
+  it("PUT payment_day = 32 retorna 422", async () => {
+    const token = await registerAndLogin("sal-val-day-32@test.dev");
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000, payment_day: 32 });
+    expectErrorResponseWithRequestId(
+      res,
+      422,
+      "payment_day deve ser um inteiro entre 1 e 31.",
+    );
+  });
+
+  it("PUT payment_day = 31 aceito (limite superior)", async () => {
+    const token = await registerAndLogin("sal-val-day-31@test.dev");
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000, payment_day: 31 });
+    expect(res.status).toBe(200);
+    expect(res.body.paymentDay).toBe(31);
+  });
+
+  // ─── Ownership ────────────────────────────────────────────────────────────
+
+  it("dois usuarios tem perfis independentes", async () => {
+    const tokenA = await registerAndLogin("sal-owner-a@test.dev");
+    const tokenB = await registerAndLogin("sal-owner-b@test.dev");
+
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${tokenA}`)
+      .send({ gross_salary: 5000 });
+
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${tokenB}`)
+      .send({ gross_salary: 10000 });
+
+    const resA = await request(app)
+      .get("/salary/profile")
+      .set("Authorization", `Bearer ${tokenA}`);
+
+    const resB = await request(app)
+      .get("/salary/profile")
+      .set("Authorization", `Bearer ${tokenB}`);
+
+    expect(resA.body.grossSalary).toBe(5000);
+    expect(resB.body.grossSalary).toBe(10000);
+    expect(resA.body.id).not.toBe(resB.body.id);
+  });
+});

--- a/apps/api/src/services/salary-profile.service.js
+++ b/apps/api/src/services/salary-profile.service.js
@@ -1,0 +1,126 @@
+import { dbQuery } from "../db/index.js";
+import { calculateNetSalary } from "../domain/salary/salary.calculator.js";
+
+const PAYMENT_DAY_MIN = 1;
+const PAYMENT_DAY_MAX = 31;
+
+const createError = (status, message) => {
+  const err = new Error(message);
+  err.status = status;
+  return err;
+};
+
+const toMoney = (value) => Number(Number(value || 0).toFixed(2));
+
+// ─── Validation ───────────────────────────────────────────────────────────────
+
+const validateInput = ({ grossSalary, dependents, paymentDay }) => {
+  if (grossSalary === undefined || grossSalary === null) {
+    throw createError(422, "gross_salary é obrigatório.");
+  }
+  const gross = Number(grossSalary);
+  if (!Number.isFinite(gross) || gross <= 0) {
+    throw createError(422, "gross_salary deve ser um número positivo.");
+  }
+
+  if (dependents !== undefined && dependents !== null) {
+    const dep = Number(dependents);
+    if (!Number.isInteger(dep) || dep < 0) {
+      throw createError(422, "dependents deve ser um inteiro não negativo.");
+    }
+  }
+
+  if (paymentDay !== undefined && paymentDay !== null) {
+    const day = Number(paymentDay);
+    if (
+      !Number.isInteger(day) ||
+      day < PAYMENT_DAY_MIN ||
+      day > PAYMENT_DAY_MAX
+    ) {
+      throw createError(
+        422,
+        `payment_day deve ser um inteiro entre ${PAYMENT_DAY_MIN} e ${PAYMENT_DAY_MAX}.`,
+      );
+    }
+  }
+};
+
+// ─── Shape ────────────────────────────────────────────────────────────────────
+
+const toProfile = (row) => ({
+  id:           Number(row.id),
+  userId:       Number(row.user_id),
+  grossSalary:  toMoney(row.gross_salary),
+  dependents:   Number(row.dependents),
+  paymentDay:   Number(row.payment_day),
+  createdAt:    row.created_at,
+  updatedAt:    row.updated_at,
+});
+
+const withCalculation = (profile) => ({
+  ...profile,
+  calculation: calculateNetSalary({
+    grossSalary: profile.grossSalary,
+    dependents:  profile.dependents,
+  }),
+});
+
+// ─── Queries ──────────────────────────────────────────────────────────────────
+
+const FIND_SQL = `
+  SELECT id, user_id, gross_salary, dependents, payment_day, created_at, updated_at
+  FROM salary_profiles
+  WHERE user_id = $1
+  LIMIT 1
+`;
+
+const INSERT_SQL = `
+  INSERT INTO salary_profiles (user_id, gross_salary, dependents, payment_day)
+  VALUES ($1, $2, $3, $4)
+  RETURNING id, user_id, gross_salary, dependents, payment_day, created_at, updated_at
+`;
+
+const UPDATE_SQL = `
+  UPDATE salary_profiles
+  SET gross_salary = $1,
+      dependents   = $2,
+      payment_day  = $3,
+      updated_at   = NOW()
+  WHERE user_id = $4
+  RETURNING id, user_id, gross_salary, dependents, payment_day, created_at, updated_at
+`;
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+export const getSalaryProfileForUser = async (userId) => {
+  const result = await dbQuery(FIND_SQL, [userId]);
+  if (!result.rows[0]) {
+    throw createError(404, "Perfil salarial não encontrado.");
+  }
+  return withCalculation(toProfile(result.rows[0]));
+};
+
+export const upsertSalaryProfileForUser = async (userId, body = {}) => {
+  const {
+    gross_salary: grossSalary,
+    dependents = 0,
+    payment_day: paymentDay = 5,
+  } = body;
+
+  validateInput({ grossSalary, dependents, paymentDay });
+
+  const gross = Number(grossSalary);
+  const dep   = Number(dependents);
+  const day   = Number(paymentDay);
+
+  const existing = await dbQuery(FIND_SQL, [userId]);
+  let result;
+
+  if (existing.rows[0]) {
+    result = await dbQuery(UPDATE_SQL, [gross, dep, day, userId]);
+  } else {
+    result = await dbQuery(INSERT_SQL, [userId, gross, dep, day]);
+  }
+
+  return withCalculation(toProfile(result.rows[0]));
+};


### PR DESCRIPTION
## What
- `GET /salary/profile` — returns user's salary profile + net salary calculation
- `PUT /salary/profile` — create or update salary profile (idempotent upsert)
- Both endpoints require JWT auth

## Why
Exposes the CLT salary engine from PR-SAL1 via REST. Profile stores `gross_salary`, `dependents`, `payment_day`; every response includes the full `calculation` object so the frontend has everything it needs without a second call.

## Notes
- `effectiveYear` is **not accepted from the client** — hard-coded 2026 in the engine (MVP rule)
- Upsert implemented as SELECT + INSERT/UPDATE (avoids pg-mem `ON CONFLICT` limitation while behaving identically in real Postgres)
- Stacks on top of PR-SAL1 (base branch)

## Validation
| Field | Rule |
|---|---|
| `gross_salary` | required, number > 0 |
| `dependents` | non-negative integer, default 0 |
| `payment_day` | integer 1–31, default 5 |

## Tests
- 20 integration tests: auth gates, 404, upsert create, upsert update, same-id invariant, calculation sanity (R\$1.621 IRRF=0), effectiveYear isolation, all validation branches, ownership isolation
- 347/347 full API suite — no regression
- ESLint: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)