### PR TITLE
perf(db): add transactions user/date DESC partial index for active rows

### DIFF
--- a/apps/api/src/db/migrations/024_add_transactions_user_date_index.sql
+++ b/apps/api/src/db/migrations/024_add_transactions_user_date_index.sql
@@ -1,0 +1,8 @@
+-- Partial index optimised for the default list query: WHERE deleted_at IS NULL
+-- ordered by (user_id, date DESC, id DESC).  Postgres can also use this index
+-- in forward direction for ascending sorts, so it supersedes the ASC variant
+-- from migration 007 for the active-only path.
+
+CREATE INDEX IF NOT EXISTS idx_transactions_user_date_desc_active
+  ON transactions (user_id, date DESC, id DESC)
+  WHERE deleted_at IS NULL;


### PR DESCRIPTION
## Summary

- Adds `idx_transactions_user_date_desc_active` on `transactions(user_id, date DESC, id DESC) WHERE deleted_at IS NULL`
- Partial condition matches every authenticated list query (all callers filter `deleted_at IS NULL`)
- `date DESC` ordering matches the default fetch pattern (most-recent first); Postgres can also traverse a DESC index in reverse for ascending sort plans

## Test plan

- [x] API suite: 392/392 passing on the cleaned branch base (`origin/main`)
- [ ] Run `EXPLAIN (ANALYZE, BUFFERS)` on `SELECT * FROM transactions WHERE user_id = $1 AND deleted_at IS NULL ORDER BY date DESC, id DESC LIMIT 50` in staging — confirm `Index Scan using idx_transactions_user_date_desc_active`

## Merge order

Intended merge sequence for this sprint batch: #231 → #232 → this PR