### PR TITLE
chore(api): fail fast on stripe env mismatch

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -18,6 +18,13 @@ DB_SSL=false
 # Aceita lista separada por virgula (ex.: local + Vercel)
 # CORS_ORIGIN=http://localhost:5173,https://control-finance-react-tail-wind.vercel.app
 CORS_ORIGIN=http://localhost:5173
+# Stripe guardrail:
+# - production requires sk_live_*
+# - non-production requires sk_test_*
+# STRIPE_SECRET_KEY=sk_test_...
+# STRIPE_PRICE_ID_PRO=price_...
+# STRIPE_CHECKOUT_SUCCESS_URL=http://localhost:5173/app/settings/billing?checkout=success
+# STRIPE_CHECKOUT_CANCEL_URL=http://localhost:5173/app/settings/billing?checkout=cancel
 # Paywall bypass -- DEV / STAGING ONLY. Ignored when NODE_ENV=production.
 # Set PAYWALL_BYPASS_ENABLED=true and list emails to grant full PRO access without a subscription.
 PAYWALL_BYPASS_ENABLED=false

--- a/apps/api/src/config/stripe-env-guard.js
+++ b/apps/api/src/config/stripe-env-guard.js
@@ -1,0 +1,41 @@
+const normalizeEnvValue = (value) =>
+  typeof value === "string" ? value.trim().toLowerCase() : "";
+
+const normalizeSecretKey = (value) =>
+  typeof value === "string" ? value.trim() : "";
+
+const createStripeEnvError = (message) => {
+  const error = new Error(message);
+  error.code = "STRIPE_ENV_MISMATCH";
+  return error;
+};
+
+export const assertStripeEnvironmentConsistency = (env = process.env) => {
+  const nodeEnv = normalizeEnvValue(env.NODE_ENV || "");
+  const stripeSecretKey = normalizeSecretKey(env.STRIPE_SECRET_KEY || "");
+
+  // Guardrail only applies when a Stripe key is configured.
+  if (!stripeSecretKey) {
+    return;
+  }
+
+  const isLiveKey = stripeSecretKey.startsWith("sk_live_");
+  const isTestKey = stripeSecretKey.startsWith("sk_test_");
+
+  if (!isLiveKey && !isTestKey) {
+    return;
+  }
+
+  if (nodeEnv === "production" && isTestKey) {
+    throw createStripeEnvError(
+      "Invalid Stripe environment: NODE_ENV=production requires STRIPE_SECRET_KEY starting with sk_live_.",
+    );
+  }
+
+  if (nodeEnv !== "production" && isLiveKey) {
+    throw createStripeEnvError(
+      "Invalid Stripe environment: non-production environments require STRIPE_SECRET_KEY starting with sk_test_.",
+    );
+  }
+};
+

--- a/apps/api/src/config/stripe-env-guard.test.js
+++ b/apps/api/src/config/stripe-env-guard.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { assertStripeEnvironmentConsistency } from "./stripe-env-guard.js";
+
+describe("stripe env guard", () => {
+  it("permite sem STRIPE_SECRET_KEY configurada", () => {
+    expect(() => {
+      assertStripeEnvironmentConsistency({
+        NODE_ENV: "staging",
+        STRIPE_SECRET_KEY: "",
+      });
+    }).not.toThrow();
+  });
+
+  it("permite sk_test em staging", () => {
+    expect(() => {
+      assertStripeEnvironmentConsistency({
+        NODE_ENV: "staging",
+        STRIPE_SECRET_KEY: "sk_test_example",
+      });
+    }).not.toThrow();
+  });
+
+  it("bloqueia sk_live em staging", () => {
+    expect(() => {
+      assertStripeEnvironmentConsistency({
+        NODE_ENV: "staging",
+        STRIPE_SECRET_KEY: "sk_live_example",
+      });
+    }).toThrow("non-production");
+  });
+
+  it("bloqueia sk_test em production", () => {
+    expect(() => {
+      assertStripeEnvironmentConsistency({
+        NODE_ENV: "production",
+        STRIPE_SECRET_KEY: "sk_test_example",
+      });
+    }).toThrow("NODE_ENV=production");
+  });
+
+  it("permite sk_live em production", () => {
+    expect(() => {
+      assertStripeEnvironmentConsistency({
+        NODE_ENV: "production",
+        STRIPE_SECRET_KEY: "sk_live_example",
+      });
+    }).not.toThrow();
+  });
+
+  it("ignora prefixo desconhecido", () => {
+    expect(() => {
+      assertStripeEnvironmentConsistency({
+        NODE_ENV: "staging",
+        STRIPE_SECRET_KEY: "rk_live_example",
+      });
+    }).not.toThrow();
+  });
+});
+

--- a/apps/api/src/server.js
+++ b/apps/api/src/server.js
@@ -1,4 +1,5 @@
 import app from "./app.js";
+import { assertStripeEnvironmentConsistency } from "./config/stripe-env-guard.js";
 import { getDatabaseConnectionDiagnostics } from "./db/index.js";
 import { runMigrations } from "./db/migrate.js";
 import { startImportSessionsCleanupJob } from "./jobs/import-sessions-cleanup.job.js";
@@ -7,6 +8,7 @@ import { logError, logInfo } from "./observability/logger.js";
 const port = Number(process.env.PORT) || 3001;
 
 const startServer = async () => {
+  assertStripeEnvironmentConsistency();
   await runMigrations();
   startImportSessionsCleanupJob();
 


### PR DESCRIPTION
## Summary
- add startup guardrail for Stripe environment mismatch
- fail fast when non-production uses `sk_live_*`
- fail fast when production uses `sk_test_*`
- keep behavior unchanged when `STRIPE_SECRET_KEY` is not configured
- document guardrail in API env example

## Validation
- `npm -w apps/api run test -- src/config/stripe-env-guard.test.js`
- `npm -w apps/api run lint`