### PR TITLE
fix(db): guard migrations with postgres advisory lock

### DIFF
--- a/apps/api/src/db/index.js
+++ b/apps/api/src/db/index.js
@@ -165,6 +165,24 @@ export const clearDbClientForTests = async () => {
   dbClientOverride = undefined;
 };
 
+export const withDbClient = async (callback) => {
+  const dbClient = getDbClient();
+
+  if (!dbClient || typeof dbClient.connect !== "function") {
+    throw createDatabaseError("Cliente de banco invalido para conexao dedicada.");
+  }
+
+  const client = await dbClient.connect();
+
+  try {
+    return await callback(client);
+  } finally {
+    if (typeof client.release === "function") {
+      client.release();
+    }
+  }
+};
+
 export const closePool = async () => {
   if (!poolInstance) {
     return;

--- a/apps/api/src/db/migrate.js
+++ b/apps/api/src/db/migrate.js
@@ -1,15 +1,31 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { dbQuery } from "./index.js";
+import { withDbClient } from "./index.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const MIGRATIONS_DIR = path.join(__dirname, "migrations");
 const MIGRATIONS_TABLE = "schema_migrations";
 
-const ensureMigrationsTable = async () => {
-  await dbQuery(`
+// Stable bigint key for pg_try_advisory_lock — unique to this application.
+const MIGRATION_LOCK_KEY = 6329271;
+
+const tryAcquireMigrationLock = async (client) => {
+  try {
+    const { rows } = await client.query(
+      "SELECT pg_try_advisory_lock($1::bigint) AS acquired",
+      [MIGRATION_LOCK_KEY],
+    );
+    return rows[0].acquired === true;
+  } catch {
+    // pg_try_advisory_lock not available (e.g. pg-mem in tests) — proceed unlocked.
+    return true;
+  }
+};
+
+const ensureMigrationsTable = async (client) => {
+  await client.query(`
     CREATE TABLE IF NOT EXISTS ${MIGRATIONS_TABLE} (
       id SERIAL PRIMARY KEY,
       name TEXT NOT NULL UNIQUE,
@@ -29,30 +45,41 @@ const listMigrationFiles = async () => {
     .sort();
 };
 
-const getAppliedMigrations = async () => {
-  const { rows } = await dbQuery(`SELECT name FROM ${MIGRATIONS_TABLE}`);
+const getAppliedMigrations = async (client) => {
+  const { rows } = await client.query(`SELECT name FROM ${MIGRATIONS_TABLE}`);
   return new Set(rows.map((row) => row.name));
 };
 
 export const runMigrations = async () => {
-  await ensureMigrationsTable();
+  return withDbClient(async (client) => {
+    const acquired = await tryAcquireMigrationLock(client);
 
-  const migrationFiles = await listMigrationFiles();
-  const appliedMigrations = await getAppliedMigrations();
-
-  for (const migrationFile of migrationFiles) {
-    if (appliedMigrations.has(migrationFile)) {
-      continue;
+    if (!acquired) {
+      console.warn("Migrations already running in another process. Skipping to avoid conflict.");
+      return;
     }
 
-    const filePath = path.join(MIGRATIONS_DIR, migrationFile);
-    const migrationSql = await fs.readFile(filePath, "utf8");
+    await ensureMigrationsTable(client);
 
-    await dbQuery(migrationSql);
-    await dbQuery(`INSERT INTO ${MIGRATIONS_TABLE} (name) VALUES ($1)`, [
-      migrationFile,
-    ]);
-  }
+    const migrationFiles = await listMigrationFiles();
+    const appliedMigrations = await getAppliedMigrations(client);
+
+    for (const migrationFile of migrationFiles) {
+      if (appliedMigrations.has(migrationFile)) {
+        continue;
+      }
+
+      const filePath = path.join(MIGRATIONS_DIR, migrationFile);
+      const migrationSql = await fs.readFile(filePath, "utf8");
+
+      await client.query(migrationSql);
+      await client.query(`INSERT INTO ${MIGRATIONS_TABLE} (name) VALUES ($1)`, [
+        migrationFile,
+      ]);
+    }
+
+    // Advisory lock is released automatically when the client is released.
+  });
 };
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/apps/api/src/db/migrate.test.js
+++ b/apps/api/src/db/migrate.test.js
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Keep a reference so individual tests can change query behaviour.
+let queryMock;
+let releaseMock;
+
+vi.mock("./index.js", () => ({
+  withDbClient: vi.fn(async (callback) => {
+    const client = { query: queryMock, release: releaseMock };
+    return callback(client);
+  }),
+}));
+
+// Stub the filesystem so we control which migration files exist.
+vi.mock("node:fs/promises", () => ({
+  default: {
+    readdir: vi.fn(),
+    readFile: vi.fn(),
+  },
+}));
+
+import fs from "node:fs/promises";
+import { withDbClient } from "./index.js";
+import { runMigrations } from "./migrate.js";
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+const makeEntry = (name) => ({ isFile: () => true, name });
+
+const setupQueryMock = ({
+  lockAcquired = true,
+  appliedMigrations = [],
+} = {}) => {
+  queryMock = vi.fn(async (sql) => {
+    if (sql.includes("pg_try_advisory_lock")) {
+      return { rows: [{ acquired: lockAcquired }] };
+    }
+    if (sql.includes("SELECT name FROM schema_migrations")) {
+      return { rows: appliedMigrations.map((name) => ({ name })) };
+    }
+    return { rows: [] };
+  });
+};
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+describe("runMigrations", () => {
+  beforeEach(() => {
+    releaseMock = vi.fn();
+    vi.clearAllMocks();
+    fs.readFile.mockResolvedValue("SELECT 1;");
+  });
+
+  it("executa migracoes pendentes quando lock e adquirido", async () => {
+    setupQueryMock({ appliedMigrations: ["001_initial.sql"] });
+    fs.readdir.mockResolvedValue([
+      makeEntry("001_initial.sql"),
+      makeEntry("002_add_users.sql"),
+    ]);
+
+    await runMigrations();
+
+    const sqlCalls = queryMock.mock.calls.map(([sql]) => sql);
+    const insertCalls = sqlCalls.filter((sql) => sql.includes("INSERT INTO schema_migrations"));
+    expect(insertCalls).toHaveLength(1);
+    expect(queryMock).toHaveBeenCalledWith(expect.stringContaining("INSERT INTO schema_migrations"), [
+      "002_add_users.sql",
+    ]);
+  });
+
+  it("nao executa migracoes quando lock nao e adquirido", async () => {
+    setupQueryMock({ lockAcquired: false });
+    fs.readdir.mockResolvedValue([makeEntry("001_initial.sql")]);
+
+    await runMigrations();
+
+    // Only the advisory lock query should have been called — no CREATE TABLE, no INSERT.
+    const sqlCalls = queryMock.mock.calls.map(([sql]) => sql);
+    expect(sqlCalls.filter((s) => s.includes("CREATE TABLE"))).toHaveLength(0);
+    expect(sqlCalls.filter((s) => s.includes("INSERT"))).toHaveLength(0);
+  });
+
+  it("prossegue sem lock quando pg_try_advisory_lock lanca erro (pg-mem)", async () => {
+    queryMock = vi.fn(async (sql) => {
+      if (sql.includes("pg_try_advisory_lock")) {
+        throw new Error("function pg_try_advisory_lock does not exist");
+      }
+      if (sql.includes("SELECT name FROM schema_migrations")) {
+        return { rows: [] };
+      }
+      return { rows: [] };
+    });
+    fs.readdir.mockResolvedValue([makeEntry("001_initial.sql")]);
+
+    await expect(runMigrations()).resolves.not.toThrow();
+
+    const insertCalls = queryMock.mock.calls.filter(([sql]) =>
+      sql.includes("INSERT INTO schema_migrations"),
+    );
+    expect(insertCalls).toHaveLength(1);
+  });
+
+  it("nao aplica migracoes ja executadas", async () => {
+    setupQueryMock({ appliedMigrations: ["001_initial.sql", "002_add_users.sql"] });
+    fs.readdir.mockResolvedValue([
+      makeEntry("001_initial.sql"),
+      makeEntry("002_add_users.sql"),
+    ]);
+
+    await runMigrations();
+
+    const insertCalls = queryMock.mock.calls.filter(([sql]) =>
+      sql.includes("INSERT INTO schema_migrations"),
+    );
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it("propaga erro quando uma migracao falha", async () => {
+    queryMock = vi.fn(async (sql) => {
+      if (sql.includes("pg_try_advisory_lock")) return { rows: [{ acquired: true }] };
+      if (sql.includes("SELECT name FROM schema_migrations")) return { rows: [] };
+      if (sql === "SELECT 1;") throw new Error("syntax error in migration");
+      return { rows: [] };
+    });
+    fs.readdir.mockResolvedValue([makeEntry("001_initial.sql")]);
+
+    await expect(runMigrations()).rejects.toThrow("syntax error in migration");
+  });
+
+  it("usa withDbClient para garantir liberacao do client via finally", async () => {
+    setupQueryMock();
+    fs.readdir.mockResolvedValue([]);
+
+    await runMigrations();
+
+    expect(withDbClient).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- **`withDbClient()`** added to `db/index.js` — acquires a dedicated pool connection and guarantees release via `finally`; the dedicated connection is needed so the advisory lock stays alive for the full migration session (session-level locks are tied to the connection)
- **`migrate.js`** refactored to run all queries on a single dedicated client acquired via `withDbClient`; calls `pg_try_advisory_lock` before touching `schema_migrations` — if the lock is already held (another pod/process), logs a warning and returns immediately without running any SQL
- **Fallback** — if `pg_try_advisory_lock` is not available (pg-mem in test environment throws "function does not exist"), the `catch` block returns `true` and migrations proceed unlocked as before
- **6 new unit tests** — lock acquired runs migrations, lock busy skips all SQL, pg-mem fallback proceeds, already-applied skipped, error propagated, `withDbClient` delegation verified

## Test plan

- [x] API suite: 392/392 passing on the cleaned branch base (`origin/main`)
- [ ] Deploy to staging with two simultaneous cold-start pods — only one should run migrations, the other should log the warning and skip