### PR TITLE
chore(api): add explicit webhook diagnostic error codes

### DIFF
--- a/apps/api/src/routes/stripe-webhooks.routes.js
+++ b/apps/api/src/routes/stripe-webhooks.routes.js
@@ -2,9 +2,12 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import express, { Router } from "express";
 import { processStripeEvent } from "../services/stripe-webhook.service.js";
 
-const createError = (status, message) => {
+const createError = (status, message, publicCode = "") => {
   const error = new Error(message);
   error.status = status;
+  if (typeof publicCode === "string" && publicCode.trim()) {
+    error.publicCode = publicCode.trim();
+  }
   return error;
 };
 
@@ -31,7 +34,11 @@ const verifyStripeSignature = (rawBodyBuffer, signatureHeader, secret) => {
   const { t, v1s } = parseStripeSignatureHeader(signatureHeader);
 
   if (!t || v1s.length === 0) {
-    throw createError(400, "Stripe signature malformed.");
+    throw createError(
+      400,
+      "Stripe signature malformed.",
+      "BILLING_WEBHOOK_SIGNATURE_MALFORMED",
+    );
   }
 
   const expectedHex = createHmac("sha256", secret)
@@ -49,13 +56,21 @@ const verifyStripeSignature = (rawBodyBuffer, signatureHeader, secret) => {
   });
 
   if (!ok) {
-    throw createError(400, "Stripe signature invalid.");
+    throw createError(
+      400,
+      "Stripe signature invalid.",
+      "BILLING_WEBHOOK_SIGNATURE_INVALID",
+    );
   }
 
   const TOLERANCE_SECONDS = 300;
   const age = Math.abs(Math.floor(Date.now() / 1000) - parseInt(t, 10));
   if (!Number.isFinite(age) || age > TOLERANCE_SECONDS) {
-    throw createError(400, "Stripe webhook timestamp expired.");
+    throw createError(
+      400,
+      "Stripe webhook timestamp expired.",
+      "BILLING_WEBHOOK_TIMESTAMP_EXPIRED",
+    );
   }
 };
 
@@ -67,10 +82,26 @@ router.post(
   async (req, res, next) => {
     try {
       const secret = process.env.STRIPE_WEBHOOK_SECRET;
-      if (!secret) return next(createError(500, "Webhook secret not configured."));
+      if (!secret) {
+        return next(
+          createError(
+            500,
+            "Stripe webhook secret missing.",
+            "BILLING_WEBHOOK_SECRET_MISSING",
+          ),
+        );
+      }
 
       const sig = req.headers["stripe-signature"];
-      if (!sig) return next(createError(400, "Missing Stripe-Signature header."));
+      if (!sig) {
+        return next(
+          createError(
+            400,
+            "Missing Stripe-Signature header.",
+            "BILLING_WEBHOOK_SIGNATURE_MISSING",
+          ),
+        );
+      }
 
       verifyStripeSignature(req.body, sig, secret);
 

--- a/apps/api/src/stripe-webhooks.test.js
+++ b/apps/api/src/stripe-webhooks.test.js
@@ -74,6 +74,25 @@ describe("stripe webhooks", () => {
 
     expect(response.status).toBe(400);
     expect(response.body.message).toBe("Missing Stripe-Signature header.");
+    expect(response.body.code).toBe("BILLING_WEBHOOK_SIGNATURE_MISSING");
+  });
+
+  it("retorna 500 com code explicito sem STRIPE_WEBHOOK_SECRET", async () => {
+    const savedSecret = process.env.STRIPE_WEBHOOK_SECRET;
+    delete process.env.STRIPE_WEBHOOK_SECRET;
+
+    try {
+      const response = await request(app)
+        .post("/billing/webhooks/stripe")
+        .set("Content-Type", "application/json")
+        .send(JSON.stringify({ type: "checkout.session.completed" }));
+
+      expect(response.status).toBe(500);
+      expect(response.body.message).toBe("Unexpected error.");
+      expect(response.body.code).toBe("BILLING_WEBHOOK_SECRET_MISSING");
+    } finally {
+      process.env.STRIPE_WEBHOOK_SECRET = savedSecret;
+    }
   });
 
   it("retorna 400 com assinatura invalida (secret errado)", async () => {
@@ -90,6 +109,7 @@ describe("stripe webhooks", () => {
 
     expect(response.status).toBe(400);
     expect(response.body.message).toBe("Stripe signature invalid.");
+    expect(response.body.code).toBe("BILLING_WEBHOOK_SIGNATURE_INVALID");
   });
 
   it("retorna 400 com timestamp expirado (replay attack)", async () => {
@@ -108,6 +128,7 @@ describe("stripe webhooks", () => {
 
     expect(response.status).toBe(400);
     expect(response.body.message).toBe("Stripe webhook timestamp expired.");
+    expect(response.body.code).toBe("BILLING_WEBHOOK_TIMESTAMP_EXPIRED");
   });
 
   it("retorna 200 para evento desconhecido sem efeito colateral", async () => {


### PR DESCRIPTION
Summary: add explicit webhook diagnostic codes for missing secret/signature and signature verification failures; add missing STRIPE_WEBHOOK_SECRET test. Validation: npm -w apps/api run test -- src/stripe-webhooks.test.js; npm -w apps/api run lint.