### PR TITLE
feat(api): add ops force-plan endpoint for deterministic pro proof

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,8 @@ DB_SSL=false
 # Aceita lista separada por virgula (ex.: local + Vercel):
 # CORS_ORIGIN=http://localhost:5173,https://control-finance-react-tail-wind.vercel.app
 CORS_ORIGIN=http://localhost:5173
+# Ops endpoint guard (non-production only; required for /ops/force-plan)
+# OPS_TOKEN=troque-isto-por-um-token-forte
 # Login hardening
 AUTH_RATE_LIMIT_WINDOW_MS=900000
 AUTH_RATE_LIMIT_MAX_REQUESTS=20

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -22,6 +22,8 @@ CORS_ORIGIN=http://localhost:5173
 # Set PAYWALL_BYPASS_ENABLED=true and list emails to grant full PRO access without a subscription.
 PAYWALL_BYPASS_ENABLED=false
 # PAYWALL_BYPASS_EMAILS=dev@example.com,qa@example.com
+# Ops endpoint guard (non-production only; required for /ops/force-plan)
+# OPS_TOKEN=troque-isto-por-um-token-forte
 # Login hardening
 AUTH_RATE_LIMIT_WINDOW_MS=900000
 AUTH_RATE_LIMIT_MAX_REQUESTS=20

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -15,6 +15,7 @@ import stripeWebhooksRoutes from "./routes/stripe-webhooks.routes.js";
 import billsRoutes from "./routes/bills.routes.js";
 import incomeSourcesRoutes from "./routes/income-sources.routes.js";
 import salaryRoutes from "./routes/salary.routes.js";
+import opsRoutes from "./routes/ops.routes.js";
 import { notFoundHandler, errorHandler } from "./middlewares/error.middleware.js";
 import { requestIdMiddleware } from "./middlewares/request-id.middleware.js";
 import { requestLoggingMiddleware } from "./middlewares/request-logging.middleware.js";
@@ -92,6 +93,7 @@ app.use("/forecasts", forecastRoutes);
 app.use("/bills", billsRoutes);
 app.use("/income-sources", incomeSourcesRoutes);
 app.use("/salary", salaryRoutes);
+app.use("/ops", opsRoutes);
 
 app.use(notFoundHandler);
 app.use(errorHandler);

--- a/apps/api/src/ops-force-plan.test.js
+++ b/apps/api/src/ops-force-plan.test.js
@@ -1,0 +1,142 @@
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import app from "./app.js";
+import { clearDbClientForTests, dbQuery } from "./db/index.js";
+import { resetLoginProtectionState } from "./middlewares/login-protection.middleware.js";
+import {
+  resetImportRateLimiterState,
+  resetWriteRateLimiterState,
+} from "./middlewares/rate-limit.middleware.js";
+import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
+import {
+  expectErrorResponseWithRequestId,
+  getUserIdByEmail,
+  registerAndLogin,
+  setupTestDb,
+} from "./test-helpers.js";
+
+const OPS_TOKEN_TEST = "ops-token-test";
+
+describe("ops force-plan", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalOpsToken = process.env.OPS_TOKEN;
+
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  afterAll(async () => {
+    process.env.NODE_ENV = originalNodeEnv;
+    process.env.OPS_TOKEN = originalOpsToken;
+    await clearDbClientForTests();
+  });
+
+  beforeEach(async () => {
+    process.env.NODE_ENV = "test";
+    process.env.OPS_TOKEN = OPS_TOKEN_TEST;
+
+    resetLoginProtectionState();
+    resetImportRateLimiterState();
+    resetWriteRateLimiterState();
+    resetHttpMetricsForTests();
+
+    await dbQuery("DELETE FROM subscriptions");
+    await dbQuery("DELETE FROM transactions");
+    await dbQuery("DELETE FROM users");
+  });
+
+  it("POST /ops/force-plan retorna 401 sem x-ops-token", async () => {
+    const response = await request(app).post("/ops/force-plan").send({
+      email: "ops-no-token@controlfinance.dev",
+      plan: "pro",
+    });
+
+    expectErrorResponseWithRequestId(response, 401, "Ops token ausente ou invalido.");
+  });
+
+  it("POST /ops/force-plan retorna 404 quando OPS_TOKEN nao esta configurado", async () => {
+    delete process.env.OPS_TOKEN;
+
+    const response = await request(app)
+      .post("/ops/force-plan")
+      .set("x-ops-token", OPS_TOKEN_TEST)
+      .send({
+        email: "ops-no-env@controlfinance.dev",
+        plan: "pro",
+      });
+
+    expectErrorResponseWithRequestId(response, 404, "Route not found");
+  });
+
+  it("POST /ops/force-plan retorna 404 em NODE_ENV=production", async () => {
+    process.env.NODE_ENV = "production";
+
+    const response = await request(app)
+      .post("/ops/force-plan")
+      .set("x-ops-token", OPS_TOKEN_TEST)
+      .send({
+        email: "ops-production@controlfinance.dev",
+        plan: "pro",
+      });
+
+    expectErrorResponseWithRequestId(response, 404, "Route not found");
+  });
+
+  it("POST /ops/force-plan retorna 422 para plan diferente de pro", async () => {
+    const response = await request(app)
+      .post("/ops/force-plan")
+      .set("x-ops-token", OPS_TOKEN_TEST)
+      .send({
+        email: "ops-invalid-plan@controlfinance.dev",
+        plan: "free",
+      });
+
+    expectErrorResponseWithRequestId(response, 422, "plan deve ser 'pro'.");
+  });
+
+  it("promove usuario para pro e /billing/subscription retorna salary_annual=true", async () => {
+    const email = "ops-force-pro@controlfinance.dev";
+    const token = await registerAndLogin(email);
+    const userId = await getUserIdByEmail(email);
+
+    await dbQuery(
+      `UPDATE users SET trial_ends_at = NOW() - INTERVAL '1 day' WHERE id = $1`,
+      [userId],
+    );
+
+    const preResponse = await request(app)
+      .get("/billing/subscription")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(preResponse.status).toBe(200);
+    expect(preResponse.body.plan).toBe("free");
+    expect(preResponse.body.features.salary_annual).toBe(false);
+
+    const forceResponse = await request(app)
+      .post("/ops/force-plan")
+      .set("x-ops-token", OPS_TOKEN_TEST)
+      .send({
+        email,
+        plan: "pro",
+      });
+
+    expect(forceResponse.status).toBe(200);
+    expect(forceResponse.body).toMatchObject({
+      email,
+      plan: "pro",
+      status: "active",
+    });
+
+    const postResponse = await request(app)
+      .get("/billing/subscription")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(postResponse.status).toBe(200);
+    expect(postResponse.body.plan).toBe("pro");
+    expect(postResponse.body.features.salary_annual).toBe(true);
+    expect(postResponse.body.subscription).toMatchObject({
+      status: "active",
+    });
+  });
+});
+

--- a/apps/api/src/routes/ops.routes.js
+++ b/apps/api/src/routes/ops.routes.js
@@ -1,0 +1,78 @@
+import { timingSafeEqual } from "node:crypto";
+import { Router } from "express";
+import { forcePlanForEmail } from "../services/ops-force-plan.service.js";
+
+const router = Router();
+
+const createError = (status, message) => {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+};
+
+const readHeaderValue = (value) => {
+  if (Array.isArray(value)) {
+    const firstItem = value.find(
+      (item) => typeof item === "string" && item.trim(),
+    );
+    return readHeaderValue(firstItem || "");
+  }
+
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  return value.trim();
+};
+
+const secureTokenEquals = (provided, expected) => {
+  const providedBuffer = Buffer.from(provided, "utf8");
+  const expectedBuffer = Buffer.from(expected, "utf8");
+
+  if (providedBuffer.length !== expectedBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(providedBuffer, expectedBuffer);
+};
+
+const isProduction = () =>
+  (process.env.NODE_ENV || "").trim().toLowerCase() === "production";
+
+const getOpsToken = () =>
+  typeof process.env.OPS_TOKEN === "string" ? process.env.OPS_TOKEN.trim() : "";
+
+router.use((req, _res, next) => {
+  if (isProduction()) {
+    return next(createError(404, "Route not found"));
+  }
+
+  const expectedToken = getOpsToken();
+
+  if (!expectedToken) {
+    return next(createError(404, "Route not found"));
+  }
+
+  const providedToken = readHeaderValue(req.headers["x-ops-token"]);
+
+  if (!providedToken || !secureTokenEquals(providedToken, expectedToken)) {
+    return next(createError(401, "Ops token ausente ou invalido."));
+  }
+
+  return next();
+});
+
+router.post("/force-plan", async (req, res, next) => {
+  try {
+    const result = await forcePlanForEmail({
+      email: req.body?.email,
+      plan: req.body?.plan,
+    });
+    res.status(200).json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;
+

--- a/apps/api/src/services/ops-force-plan.service.js
+++ b/apps/api/src/services/ops-force-plan.service.js
@@ -1,0 +1,74 @@
+import { withDbTransaction } from "../db/index.js";
+
+const createError = (status, message) => {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+};
+
+const normalizeEmail = (value) =>
+  typeof value === "string" ? value.trim().toLowerCase() : "";
+
+const normalizePlan = (value) =>
+  typeof value === "string" ? value.trim().toLowerCase() : "";
+
+export const forcePlanForEmail = async ({ email, plan } = {}) => {
+  const normalizedEmail = normalizeEmail(email);
+  const normalizedPlan = normalizePlan(plan);
+
+  if (!normalizedEmail) {
+    throw createError(422, "email e obrigatorio.");
+  }
+
+  if (normalizedPlan !== "pro") {
+    throw createError(422, "plan deve ser 'pro'.");
+  }
+
+  return withDbTransaction(async (client) => {
+    const userResult = await client.query(
+      `SELECT id, email FROM users WHERE email = $1 LIMIT 1`,
+      [normalizedEmail],
+    );
+
+    if (userResult.rows.length === 0) {
+      throw createError(404, "Usuario nao encontrado.");
+    }
+
+    const user = userResult.rows[0];
+
+    const planResult = await client.query(
+      `SELECT id, name FROM plans WHERE name = $1 AND is_active = true LIMIT 1`,
+      [normalizedPlan],
+    );
+
+    if (planResult.rows.length === 0) {
+      throw createError(404, "Plano nao encontrado.");
+    }
+
+    const planRow = planResult.rows[0];
+
+    await client.query(
+      `UPDATE subscriptions
+       SET status = 'canceled',
+           cancel_at_period_end = false,
+           updated_at = NOW()
+       WHERE user_id = $1
+         AND status IN ('active', 'trialing', 'past_due')`,
+      [user.id],
+    );
+
+    await client.query(
+      `INSERT INTO subscriptions
+        (user_id, plan_id, status, current_period_start, current_period_end, cancel_at_period_end)
+       VALUES ($1, $2, 'active', NOW(), NOW() + INTERVAL '30 days', false)`,
+      [user.id, planRow.id],
+    );
+
+    return {
+      email: user.email,
+      plan: planRow.name,
+      status: "active",
+    };
+  });
+};
+

--- a/scripts/smoke-salary-profile.ps1
+++ b/scripts/smoke-salary-profile.ps1
@@ -12,11 +12,15 @@
   Base expectation: for a fresh trial user, calculation.netAnnual and
   calculation.taxAnnual are numeric values.
 
-  Optional flow (requires -DbConnectionString and psql):
-    5. Expire trial in DB -> user falls back to free
-    6. GET /salary/profile -> netAnnual/taxAnnual must be null
-    7. Grant pro subscription in DB
-    8. GET /salary/profile -> netAnnual/taxAnnual must be numeric again
+  Optional flow #1 (requires -OpsToken, no DB credentials needed):
+    5. POST /ops/force-plan { email, plan: "pro" } with x-ops-token
+    6. GET /billing/subscription -> plan=pro, features.salary_annual=true
+
+  Optional flow #2 (requires -DbConnectionString and psql):
+    7. Expire trial in DB -> user falls back to free
+    8. GET /salary/profile -> netAnnual/taxAnnual must be null
+    9. Grant pro subscription in DB
+   10. GET /salary/profile -> netAnnual/taxAnnual must be numeric again
 
   Every API call sends x-request-id and validates it is echoed back.
 
@@ -36,6 +40,10 @@
   Optional Postgres connection string for free/pro verification steps.
   Example: "postgresql://user:pass@host/db"
 
+.PARAMETER OpsToken
+  Optional token for POST /ops/force-plan.
+  Enables deterministic Pro verification without direct DB credentials.
+
 .PARAMETER PsqlPath
   Path to psql.exe when DbConnectionString is provided.
 
@@ -44,7 +52,13 @@
   .\scripts\smoke-salary-profile.ps1 -BaseUrl "https://your-api.onrender.com"
 
 .EXAMPLE
-  # Full smoke (trial -> free -> pro)
+  # Optional pro verification via /ops/force-plan (no DB credentials)
+  .\scripts\smoke-salary-profile.ps1 `
+    -BaseUrl "https://your-api.onrender.com" `
+    -OpsToken "your-ops-token"
+
+.EXAMPLE
+  # Full smoke (trial -> free -> pro) via DB
   .\scripts\smoke-salary-profile.ps1 `
     -BaseUrl "https://your-api.onrender.com" `
     -DbConnectionString "postgresql://user:pass@host/db"
@@ -55,6 +69,7 @@ param(
   [double]$GrossSalary = 5000,
   [int]$Dependents = 1,
   [int]$PaymentDay = 5,
+  [string]$OpsToken = "",
   [string]$DbConnectionString = "",
   [string]$PsqlPath = "C:\Program Files\PostgreSQL\16\bin\psql.exe"
 )
@@ -75,6 +90,11 @@ Write-Host "=== Smoke Test: Salary Profile + Annual Paywall ===" -ForegroundColo
 Write-Host "RunId  : $runId"
 Write-Host "BaseUrl: $BaseUrl"
 Write-Host "Email  : $email"
+if ($OpsToken) {
+  Write-Host "OPS    : provided (/ops/force-plan enabled)"
+} else {
+  Write-Host "OPS    : not provided (/ops/force-plan skipped)"
+}
 if ($DbConnectionString) {
   Write-Host "DB     : provided (free/pro checks enabled)"
 } else {
@@ -103,7 +123,6 @@ function Skip([string]$step, [string]$reason = "") {
   $script:skipped++
 }
 
-# no-op marker used to short-circuit to summary section
 function New-RequestId([string]$label) {
   $script:requestSeq++
   return "smoke-salary-$runId-$($script:requestSeq)-$label"
@@ -259,6 +278,22 @@ function Assert-AnnualIsNull($resp, [string]$step) {
   }
 }
 
+function Assert-SubscriptionIsPro($resp, [string]$step) {
+  if (-not $resp.Body -or -not $resp.Body.features) {
+    Fail $step "Response body missing plan/features."
+    return
+  }
+
+  $plan = $resp.Body.plan
+  $salaryAnnual = $resp.Body.features.salary_annual
+
+  if ($plan -eq "pro" -and $salaryAnnual -eq $true) {
+    Pass $step
+  } else {
+    Fail $step "Expected plan=pro and features.salary_annual=true. plan=$plan salary_annual=$salaryAnnual"
+  }
+}
+
 function Invoke-Psql([string]$sql, [string]$step) {
   if (-not (Test-Path $PsqlPath)) {
     Fail $step "psql not found at '$PsqlPath'."
@@ -326,6 +361,29 @@ if ($rRegister.StatusCode -eq 201) {
 
     Write-Host ""
     Write-Host "--- Optional flow (free/pro) ---"
+
+    if ($OpsToken) {
+      $opsHeaders = @{
+        "x-ops-token" = $OpsToken
+      }
+
+      $rOpsForcePlan = Invoke-Api -Method "POST" -Path "/ops/force-plan" -Headers $opsHeaders -Body @{
+        email = $email
+        plan = "pro"
+      } -RequestId (New-RequestId "ops-force-plan")
+      Assert-Code $rOpsForcePlan 200 "POST /ops/force-plan"
+      Assert-RequestIdEcho $rOpsForcePlan "POST /ops/force-plan"
+
+      $rBillingPro = Invoke-Api -Method "GET" -Path "/billing/subscription" -Headers $auth -RequestId (New-RequestId "billing-subscription-pro")
+      Assert-Code $rBillingPro 200 "GET /billing/subscription (after ops force-plan)"
+      Assert-RequestIdEcho $rBillingPro "GET /billing/subscription (after ops force-plan)"
+      if ($rBillingPro.StatusCode -eq 200) {
+        Assert-SubscriptionIsPro $rBillingPro "GET /billing/subscription: plan=pro and salary_annual=true"
+      }
+    } else {
+      Skip "POST /ops/force-plan" "Provide -OpsToken."
+      Skip "GET /billing/subscription (after ops force-plan)" "Provide -OpsToken."
+    }
 
     if (-not $DbConnectionString) {
       Skip "GET /salary/profile (free): annual fields null" "Provide -DbConnectionString."


### PR DESCRIPTION
## Summary
- add `POST /ops/force-plan` guarded by `x-ops-token` (`OPS_TOKEN`)
- keep endpoint unavailable in production (`NODE_ENV=production` returns 404)
- implement service to force a user subscription to `pro` by email
- extend salary smoke script with `-OpsToken` path to validate `plan=pro` + `salary_annual=true` without DB creds
- document `OPS_TOKEN` in `.env.example` files

## Validation
- `npm -w apps/api run test -- ops-force-plan.test.js`
- `npm -w apps/api run test -- billing.test.js salary-profile.test.js`
- `npm -w apps/api run lint`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\smoke-salary-profile.ps1 -BaseUrl https://control-finance-react-tailwind.onrender.com` (base flow still PASS)