### PR TITLE
refactor(ui): replace window.confirm with reusable ConfirmDialog component

### DIFF
--- a/apps/web/src/components/ConfirmDialog.tsx
+++ b/apps/web/src/components/ConfirmDialog.tsx
@@ -1,0 +1,78 @@
+import { useEffect } from "react";
+
+interface ConfirmDialogProps {
+  isOpen: boolean;
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const ConfirmDialog = ({
+  isOpen,
+  title,
+  description,
+  confirmLabel = "Confirmar",
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps): JSX.Element | null => {
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onCancel();
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onCancel]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={onCancel}
+      role="presentation"
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirm-dialog-title"
+        className="w-full max-w-sm rounded-lg bg-cf-surface p-5 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3
+          id="confirm-dialog-title"
+          className="text-base font-semibold text-cf-text-primary"
+        >
+          {title}
+        </h3>
+
+        {description ? (
+          <p className="mt-1.5 text-sm text-cf-text-secondary">{description}</p>
+        ) : null}
+
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded border border-cf-border px-3 py-1.5 text-sm font-semibold text-cf-text-secondary hover:bg-cf-bg-subtle"
+          >
+            Cancelar
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="rounded bg-red-600 px-3 py-1.5 text-sm font-semibold text-white hover:bg-red-700"
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmDialog;

--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -934,7 +934,6 @@ describe("App", () => {
 
   it("exclui meta mensal e recarrega estado vazio", async () => {
     const user = userEvent.setup();
-    const confirmMock = vi.spyOn(window, "confirm").mockReturnValue(true);
     transactionsService.getMonthlyBudgets
       .mockResolvedValueOnce(
         buildMonthlyBudgetsResponse([
@@ -953,17 +952,14 @@ describe("App", () => {
       )
       .mockResolvedValueOnce(buildMonthlyBudgetsResponse([]));
 
-    try {
-      render(<App />);
+    render(<App />);
 
-      expect(await screen.findByText("Transporte")).toBeInTheDocument();
-      await user.click(screen.getByRole("button", { name: "Excluir meta: Transporte" }));
+    expect(await screen.findByText("Transporte")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Excluir meta: Transporte" }));
+    await user.click(await screen.findByRole("button", { name: "Confirmar" }));
 
-      expect(transactionsService.deleteMonthlyBudget).toHaveBeenCalledWith(11);
-      expect(await screen.findByText("Nenhuma meta cadastrada para o mês selecionado.")).toBeInTheDocument();
-    } finally {
-      confirmMock.mockRestore();
-    }
+    expect(transactionsService.deleteMonthlyBudget).toHaveBeenCalledWith(11);
+    expect(await screen.findByText("Nenhuma meta cadastrada para o mês selecionado.")).toBeInTheDocument();
   });
 
   it("aplica filtro por categoria e envia categoryId para listagem", async () => {

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -1,4 +1,5 @@
 import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import ConfirmDialog from "../components/ConfirmDialog";
 import Modal from "../components/Modal";
 import ImportCsvModal from "../components/ImportCsvModal";
 import ImportHistoryModal from "../components/ImportHistoryModal";
@@ -494,6 +495,7 @@ const App = ({
   const [editingBudget, setEditingBudget] = useState<MonthlyBudget | null>(null);
   const [budgetForm, setBudgetForm] = useState<BudgetFormState>(DEFAULT_BUDGET_FORM);
   const [pendingDeleteTransactionId, setPendingDeleteTransactionId] = useState<number | null>(null);
+  const [pendingDeleteBudget, setPendingDeleteBudget] = useState<MonthlyBudget | null>(null);
   const [undoState, setUndoState] = useState<UndoState | null>(null);
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [isLoadingTransactions, setLoadingTransactions] = useState(false);
@@ -929,15 +931,14 @@ const App = ({
     }
   };
 
-  const handleDeleteBudget = async (budget: MonthlyBudget) => {
-    const confirmationMessage = `Excluir meta de "${budget.categoryName}"?`;
-    // In non-browser test environments, skip native confirm prompt.
-    const isConfirmed = typeof window === "undefined" ? true : window.confirm(confirmationMessage);
+  const handleDeleteBudget = (budget: MonthlyBudget) => {
+    setPendingDeleteBudget(budget);
+  };
 
-    if (!isConfirmed) {
-      return;
-    }
-
+  const handleConfirmDeleteBudget = async () => {
+    if (!pendingDeleteBudget) return;
+    const budget = pendingDeleteBudget;
+    setPendingDeleteBudget(null);
     setBudgetsError("");
     clearBudgetSuccessMessage();
 
@@ -2783,32 +2784,22 @@ const App = ({
         </div>
       ) : null}
 
-      {pendingDeleteTransactionId ? (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-          <div className="w-full max-w-sm rounded bg-cf-surface p-4 shadow-lg">
-            <h3 className="text-base font-semibold text-cf-text-primary">Confirmar exclusão</h3>
-            <p className="mt-2 text-sm text-cf-text-secondary">
-              Deseja realmente excluir esta transação?
-            </p>
-            <div className="mt-4 flex justify-end gap-2">
-              <button
-                type="button"
-                onClick={closeDeleteDialog}
-                className="rounded border border-cf-border px-3 py-1.5 text-sm font-semibold text-cf-text-secondary"
-              >
-                Cancelar
-              </button>
-              <button
-                type="button"
-                onClick={confirmDeleteTransaction}
-                className="rounded bg-red-600 px-3 py-1.5 text-sm font-semibold text-white hover:bg-red-700"
-              >
-                Confirmar exclusão
-              </button>
-            </div>
-          </div>
-        </div>
-      ) : null}
+      <ConfirmDialog
+        isOpen={pendingDeleteTransactionId !== null}
+        title="Confirmar exclusão"
+        description="Deseja realmente excluir esta transação?"
+        confirmLabel="Confirmar exclusão"
+        onConfirm={confirmDeleteTransaction}
+        onCancel={closeDeleteDialog}
+      />
+
+      <ConfirmDialog
+        isOpen={pendingDeleteBudget !== null}
+        title={`Excluir meta de "${pendingDeleteBudget?.categoryName}"?`}
+        confirmLabel="Confirmar"
+        onConfirm={handleConfirmDeleteBudget}
+        onCancel={() => setPendingDeleteBudget(null)}
+      />
 
       <Modal
         isOpen={isModalOpen}

--- a/apps/web/src/pages/CategoriesSettings.test.jsx
+++ b/apps/web/src/pages/CategoriesSettings.test.jsx
@@ -40,7 +40,6 @@ const renderPage = (initialPath = "/app/settings/categories") =>
 describe("CategoriesSettings", () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    vi.stubGlobal("confirm", vi.fn(() => true));
 
     categoriesService.listCategories.mockResolvedValue([buildCategory()]);
     categoriesService.createCategory.mockResolvedValue(buildCategory({ id: 2, name: "Mercado" }));
@@ -124,6 +123,7 @@ describe("CategoriesSettings", () => {
     expect(categoriesService.listCategories).toHaveBeenNthCalledWith(1, true);
 
     await user.click(screen.getByRole("button", { name: "Restaurar" }));
+    await user.click(await screen.findByRole("button", { name: "Confirmar" }));
 
     await waitFor(() => {
       expect(categoriesService.restoreCategory).toHaveBeenCalledWith(7);

--- a/apps/web/src/pages/CategoriesSettings.tsx
+++ b/apps/web/src/pages/CategoriesSettings.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { FormEvent } from "react";
 import { useSearchParams } from "react-router-dom";
+import ConfirmDialog from "../components/ConfirmDialog";
 import {
   categoriesService,
   type CategoryItem,
@@ -61,6 +62,10 @@ const CategoriesSettings = ({
   const [pageErrorMessage, setPageErrorMessage] = useState("");
   const [categoryModalErrorMessage, setCategoryModalErrorMessage] = useState("");
   const [successMessage, setSuccessMessage] = useState("");
+  const [pendingConfirm, setPendingConfirm] = useState<{
+    title: string;
+    onConfirm: () => Promise<void>;
+  } | null>(null);
 
   const loadCategories = useCallback(async () => {
     setLoadingCategories(true);
@@ -140,52 +145,42 @@ const CategoriesSettings = ({
     }
   };
 
-  const handleDeleteCategory = async (category: CategoryItem) => {
-    const isConfirmed =
-      typeof window === "undefined"
-        ? true
-        : window.confirm(`Remover categoria "${category.name}"?`);
-
-    if (!isConfirmed) {
-      return;
-    }
-
-    setPageErrorMessage("");
-    setSuccessMessage("");
-
-    try {
-      await categoriesService.deleteCategory(category.id);
-      setSuccessMessage("Categoria removida.");
-      await loadCategories();
-    } catch (error) {
-      setPageErrorMessage(
-        resolveCategoryMutationErrorMessage(error, "Não foi possível remover a categoria."),
-      );
-    }
+  const handleDeleteCategory = (category: CategoryItem) => {
+    setPendingConfirm({
+      title: `Remover categoria "${category.name}"?`,
+      onConfirm: async () => {
+        setPageErrorMessage("");
+        setSuccessMessage("");
+        try {
+          await categoriesService.deleteCategory(category.id);
+          setSuccessMessage("Categoria removida.");
+          await loadCategories();
+        } catch (error) {
+          setPageErrorMessage(
+            resolveCategoryMutationErrorMessage(error, "Não foi possível remover a categoria."),
+          );
+        }
+      },
+    });
   };
 
-  const handleRestoreCategory = async (category: CategoryItem) => {
-    const isConfirmed =
-      typeof window === "undefined"
-        ? true
-        : window.confirm(`Restaurar categoria "${category.name}"?`);
-
-    if (!isConfirmed) {
-      return;
-    }
-
-    setPageErrorMessage("");
-    setSuccessMessage("");
-
-    try {
-      await categoriesService.restoreCategory(category.id);
-      setSuccessMessage("Categoria restaurada.");
-      await loadCategories();
-    } catch (error) {
-      setPageErrorMessage(
-        resolveCategoryMutationErrorMessage(error, "Não foi possível restaurar a categoria."),
-      );
-    }
+  const handleRestoreCategory = (category: CategoryItem) => {
+    setPendingConfirm({
+      title: `Restaurar categoria "${category.name}"?`,
+      onConfirm: async () => {
+        setPageErrorMessage("");
+        setSuccessMessage("");
+        try {
+          await categoriesService.restoreCategory(category.id);
+          setSuccessMessage("Categoria restaurada.");
+          await loadCategories();
+        } catch (error) {
+          setPageErrorMessage(
+            resolveCategoryMutationErrorMessage(error, "Não foi possível restaurar a categoria."),
+          );
+        }
+      },
+    });
   };
 
   const handleToggleIncludeDeleted = (nextCheckedState: boolean) => {
@@ -345,6 +340,17 @@ const CategoriesSettings = ({
           ) : null}
         </section>
       </main>
+
+      <ConfirmDialog
+        isOpen={pendingConfirm !== null}
+        title={pendingConfirm?.title ?? ""}
+        onConfirm={() => {
+          const action = pendingConfirm;
+          setPendingConfirm(null);
+          void action?.onConfirm();
+        }}
+        onCancel={() => setPendingConfirm(null)}
+      />
 
       {isCategoryModalOpen ? (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">


### PR DESCRIPTION
## Summary
- Add reusable `ConfirmDialog` component (`isOpen`, `title`, `description?`, `confirmLabel?`, `onConfirm`, `onCancel`) with backdrop, Escape key handler, and accessible dialog markup
- Replace `window.confirm` in `App.tsx` (budget delete) and `CategoriesSettings.tsx` (category delete + restore) with `ConfirmDialog` + pending-state pattern
- Replace inline transaction confirm dialog in `App.tsx` (25-line custom div) with the new component for consistency
- Update tests: remove `vi.spyOn/vi.stubGlobal` for `window.confirm`; click the rendered "Confirmar" button instead

## Test plan
- [ ] Delete a monthly budget → confirm dialog appears → confirm removes it
- [ ] Delete a monthly budget → cancel → budget remains
- [ ] Delete a category → confirm dialog appears → confirm removes it
- [ ] Restore a deleted category → confirm dialog appears → confirm restores it
- [ ] Delete a transaction → confirm dialog appears (unchanged flow, now via shared component)
- [ ] Press Escape on any confirm dialog → dialog closes without action
- [ ] Web tests: `CategoriesSettings.test.jsx` and `App.test.jsx` budget delete test pass (pre-existing env failures unrelated)