### PR TITLE
feat(api): centralize entitlement resolution with past_due grace

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -25,6 +25,8 @@ CORS_ORIGIN=http://localhost:5173
 # STRIPE_PRICE_ID_PRO=price_...
 # STRIPE_CHECKOUT_SUCCESS_URL=http://localhost:5173/app/settings/billing?checkout=success
 # STRIPE_CHECKOUT_CANCEL_URL=http://localhost:5173/app/settings/billing?checkout=cancel
+# Billing entitlement policy
+# BILLING_PAST_DUE_GRACE_DAYS=3
 # Paywall bypass -- DEV / STAGING ONLY. Ignored when NODE_ENV=production.
 # Set PAYWALL_BYPASS_ENABLED=true and list emails to grant full PRO access without a subscription.
 PAYWALL_BYPASS_ENABLED=false

--- a/apps/api/src/billing.test.js
+++ b/apps/api/src/billing.test.js
@@ -88,10 +88,64 @@ describe("billing", () => {
       .set("Authorization", `Bearer ${token}`);
 
     expect(response.status).toBe(200);
-    expect(response.body.plan).toBe("free");
+    expect(response.body.plan).toBe("trial");
     expect(response.body.source).toBe("trial");
     expect(typeof response.body.trialEndsAt).toBe("string");
     expect(response.body.proExpiresAt).toBeNull();
+  });
+
+  it("GET /billing/entitlement retorna source=recurring_grace para usuario past_due dentro da janela", async () => {
+    const email = "billing-entitlement-grace@controlfinance.dev";
+    const token = await registerAndLogin(email);
+    const userId = await getUserIdByEmail(email);
+    await makeProUser(email);
+    await dbQuery(
+      `UPDATE users SET trial_ends_at = NOW() - INTERVAL '1 day' WHERE id = $1`,
+      [userId],
+    );
+    await dbQuery(
+      `UPDATE subscriptions
+        SET status = 'past_due', updated_at = NOW() - INTERVAL '2 days'
+        WHERE user_id = $1`,
+      [userId],
+    );
+
+    const response = await request(app)
+      .get("/billing/entitlement")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.plan).toBe("pro");
+    expect(response.body.source).toBe("recurring_grace");
+    expect(response.body.subscriptionStatus).toBe("past_due");
+    expect(typeof response.body.graceEndsAt).toBe("string");
+  });
+
+  it("GET /billing/entitlement retorna source=none para usuario past_due fora da janela", async () => {
+    const email = "billing-entitlement-grace-expired@controlfinance.dev";
+    const token = await registerAndLogin(email);
+    const userId = await getUserIdByEmail(email);
+    await makeProUser(email);
+    await dbQuery(
+      `UPDATE users SET trial_ends_at = NOW() - INTERVAL '1 day' WHERE id = $1`,
+      [userId],
+    );
+    await dbQuery(
+      `UPDATE subscriptions
+        SET status = 'past_due', updated_at = NOW() - INTERVAL '4 days'
+        WHERE user_id = $1`,
+      [userId],
+    );
+
+    const response = await request(app)
+      .get("/billing/entitlement")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.plan).toBe("free");
+    expect(response.body.source).toBe("none");
+    expect(response.body.subscriptionStatus).toBe("past_due");
+    expect(typeof response.body.graceEndsAt).toBe("string");
   });
 
   it("GET /billing/entitlement retorna source=prepaid para usuario com pro_expires_at ativo", async () => {
@@ -135,6 +189,35 @@ describe("billing", () => {
       cancelAtPeriodEnd: true,
     });
     expect(typeof response.body.subscription.currentPeriodEnd).toBe("string");
+  });
+
+  it("GET /billing/subscription retorna entitlementSource=subscription_grace para usuario past_due dentro da janela", async () => {
+    const email = "billing-summary-grace@controlfinance.dev";
+    const token = await registerAndLogin(email);
+    const userId = await getUserIdByEmail(email);
+    await makeProUser(email);
+    await dbQuery(
+      `UPDATE users SET trial_ends_at = NOW() - INTERVAL '1 day' WHERE id = $1`,
+      [userId],
+    );
+    await dbQuery(
+      `UPDATE subscriptions
+        SET status = 'past_due', updated_at = NOW() - INTERVAL '2 days'
+        WHERE user_id = $1`,
+      [userId],
+    );
+
+    const response = await request(app)
+      .get("/billing/subscription")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.plan).toBe("pro");
+    expect(response.body.entitlementSource).toBe("subscription_grace");
+    expect(response.body.subscription).toMatchObject({
+      status: "past_due",
+    });
+    expect(typeof response.body.graceEndsAt).toBe("string");
   });
 
   it("POST /transactions/import/dry-run retorna 402 para usuario free", async () => {

--- a/apps/api/src/middlewares/entitlement.middleware.js
+++ b/apps/api/src/middlewares/entitlement.middleware.js
@@ -1,5 +1,7 @@
-import { dbQuery } from "../db/index.js";
-import { getActivePlanFeaturesForUser } from "../services/billing.service.js";
+import {
+  getActivePlanFeaturesForUser,
+  resolveEntitlement,
+} from "../services/billing.service.js";
 
 // ---------------------------------------------------------------------------
 // Paywall bypass (dev / staging only)
@@ -116,39 +118,15 @@ export const requireActiveTrialOrPaidPlan = async (req, res, next) => {
       return next();
     }
 
-    const userId = req.user.id;
+    const entitlement = await resolveEntitlement(req.user.id);
 
-    // Check for an active paid subscription
-    const subResult = await dbQuery(
-      `SELECT 1 FROM subscriptions
-       WHERE user_id = $1
-         AND status IN ('active', 'trialing', 'past_due')
-       LIMIT 1`,
-      [userId],
-    );
-    if (subResult.rows.length > 0) return next();
+    if (entitlement.source === "recurring_grace") {
+      res.set("X-Subscription-Status", "past_due_grace");
+    }
 
-    // Check for active prepaid PRO entitlement
-    const prepaidResult = await dbQuery(
-      `SELECT pro_expires_at
-       FROM users
-       WHERE id = $1
-       LIMIT 1`,
-      [userId],
-    );
-    const prepaidProExpiresAt =
-      prepaidResult.rows.length > 0 ? prepaidResult.rows[0].pro_expires_at : null;
-    if (prepaidProExpiresAt && new Date(prepaidProExpiresAt) > new Date()) return next();
-
-    // Check for an active trial (trial_ends_at column added by migration 014)
-    const trialResult = await dbQuery(
-      `SELECT trial_ends_at FROM users WHERE id = $1 LIMIT 1`,
-      [userId],
-    );
-    const trialEndsAt =
-      trialResult.rows.length > 0 ? trialResult.rows[0].trial_ends_at : null;
-
-    if (trialEndsAt && new Date(trialEndsAt) > new Date()) return next();
+    if (entitlement.plan === "pro" || entitlement.plan === "trial") {
+      return next();
+    }
 
     return next(createPaymentRequiredError(TRIAL_EXPIRED_MESSAGE));
   } catch (error) {

--- a/apps/api/src/paywall.test.js
+++ b/apps/api/src/paywall.test.js
@@ -142,6 +142,54 @@ describe("requireActiveTrialOrPaidPlan", () => {
     expect(res.status).toBe(200);
   });
 
+  it("permite acesso em past_due dentro de 3 dias (grace) e envia header de status", async () => {
+    const token = await registerAndLogin("paywall-past-due-grace@test.dev");
+    const userId = await getUserIdByEmail("paywall-past-due-grace@test.dev");
+
+    await dbQuery(
+      `UPDATE users SET trial_ends_at = NOW() - INTERVAL '1 day' WHERE id = $1`,
+      [userId],
+    );
+    await makeProUser("paywall-past-due-grace@test.dev");
+    await dbQuery(
+      `UPDATE subscriptions
+        SET status = 'past_due', updated_at = NOW() - INTERVAL '2 days'
+        WHERE user_id = $1`,
+      [userId],
+    );
+
+    const res = await request(testApp)
+      .get("/trial-gated")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.headers["x-subscription-status"]).toBe("past_due_grace");
+  });
+
+  it("retorna 402 quando past_due ultrapassa 3 dias de grace", async () => {
+    const token = await registerAndLogin("paywall-past-due-expired@test.dev");
+    const userId = await getUserIdByEmail("paywall-past-due-expired@test.dev");
+
+    await dbQuery(
+      `UPDATE users SET trial_ends_at = NOW() - INTERVAL '1 day' WHERE id = $1`,
+      [userId],
+    );
+    await makeProUser("paywall-past-due-expired@test.dev");
+    await dbQuery(
+      `UPDATE subscriptions
+        SET status = 'past_due', updated_at = NOW() - INTERVAL '4 days'
+        WHERE user_id = $1`,
+      [userId],
+    );
+
+    const res = await request(testApp)
+      .get("/trial-gated")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(402);
+    expect(res.body.message).toContain("Periodo de teste encerrado");
+  });
+
   it("retorna 402 para usuario sem trial nem assinatura (legacy sem trial_ends_at)", async () => {
     const token = await registerAndLogin("paywall-no-trial@test.dev");
     const userId = await getUserIdByEmail("paywall-no-trial@test.dev");

--- a/apps/api/src/services/billing.service.js
+++ b/apps/api/src/services/billing.service.js
@@ -149,6 +149,10 @@ const getUserBillingDates = async (userId) => {
  *  3. prepaid active (pro_expires_at)
  *  4. active trial
  *  5. free
+ *
+ * NOTE: for now, the grace reference timestamp comes from subscription.updated_at.
+ * This keeps the model migration-free, but webhook noise may move updated_at.
+ * Future hardening can add subscriptions.past_due_since for immutable tracking.
  */
 export const resolveEntitlement = async (userId) => {
   const normalizedUserId = normalizeUserId(userId);
@@ -275,6 +279,9 @@ export const getSubscriptionSummaryForUser = async (userId) => {
     (entitlement.source === "recurring" || entitlement.source === "recurring_grace")
   ) {
     const row = entitlement.subscription;
+    // Keep API contract stable:
+    // - /billing/entitlement uses source=recurring_grace
+    // - /billing/subscription uses entitlementSource=subscription_grace
     const entitlementSource =
       entitlement.source === "recurring_grace"
         ? "subscription_grace"

--- a/apps/api/src/services/billing.service.js
+++ b/apps/api/src/services/billing.service.js
@@ -6,6 +6,9 @@ const createError = (status, message) => {
   return error;
 };
 
+const DEFAULT_PAST_DUE_GRACE_DAYS = 3;
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+
 // Features available during an active trial.
 // csv_import/export remain PRO-only; analytics cap is set to 6 months.
 const TRIAL_FEATURES = {
@@ -25,6 +28,40 @@ const normalizeUserId = (value) => {
 
   return parsed;
 };
+
+const parsePositiveInteger = (value, fallbackValue) => {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return fallbackValue;
+  }
+  return parsed;
+};
+
+const getPastDueGraceDays = () =>
+  parsePositiveInteger(
+    process.env.BILLING_PAST_DUE_GRACE_DAYS,
+    DEFAULT_PAST_DUE_GRACE_DAYS,
+  );
+
+const toDateOrNull = (value) => {
+  if (!value) return null;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed;
+};
+
+const toIsoOrNull = (value) => {
+  if (!value) return null;
+  return value.toISOString();
+};
+
+const isFutureDate = (value, now = new Date()) => {
+  const parsed = toDateOrNull(value);
+  if (!parsed) return false;
+  return parsed.getTime() > now.getTime();
+};
+
+const addDays = (date, days) => new Date(date.getTime() + days * MILLISECONDS_PER_DAY);
 
 const getFreePlan = async () => {
   const result = await dbQuery(
@@ -56,7 +93,7 @@ const getProPlan = async () => {
   return result.rows[0];
 };
 
-const getActivePaidSubscriptionSummary = async (userId) => {
+const getCurrentSubscriptionForEntitlement = async (userId) => {
   const result = await dbQuery(
     `
       SELECT
@@ -65,11 +102,21 @@ const getActivePaidSubscriptionSummary = async (userId) => {
         p.features,
         s.status,
         s.current_period_end AS "currentPeriodEnd",
-        s.cancel_at_period_end AS "cancelAtPeriodEnd"
+        s.cancel_at_period_end AS "cancelAtPeriodEnd",
+        s.updated_at AS "updatedAt"
       FROM subscriptions s
       JOIN plans p ON p.id = s.plan_id
       WHERE s.user_id = $1
         AND s.status IN ('active', 'trialing', 'past_due')
+      ORDER BY
+        CASE s.status
+          WHEN 'active' THEN 1
+          WHEN 'trialing' THEN 2
+          WHEN 'past_due' THEN 3
+          ELSE 4
+        END,
+        COALESCE(s.updated_at, s.created_at) DESC,
+        s.id DESC
       LIMIT 1
     `,
     [userId],
@@ -78,28 +125,9 @@ const getActivePaidSubscriptionSummary = async (userId) => {
   return result.rows[0] ?? null;
 };
 
-const getActiveTrialEndsAtForUser = async (userId) => {
-  const trialResult = await dbQuery(
-    `SELECT trial_ends_at FROM users WHERE id = $1 LIMIT 1`,
-    [userId],
-  );
-  const trialEndsAt =
-    trialResult.rows.length > 0 ? trialResult.rows[0].trial_ends_at : null;
-
-  if (!trialEndsAt) {
-    return null;
-  }
-
-  if (new Date(trialEndsAt) <= new Date()) {
-    return null;
-  }
-
-  return trialEndsAt;
-};
-
-const getActivePrepaidProExpiresAtForUser = async (userId) => {
+const getUserBillingDates = async (userId) => {
   const result = await dbQuery(
-    `SELECT pro_expires_at
+    `SELECT trial_ends_at AS "trialEndsAt", pro_expires_at AS "proExpiresAt"
       FROM users
       WHERE id = $1
       LIMIT 1`,
@@ -110,45 +138,125 @@ const getActivePrepaidProExpiresAtForUser = async (userId) => {
     return null;
   }
 
-  const proExpiresAt = result.rows[0].pro_expires_at;
-  if (!proExpiresAt) {
-    return null;
+  return result.rows[0];
+};
+
+/**
+ * Resolves effective entitlement for a user.
+ * Priority order:
+ *  1. recurring active/trialing
+ *  2. recurring past_due within grace window
+ *  3. prepaid active (pro_expires_at)
+ *  4. active trial
+ *  5. free
+ */
+export const resolveEntitlement = async (userId) => {
+  const normalizedUserId = normalizeUserId(userId);
+  const now = new Date();
+
+  const activeSubscription = await getCurrentSubscriptionForEntitlement(
+    normalizedUserId,
+  );
+  const userBillingDates = await getUserBillingDates(normalizedUserId);
+
+  const trialEndsAt = toDateOrNull(userBillingDates?.trialEndsAt ?? null);
+  const proExpiresAt = toDateOrNull(userBillingDates?.proExpiresAt ?? null);
+
+  let pastDueContext = null;
+
+  if (activeSubscription?.status === "active" || activeSubscription?.status === "trialing") {
+    return {
+      plan: "pro",
+      source: "recurring",
+      subscriptionStatus: activeSubscription.status,
+      trialEndsAt: null,
+      proExpiresAt: null,
+      graceEndsAt: null,
+      subscription: activeSubscription,
+    };
   }
 
-  if (new Date(proExpiresAt) <= new Date()) {
-    return null;
+  if (activeSubscription?.status === "past_due") {
+    const graceDays = getPastDueGraceDays();
+    const referenceDate = toDateOrNull(activeSubscription.updatedAt) ?? now;
+    const graceEndsAt = addDays(referenceDate, graceDays);
+
+    if (now.getTime() <= graceEndsAt.getTime()) {
+      return {
+        plan: "pro",
+        source: "recurring_grace",
+        subscriptionStatus: "past_due",
+        trialEndsAt: null,
+        proExpiresAt: null,
+        graceEndsAt,
+        subscription: activeSubscription,
+      };
+    }
+
+    pastDueContext = {
+      subscriptionStatus: "past_due",
+      graceEndsAt,
+      subscription: activeSubscription,
+    };
   }
 
-  return proExpiresAt;
+  if (isFutureDate(proExpiresAt, now)) {
+    return {
+      plan: "pro",
+      source: "prepaid",
+      subscriptionStatus: pastDueContext?.subscriptionStatus ?? null,
+      trialEndsAt: null,
+      proExpiresAt,
+      graceEndsAt: pastDueContext?.graceEndsAt ?? null,
+      subscription: pastDueContext?.subscription ?? null,
+    };
+  }
+
+  if (isFutureDate(trialEndsAt, now)) {
+    return {
+      plan: "trial",
+      source: "trial",
+      subscriptionStatus: pastDueContext?.subscriptionStatus ?? null,
+      trialEndsAt,
+      proExpiresAt: null,
+      graceEndsAt: pastDueContext?.graceEndsAt ?? null,
+      subscription: pastDueContext?.subscription ?? null,
+    };
+  }
+
+  return {
+    plan: "free",
+    source: "none",
+    subscriptionStatus: pastDueContext?.subscriptionStatus ?? null,
+    trialEndsAt: null,
+    proExpiresAt: null,
+    graceEndsAt: pastDueContext?.graceEndsAt ?? null,
+    subscription: pastDueContext?.subscription ?? null,
+  };
 };
 
 /**
  * Returns the active plan features for a user.
- * Priority order:
- *  1. Active recurring subscription
- *  2. Active prepaid PRO entitlement (users.pro_expires_at)
- *  3. Active trial
- *  4. Free plan
  */
 export const getActivePlanFeaturesForUser = async (userId) => {
   const normalizedUserId = normalizeUserId(userId);
+  const entitlement = await resolveEntitlement(normalizedUserId);
 
-  const activeSubscription = await getActivePaidSubscriptionSummary(
-    normalizedUserId,
-  );
-  if (activeSubscription) {
-    return activeSubscription.features;
-  }
+  if (entitlement.plan === "pro") {
+    if (
+      entitlement.source === "recurring" ||
+      entitlement.source === "recurring_grace"
+    ) {
+      if (entitlement.subscription?.features) {
+        return entitlement.subscription.features;
+      }
+    }
 
-  const prepaidProExpiresAt =
-    await getActivePrepaidProExpiresAtForUser(normalizedUserId);
-  if (prepaidProExpiresAt) {
     const proPlan = await getProPlan();
     return proPlan.features;
   }
 
-  const trialEndsAt = await getActiveTrialEndsAtForUser(normalizedUserId);
-  if (trialEndsAt && new Date(trialEndsAt) > new Date()) {
+  if (entitlement.plan === "trial") {
     return TRIAL_FEATURES;
   }
 
@@ -160,14 +268,33 @@ export const getActivePlanFeaturesForUser = async (userId) => {
  * Returns a summary of the user's current subscription for the /billing/subscription endpoint.
  */
 export const getSubscriptionSummaryForUser = async (userId) => {
-  const normalizedUserId = normalizeUserId(userId);
+  const entitlement = await resolveEntitlement(userId);
 
-  const activeSubscription = await getActivePaidSubscriptionSummary(
-    normalizedUserId,
-  );
+  if (
+    entitlement.plan === "pro" &&
+    (entitlement.source === "recurring" || entitlement.source === "recurring_grace")
+  ) {
+    const row = entitlement.subscription;
+    const entitlementSource =
+      entitlement.source === "recurring_grace"
+        ? "subscription_grace"
+        : "subscription";
 
-  if (activeSubscription) {
-    const row = activeSubscription;
+    if (!row) {
+      const proPlan = await getProPlan();
+      return {
+        plan: proPlan.name,
+        displayName: proPlan.displayName,
+        features: proPlan.features,
+        subscription: {
+          status: "active",
+          currentPeriodEnd: null,
+          cancelAtPeriodEnd: false,
+        },
+        entitlementSource,
+        graceEndsAt: toIsoOrNull(entitlement.graceEndsAt),
+      };
+    }
 
     return {
       plan: row.plan,
@@ -178,13 +305,12 @@ export const getSubscriptionSummaryForUser = async (userId) => {
         currentPeriodEnd: row.currentPeriodEnd,
         cancelAtPeriodEnd: row.cancelAtPeriodEnd,
       },
-      entitlementSource: "subscription",
+      entitlementSource,
+      graceEndsAt: toIsoOrNull(entitlement.graceEndsAt),
     };
   }
 
-  const prepaidProExpiresAt =
-    await getActivePrepaidProExpiresAtForUser(normalizedUserId);
-  if (prepaidProExpiresAt) {
+  if (entitlement.plan === "pro" && entitlement.source === "prepaid") {
     const proPlan = await getProPlan();
     return {
       plan: proPlan.name,
@@ -192,11 +318,11 @@ export const getSubscriptionSummaryForUser = async (userId) => {
       features: proPlan.features,
       subscription: {
         status: "prepaid_active",
-        currentPeriodEnd: prepaidProExpiresAt,
+        currentPeriodEnd: toIsoOrNull(entitlement.proExpiresAt),
         cancelAtPeriodEnd: true,
       },
       entitlementSource: "prepaid",
-      proExpiresAt: prepaidProExpiresAt,
+      proExpiresAt: toIsoOrNull(entitlement.proExpiresAt),
     };
   }
 
@@ -216,46 +342,14 @@ export const getSubscriptionSummaryForUser = async (userId) => {
  * Returns the user's effective entitlement source.
  */
 export const getEntitlementSummaryForUser = async (userId) => {
-  const normalizedUserId = normalizeUserId(userId);
-
-  const activeSubscription = await getActivePaidSubscriptionSummary(
-    normalizedUserId,
-  );
-
-  if (activeSubscription) {
-    return {
-      plan: activeSubscription.plan,
-      source: "subscription",
-      proExpiresAt: null,
-      trialEndsAt: null,
-    };
-  }
-
-  const prepaidProExpiresAt =
-    await getActivePrepaidProExpiresAtForUser(normalizedUserId);
-  if (prepaidProExpiresAt) {
-    return {
-      plan: "pro",
-      source: "prepaid",
-      proExpiresAt: prepaidProExpiresAt,
-      trialEndsAt: null,
-    };
-  }
-
-  const trialEndsAt = await getActiveTrialEndsAtForUser(normalizedUserId);
-  if (trialEndsAt) {
-    return {
-      plan: "free",
-      source: "trial",
-      proExpiresAt: null,
-      trialEndsAt,
-    };
-  }
+  const entitlement = await resolveEntitlement(userId);
 
   return {
-    plan: "free",
-    source: "free",
-    proExpiresAt: null,
-    trialEndsAt: null,
+    plan: entitlement.plan,
+    source: entitlement.source,
+    subscriptionStatus: entitlement.subscriptionStatus,
+    proExpiresAt: toIsoOrNull(entitlement.proExpiresAt),
+    trialEndsAt: toIsoOrNull(entitlement.trialEndsAt),
+    graceEndsAt: toIsoOrNull(entitlement.graceEndsAt),
   };
 };

--- a/docs/architecture/v1.6.11-billing-state-machine.md
+++ b/docs/architecture/v1.6.11-billing-state-machine.md
@@ -15,12 +15,22 @@
 
 ## Entitlement Precedence (runtime)
 1. Active recurring subscription (`active` or `trialing`) => `pro`
-2. Recurring `past_due` => `pro` (policy decision: grace period vs strict block)
+2. Recurring `past_due` => grace policy (`3 days` by default)
+   - within grace => `pro` (`source=recurring_grace`)
+   - after grace => continue precedence evaluation
 3. `users.pro_expires_at > now()` => `pro` (prepaid)
 4. `users.trial_ends_at > now()` => `trial`
 5. Otherwise => `free`
 
 `users.plan` is a cache and may be used for UI hints. Feature gating should follow the precedence above.
+
+### Grace Configuration
+- `BILLING_PAST_DUE_GRACE_DAYS` (optional, default `3`).
+
+### Known Limitation (v1)
+- Grace reference currently uses `subscriptions.updated_at` when status is `past_due`.
+- This avoids a migration now, but webhook updates may move `updated_at`.
+- Planned hardening: add immutable `past_due_since`/`status_updated_at` field.
 
 ## State Transitions
 - `signup` => `trial_active` (`trial_ends_at = now + 14 days`)
@@ -44,6 +54,10 @@
   "proExpiresAt": null
 }
 ```
+
+### Response Notes
+- `/billing/entitlement` exposes `source` values (e.g. `recurring_grace`).
+- `/billing/subscription` keeps legacy naming in `entitlementSource` (e.g. `subscription_grace`).
 
 ## Integration Test Checklist
 

--- a/docs/runbooks/release-production-checklist.md
+++ b/docs/runbooks/release-production-checklist.md
@@ -24,6 +24,7 @@ Standardize post-release verification for API + Web in production, with traceabl
   - [ ] `CORS_ORIGIN`
   - [ ] `TRUST_PROXY=1`
   - [ ] `APP_BUILD_TIMESTAMP` (set in Render deploy environment)
+  - [ ] `BILLING_PAST_DUE_GRACE_DAYS` (optional, default `3`)
 
 ### Web (Vercel)
 - [ ] Confirm latest deployment is from `main`.


### PR DESCRIPTION
﻿## Summary
Centralizes billing entitlement decisions in `resolveEntitlement()` and removes parallel logic from middleware and `/billing/*` summary paths.

## Policy
Precedence:
1. recurring `active|trialing` -> `pro` (`source=recurring`)
2. recurring `past_due` within grace -> `pro` (`source=recurring_grace`)
3. prepaid (`pro_expires_at > now`) -> `pro` (`source=prepaid`)
4. trial (`trial_ends_at > now`) -> `trial`
5. fallback -> `free` (`source=none`)

Grace:
- `BILLING_PAST_DUE_GRACE_DAYS` (default `3`)

## API Contract Notes
- `/billing/entitlement`: uses `source=recurring_grace`
- `/billing/subscription`: keeps `entitlementSource=subscription_grace` (stable contract)

## Known Limitation (v1)
- Grace reference timestamp uses `subscriptions.updated_at`.
- Future hardening: immutable `past_due_since` / `status_updated_at`.

## Changes
- Refactor entitlement resolver and consumers
- Add/adjust tests for grace inside/outside window
- Update architecture doc + env example + release checklist

## Validation
- `npm -w apps/api run lint` ✅
- `npm -w apps/api run test` ✅
