### PR TITLE
feat(web): SalaryWidget — CLT net salary card on dashboard (PR-SAL3)

### DIFF
--- a/apps/web/src/components/SalaryWidget.test.tsx
+++ b/apps/web/src/components/SalaryWidget.test.tsx
@@ -1,0 +1,266 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SalaryWidget from "./SalaryWidget";
+import { salaryService, type SalaryProfile } from "../services/salary.service";
+
+vi.mock("../services/salary.service", () => ({
+  salaryService: {
+    getProfile:    vi.fn(),
+    upsertProfile: vi.fn(),
+  },
+}));
+
+// ─── Builders ─────────────────────────────────────────────────────────────────
+
+const buildProfile = (overrides: Partial<SalaryProfile> = {}): SalaryProfile => ({
+  id:          1,
+  userId:      1,
+  grossSalary: 5000,
+  dependents:  0,
+  paymentDay:  5,
+  createdAt:   "2026-02-01T00:00:00Z",
+  updatedAt:   "2026-02-01T00:00:00Z",
+  calculation: {
+    grossMonthly: 5000,
+    inssMonthly:  501.51,
+    irrfMonthly:  336.67,
+    netMonthly:   4161.82,
+    netAnnual:    49941.84,
+    taxAnnual:    10058.16,
+  },
+  ...overrides,
+});
+
+const renderWidget = () => render(<SalaryWidget />);
+
+// ─── Loading ──────────────────────────────────────────────────────────────────
+
+describe("SalaryWidget — loading", () => {
+  it("exibe estado de carregamento enquanto busca dados", () => {
+    vi.mocked(salaryService.getProfile).mockReturnValue(new Promise(() => {}));
+    renderWidget();
+    expect(screen.getByText("Carregando salário...")).toBeInTheDocument();
+  });
+});
+
+// ─── Empty state (sem perfil) ─────────────────────────────────────────────────
+
+describe("SalaryWidget — sem perfil (404)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(salaryService.getProfile).mockResolvedValue(null);
+  });
+
+  it("exibe CTA para criar perfil", async () => {
+    renderWidget();
+    await waitFor(() => {
+      expect(screen.getByText("Definir salário bruto")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Calcule seu salário líquido/)).toBeInTheDocument();
+  });
+
+  it("abre formulário ao clicar no CTA", async () => {
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText("Definir salário bruto")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("Definir salário bruto"));
+
+    expect(screen.getByLabelText("Salário bruto (R$)")).toBeInTheDocument();
+    expect(screen.getByLabelText("Dependentes")).toBeInTheDocument();
+    expect(screen.getByLabelText("Dia de pagamento")).toBeInTheDocument();
+  });
+});
+
+// ─── Com perfil ───────────────────────────────────────────────────────────────
+
+describe("SalaryWidget — com perfil", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(salaryService.getProfile).mockResolvedValue(buildProfile());
+  });
+
+  it("exibe título Salário líquido", async () => {
+    renderWidget();
+    await waitFor(() => {
+      expect(screen.getByText("Salário líquido")).toBeInTheDocument();
+    });
+  });
+
+  it("exibe líquido mensal formatado", async () => {
+    renderWidget();
+    await waitFor(() => {
+      expect(screen.getAllByText(/4\.161/).length).toBeGreaterThan(0);
+    });
+  });
+
+  it("exibe bruto, INSS e IRRF no breakdown", async () => {
+    renderWidget();
+    await waitFor(() => {
+      expect(screen.getByText("Salário bruto")).toBeInTheDocument();
+    });
+    expect(screen.getByText("(-) INSS")).toBeInTheDocument();
+    expect(screen.getByText("(-) IRRF")).toBeInTheDocument();
+  });
+
+  it("exibe botão Editar", async () => {
+    renderWidget();
+    await waitFor(() => {
+      expect(screen.getByText("Editar")).toBeInTheDocument();
+    });
+  });
+});
+
+// ─── Edição ───────────────────────────────────────────────────────────────────
+
+describe("SalaryWidget — edição", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(salaryService.getProfile).mockResolvedValue(buildProfile());
+  });
+
+  it("abre formulário ao clicar em Editar", async () => {
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText("Editar")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("Editar"));
+
+    expect(screen.getByLabelText("Salário bruto (R$)")).toBeInTheDocument();
+  });
+
+  it("formulário pré-preenchido com dados atuais", async () => {
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText("Editar")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("Editar"));
+
+    const grossInput = screen.getByLabelText("Salário bruto (R$)") as HTMLInputElement;
+    expect(grossInput.value).toBe("5000");
+  });
+
+  it("cancela edição e volta para exibição", async () => {
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText("Editar")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("Editar"));
+    await user.click(screen.getByText("Cancelar"));
+
+    expect(screen.queryByLabelText("Salário bruto (R$)")).not.toBeInTheDocument();
+    expect(screen.getByText("Editar")).toBeInTheDocument();
+  });
+
+  it("salva perfil atualizado e fecha formulário", async () => {
+    const updatedProfile = buildProfile({
+      grossSalary: 6000,
+      calculation: { ...buildProfile().calculation, grossMonthly: 6000, netMonthly: 5000 },
+    });
+    vi.mocked(salaryService.upsertProfile).mockResolvedValue(updatedProfile);
+
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText("Editar")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("Editar"));
+
+    const grossInput = screen.getByLabelText("Salário bruto (R$)");
+    await user.clear(grossInput);
+    await user.type(grossInput, "6000");
+
+    await user.click(screen.getByText("Salvar"));
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Salário bruto (R$)")).not.toBeInTheDocument();
+    });
+
+    expect(vi.mocked(salaryService.upsertProfile)).toHaveBeenCalledWith(
+      expect.objectContaining({ gross_salary: 6000 }),
+    );
+  });
+
+  it("exibe erro ao salvar com salário inválido (0)", async () => {
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText("Editar")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("Editar"));
+
+    const grossInput = screen.getByLabelText("Salário bruto (R$)");
+    await user.clear(grossInput);
+    await user.type(grossInput, "0");
+
+    await user.click(screen.getByText("Salvar"));
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Informe um salário bruto válido.");
+    expect(vi.mocked(salaryService.upsertProfile)).not.toHaveBeenCalled();
+  });
+
+  it("exibe erro de rede ao salvar", async () => {
+    vi.mocked(salaryService.upsertProfile).mockRejectedValue(new Error("Network Error"));
+
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText("Editar")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("Editar"));
+
+    await user.click(screen.getByText("Salvar"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("Erro ao salvar. Tente novamente.");
+    });
+  });
+});
+
+// ─── Criação via formulário (sem perfil) ──────────────────────────────────────
+
+describe("SalaryWidget — criação via formulário", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(salaryService.getProfile).mockResolvedValue(null);
+  });
+
+  it("cria perfil e exibe breakdown após salvar", async () => {
+    const newProfile = buildProfile({ grossSalary: 3000 });
+    vi.mocked(salaryService.upsertProfile).mockResolvedValue(newProfile);
+
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText("Definir salário bruto")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("Definir salário bruto"));
+
+    const grossInput = screen.getByLabelText("Salário bruto (R$)");
+    await user.clear(grossInput);
+    await user.type(grossInput, "3000");
+
+    await user.click(screen.getByText("Salvar"));
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Salário bruto (R$)")).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Editar")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/SalaryWidget.tsx
+++ b/apps/web/src/components/SalaryWidget.tsx
@@ -1,0 +1,299 @@
+import { useEffect, useState } from "react";
+import { salaryService, type SalaryProfile } from "../services/salary.service";
+import { formatCurrency } from "../utils/formatCurrency";
+
+// ─── Form state ───────────────────────────────────────────────────────────────
+
+interface FormState {
+  grossSalary: string;
+  dependents: string;
+  paymentDay: string;
+}
+
+const EMPTY_FORM: FormState = { grossSalary: "", dependents: "0", paymentDay: "5" };
+
+const profileToForm = (p: SalaryProfile): FormState => ({
+  grossSalary: String(p.grossSalary),
+  dependents:  String(p.dependents),
+  paymentDay:  String(p.paymentDay),
+});
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function BreakdownRow({
+  label,
+  value,
+  highlight,
+  negative,
+}: {
+  label: string;
+  value: number;
+  highlight?: boolean;
+  negative?: boolean;
+}) {
+  const valueClass = highlight
+    ? "font-semibold text-cf-text-primary"
+    : negative
+      ? "text-red-500"
+      : "text-cf-text-secondary";
+
+  return (
+    <div className="flex items-center justify-between">
+      <span className={`text-xs ${highlight ? "font-medium text-cf-text-primary" : "text-cf-text-secondary"}`}>
+        {label}
+      </span>
+      <span className={`text-xs ${valueClass}`}>{formatCurrency(value)}</span>
+    </div>
+  );
+}
+
+function ProfileView({
+  profile,
+  onEdit,
+}: {
+  profile: SalaryProfile;
+  onEdit: () => void;
+}) {
+  const { calculation } = profile;
+  return (
+    <>
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-medium text-cf-text-primary">Salário líquido</h3>
+        <button
+          type="button"
+          onClick={onEdit}
+          className="text-xs text-brand-1 hover:underline"
+        >
+          Editar
+        </button>
+      </div>
+
+      <div className="mb-3 rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
+        <p className="text-xs text-cf-text-secondary">Líquido mensal</p>
+        <p className="text-lg font-bold text-cf-text-primary">
+          {formatCurrency(calculation.netMonthly)}
+        </p>
+        <p className="text-xs text-cf-text-secondary">
+          {formatCurrency(calculation.netAnnual)} / ano
+        </p>
+      </div>
+
+      <div className="space-y-1.5">
+        <BreakdownRow label="Salário bruto"    value={calculation.grossMonthly} highlight />
+        <BreakdownRow label="(-) INSS"         value={calculation.inssMonthly}  negative />
+        <BreakdownRow label="(-) IRRF"         value={calculation.irrfMonthly}  negative />
+        <div className="my-1.5 border-t border-cf-border" />
+        <BreakdownRow label="= Líquido mensal" value={calculation.netMonthly}   highlight />
+      </div>
+    </>
+  );
+}
+
+function ProfileForm({
+  initial,
+  onSave,
+  onCancel,
+  saving,
+  error,
+}: {
+  initial: FormState;
+  onSave: (form: FormState) => void;
+  onCancel: () => void;
+  saving: boolean;
+  error: string | null;
+}) {
+  const [form, setForm] = useState<FormState>(initial);
+
+  const set = (field: keyof FormState) => (e: React.ChangeEvent<HTMLInputElement>) =>
+    setForm((prev) => ({ ...prev, [field]: e.target.value }));
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSave(form);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} noValidate>
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-medium text-cf-text-primary">Salário líquido</h3>
+      </div>
+
+      <div className="space-y-3">
+        <div>
+          <label
+            htmlFor="sw-gross"
+            className="mb-1 block text-xs font-medium text-cf-text-secondary"
+          >
+            Salário bruto (R$)
+          </label>
+          <input
+            id="sw-gross"
+            type="number"
+            min="0.01"
+            step="0.01"
+            required
+            value={form.grossSalary}
+            onChange={set("grossSalary")}
+            placeholder="Ex: 5000"
+            className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label
+              htmlFor="sw-dep"
+              className="mb-1 block text-xs font-medium text-cf-text-secondary"
+            >
+              Dependentes
+            </label>
+            <input
+              id="sw-dep"
+              type="number"
+              min="0"
+              step="1"
+              value={form.dependents}
+              onChange={set("dependents")}
+              className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary focus:outline-none focus:ring-1 focus:ring-brand-1"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="sw-day"
+              className="mb-1 block text-xs font-medium text-cf-text-secondary"
+            >
+              Dia de pagamento
+            </label>
+            <input
+              id="sw-day"
+              type="number"
+              min="1"
+              max="31"
+              step="1"
+              value={form.paymentDay}
+              onChange={set("paymentDay")}
+              className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary focus:outline-none focus:ring-1 focus:ring-brand-1"
+            />
+          </div>
+        </div>
+
+        {error ? (
+          <p role="alert" className="text-xs text-red-500">
+            {error}
+          </p>
+        ) : null}
+
+        <div className="flex gap-2 pt-1">
+          <button
+            type="submit"
+            disabled={saving}
+            className="flex-1 rounded bg-brand-1 px-3 py-1.5 text-xs font-semibold text-white hover:opacity-90 disabled:opacity-50"
+          >
+            {saving ? "Salvando..." : "Salvar"}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={saving}
+            className="flex-1 rounded border border-cf-border px-3 py-1.5 text-xs font-medium text-cf-text-secondary hover:bg-cf-bg-subtle disabled:opacity-50"
+          >
+            Cancelar
+          </button>
+        </div>
+      </div>
+    </form>
+  );
+}
+
+// ─── Main widget ──────────────────────────────────────────────────────────────
+
+const SalaryWidget = (): JSX.Element | null => {
+  const [profile, setProfile] = useState<SalaryProfile | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    salaryService
+      .getProfile()
+      .then(setProfile)
+      .catch(() => setProfile(null))
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  const handleSave = async (form: FormState) => {
+    const gross = Number(form.grossSalary);
+    const dep   = Number(form.dependents);
+    const day   = Number(form.paymentDay);
+
+    if (!gross || gross <= 0) {
+      setSaveError("Informe um salário bruto válido.");
+      return;
+    }
+
+    setSaving(true);
+    setSaveError(null);
+
+    try {
+      const updated = await salaryService.upsertProfile({
+        gross_salary: gross,
+        dependents:   dep,
+        payment_day:  day,
+      });
+      setProfile(updated);
+      setEditing(false);
+    } catch {
+      setSaveError("Erro ao salvar. Tente novamente.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setEditing(false);
+    setSaveError(null);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="rounded border border-cf-border bg-cf-surface p-4">
+        <p className="text-xs text-cf-text-secondary">Carregando salário...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded border border-cf-border bg-cf-surface p-4">
+      {editing || !profile ? (
+        <ProfileForm
+          initial={profile ? profileToForm(profile) : EMPTY_FORM}
+          onSave={handleSave}
+          onCancel={handleCancel}
+          saving={saving}
+          error={saveError}
+        />
+      ) : (
+        <ProfileView profile={profile} onEdit={() => setEditing(true)} />
+      )}
+
+      {!profile && !editing ? (
+        <div className="text-center">
+          <p className="mb-2 text-xs text-cf-text-secondary">
+            Calcule seu salário líquido (CLT) com INSS e IRRF 2026.
+          </p>
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="rounded bg-brand-1 px-4 py-1.5 text-xs font-semibold text-white hover:opacity-90"
+          >
+            Definir salário bruto
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default SalaryWidget;

--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -8,6 +8,7 @@ import { analyticsService } from "../services/analytics.service";
 import { forecastService } from "../services/forecast.service";
 import { profileService } from "../services/profile.service";
 import { billsService } from "../services/bills.service";
+import { salaryService } from "../services/salary.service";
 
 vi.mock("../hooks/useTheme", () => ({
   useTheme: () => ({ theme: "light", toggleTheme: vi.fn() }),
@@ -66,6 +67,13 @@ vi.mock("../services/profile.service", () => ({
 vi.mock("../services/bills.service", () => ({
   billsService: {
     getSummary: vi.fn(),
+  },
+}));
+
+vi.mock("../services/salary.service", () => ({
+  salaryService: {
+    getProfile:    vi.fn(),
+    upsertProfile: vi.fn(),
   },
 }));
 
@@ -297,6 +305,7 @@ describe("App", () => {
       overdueCount: 0,
       overdueTotal: 0,
     });
+    salaryService.getProfile.mockResolvedValue(null);
     transactionsService.exportCsv.mockResolvedValue({
       blob: new Blob(["id,type\n1,Entrada"], { type: "text/csv;charset=utf-8" }),
       fileName: "transacoes.csv",

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -5,6 +5,7 @@ import ImportHistoryModal from "../components/ImportHistoryModal";
 import UpgradeModal from "../components/UpgradeModal";
 import ForecastCard from "../components/ForecastCard";
 import BillsSummaryWidget from "../components/BillsSummaryWidget";
+import SalaryWidget from "../components/SalaryWidget";
 import TransactionList from "../components/TransactionList";
 import {
   transactionsService,
@@ -2125,6 +2126,8 @@ const App = ({
         <ForecastCard onOpenProfileSettings={onOpenProfileSettings} />
 
         <BillsSummaryWidget onOpenBills={handleOpenBills} />
+
+        <SalaryWidget />
 
         <div className="space-y-6">
           <section ref={summarySectionRef}>

--- a/apps/web/src/services/salary.service.ts
+++ b/apps/web/src/services/salary.service.ts
@@ -1,0 +1,73 @@
+import { api } from "./api";
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+export interface SalaryCalculation {
+  grossMonthly: number;
+  inssMonthly: number;
+  irrfMonthly: number;
+  netMonthly: number;
+  netAnnual: number;
+  taxAnnual: number;
+}
+
+export interface SalaryProfile {
+  id: number;
+  userId: number;
+  grossSalary: number;
+  dependents: number;
+  paymentDay: number;
+  createdAt: string;
+  updatedAt: string;
+  calculation: SalaryCalculation;
+}
+
+export interface UpsertSalaryProfilePayload {
+  gross_salary: number;
+  dependents?: number;
+  payment_day?: number;
+}
+
+// ─── Normalization ────────────────────────────────────────────────────────────
+
+const normalizeCalculation = (raw: Record<string, unknown>): SalaryCalculation => ({
+  grossMonthly: Number(raw.grossMonthly) || 0,
+  inssMonthly:  Number(raw.inssMonthly)  || 0,
+  irrfMonthly:  Number(raw.irrfMonthly)  || 0,
+  netMonthly:   Number(raw.netMonthly)   || 0,
+  netAnnual:    Number(raw.netAnnual)    || 0,
+  taxAnnual:    Number(raw.taxAnnual)    || 0,
+});
+
+const normalizeProfile = (raw: Record<string, unknown>): SalaryProfile => ({
+  id:          Number(raw.id) || 0,
+  userId:      Number(raw.userId) || 0,
+  grossSalary: Number(raw.grossSalary) || 0,
+  dependents:  Number(raw.dependents) || 0,
+  paymentDay:  Number(raw.paymentDay) || 5,
+  createdAt:   typeof raw.createdAt === "string" ? raw.createdAt : "",
+  updatedAt:   typeof raw.updatedAt === "string" ? raw.updatedAt : "",
+  calculation: normalizeCalculation(
+    (raw.calculation as Record<string, unknown>) ?? {},
+  ),
+});
+
+// ─── Service ──────────────────────────────────────────────────────────────────
+
+export const salaryService = {
+  getProfile: async (): Promise<SalaryProfile | null> => {
+    try {
+      const { data } = await api.get("/salary/profile");
+      return normalizeProfile(data as Record<string, unknown>);
+    } catch (err: unknown) {
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      if (status === 404) return null;
+      throw err;
+    }
+  },
+
+  upsertProfile: async (payload: UpsertSalaryProfilePayload): Promise<SalaryProfile> => {
+    const { data } = await api.put("/salary/profile", payload);
+    return normalizeProfile(data as Record<string, unknown>);
+  },
+};


### PR DESCRIPTION
## What
- `salary.service.ts` — `getProfile()` (404 → null) + `upsertProfile()`
- `SalaryWidget.tsx` — self-contained dashboard card with 3 states:
  - **Loading** → skeleton line
  - **No profile** → descriptive CTA + "Definir salário bruto" button
  - **Has profile** → breakdown (bruto / −INSS / −IRRF / = líquido mensal + líquido anual) + "Editar" link
  - **Editing** → inline form (gross_salary, dependents, payment_day) with client-side validation
- `App.tsx` — `<SalaryWidget />` added below `<BillsSummaryWidget />`
- `App.test.jsx` — `salaryService` mock added to prevent unmocked async from blocking existing tests

## Why
Closes the loop between the CLT engine (SAL1) and the API endpoints (SAL2): the user now sees their net salary breakdown directly on the dashboard without navigating anywhere.

## Notes
- `effectiveYear` **never sent** to the API — backend hard-codes 2026 (MVP rule)  
- Widget is fully self-contained: fetches its own data, owns its loading/error/form state
- Stacks on SAL2 (base branch)

## Tests
- 14 component tests (SalaryWidget): loading, empty state CTA, profile view, edit flow, save/cancel, error states, create from scratch
- 160/160 full web suite — no regression  
- ESLint: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)