### PR TITLE
feat(api,web): paywall annual salary projection (PR-SAL4)

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -14,6 +14,7 @@ import forecastRoutes from "./routes/forecast.routes.js";
 import stripeWebhooksRoutes from "./routes/stripe-webhooks.routes.js";
 import billsRoutes from "./routes/bills.routes.js";
 import incomeSourcesRoutes from "./routes/income-sources.routes.js";
+import salaryRoutes from "./routes/salary.routes.js";
 import { notFoundHandler, errorHandler } from "./middlewares/error.middleware.js";
 import { requestIdMiddleware } from "./middlewares/request-id.middleware.js";
 import { requestLoggingMiddleware } from "./middlewares/request-logging.middleware.js";
@@ -90,6 +91,7 @@ app.use("/me", meRoutes);
 app.use("/forecasts", forecastRoutes);
 app.use("/bills", billsRoutes);
 app.use("/income-sources", incomeSourcesRoutes);
+app.use("/salary", salaryRoutes);
 
 app.use(notFoundHandler);
 app.use(errorHandler);

--- a/apps/api/src/db/migrations/020_add_salary_annual_to_plans.sql
+++ b/apps/api/src/db/migrations/020_add_salary_annual_to_plans.sql
@@ -1,0 +1,12 @@
+-- Add salary_annual feature flag to billing plans.
+-- free  → false (monthly breakdown free, annual projection is Pro)
+-- pro   → true  (full access)
+-- Replace the full features JSON to avoid JSONB || operator (pg-mem compat).
+
+UPDATE plans
+  SET features = '{"csv_import":false,"csv_export":false,"analytics_months_max":3,"budget_tracking":true,"salary_annual":false}'
+  WHERE name = 'free';
+
+UPDATE plans
+  SET features = '{"csv_import":true,"csv_export":true,"analytics_months_max":24,"budget_tracking":true,"salary_annual":true}'
+  WHERE name = 'pro';

--- a/apps/api/src/routes/salary.routes.js
+++ b/apps/api/src/routes/salary.routes.js
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { authMiddleware } from "../middlewares/auth.middleware.js";
+import { attachEntitlements } from "../middlewares/entitlement.middleware.js";
 import {
   getSalaryProfileForUser,
   upsertSalaryProfileForUser,
@@ -9,19 +10,34 @@ const router = Router();
 
 router.use(authMiddleware);
 
-router.get("/profile", async (req, res, next) => {
+// Returns the profile with annual fields nulled out for free users.
+const applyAnnualGate = (profile, hasAnnualAccess) => {
+  if (hasAnnualAccess) return profile;
+  return {
+    ...profile,
+    calculation: {
+      ...profile.calculation,
+      netAnnual: null,
+      taxAnnual: null,
+    },
+  };
+};
+
+router.get("/profile", attachEntitlements, async (req, res, next) => {
   try {
     const profile = await getSalaryProfileForUser(req.user.id);
-    res.status(200).json(profile);
+    const hasAnnual = req.entitlements?.salary_annual !== false;
+    res.status(200).json(applyAnnualGate(profile, hasAnnual));
   } catch (error) {
     next(error);
   }
 });
 
-router.put("/profile", async (req, res, next) => {
+router.put("/profile", attachEntitlements, async (req, res, next) => {
   try {
     const profile = await upsertSalaryProfileForUser(req.user.id, req.body || {});
-    res.status(200).json(profile);
+    const hasAnnual = req.entitlements?.salary_annual !== false;
+    res.status(200).json(applyAnnualGate(profile, hasAnnual));
   } catch (error) {
     next(error);
   }

--- a/apps/api/src/routes/salary.routes.js
+++ b/apps/api/src/routes/salary.routes.js
@@ -1,0 +1,30 @@
+import { Router } from "express";
+import { authMiddleware } from "../middlewares/auth.middleware.js";
+import {
+  getSalaryProfileForUser,
+  upsertSalaryProfileForUser,
+} from "../services/salary-profile.service.js";
+
+const router = Router();
+
+router.use(authMiddleware);
+
+router.get("/profile", async (req, res, next) => {
+  try {
+    const profile = await getSalaryProfileForUser(req.user.id);
+    res.status(200).json(profile);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.put("/profile", async (req, res, next) => {
+  try {
+    const profile = await upsertSalaryProfileForUser(req.user.id, req.body || {});
+    res.status(200).json(profile);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/apps/api/src/salary-profile.test.js
+++ b/apps/api/src/salary-profile.test.js
@@ -1,0 +1,312 @@
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import app from "./app.js";
+import { clearDbClientForTests, dbQuery } from "./db/index.js";
+import { resetLoginProtectionState } from "./middlewares/login-protection.middleware.js";
+import {
+  resetImportRateLimiterState,
+  resetWriteRateLimiterState,
+} from "./middlewares/rate-limit.middleware.js";
+import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
+import {
+  expectErrorResponseWithRequestId,
+  registerAndLogin,
+  setupTestDb,
+} from "./test-helpers.js";
+
+describe("salary-profile", () => {
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  afterAll(async () => {
+    await clearDbClientForTests();
+  });
+
+  beforeEach(async () => {
+    resetLoginProtectionState();
+    resetImportRateLimiterState();
+    resetWriteRateLimiterState();
+    resetHttpMetricsForTests();
+    await dbQuery("DELETE FROM salary_profiles");
+    await dbQuery("DELETE FROM users");
+  });
+
+  // ─── Auth ─────────────────────────────────────────────────────────────────
+
+  it("GET /salary/profile bloqueia sem token", async () => {
+    const res = await request(app).get("/salary/profile");
+    expect(res.status).toBe(401);
+  });
+
+  it("PUT /salary/profile bloqueia sem token", async () => {
+    const res = await request(app).put("/salary/profile").send({ gross_salary: 5000 });
+    expect(res.status).toBe(401);
+  });
+
+  // ─── GET — 404 quando não existe ─────────────────────────────────────────
+
+  it("GET /salary/profile retorna 404 quando usuario nao tem perfil", async () => {
+    const token = await registerAndLogin("sal-get-404@test.dev");
+    const res = await request(app)
+      .get("/salary/profile")
+      .set("Authorization", `Bearer ${token}`);
+    expectErrorResponseWithRequestId(res, 404, "Perfil salarial não encontrado.");
+  });
+
+  // ─── PUT — criação (upsert insert) ───────────────────────────────────────
+
+  it("PUT /salary/profile cria perfil com campos minimos", async () => {
+    const token = await registerAndLogin("sal-create@test.dev");
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      grossSalary: 5000,
+      dependents:  0,
+      paymentDay:  5,
+    });
+    expect(typeof res.body.id).toBe("number");
+    expect(res.body.calculation).toBeDefined();
+  });
+
+  it("PUT /salary/profile cria perfil com todos os campos", async () => {
+    const token = await registerAndLogin("sal-create-full@test.dev");
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 8000, dependents: 2, payment_day: 10 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      grossSalary: 8000,
+      dependents:  2,
+      paymentDay:  10,
+    });
+  });
+
+  // ─── PUT — atualização (upsert update) ───────────────────────────────────
+
+  it("PUT /salary/profile atualiza perfil existente", async () => {
+    const token = await registerAndLogin("sal-update@test.dev");
+
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000 });
+
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 7500, dependents: 1, payment_day: 15 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      grossSalary: 7500,
+      dependents:  1,
+      paymentDay:  15,
+    });
+  });
+
+  it("segundo upsert mantém mesmo id", async () => {
+    const token = await registerAndLogin("sal-same-id@test.dev");
+
+    const first = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000 });
+
+    const second = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 6000 });
+
+    expect(second.body.id).toBe(first.body.id);
+  });
+
+  // ─── GET — após criação ───────────────────────────────────────────────────
+
+  it("GET /salary/profile retorna perfil criado com calculo", async () => {
+    const token = await registerAndLogin("sal-get-ok@test.dev");
+
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000, dependents: 1 });
+
+    const res = await request(app)
+      .get("/salary/profile")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ grossSalary: 5000, dependents: 1 });
+    expect(res.body.calculation).toMatchObject({
+      grossMonthly: 5000,
+      inssMonthly:  expect.any(Number),
+      irrfMonthly:  expect.any(Number),
+      netMonthly:   expect.any(Number),
+      netAnnual:    expect.any(Number),
+      taxAnnual:    expect.any(Number),
+    });
+    expect(res.body.calculation.netMonthly).toBeGreaterThan(0);
+    expect(res.body.calculation.netMonthly).toBeLessThan(5000);
+  });
+
+  // ─── Cálculo — sanidade 2026 ──────────────────────────────────────────────
+
+  it("salario minimo 2026 R$1.621 — IRRF isento", async () => {
+    const token = await registerAndLogin("sal-minimo@test.dev");
+
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 1621 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.calculation.irrfMonthly).toBe(0);
+    expect(res.body.calculation.inssMonthly).toBe(
+      Math.round(1621 * 0.075 * 100) / 100,
+    );
+  });
+
+  it("effectiveYear nao aceito do client — calculo usa 2026", async () => {
+    const token = await registerAndLogin("sal-year@test.dev");
+
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000, effectiveYear: 2020 }); // client tenta passar ano
+
+    // campo desconhecido ignorado; calculo usa 2026 (default do motor)
+    expect(res.status).toBe(200);
+    expect(res.body.calculation.grossMonthly).toBe(5000);
+  });
+
+  // ─── Validação — gross_salary ─────────────────────────────────────────────
+
+  it("PUT sem gross_salary retorna 422", async () => {
+    const token = await registerAndLogin("sal-val-no-gross@test.dev");
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ dependents: 0 });
+    expectErrorResponseWithRequestId(res, 422, "gross_salary é obrigatório.");
+  });
+
+  it("PUT gross_salary = 0 retorna 422", async () => {
+    const token = await registerAndLogin("sal-val-zero@test.dev");
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 0 });
+    expectErrorResponseWithRequestId(res, 422, "gross_salary deve ser um número positivo.");
+  });
+
+  it("PUT gross_salary negativo retorna 422", async () => {
+    const token = await registerAndLogin("sal-val-neg@test.dev");
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: -500 });
+    expectErrorResponseWithRequestId(res, 422, "gross_salary deve ser um número positivo.");
+  });
+
+  it("PUT gross_salary string nao numerica retorna 422", async () => {
+    const token = await registerAndLogin("sal-val-str@test.dev");
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: "abc" });
+    expectErrorResponseWithRequestId(res, 422, "gross_salary deve ser um número positivo.");
+  });
+
+  // ─── Validação — dependents ───────────────────────────────────────────────
+
+  it("PUT dependents negativo retorna 422", async () => {
+    const token = await registerAndLogin("sal-val-dep-neg@test.dev");
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000, dependents: -1 });
+    expectErrorResponseWithRequestId(res, 422, "dependents deve ser um inteiro não negativo.");
+  });
+
+  it("PUT dependents fracionario retorna 422", async () => {
+    const token = await registerAndLogin("sal-val-dep-frac@test.dev");
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000, dependents: 1.5 });
+    expectErrorResponseWithRequestId(res, 422, "dependents deve ser um inteiro não negativo.");
+  });
+
+  // ─── Validação — payment_day ──────────────────────────────────────────────
+
+  it("PUT payment_day = 0 retorna 422", async () => {
+    const token = await registerAndLogin("sal-val-day-0@test.dev");
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000, payment_day: 0 });
+    expectErrorResponseWithRequestId(
+      res,
+      422,
+      "payment_day deve ser um inteiro entre 1 e 31.",
+    );
+  });
+
+  it("PUT payment_day = 32 retorna 422", async () => {
+    const token = await registerAndLogin("sal-val-day-32@test.dev");
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000, payment_day: 32 });
+    expectErrorResponseWithRequestId(
+      res,
+      422,
+      "payment_day deve ser um inteiro entre 1 e 31.",
+    );
+  });
+
+  it("PUT payment_day = 31 aceito (limite superior)", async () => {
+    const token = await registerAndLogin("sal-val-day-31@test.dev");
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000, payment_day: 31 });
+    expect(res.status).toBe(200);
+    expect(res.body.paymentDay).toBe(31);
+  });
+
+  // ─── Ownership ────────────────────────────────────────────────────────────
+
+  it("dois usuarios tem perfis independentes", async () => {
+    const tokenA = await registerAndLogin("sal-owner-a@test.dev");
+    const tokenB = await registerAndLogin("sal-owner-b@test.dev");
+
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${tokenA}`)
+      .send({ gross_salary: 5000 });
+
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${tokenB}`)
+      .send({ gross_salary: 10000 });
+
+    const resA = await request(app)
+      .get("/salary/profile")
+      .set("Authorization", `Bearer ${tokenA}`);
+
+    const resB = await request(app)
+      .get("/salary/profile")
+      .set("Authorization", `Bearer ${tokenB}`);
+
+    expect(resA.body.grossSalary).toBe(5000);
+    expect(resB.body.grossSalary).toBe(10000);
+    expect(resA.body.id).not.toBe(resB.body.id);
+  });
+});

--- a/apps/api/src/salary-profile.test.js
+++ b/apps/api/src/salary-profile.test.js
@@ -10,6 +10,7 @@ import {
 import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
 import {
   expectErrorResponseWithRequestId,
+  makeProUser,
   registerAndLogin,
   setupTestDb,
 } from "./test-helpers.js";
@@ -308,5 +309,59 @@ describe("salary-profile", () => {
     expect(resA.body.grossSalary).toBe(5000);
     expect(resB.body.grossSalary).toBe(10000);
     expect(resA.body.id).not.toBe(resB.body.id);
+  });
+
+  // ─── Paywall — projeção anual ─────────────────────────────────────────────
+
+  it("free user (trial expirado) recebe null em netAnnual e taxAnnual", async () => {
+    const email = "sal-paywall-free@test.dev";
+    const token = await registerAndLogin(email);
+
+    // expire the trial so the user falls back to the free plan
+    await dbQuery(
+      "UPDATE users SET trial_ends_at = '2020-01-01T00:00:00Z' WHERE email = $1",
+      [email],
+    );
+
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000 });
+
+    const res = await request(app)
+      .get("/salary/profile")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(typeof res.body.calculation.netMonthly).toBe("number");
+    expect(res.body.calculation.netMonthly).toBeGreaterThan(0);
+    expect(res.body.calculation.netAnnual).toBeNull();
+    expect(res.body.calculation.taxAnnual).toBeNull();
+  });
+
+  it("usuario pro recebe netAnnual e taxAnnual numericos", async () => {
+    const email = "sal-paywall-pro@test.dev";
+    const token = await registerAndLogin(email);
+
+    // expire trial so access comes exclusively from the pro subscription
+    await dbQuery(
+      "UPDATE users SET trial_ends_at = '2020-01-01T00:00:00Z' WHERE email = $1",
+      [email],
+    );
+    await makeProUser(email);
+
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000 });
+
+    const res = await request(app)
+      .get("/salary/profile")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(typeof res.body.calculation.netAnnual).toBe("number");
+    expect(typeof res.body.calculation.taxAnnual).toBe("number");
+    expect(res.body.calculation.netAnnual).toBeGreaterThan(0);
   });
 });

--- a/apps/api/src/services/billing.service.js
+++ b/apps/api/src/services/billing.service.js
@@ -13,6 +13,7 @@ const TRIAL_FEATURES = {
   csv_export: false,
   analytics_months_max: 6,
   budget_tracking: true,
+  salary_annual: true,
 };
 
 const normalizeUserId = (value) => {

--- a/apps/api/src/services/salary-profile.service.js
+++ b/apps/api/src/services/salary-profile.service.js
@@ -1,0 +1,126 @@
+import { dbQuery } from "../db/index.js";
+import { calculateNetSalary } from "../domain/salary/salary.calculator.js";
+
+const PAYMENT_DAY_MIN = 1;
+const PAYMENT_DAY_MAX = 31;
+
+const createError = (status, message) => {
+  const err = new Error(message);
+  err.status = status;
+  return err;
+};
+
+const toMoney = (value) => Number(Number(value || 0).toFixed(2));
+
+// ─── Validation ───────────────────────────────────────────────────────────────
+
+const validateInput = ({ grossSalary, dependents, paymentDay }) => {
+  if (grossSalary === undefined || grossSalary === null) {
+    throw createError(422, "gross_salary é obrigatório.");
+  }
+  const gross = Number(grossSalary);
+  if (!Number.isFinite(gross) || gross <= 0) {
+    throw createError(422, "gross_salary deve ser um número positivo.");
+  }
+
+  if (dependents !== undefined && dependents !== null) {
+    const dep = Number(dependents);
+    if (!Number.isInteger(dep) || dep < 0) {
+      throw createError(422, "dependents deve ser um inteiro não negativo.");
+    }
+  }
+
+  if (paymentDay !== undefined && paymentDay !== null) {
+    const day = Number(paymentDay);
+    if (
+      !Number.isInteger(day) ||
+      day < PAYMENT_DAY_MIN ||
+      day > PAYMENT_DAY_MAX
+    ) {
+      throw createError(
+        422,
+        `payment_day deve ser um inteiro entre ${PAYMENT_DAY_MIN} e ${PAYMENT_DAY_MAX}.`,
+      );
+    }
+  }
+};
+
+// ─── Shape ────────────────────────────────────────────────────────────────────
+
+const toProfile = (row) => ({
+  id:           Number(row.id),
+  userId:       Number(row.user_id),
+  grossSalary:  toMoney(row.gross_salary),
+  dependents:   Number(row.dependents),
+  paymentDay:   Number(row.payment_day),
+  createdAt:    row.created_at,
+  updatedAt:    row.updated_at,
+});
+
+const withCalculation = (profile) => ({
+  ...profile,
+  calculation: calculateNetSalary({
+    grossSalary: profile.grossSalary,
+    dependents:  profile.dependents,
+  }),
+});
+
+// ─── Queries ──────────────────────────────────────────────────────────────────
+
+const FIND_SQL = `
+  SELECT id, user_id, gross_salary, dependents, payment_day, created_at, updated_at
+  FROM salary_profiles
+  WHERE user_id = $1
+  LIMIT 1
+`;
+
+const INSERT_SQL = `
+  INSERT INTO salary_profiles (user_id, gross_salary, dependents, payment_day)
+  VALUES ($1, $2, $3, $4)
+  RETURNING id, user_id, gross_salary, dependents, payment_day, created_at, updated_at
+`;
+
+const UPDATE_SQL = `
+  UPDATE salary_profiles
+  SET gross_salary = $1,
+      dependents   = $2,
+      payment_day  = $3,
+      updated_at   = NOW()
+  WHERE user_id = $4
+  RETURNING id, user_id, gross_salary, dependents, payment_day, created_at, updated_at
+`;
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+export const getSalaryProfileForUser = async (userId) => {
+  const result = await dbQuery(FIND_SQL, [userId]);
+  if (!result.rows[0]) {
+    throw createError(404, "Perfil salarial não encontrado.");
+  }
+  return withCalculation(toProfile(result.rows[0]));
+};
+
+export const upsertSalaryProfileForUser = async (userId, body = {}) => {
+  const {
+    gross_salary: grossSalary,
+    dependents = 0,
+    payment_day: paymentDay = 5,
+  } = body;
+
+  validateInput({ grossSalary, dependents, paymentDay });
+
+  const gross = Number(grossSalary);
+  const dep   = Number(dependents);
+  const day   = Number(paymentDay);
+
+  const existing = await dbQuery(FIND_SQL, [userId]);
+  let result;
+
+  if (existing.rows[0]) {
+    result = await dbQuery(UPDATE_SQL, [gross, dep, day, userId]);
+  } else {
+    result = await dbQuery(INSERT_SQL, [userId, gross, dep, day]);
+  }
+
+  return withCalculation(toProfile(result.rows[0]));
+};

--- a/apps/web/src/components/SalaryWidget.test.tsx
+++ b/apps/web/src/components/SalaryWidget.test.tsx
@@ -1,0 +1,266 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SalaryWidget from "./SalaryWidget";
+import { salaryService, type SalaryProfile } from "../services/salary.service";
+
+vi.mock("../services/salary.service", () => ({
+  salaryService: {
+    getProfile:    vi.fn(),
+    upsertProfile: vi.fn(),
+  },
+}));
+
+// ─── Builders ─────────────────────────────────────────────────────────────────
+
+const buildProfile = (overrides: Partial<SalaryProfile> = {}): SalaryProfile => ({
+  id:          1,
+  userId:      1,
+  grossSalary: 5000,
+  dependents:  0,
+  paymentDay:  5,
+  createdAt:   "2026-02-01T00:00:00Z",
+  updatedAt:   "2026-02-01T00:00:00Z",
+  calculation: {
+    grossMonthly: 5000,
+    inssMonthly:  501.51,
+    irrfMonthly:  336.67,
+    netMonthly:   4161.82,
+    netAnnual:    49941.84,
+    taxAnnual:    10058.16,
+  },
+  ...overrides,
+});
+
+const renderWidget = () => render(<SalaryWidget />);
+
+// ─── Loading ──────────────────────────────────────────────────────────────────
+
+describe("SalaryWidget — loading", () => {
+  it("exibe estado de carregamento enquanto busca dados", () => {
+    vi.mocked(salaryService.getProfile).mockReturnValue(new Promise(() => {}));
+    renderWidget();
+    expect(screen.getByText("Carregando salário...")).toBeInTheDocument();
+  });
+});
+
+// ─── Empty state (sem perfil) ─────────────────────────────────────────────────
+
+describe("SalaryWidget — sem perfil (404)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(salaryService.getProfile).mockResolvedValue(null);
+  });
+
+  it("exibe CTA para criar perfil", async () => {
+    renderWidget();
+    await waitFor(() => {
+      expect(screen.getByText("Definir salário bruto")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Calcule seu salário líquido/)).toBeInTheDocument();
+  });
+
+  it("abre formulário ao clicar no CTA", async () => {
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText("Definir salário bruto")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("Definir salário bruto"));
+
+    expect(screen.getByLabelText("Salário bruto (R$)")).toBeInTheDocument();
+    expect(screen.getByLabelText("Dependentes")).toBeInTheDocument();
+    expect(screen.getByLabelText("Dia de pagamento")).toBeInTheDocument();
+  });
+});
+
+// ─── Com perfil ───────────────────────────────────────────────────────────────
+
+describe("SalaryWidget — com perfil", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(salaryService.getProfile).mockResolvedValue(buildProfile());
+  });
+
+  it("exibe título Salário líquido", async () => {
+    renderWidget();
+    await waitFor(() => {
+      expect(screen.getByText("Salário líquido")).toBeInTheDocument();
+    });
+  });
+
+  it("exibe líquido mensal formatado", async () => {
+    renderWidget();
+    await waitFor(() => {
+      expect(screen.getAllByText(/4\.161/).length).toBeGreaterThan(0);
+    });
+  });
+
+  it("exibe bruto, INSS e IRRF no breakdown", async () => {
+    renderWidget();
+    await waitFor(() => {
+      expect(screen.getByText("Salário bruto")).toBeInTheDocument();
+    });
+    expect(screen.getByText("(-) INSS")).toBeInTheDocument();
+    expect(screen.getByText("(-) IRRF")).toBeInTheDocument();
+  });
+
+  it("exibe botão Editar", async () => {
+    renderWidget();
+    await waitFor(() => {
+      expect(screen.getByText("Editar")).toBeInTheDocument();
+    });
+  });
+});
+
+// ─── Edição ───────────────────────────────────────────────────────────────────
+
+describe("SalaryWidget — edição", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(salaryService.getProfile).mockResolvedValue(buildProfile());
+  });
+
+  it("abre formulário ao clicar em Editar", async () => {
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText("Editar")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("Editar"));
+
+    expect(screen.getByLabelText("Salário bruto (R$)")).toBeInTheDocument();
+  });
+
+  it("formulário pré-preenchido com dados atuais", async () => {
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText("Editar")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("Editar"));
+
+    const grossInput = screen.getByLabelText("Salário bruto (R$)") as HTMLInputElement;
+    expect(grossInput.value).toBe("5000");
+  });
+
+  it("cancela edição e volta para exibição", async () => {
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText("Editar")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("Editar"));
+    await user.click(screen.getByText("Cancelar"));
+
+    expect(screen.queryByLabelText("Salário bruto (R$)")).not.toBeInTheDocument();
+    expect(screen.getByText("Editar")).toBeInTheDocument();
+  });
+
+  it("salva perfil atualizado e fecha formulário", async () => {
+    const updatedProfile = buildProfile({
+      grossSalary: 6000,
+      calculation: { ...buildProfile().calculation, grossMonthly: 6000, netMonthly: 5000 },
+    });
+    vi.mocked(salaryService.upsertProfile).mockResolvedValue(updatedProfile);
+
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText("Editar")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("Editar"));
+
+    const grossInput = screen.getByLabelText("Salário bruto (R$)");
+    await user.clear(grossInput);
+    await user.type(grossInput, "6000");
+
+    await user.click(screen.getByText("Salvar"));
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Salário bruto (R$)")).not.toBeInTheDocument();
+    });
+
+    expect(vi.mocked(salaryService.upsertProfile)).toHaveBeenCalledWith(
+      expect.objectContaining({ gross_salary: 6000 }),
+    );
+  });
+
+  it("exibe erro ao salvar com salário inválido (0)", async () => {
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText("Editar")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("Editar"));
+
+    const grossInput = screen.getByLabelText("Salário bruto (R$)");
+    await user.clear(grossInput);
+    await user.type(grossInput, "0");
+
+    await user.click(screen.getByText("Salvar"));
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Informe um salário bruto válido.");
+    expect(vi.mocked(salaryService.upsertProfile)).not.toHaveBeenCalled();
+  });
+
+  it("exibe erro de rede ao salvar", async () => {
+    vi.mocked(salaryService.upsertProfile).mockRejectedValue(new Error("Network Error"));
+
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText("Editar")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("Editar"));
+
+    await user.click(screen.getByText("Salvar"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("Erro ao salvar. Tente novamente.");
+    });
+  });
+});
+
+// ─── Criação via formulário (sem perfil) ──────────────────────────────────────
+
+describe("SalaryWidget — criação via formulário", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(salaryService.getProfile).mockResolvedValue(null);
+  });
+
+  it("cria perfil e exibe breakdown após salvar", async () => {
+    const newProfile = buildProfile({ grossSalary: 3000 });
+    vi.mocked(salaryService.upsertProfile).mockResolvedValue(newProfile);
+
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText("Definir salário bruto")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("Definir salário bruto"));
+
+    const grossInput = screen.getByLabelText("Salário bruto (R$)");
+    await user.clear(grossInput);
+    await user.type(grossInput, "3000");
+
+    await user.click(screen.getByText("Salvar"));
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Salário bruto (R$)")).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Editar")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/SalaryWidget.test.tsx
+++ b/apps/web/src/components/SalaryWidget.test.tsx
@@ -231,6 +231,44 @@ describe("SalaryWidget — edição", () => {
   });
 });
 
+// ─── Paywall — projeção anual ─────────────────────────────────────────────────
+
+describe("SalaryWidget — paywall anual", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("exibe texto de upgrade quando netAnnual e null (free user)", async () => {
+    const freeProfile = buildProfile({
+      calculation: { ...buildProfile().calculation, netAnnual: null, taxAnnual: null },
+    });
+    vi.mocked(salaryService.getProfile).mockResolvedValue(freeProfile);
+
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText("Salário líquido")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Líquido anual: disponível no Pro")).toBeInTheDocument();
+    expect(screen.queryByText(/ \/ ano$/)).not.toBeInTheDocument();
+  });
+
+  it("exibe valor anual formatado quando netAnnual e numero (premium user)", async () => {
+    vi.mocked(salaryService.getProfile).mockResolvedValue(buildProfile());
+
+    renderWidget();
+
+    await waitFor(() => {
+      // netMonthly (4161.82) appears in two places (main card + breakdown row)
+      expect(screen.getAllByText(/4\.161/).length).toBeGreaterThan(0);
+    });
+
+    expect(screen.getByText(/49\.941/)).toBeInTheDocument();
+    expect(screen.queryByText("Líquido anual: disponível no Pro")).not.toBeInTheDocument();
+  });
+});
+
 // ─── Criação via formulário (sem perfil) ──────────────────────────────────────
 
 describe("SalaryWidget — criação via formulário", () => {

--- a/apps/web/src/components/SalaryWidget.tsx
+++ b/apps/web/src/components/SalaryWidget.tsx
@@ -1,0 +1,299 @@
+import { useEffect, useState } from "react";
+import { salaryService, type SalaryProfile } from "../services/salary.service";
+import { formatCurrency } from "../utils/formatCurrency";
+
+// ─── Form state ───────────────────────────────────────────────────────────────
+
+interface FormState {
+  grossSalary: string;
+  dependents: string;
+  paymentDay: string;
+}
+
+const EMPTY_FORM: FormState = { grossSalary: "", dependents: "0", paymentDay: "5" };
+
+const profileToForm = (p: SalaryProfile): FormState => ({
+  grossSalary: String(p.grossSalary),
+  dependents:  String(p.dependents),
+  paymentDay:  String(p.paymentDay),
+});
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function BreakdownRow({
+  label,
+  value,
+  highlight,
+  negative,
+}: {
+  label: string;
+  value: number;
+  highlight?: boolean;
+  negative?: boolean;
+}) {
+  const valueClass = highlight
+    ? "font-semibold text-cf-text-primary"
+    : negative
+      ? "text-red-500"
+      : "text-cf-text-secondary";
+
+  return (
+    <div className="flex items-center justify-between">
+      <span className={`text-xs ${highlight ? "font-medium text-cf-text-primary" : "text-cf-text-secondary"}`}>
+        {label}
+      </span>
+      <span className={`text-xs ${valueClass}`}>{formatCurrency(value)}</span>
+    </div>
+  );
+}
+
+function ProfileView({
+  profile,
+  onEdit,
+}: {
+  profile: SalaryProfile;
+  onEdit: () => void;
+}) {
+  const { calculation } = profile;
+  return (
+    <>
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-medium text-cf-text-primary">Salário líquido</h3>
+        <button
+          type="button"
+          onClick={onEdit}
+          className="text-xs text-brand-1 hover:underline"
+        >
+          Editar
+        </button>
+      </div>
+
+      <div className="mb-3 rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
+        <p className="text-xs text-cf-text-secondary">Líquido mensal</p>
+        <p className="text-lg font-bold text-cf-text-primary">
+          {formatCurrency(calculation.netMonthly)}
+        </p>
+        <p className="text-xs text-cf-text-secondary">
+          {formatCurrency(calculation.netAnnual)} / ano
+        </p>
+      </div>
+
+      <div className="space-y-1.5">
+        <BreakdownRow label="Salário bruto"    value={calculation.grossMonthly} highlight />
+        <BreakdownRow label="(-) INSS"         value={calculation.inssMonthly}  negative />
+        <BreakdownRow label="(-) IRRF"         value={calculation.irrfMonthly}  negative />
+        <div className="my-1.5 border-t border-cf-border" />
+        <BreakdownRow label="= Líquido mensal" value={calculation.netMonthly}   highlight />
+      </div>
+    </>
+  );
+}
+
+function ProfileForm({
+  initial,
+  onSave,
+  onCancel,
+  saving,
+  error,
+}: {
+  initial: FormState;
+  onSave: (form: FormState) => void;
+  onCancel: () => void;
+  saving: boolean;
+  error: string | null;
+}) {
+  const [form, setForm] = useState<FormState>(initial);
+
+  const set = (field: keyof FormState) => (e: React.ChangeEvent<HTMLInputElement>) =>
+    setForm((prev) => ({ ...prev, [field]: e.target.value }));
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSave(form);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} noValidate>
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-medium text-cf-text-primary">Salário líquido</h3>
+      </div>
+
+      <div className="space-y-3">
+        <div>
+          <label
+            htmlFor="sw-gross"
+            className="mb-1 block text-xs font-medium text-cf-text-secondary"
+          >
+            Salário bruto (R$)
+          </label>
+          <input
+            id="sw-gross"
+            type="number"
+            min="0.01"
+            step="0.01"
+            required
+            value={form.grossSalary}
+            onChange={set("grossSalary")}
+            placeholder="Ex: 5000"
+            className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label
+              htmlFor="sw-dep"
+              className="mb-1 block text-xs font-medium text-cf-text-secondary"
+            >
+              Dependentes
+            </label>
+            <input
+              id="sw-dep"
+              type="number"
+              min="0"
+              step="1"
+              value={form.dependents}
+              onChange={set("dependents")}
+              className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary focus:outline-none focus:ring-1 focus:ring-brand-1"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="sw-day"
+              className="mb-1 block text-xs font-medium text-cf-text-secondary"
+            >
+              Dia de pagamento
+            </label>
+            <input
+              id="sw-day"
+              type="number"
+              min="1"
+              max="31"
+              step="1"
+              value={form.paymentDay}
+              onChange={set("paymentDay")}
+              className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary focus:outline-none focus:ring-1 focus:ring-brand-1"
+            />
+          </div>
+        </div>
+
+        {error ? (
+          <p role="alert" className="text-xs text-red-500">
+            {error}
+          </p>
+        ) : null}
+
+        <div className="flex gap-2 pt-1">
+          <button
+            type="submit"
+            disabled={saving}
+            className="flex-1 rounded bg-brand-1 px-3 py-1.5 text-xs font-semibold text-white hover:opacity-90 disabled:opacity-50"
+          >
+            {saving ? "Salvando..." : "Salvar"}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={saving}
+            className="flex-1 rounded border border-cf-border px-3 py-1.5 text-xs font-medium text-cf-text-secondary hover:bg-cf-bg-subtle disabled:opacity-50"
+          >
+            Cancelar
+          </button>
+        </div>
+      </div>
+    </form>
+  );
+}
+
+// ─── Main widget ──────────────────────────────────────────────────────────────
+
+const SalaryWidget = (): JSX.Element | null => {
+  const [profile, setProfile] = useState<SalaryProfile | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    salaryService
+      .getProfile()
+      .then(setProfile)
+      .catch(() => setProfile(null))
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  const handleSave = async (form: FormState) => {
+    const gross = Number(form.grossSalary);
+    const dep   = Number(form.dependents);
+    const day   = Number(form.paymentDay);
+
+    if (!gross || gross <= 0) {
+      setSaveError("Informe um salário bruto válido.");
+      return;
+    }
+
+    setSaving(true);
+    setSaveError(null);
+
+    try {
+      const updated = await salaryService.upsertProfile({
+        gross_salary: gross,
+        dependents:   dep,
+        payment_day:  day,
+      });
+      setProfile(updated);
+      setEditing(false);
+    } catch {
+      setSaveError("Erro ao salvar. Tente novamente.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setEditing(false);
+    setSaveError(null);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="rounded border border-cf-border bg-cf-surface p-4">
+        <p className="text-xs text-cf-text-secondary">Carregando salário...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded border border-cf-border bg-cf-surface p-4">
+      {editing || !profile ? (
+        <ProfileForm
+          initial={profile ? profileToForm(profile) : EMPTY_FORM}
+          onSave={handleSave}
+          onCancel={handleCancel}
+          saving={saving}
+          error={saveError}
+        />
+      ) : (
+        <ProfileView profile={profile} onEdit={() => setEditing(true)} />
+      )}
+
+      {!profile && !editing ? (
+        <div className="text-center">
+          <p className="mb-2 text-xs text-cf-text-secondary">
+            Calcule seu salário líquido (CLT) com INSS e IRRF 2026.
+          </p>
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="rounded bg-brand-1 px-4 py-1.5 text-xs font-semibold text-white hover:opacity-90"
+          >
+            Definir salário bruto
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default SalaryWidget;

--- a/apps/web/src/components/SalaryWidget.tsx
+++ b/apps/web/src/components/SalaryWidget.tsx
@@ -74,7 +74,9 @@ function ProfileView({
           {formatCurrency(calculation.netMonthly)}
         </p>
         <p className="text-xs text-cf-text-secondary">
-          {formatCurrency(calculation.netAnnual)} / ano
+          {calculation.netAnnual == null
+            ? "Líquido anual: disponível no Pro"
+            : `${formatCurrency(calculation.netAnnual)} / ano`}
         </p>
       </div>
 

--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -8,6 +8,7 @@ import { analyticsService } from "../services/analytics.service";
 import { forecastService } from "../services/forecast.service";
 import { profileService } from "../services/profile.service";
 import { billsService } from "../services/bills.service";
+import { salaryService } from "../services/salary.service";
 
 vi.mock("../hooks/useTheme", () => ({
   useTheme: () => ({ theme: "light", toggleTheme: vi.fn() }),
@@ -66,6 +67,13 @@ vi.mock("../services/profile.service", () => ({
 vi.mock("../services/bills.service", () => ({
   billsService: {
     getSummary: vi.fn(),
+  },
+}));
+
+vi.mock("../services/salary.service", () => ({
+  salaryService: {
+    getProfile:    vi.fn(),
+    upsertProfile: vi.fn(),
   },
 }));
 
@@ -297,6 +305,7 @@ describe("App", () => {
       overdueCount: 0,
       overdueTotal: 0,
     });
+    salaryService.getProfile.mockResolvedValue(null);
     transactionsService.exportCsv.mockResolvedValue({
       blob: new Blob(["id,type\n1,Entrada"], { type: "text/csv;charset=utf-8" }),
       fileName: "transacoes.csv",

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -5,6 +5,7 @@ import ImportHistoryModal from "../components/ImportHistoryModal";
 import UpgradeModal from "../components/UpgradeModal";
 import ForecastCard from "../components/ForecastCard";
 import BillsSummaryWidget from "../components/BillsSummaryWidget";
+import SalaryWidget from "../components/SalaryWidget";
 import TransactionList from "../components/TransactionList";
 import {
   transactionsService,
@@ -2125,6 +2126,8 @@ const App = ({
         <ForecastCard onOpenProfileSettings={onOpenProfileSettings} />
 
         <BillsSummaryWidget onOpenBills={handleOpenBills} />
+
+        <SalaryWidget />
 
         <div className="space-y-6">
           <section ref={summarySectionRef}>

--- a/apps/web/src/services/salary.service.ts
+++ b/apps/web/src/services/salary.service.ts
@@ -7,8 +7,8 @@ export interface SalaryCalculation {
   inssMonthly: number;
   irrfMonthly: number;
   netMonthly: number;
-  netAnnual: number;
-  taxAnnual: number;
+  netAnnual: number | null;  // null for free-plan users
+  taxAnnual: number | null;  // null for free-plan users
 }
 
 export interface SalaryProfile {
@@ -35,8 +35,8 @@ const normalizeCalculation = (raw: Record<string, unknown>): SalaryCalculation =
   inssMonthly:  Number(raw.inssMonthly)  || 0,
   irrfMonthly:  Number(raw.irrfMonthly)  || 0,
   netMonthly:   Number(raw.netMonthly)   || 0,
-  netAnnual:    Number(raw.netAnnual)    || 0,
-  taxAnnual:    Number(raw.taxAnnual)    || 0,
+  netAnnual:    raw.netAnnual == null ? null : Number(raw.netAnnual) || 0,
+  taxAnnual:    raw.taxAnnual == null ? null : Number(raw.taxAnnual) || 0,
 });
 
 const normalizeProfile = (raw: Record<string, unknown>): SalaryProfile => ({

--- a/apps/web/src/services/salary.service.ts
+++ b/apps/web/src/services/salary.service.ts
@@ -1,0 +1,73 @@
+import { api } from "./api";
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+export interface SalaryCalculation {
+  grossMonthly: number;
+  inssMonthly: number;
+  irrfMonthly: number;
+  netMonthly: number;
+  netAnnual: number;
+  taxAnnual: number;
+}
+
+export interface SalaryProfile {
+  id: number;
+  userId: number;
+  grossSalary: number;
+  dependents: number;
+  paymentDay: number;
+  createdAt: string;
+  updatedAt: string;
+  calculation: SalaryCalculation;
+}
+
+export interface UpsertSalaryProfilePayload {
+  gross_salary: number;
+  dependents?: number;
+  payment_day?: number;
+}
+
+// ─── Normalization ────────────────────────────────────────────────────────────
+
+const normalizeCalculation = (raw: Record<string, unknown>): SalaryCalculation => ({
+  grossMonthly: Number(raw.grossMonthly) || 0,
+  inssMonthly:  Number(raw.inssMonthly)  || 0,
+  irrfMonthly:  Number(raw.irrfMonthly)  || 0,
+  netMonthly:   Number(raw.netMonthly)   || 0,
+  netAnnual:    Number(raw.netAnnual)    || 0,
+  taxAnnual:    Number(raw.taxAnnual)    || 0,
+});
+
+const normalizeProfile = (raw: Record<string, unknown>): SalaryProfile => ({
+  id:          Number(raw.id) || 0,
+  userId:      Number(raw.userId) || 0,
+  grossSalary: Number(raw.grossSalary) || 0,
+  dependents:  Number(raw.dependents) || 0,
+  paymentDay:  Number(raw.paymentDay) || 5,
+  createdAt:   typeof raw.createdAt === "string" ? raw.createdAt : "",
+  updatedAt:   typeof raw.updatedAt === "string" ? raw.updatedAt : "",
+  calculation: normalizeCalculation(
+    (raw.calculation as Record<string, unknown>) ?? {},
+  ),
+});
+
+// ─── Service ──────────────────────────────────────────────────────────────────
+
+export const salaryService = {
+  getProfile: async (): Promise<SalaryProfile | null> => {
+    try {
+      const { data } = await api.get("/salary/profile");
+      return normalizeProfile(data as Record<string, unknown>);
+    } catch (err: unknown) {
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      if (status === 404) return null;
+      throw err;
+    }
+  },
+
+  upsertProfile: async (payload: UpsertSalaryProfilePayload): Promise<SalaryProfile> => {
+    const { data } = await api.put("/salary/profile", payload);
+    return normalizeProfile(data as Record<string, unknown>);
+  },
+};


### PR DESCRIPTION
## What

Paywall gate on the annual salary projection fields.

- **Free users** (`salary_annual: false`): `calculation.netAnnual` and `calculation.taxAnnual` are `null` in both `GET` and `PUT /salary/profile` responses.
- **Trial users**: get annual access (`salary_annual: true` in `TRIAL_FEATURES`) — full product value during trial period.
- **Pro users**: full access, no change in behaviour.
- Monthly breakdown (netMonthly / INSS / IRRF) is **always free**.

## Why

Blocks trivial free-tier bypass via DevTools; enforces the "monthly is free, annual is pro" product boundary server-side. No client-side tricks needed.

## Files changed

| File | Change |
|---|---|
| `apps/api/src/db/migrations/020_add_salary_annual_to_plans.sql` | Adds `salary_annual` flag to free/pro plan features (full JSON replace for pg-mem compat) |
| `apps/api/src/services/billing.service.js` | `TRIAL_FEATURES.salary_annual = true` |
| `apps/api/src/routes/salary.routes.js` | `attachEntitlements` middleware + `applyAnnualGate()` on GET and PUT |
| `apps/api/src/salary-profile.test.js` | +2 tests: free (trial expired) → null; pro → number |
| `apps/web/src/services/salary.service.ts` | `netAnnual / taxAnnual: number \| null`; normalizer preserves null |
| `apps/web/src/components/SalaryWidget.tsx` | Annual row shows "Líquido anual: disponível no Pro" when null |
| `apps/web/src/components/SalaryWidget.test.tsx` | +2 tests: null annual → upgrade text; number → formatted value |

## Tests

- **API**: 349/349 (incl. +2 paywall tests)
- **Web**: 162/162 (incl. +2 paywall widget tests)
- Lint: clean

## Notes

- `applyAnnualGate` is in the route layer (not service) — keeps the service pure/testable.
- Null is preferred over `0` so free-user data is never mistaken for a real value.
- Base branch is `feat/sal3-salary-dashboard-ui` (stacked on SAL3); rebase on main before merging.
