### PR TITLE
refactor(utils): centralize getApiErrorMessage into shared apiError util

### DIFF
--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -2,10 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { transactionsService } from "../services/transactions.service";
 import { formatCurrency } from "../utils/formatCurrency";
-
-const getApiErrorMessage = (error, fallbackMessage) => {
-  return error?.response?.data?.message || error?.message || fallbackMessage;
-};
+import { getApiErrorMessage } from "../utils/apiError";
 
 const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
   const fileInputRef = useRef(null);

--- a/apps/web/src/components/ImportHistoryModal.jsx
+++ b/apps/web/src/components/ImportHistoryModal.jsx
@@ -2,12 +2,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { transactionsService } from "../services/transactions.service";
 import { formatCurrency } from "../utils/formatCurrency";
+import { getApiErrorMessage } from "../utils/apiError";
 
 const DEFAULT_LIMIT = 20;
-
-const getApiErrorMessage = (error, fallbackMessage) => {
-  return error?.response?.data?.message || error?.message || fallbackMessage;
-};
 
 const formatDateTime = (value) => {
   if (!value) {

--- a/apps/web/src/context/AuthContext.tsx
+++ b/apps/web/src/context/AuthContext.tsx
@@ -11,28 +11,11 @@ import type {
 import { setUnauthorizedHandler } from "../services/api";
 import { AuthContext } from "./auth-context";
 import type { AuthContextValue } from "./auth-context";
-
-interface ApiLikeError {
-  response?: {
-    data?: {
-      message?: string;
-    };
-  };
-  message?: string;
-}
+import { getApiErrorMessage } from "../utils/apiError";
 
 interface AuthProviderProps {
   children: ReactNode;
 }
-
-const getApiErrorMessage = (error: unknown, fallbackMessage: string): string => {
-  if (!error || typeof error !== "object") {
-    return fallbackMessage;
-  }
-
-  const apiError = error as ApiLikeError;
-  return apiError.response?.data?.message || apiError.message || fallbackMessage;
-};
 
 export const AuthProvider = ({ children }: AuthProviderProps) => {
   const [user, setUser] = useState<AuthUser | null>(null);

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -1,4 +1,5 @@
 import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { getApiErrorMessage } from "../utils/apiError";
 import ConfirmDialog from "../components/ConfirmDialog";
 import Modal from "../components/Modal";
 import ImportCsvModal from "../components/ImportCsvModal";
@@ -93,15 +94,6 @@ interface MonthOverMonthMetric {
   deltaPercent: number | null;
   direction: MonthOverMonthDirection;
   tone: MonthOverMonthTone;
-}
-
-interface ApiLikeError {
-  response?: {
-    data?: {
-      message?: string;
-    };
-  };
-  message?: string;
 }
 
 interface AppProps {
@@ -282,10 +274,6 @@ const getInitialFilterState = (): FilterState => {
   };
 };
 
-const getApiErrorMessage = (error: unknown, fallbackMessage: string): string => {
-  const normalizedError = error as ApiLikeError;
-  return normalizedError?.response?.data?.message || normalizedError?.message || fallbackMessage;
-};
 
 const normalizeTransactions = (transactions: unknown): Transaction[] => {
   if (!Array.isArray(transactions)) {

--- a/apps/web/src/pages/BillingSettings.tsx
+++ b/apps/web/src/pages/BillingSettings.tsx
@@ -3,25 +3,7 @@ import {
   billingService,
   type SubscriptionSummary,
 } from "../services/billing.service";
-
-interface ApiLikeError {
-  response?: {
-    data?: {
-      message?: string;
-    };
-    status?: number;
-  };
-  message?: string;
-}
-
-const getApiErrorMessage = (error: unknown, fallbackMessage: string): string => {
-  const normalizedError = error as ApiLikeError;
-  return (
-    normalizedError?.response?.data?.message ||
-    normalizedError?.message ||
-    fallbackMessage
-  );
-};
+import { getApiErrorMessage, getApiErrorStatus } from "../utils/apiError";
 
 const formatDate = (isoString: string | null | undefined): string => {
   if (!isoString) return "";
@@ -112,7 +94,7 @@ const BillingSettings = ({
       const { url } = await billingService.createPortal();
       window.location.href = url;
     } catch (error) {
-      const status = (error as ApiLikeError)?.response?.status;
+      const status = getApiErrorStatus(error);
       if (status === 422) {
         setActionError(
           "Portal de gerenciamento indisponivel. Entre em contato com o suporte.",

--- a/apps/web/src/pages/BillsPage.tsx
+++ b/apps/web/src/pages/BillsPage.tsx
@@ -8,6 +8,7 @@ import {
   type BillStatusFilter,
 } from "../services/bills.service";
 import { formatCurrency } from "../utils/formatCurrency";
+import { getApiErrorMessage } from "../utils/apiError";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -19,16 +20,6 @@ interface CategoryOption {
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
-
-interface ApiLikeError {
-  response?: { data?: { message?: string } };
-  message?: string;
-}
-
-const getApiErrorMessage = (error: unknown, fallback: string): string => {
-  const e = error as ApiLikeError;
-  return e?.response?.data?.message || e?.message || fallback;
-};
 
 const formatDueDate = (dateStr: string): string => {
   if (!dateStr) return "";

--- a/apps/web/src/pages/CategoriesSettings.tsx
+++ b/apps/web/src/pages/CategoriesSettings.tsx
@@ -6,33 +6,19 @@ import {
   categoriesService,
   type CategoryItem,
 } from "../services/categories.service";
+import { getApiErrorMessage, getApiErrorStatus } from "../utils/apiError";
 
 const parseIncludeDeletedParam = (value: string | null | undefined): boolean =>
   String(value || "").toLowerCase() === "true";
 
-interface ApiLikeError {
-  response?: {
-    data?: {
-      message?: string;
-    };
-    status?: number;
-  };
-  message?: string;
-}
-
-const getApiErrorMessage = (error: unknown, fallbackMessage: string): string => {
-  const normalizedError = error as ApiLikeError;
-  return normalizedError?.response?.data?.message || normalizedError?.message || fallbackMessage;
-};
-
 const resolveCategoryMutationErrorMessage = (error: unknown, fallbackMessage: string): string => {
-  const normalizedError = error as ApiLikeError;
+  const status = getApiErrorStatus(error);
 
-  if (normalizedError?.response?.status === 409) {
+  if (status === 409) {
     return "Categoria ja existe.";
   }
 
-  if (normalizedError?.response?.status === 404) {
+  if (status === 404) {
     return "Categoria não encontrada.";
   }
 

--- a/apps/web/src/pages/IncomeSourcesPage.tsx
+++ b/apps/web/src/pages/IncomeSourcesPage.tsx
@@ -10,21 +10,12 @@ import {
   type PostStatementResult,
 } from "../services/incomeSources.service";
 import { formatCurrency } from "../utils/formatCurrency";
+import { getApiErrorMessage } from "../utils/apiError";
 
 interface CategoryOption {
   id: number;
   name: string;
 }
-
-interface ApiLikeError {
-  response?: { data?: { message?: string } };
-  message?: string;
-}
-
-const getApiErrorMessage = (error: unknown, fallback: string): string => {
-  const e = error as ApiLikeError;
-  return e?.response?.data?.message || e?.message || fallback;
-};
 
 interface IncomeSourcesPageProps {
   onBack?: () => void;

--- a/apps/web/src/pages/ProfileSettings.tsx
+++ b/apps/web/src/pages/ProfileSettings.tsx
@@ -1,19 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { FormEvent } from "react";
 import { profileService, type UserProfile } from "../services/profile.service";
-
-interface ApiLikeError {
-  response?: {
-    data?: { message?: string };
-    status?: number;
-  };
-  message?: string;
-}
-
-const getApiErrorMessage = (error: unknown, fallback: string): string => {
-  const e = error as ApiLikeError;
-  return e?.response?.data?.message || e?.message || fallback;
-};
+import { getApiErrorMessage } from "../utils/apiError";
 
 const getInitials = (displayName: string | null, email: string): string => {
   const trimmed = displayName?.trim();

--- a/apps/web/src/pages/SecuritySettings.tsx
+++ b/apps/web/src/pages/SecuritySettings.tsx
@@ -3,19 +3,7 @@ import type { FormEvent } from "react";
 import { GoogleLogin } from "@react-oauth/google";
 import { profileService } from "../services/profile.service";
 import { securityService } from "../services/security.service";
-
-interface ApiLikeError {
-  response?: {
-    data?: { message?: string };
-    status?: number;
-  };
-  message?: string;
-}
-
-const getApiErrorMessage = (error: unknown, fallback: string): string => {
-  const e = error as ApiLikeError;
-  return e?.response?.data?.message || e?.message || fallback;
-};
+import { getApiErrorMessage } from "../utils/apiError";
 
 const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d).{8,}$/;
 

--- a/apps/web/src/utils/apiError.ts
+++ b/apps/web/src/utils/apiError.ts
@@ -1,0 +1,23 @@
+interface ApiLikeError {
+  response?: {
+    data?: {
+      message?: string;
+    };
+    status?: number;
+  };
+  message?: string;
+}
+
+export const getApiErrorMessage = (error: unknown, fallbackMessage: string): string => {
+  if (!error || typeof error !== "object") {
+    return fallbackMessage;
+  }
+
+  const apiError = error as ApiLikeError;
+  return apiError.response?.data?.message || apiError.message || fallbackMessage;
+};
+
+export const getApiErrorStatus = (error: unknown): number | undefined => {
+  if (!error || typeof error !== "object") return undefined;
+  return (error as ApiLikeError).response?.status;
+};


### PR DESCRIPTION
## Summary
- Add `apps/web/src/utils/apiError.ts` with `getApiErrorMessage` and `getApiErrorStatus` exports
- Remove 10 identical local definitions of `ApiLikeError` interface + `getApiErrorMessage` scattered across pages, context, and components
- Replace `(error as ApiLikeError)?.response?.status` direct casts with `getApiErrorStatus(error)` in `BillingSettings` and `CategoriesSettings`
- Net: −123 lines / +37 lines; zero behavior change

## Test plan
- [ ] `npx tsc --noEmit` passes with zero errors
- [ ] Error messages surface correctly in all pages (BillingSettings, BillsPage, CategoriesSettings, IncomeSourcesPage, ProfileSettings, SecuritySettings, App, AuthContext, ImportCsvModal, ImportHistoryModal)
- [ ] 409/404 status branching in CategoriesSettings still returns correct PT-BR messages
- [ ] 422 status branching in BillingSettings portal still shows support message