### PR TITLE
fix(api): remove automatic payment methods from prepaid checkout

### DIFF
--- a/apps/api/src/billing-checkout.test.js
+++ b/apps/api/src/billing-checkout.test.js
@@ -215,9 +215,8 @@ describe("billing checkout", () => {
     const args = mockSessionCreate.mock.calls[0][0];
     expect(args.mode).toBe("payment");
     expect(args.automatic_payment_methods).toBeUndefined();
-    expect(args.payment_intent_data?.automatic_payment_methods).toEqual({
-      enabled: true,
-    });
+    expect(args.payment_intent_data).toBeUndefined();
+    expect(args.payment_method_types).toEqual(["card"]);
     expect(args.line_items[0].price).toBe("price_prepaid_year_env");
     expect(args.metadata.userId).toBe(String(userId));
     expect(args.metadata.entitlement).toBe("pro_12_months");

--- a/apps/api/src/services/stripe-prepaid-checkout.service.js
+++ b/apps/api/src/services/stripe-prepaid-checkout.service.js
@@ -111,9 +111,7 @@ export const createPrepaidCheckoutSession = async ({ userId, userEmail }) => {
       mode: "payment",
       success_url: successUrl,
       cancel_url: cancelUrl,
-      payment_intent_data: {
-        automatic_payment_methods: { enabled: true },
-      },
+      payment_method_types: ["card"],
       line_items: [{ price: prepaidYearPriceId, quantity: 1 }],
       metadata: {
         userId: String(userId),


### PR DESCRIPTION
Summary: remove Stripe automatic_payment_methods usage from prepaid Checkout Session payload for compatibility; use payment_method_types=['card'] instead.\n\nThis fixes 500 /billing/checkout-prepaid failures with Stripe error: 'Received unknown parameter: automatic_payment_methods' and 'payment_intent_data[automatic_payment_methods]'.\n\nValidation:\n- npm -w apps/api run test -- src/billing-checkout.test.js\n- npm -w apps/api run lint