### PR TITLE
feat(api): wire prepaid checkout to yearly one-time Stripe Price

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,10 +31,10 @@ CORS_ORIGIN=http://localhost:5173
 # STRIPE_CHECKOUT_CANCEL_URL=https://control-finance-react-tail-wind.vercel.app/app/settings/billing?checkout=cancel
 # STRIPE_PORTAL_RETURN_URL=https://control-finance-react-tail-wind.vercel.app/app/settings/billing
 # STRIPE_WEBHOOK_SECRET=whsec_...
-# Optional prepaid config (defaults: 1990 cents, 6 months)
-# STRIPE_PREPAID_PRO_AMOUNT_CENTS=1990
-# STRIPE_PREPAID_PRO_DURATION_MONTHS=6
-# STRIPE_PREPAID_PRO_PRODUCT_NAME=Control Finance PRO (6 meses pre-pago)
+# Prepaid yearly (one-time Stripe Price)
+# STRIPE_PRICE_ID_PRO_PREPAID_YEAR=price_...
+# Optional entitlement duration override (default: 12 months)
+# STRIPE_PREPAID_PRO_DURATION_MONTHS=12
 # Login hardening
 AUTH_RATE_LIMIT_WINDOW_MS=900000
 AUTH_RATE_LIMIT_MAX_REQUESTS=20

--- a/apps/api/src/billing-checkout.test.js
+++ b/apps/api/src/billing-checkout.test.js
@@ -26,6 +26,7 @@ describe("billing checkout", () => {
     process.env.STRIPE_SECRET_KEY = "sk_test_mock_controlfinance";
     process.env.STRIPE_CHECKOUT_SUCCESS_URL = "https://app.test/billing/success";
     process.env.STRIPE_CHECKOUT_CANCEL_URL = "https://app.test/billing/cancel";
+    process.env.STRIPE_PRICE_ID_PRO_PREPAID_YEAR = "price_prepaid_year_env";
     await dbQuery(`UPDATE plans SET stripe_price_id = 'price_pro_monthly' WHERE name = 'pro'`);
   });
 
@@ -34,7 +35,7 @@ describe("billing checkout", () => {
     delete process.env.STRIPE_SECRET_KEY;
     delete process.env.STRIPE_CHECKOUT_SUCCESS_URL;
     delete process.env.STRIPE_CHECKOUT_CANCEL_URL;
-    delete process.env.STRIPE_PREPAID_PRO_AMOUNT_CENTS;
+    delete process.env.STRIPE_PRICE_ID_PRO_PREPAID_YEAR;
     delete process.env.STRIPE_PREPAID_PRO_DURATION_MONTHS;
   });
 
@@ -214,11 +215,10 @@ describe("billing checkout", () => {
     const args = mockSessionCreate.mock.calls[0][0];
     expect(args.mode).toBe("payment");
     expect(args.automatic_payment_methods).toEqual({ enabled: true });
-    expect(args.line_items[0].price_data.currency).toBe("brl");
-    expect(args.line_items[0].price_data.unit_amount).toBe(1990);
+    expect(args.line_items[0].price).toBe("price_prepaid_year_env");
     expect(args.metadata.userId).toBe(String(userId));
-    expect(args.metadata.entitlement).toBe("pro_6_months");
-    expect(args.metadata.entitlement_months).toBe("6");
+    expect(args.metadata.entitlement).toBe("pro_12_months");
+    expect(args.metadata.entitlement_months).toBe("12");
   });
 
   it("checkout-prepaid retorna 409 para usuario com assinatura recorrente ativa", async () => {
@@ -235,19 +235,37 @@ describe("billing checkout", () => {
     expect(mockSessionCreate).not.toHaveBeenCalled();
   });
 
-  it("checkout-prepaid retorna 500 com amount invalido em env", async () => {
-    process.env.STRIPE_PREPAID_PRO_AMOUNT_CENTS = "abc";
+  it("checkout-prepaid retorna 500 com price anual ausente", async () => {
+    const savedPriceId = process.env.STRIPE_PRICE_ID_PRO_PREPAID_YEAR;
+    delete process.env.STRIPE_PRICE_ID_PRO_PREPAID_YEAR;
     try {
-      const token = await registerAndLogin("checkout-prepaid-invalid-amount@controlfinance.dev");
+      const token = await registerAndLogin("checkout-prepaid-missing-price-id@controlfinance.dev");
       const response = await request(app)
         .post("/billing/checkout-prepaid")
         .set("Authorization", `Bearer ${token}`);
 
       expect(response.status).toBe(500);
-      expect(response.body.code).toBe("BILLING_PREPAID_AMOUNT_INVALID");
+      expect(response.body.code).toBe("BILLING_PREPAID_YEAR_PRICE_NOT_CONFIGURED");
       expect(mockSessionCreate).not.toHaveBeenCalled();
     } finally {
-      delete process.env.STRIPE_PREPAID_PRO_AMOUNT_CENTS;
+      process.env.STRIPE_PRICE_ID_PRO_PREPAID_YEAR = savedPriceId;
+    }
+  });
+
+  it("checkout-prepaid retorna 500 com price anual invalido em env", async () => {
+    const savedPriceId = process.env.STRIPE_PRICE_ID_PRO_PREPAID_YEAR;
+    process.env.STRIPE_PRICE_ID_PRO_PREPAID_YEAR = "prod_invalid";
+    try {
+      const token = await registerAndLogin("checkout-prepaid-invalid-price-id@controlfinance.dev");
+      const response = await request(app)
+        .post("/billing/checkout-prepaid")
+        .set("Authorization", `Bearer ${token}`);
+
+      expect(response.status).toBe(500);
+      expect(response.body.code).toBe("BILLING_PREPAID_YEAR_PRICE_INVALID");
+      expect(mockSessionCreate).not.toHaveBeenCalled();
+    } finally {
+      process.env.STRIPE_PRICE_ID_PRO_PREPAID_YEAR = savedPriceId;
     }
   });
 

--- a/apps/api/src/services/stripe-prepaid-checkout.service.js
+++ b/apps/api/src/services/stripe-prepaid-checkout.service.js
@@ -1,9 +1,9 @@
 import Stripe from "stripe";
 import { dbQuery } from "../db/index.js";
 
-const DEFAULT_PREPAID_AMOUNT_CENTS = 1990;
-const DEFAULT_PREPAID_MONTHS = 6;
-const DEFAULT_PREPAID_PRODUCT_NAME = "Control Finance PRO (6 meses pre-pago)";
+const PREPAID_YEAR_PRICE_ENV_KEY = "STRIPE_PRICE_ID_PRO_PREPAID_YEAR";
+const PREPAID_YEAR_ENTITLEMENT = "pro_12_months";
+const DEFAULT_PREPAID_MONTHS = 12;
 
 const createError = (status, message, publicCode = "") => {
   const error = new Error(message);
@@ -26,11 +26,8 @@ const parsePositiveIntegerEnv = (rawValue, fallbackValue) => {
   return parsedValue;
 };
 
-const resolvePrepaidAmountCents = () =>
-  parsePositiveIntegerEnv(
-    process.env.STRIPE_PREPAID_PRO_AMOUNT_CENTS,
-    DEFAULT_PREPAID_AMOUNT_CENTS,
-  );
+const isValidStripePriceId = (value) =>
+  typeof value === "string" && value.trim().startsWith("price_");
 
 const resolvePrepaidDurationMonths = () =>
   parsePositiveIntegerEnv(
@@ -38,13 +35,25 @@ const resolvePrepaidDurationMonths = () =>
     DEFAULT_PREPAID_MONTHS,
   );
 
-const resolvePrepaidProductName = () => {
-  const configuredName = process.env.STRIPE_PREPAID_PRO_PRODUCT_NAME;
-  if (typeof configuredName !== "string" || !configuredName.trim()) {
-    return DEFAULT_PREPAID_PRODUCT_NAME;
+const resolvePrepaidYearPriceId = () => {
+  const priceId = process.env[PREPAID_YEAR_PRICE_ENV_KEY];
+  if (!priceId || !priceId.trim()) {
+    throw createError(
+      500,
+      "Prepaid yearly price not configured.",
+      "BILLING_PREPAID_YEAR_PRICE_NOT_CONFIGURED",
+    );
   }
 
-  return configuredName.trim();
+  if (!isValidStripePriceId(priceId)) {
+    throw createError(
+      500,
+      `Invalid Stripe price ID configured in ${PREPAID_YEAR_PRICE_ENV_KEY}.`,
+      "BILLING_PREPAID_YEAR_PRICE_INVALID",
+    );
+  }
+
+  return priceId.trim();
 };
 
 const hasActiveRecurringSubscription = async (userId) => {
@@ -75,14 +84,7 @@ export const createPrepaidCheckoutSession = async ({ userId, userEmail }) => {
     );
   }
 
-  const amountCents = resolvePrepaidAmountCents();
-  if (!Number.isInteger(amountCents) || amountCents <= 0) {
-    throw createError(
-      500,
-      "Invalid prepaid amount configuration.",
-      "BILLING_PREPAID_AMOUNT_INVALID",
-    );
-  }
+  const prepaidYearPriceId = resolvePrepaidYearPriceId();
 
   const durationMonths = resolvePrepaidDurationMonths();
   if (!Number.isInteger(durationMonths) || durationMonths <= 0) {
@@ -101,8 +103,6 @@ export const createPrepaidCheckoutSession = async ({ userId, userEmail }) => {
     );
   }
 
-  const productName = resolvePrepaidProductName();
-
   const stripe = new Stripe(secretKey, { apiVersion: "2026-01-28.clover" });
 
   let session;
@@ -112,19 +112,10 @@ export const createPrepaidCheckoutSession = async ({ userId, userEmail }) => {
       success_url: successUrl,
       cancel_url: cancelUrl,
       automatic_payment_methods: { enabled: true },
-      line_items: [
-        {
-          price_data: {
-            currency: "brl",
-            product_data: { name: productName },
-            unit_amount: amountCents,
-          },
-          quantity: 1,
-        },
-      ],
+      line_items: [{ price: prepaidYearPriceId, quantity: 1 }],
       metadata: {
         userId: String(userId),
-        entitlement: "pro_6_months",
+        entitlement: PREPAID_YEAR_ENTITLEMENT,
         entitlement_months: String(durationMonths),
       },
       ...(userEmail ? { customer_email: userEmail } : {}),

--- a/apps/api/src/services/stripe-webhook.service.js
+++ b/apps/api/src/services/stripe-webhook.service.js
@@ -1,6 +1,8 @@
 import { dbQuery } from "../db/index.js";
 
 const PREPAID_PRO_ENTITLEMENT_KEYS = new Set(["pro_12_months", "pro_6_months"]);
+const LEGACY_PREPAID_ENTITLEMENT_KEY = "pro_6_months";
+const LEGACY_PREPAID_DURATION_MONTHS = 6;
 const DEFAULT_PREPAID_DURATION_MONTHS = 12;
 
 const createError = (status, message) => {
@@ -42,13 +44,19 @@ const parsePositiveInteger = (value, fallbackValue) => {
   return parsed;
 };
 
-const resolvePrepaidDurationMonths = (session) => {
+const resolvePrepaidDurationMonths = ({ entitlement, metadata }) => {
   const metadataMonths = parsePositiveInteger(
-    session?.metadata?.entitlement_months,
+    metadata?.entitlement_months,
     NaN,
   );
   if (Number.isInteger(metadataMonths) && metadataMonths > 0) {
     return metadataMonths;
+  }
+
+  // Legacy 6-month prepaid sessions may not include entitlement_months in metadata.
+  // Keep the historical behavior to avoid over-granting 12 months.
+  if (entitlement === LEGACY_PREPAID_ENTITLEMENT_KEY) {
+    return LEGACY_PREPAID_DURATION_MONTHS;
   }
 
   return parsePositiveInteger(
@@ -74,7 +82,10 @@ const extractPrepaidGrantPayload = (session) => {
     return null;
   }
 
-  const months = resolvePrepaidDurationMonths(session);
+  const months = resolvePrepaidDurationMonths({
+    entitlement,
+    metadata: session?.metadata,
+  });
   if (!Number.isInteger(months) || months <= 0) {
     return null;
   }

--- a/apps/api/src/services/stripe-webhook.service.js
+++ b/apps/api/src/services/stripe-webhook.service.js
@@ -1,7 +1,7 @@
 import { dbQuery } from "../db/index.js";
 
-const PREPAID_PRO_ENTITLEMENT_KEY = "pro_6_months";
-const DEFAULT_PREPAID_DURATION_MONTHS = 6;
+const PREPAID_PRO_ENTITLEMENT_KEYS = new Set(["pro_12_months", "pro_6_months"]);
+const DEFAULT_PREPAID_DURATION_MONTHS = 12;
 
 const createError = (status, message) => {
   const error = new Error(message);
@@ -59,7 +59,7 @@ const resolvePrepaidDurationMonths = (session) => {
 
 const extractPrepaidGrantPayload = (session) => {
   const entitlement = session?.metadata?.entitlement;
-  if (entitlement !== PREPAID_PRO_ENTITLEMENT_KEY) {
+  if (!PREPAID_PRO_ENTITLEMENT_KEYS.has(entitlement)) {
     return null;
   }
 

--- a/apps/api/src/stripe-webhooks.test.js
+++ b/apps/api/src/stripe-webhooks.test.js
@@ -395,8 +395,8 @@ describe("stripe webhooks", () => {
           payment_intent: "pi_prepaid_001",
           metadata: {
             userId: String(userId),
-            entitlement: "pro_6_months",
-            entitlement_months: "6",
+            entitlement: "pro_12_months",
+            entitlement_months: "12",
           },
         },
       },
@@ -430,6 +430,31 @@ describe("stripe webhooks", () => {
           payment_status: "unpaid",
           metadata: {
             userId: String(userId),
+            entitlement: "pro_12_months",
+            entitlement_months: "12",
+          },
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await getUserProExpiresAt(userId)).toBeNull();
+  });
+
+  it("checkout.session.completed aceita metadata legacy pro_6_months", async () => {
+    await registerAndLogin("webhook-prepaid-legacy@controlfinance.dev");
+    const userId = await getUserIdByEmail("webhook-prepaid-legacy@controlfinance.dev");
+
+    const response = await stripePost({
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_prepaid_legacy_001",
+          mode: "payment",
+          payment_status: "paid",
+          payment_intent: "pi_prepaid_legacy_001",
+          metadata: {
+            userId: String(userId),
             entitlement: "pro_6_months",
             entitlement_months: "6",
           },
@@ -438,7 +463,9 @@ describe("stripe webhooks", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(await getUserProExpiresAt(userId)).toBeNull();
+    const proExpiresAt = await getUserProExpiresAt(userId);
+    expect(proExpiresAt).not.toBeNull();
+    expect(new Date(proExpiresAt).getTime()).toBeGreaterThan(Date.now());
   });
 
   it("checkout.session.async_payment_succeeded concede pre-pago com idempotencia por session id", async () => {
@@ -455,8 +482,8 @@ describe("stripe webhooks", () => {
           payment_intent: "pi_prepaid_003",
           metadata: {
             userId: String(userId),
-            entitlement: "pro_6_months",
-            entitlement_months: "6",
+            entitlement: "pro_12_months",
+            entitlement_months: "12",
           },
         },
       },

--- a/apps/api/src/stripe-webhooks.test.js
+++ b/apps/api/src/stripe-webhooks.test.js
@@ -468,6 +468,41 @@ describe("stripe webhooks", () => {
     expect(new Date(proExpiresAt).getTime()).toBeGreaterThan(Date.now());
   });
 
+  it("checkout.session.completed aplica fallback legado de 6 meses sem entitlement_months", async () => {
+    await registerAndLogin("webhook-prepaid-legacy-fallback@controlfinance.dev");
+    const userId = await getUserIdByEmail("webhook-prepaid-legacy-fallback@controlfinance.dev");
+
+    const response = await stripePost({
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_prepaid_legacy_002",
+          mode: "payment",
+          payment_status: "paid",
+          payment_intent: "pi_prepaid_legacy_002",
+          metadata: {
+            userId: String(userId),
+            entitlement: "pro_6_months",
+          },
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+
+    const grantResult = await dbQuery(
+      `SELECT entitlement_months
+         FROM prepaid_pro_grants
+        WHERE stripe_checkout_session_id = 'cs_prepaid_legacy_002'
+        LIMIT 1`,
+    );
+    expect(grantResult.rows[0]?.entitlement_months).toBe(6);
+
+    const proExpiresAt = await getUserProExpiresAt(userId);
+    expect(proExpiresAt).not.toBeNull();
+    expect(new Date(proExpiresAt).getTime()).toBeGreaterThan(Date.now());
+  });
+
   it("checkout.session.async_payment_succeeded concede pre-pago com idempotencia por session id", async () => {
     await registerAndLogin("webhook-prepaid-async@controlfinance.dev");
     const userId = await getUserIdByEmail("webhook-prepaid-async@controlfinance.dev");


### PR DESCRIPTION
## Summary
- switch prepaid checkout from inline price_data to Stripe one-time Price env STRIPE_PRICE_ID_PRO_PREPAID_YEAR
- set prepaid entitlement metadata to yearly (pro_12_months, entitlement_months=12 by default)
- keep webhook compatibility for old metadata key (pro_6_months)
- preserve legacy safety: if pro_6_months arrives without entitlement_months, grant 6 months (avoid over-grant)
- document new env in .env.example

## Validation
- 
pm -w apps/api run test -- src/billing-checkout.test.js src/stripe-webhooks.test.js
- 
pm -w apps/api run lint

## Notes
- PR #217 is already merged; this PR applies the yearly one-time price wiring and legacy-safe fallback.