### PR TITLE
feat(api): add billing state hardening migration (022)

### DIFF
--- a/apps/api/src/db/migrations/022_billing_state_hardening.sql
+++ b/apps/api/src/db/migrations/022_billing_state_hardening.sql
@@ -1,0 +1,74 @@
+-- 022_billing_state_hardening.sql
+-- Entitlement cache + subscriptions hardening + webhook idempotency.
+
+-- 1) Optional cache on users. Source of truth remains subscriptions/plans.
+ALTER TABLE users
+ADD COLUMN IF NOT EXISTS plan TEXT NOT NULL DEFAULT 'free';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'chk_users_plan'
+  ) THEN
+    ALTER TABLE users
+      ADD CONSTRAINT chk_users_plan
+      CHECK (plan IN ('free', 'trial', 'pro'));
+  END IF;
+END $$;
+
+-- Backfill users.plan cache from existing billing state.
+-- Precedence:
+--  1) active recurring subscription
+--  2) active prepaid entitlement (pro_expires_at)
+--  3) active trial
+--  4) free
+UPDATE users u
+SET plan = CASE
+  WHEN EXISTS (
+    SELECT 1
+    FROM subscriptions s
+    WHERE s.user_id = u.id
+      AND s.status IN ('active', 'trialing', 'past_due')
+  ) THEN 'pro'
+  WHEN u.pro_expires_at IS NOT NULL AND u.pro_expires_at > NOW() THEN 'pro'
+  WHEN u.trial_ends_at IS NOT NULL AND u.trial_ends_at > NOW() THEN 'trial'
+  ELSE 'free'
+END;
+
+CREATE INDEX IF NOT EXISTS idx_users_plan ON users (plan);
+CREATE INDEX IF NOT EXISTS idx_users_trial_ends_at ON users (trial_ends_at);
+CREATE INDEX IF NOT EXISTS idx_users_pro_expires_at ON users (pro_expires_at);
+
+-- 2) Subscription status hardening.
+-- NOTE: prepaid is not a Stripe subscription status and should not be stored here.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'chk_subscriptions_status'
+  ) THEN
+    ALTER TABLE subscriptions
+      ADD CONSTRAINT chk_subscriptions_status
+      CHECK (
+        status IN (
+          'active',
+          'trialing',
+          'past_due',
+          'canceled',
+          'incomplete',
+          'incomplete_expired',
+          'unpaid'
+        )
+      );
+  END IF;
+END $$;
+
+-- 3) Stripe webhook idempotency registry.
+CREATE TABLE IF NOT EXISTS stripe_events (
+  id SERIAL PRIMARY KEY,
+  stripe_event_id TEXT NOT NULL UNIQUE,
+  event_type TEXT NOT NULL,
+  processed_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_stripe_events_processed_at
+  ON stripe_events (processed_at);

--- a/apps/api/src/db/migrations/022_billing_state_hardening.sql
+++ b/apps/api/src/db/migrations/022_billing_state_hardening.sql
@@ -5,16 +5,12 @@
 ALTER TABLE users
 ADD COLUMN IF NOT EXISTS plan TEXT NOT NULL DEFAULT 'free';
 
-DO $$
-BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_constraint WHERE conname = 'chk_users_plan'
-  ) THEN
-    ALTER TABLE users
-      ADD CONSTRAINT chk_users_plan
-      CHECK (plan IN ('free', 'trial', 'pro'));
-  END IF;
-END $$;
+ALTER TABLE users
+DROP CONSTRAINT IF EXISTS chk_users_plan;
+
+ALTER TABLE users
+ADD CONSTRAINT chk_users_plan
+CHECK (plan IN ('free', 'trial', 'pro'));
 
 -- Backfill users.plan cache from existing billing state.
 -- Precedence:
@@ -22,16 +18,15 @@ END $$;
 --  2) active prepaid entitlement (pro_expires_at)
 --  3) active trial
 --  4) free
-UPDATE users u
+UPDATE users
 SET plan = CASE
-  WHEN EXISTS (
-    SELECT 1
-    FROM subscriptions s
-    WHERE s.user_id = u.id
-      AND s.status IN ('active', 'trialing', 'past_due')
+  WHEN id IN (
+    SELECT user_id
+    FROM subscriptions
+    WHERE status IN ('active', 'trialing', 'past_due')
   ) THEN 'pro'
-  WHEN u.pro_expires_at IS NOT NULL AND u.pro_expires_at > NOW() THEN 'pro'
-  WHEN u.trial_ends_at IS NOT NULL AND u.trial_ends_at > NOW() THEN 'trial'
+  WHEN pro_expires_at IS NOT NULL AND pro_expires_at > NOW() THEN 'pro'
+  WHEN trial_ends_at IS NOT NULL AND trial_ends_at > NOW() THEN 'trial'
   ELSE 'free'
 END;
 
@@ -41,26 +36,22 @@ CREATE INDEX IF NOT EXISTS idx_users_pro_expires_at ON users (pro_expires_at);
 
 -- 2) Subscription status hardening.
 -- NOTE: prepaid is not a Stripe subscription status and should not be stored here.
-DO $$
-BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_constraint WHERE conname = 'chk_subscriptions_status'
-  ) THEN
-    ALTER TABLE subscriptions
-      ADD CONSTRAINT chk_subscriptions_status
-      CHECK (
-        status IN (
-          'active',
-          'trialing',
-          'past_due',
-          'canceled',
-          'incomplete',
-          'incomplete_expired',
-          'unpaid'
-        )
-      );
-  END IF;
-END $$;
+ALTER TABLE subscriptions
+DROP CONSTRAINT IF EXISTS chk_subscriptions_status;
+
+ALTER TABLE subscriptions
+ADD CONSTRAINT chk_subscriptions_status
+CHECK (
+  status IN (
+    'active',
+    'trialing',
+    'past_due',
+    'canceled',
+    'incomplete',
+    'incomplete_expired',
+    'unpaid'
+  )
+);
 
 -- 3) Stripe webhook idempotency registry.
 CREATE TABLE IF NOT EXISTS stripe_events (

--- a/apps/api/src/middlewares/entitlement.middleware.js
+++ b/apps/api/src/middlewares/entitlement.middleware.js
@@ -130,14 +130,15 @@ export const requireActiveTrialOrPaidPlan = async (req, res, next) => {
 
     // Check for active prepaid PRO entitlement
     const prepaidResult = await dbQuery(
-      `SELECT 1 FROM users
+      `SELECT pro_expires_at
+       FROM users
        WHERE id = $1
-         AND pro_expires_at IS NOT NULL
-         AND pro_expires_at > NOW()
        LIMIT 1`,
       [userId],
     );
-    if (prepaidResult.rows.length > 0) return next();
+    const prepaidProExpiresAt =
+      prepaidResult.rows.length > 0 ? prepaidResult.rows[0].pro_expires_at : null;
+    if (prepaidProExpiresAt && new Date(prepaidProExpiresAt) > new Date()) return next();
 
     // Check for an active trial (trial_ends_at column added by migration 014)
     const trialResult = await dbQuery(

--- a/apps/api/src/services/billing.service.js
+++ b/apps/api/src/services/billing.service.js
@@ -102,8 +102,6 @@ const getActivePrepaidProExpiresAtForUser = async (userId) => {
     `SELECT pro_expires_at
       FROM users
       WHERE id = $1
-        AND pro_expires_at IS NOT NULL
-        AND pro_expires_at > NOW()
       LIMIT 1`,
     [userId],
   );
@@ -112,7 +110,16 @@ const getActivePrepaidProExpiresAtForUser = async (userId) => {
     return null;
   }
 
-  return result.rows[0].pro_expires_at;
+  const proExpiresAt = result.rows[0].pro_expires_at;
+  if (!proExpiresAt) {
+    return null;
+  }
+
+  if (new Date(proExpiresAt) <= new Date()) {
+    return null;
+  }
+
+  return proExpiresAt;
 };
 
 /**

--- a/docs/architecture/v1.6.11-billing-state-machine.md
+++ b/docs/architecture/v1.6.11-billing-state-machine.md
@@ -1,0 +1,62 @@
+# Billing State Machine (v1)
+
+## Goal
+- Keep `subscriptions/plans` as source of truth for recurring billing.
+- Use `users.trial_ends_at` and `users.pro_expires_at` as entitlement cache for trial/prepaid.
+- Avoid drift by resolving entitlement at request time using deterministic precedence.
+
+## Product States
+- `trial_active`
+- `free`
+- `pro_recurring_active`
+- `pro_recurring_past_due`
+- `pro_prepaid_active`
+- `pro_canceled` (display state; effective access may fall back to `free`)
+
+## Entitlement Precedence (runtime)
+1. Active recurring subscription (`active` or `trialing`) => `pro`
+2. Recurring `past_due` => `pro` (policy decision: grace period vs strict block)
+3. `users.pro_expires_at > now()` => `pro` (prepaid)
+4. `users.trial_ends_at > now()` => `trial`
+5. Otherwise => `free`
+
+`users.plan` is a cache and may be used for UI hints. Feature gating should follow the precedence above.
+
+## State Transitions
+- `signup` => `trial_active` (`trial_ends_at = now + 14 days`)
+- `trial_ends_at <= now` (lazy check on authenticated request) => `free`
+- `invoice.paid` => `pro_recurring_active`
+- `customer.subscription.updated(status=past_due)` => `pro_recurring_past_due`
+- `customer.subscription.deleted` => `free` (if no active prepaid entitlement)
+- `checkout.session.completed` (prepaid payment) => extend `pro_expires_at` => `pro_prepaid_active`
+
+## Paywall Response Contract
+- HTTP `402`
+- Body shape:
+
+```json
+{
+  "error": "PAYWALL",
+  "code": "FEATURE_REQUIRES_PRO",
+  "feature": "export_csv",
+  "state": "free|trial|pro|past_due",
+  "trialEndsAt": "2026-03-01T10:00:00Z",
+  "proExpiresAt": null
+}
+```
+
+## Integration Test Checklist
+
+### Sprint 1 (trial/quota)
+- Trial expiry lazy downgrade:
+  - user with `trial_ends_at` in the past hits premium endpoint => `402`
+- Free quota:
+  - 51st transaction in same calendar month => `402` (`QUOTA_EXCEEDED`)
+- Prepaid override:
+  - free user with `pro_expires_at` in future accesses premium endpoint => `200`
+
+### Sprint 2 (Stripe idempotency)
+- Duplicate webhook event:
+  - same `stripe_event_id` processed twice => second run no-op
+- Recurring activation:
+  - `invoice.paid` updates recurring subscription status and unlocks pro features


### PR DESCRIPTION
Summary:\n- add migration 022 with users.plan cache + constraints/indexes\n- add subscriptions status CHECK hardening (Stripe-aligned statuses only)\n- add stripe_events table for webhook idempotency groundwork\n- add architecture doc for billing state machine, precedence and integration test checklist\n\nValidation:\n- npm -w apps/api run lint\n\nNotes:\n- source of truth remains subscriptions/plans\n- prepaid entitlement remains based on users.pro_expires_at