### PR TITLE
refactor(mobile-ux): center modal, fix header breakpoint, compact forecast grid

### DIFF
--- a/apps/web/src/components/ForecastCard.tsx
+++ b/apps/web/src/components/ForecastCard.tsx
@@ -215,7 +215,7 @@ const ForecastCard = ({
         <p className="mt-2 text-xs text-red-600">{error}</p>
       ) : forecast !== null ? (
         <>
-          <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="mt-3 grid grid-cols-2 gap-3 lg:grid-cols-4">
             <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
               <p className="text-xs font-medium uppercase text-cf-text-secondary">Projeção ajustada</p>
               <p

--- a/apps/web/src/components/Modal.jsx
+++ b/apps/web/src/components/Modal.jsx
@@ -143,7 +143,7 @@ const Modal = ({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex min-h-screen items-start justify-center bg-black/50 p-6 sm:items-center"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 sm:p-6"
       onClick={handleBackdropClick}
       role="presentation"
     >
@@ -158,7 +158,9 @@ const Modal = ({
             className="text-cf-text-secondary transition-colors hover:text-cf-text-primary"
             aria-label="Fechar modal"
           >
-            X
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
           </button>
         </div>
 

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -1552,7 +1552,7 @@ const App = ({
   return (
     <div className="App min-h-screen bg-cf-bg-page pb-10">
       <header className="w-full bg-cf-header-bg py-3 shadow-md sm:py-4">
-        <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 sm:px-6 lg:flex-row lg:items-center lg:justify-between">
+        <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 sm:flex-row sm:items-center sm:justify-between sm:px-6">
           <h1 className="text-2xl font-semibold sm:text-3xl lg:text-4xl">
             <span className="text-brand-1">Control</span>
             <span className="text-cf-text-primary">Finance</span>


### PR DESCRIPTION
## Summary
- **Modal**: modal colava no topo no mobile (`items-start`) — agora centralizado em todas as telas (`items-center`). Remove `min-h-screen` redundante. Padding `p-4 sm:p-6`. Botão fechar "X" substituído por SVG icon (`h-4 w-4` heroicons/x).
- **Header**: layout titulo + ações só virava row em `lg:` (1024px) — agora vira em `sm:` (640px), aproveitando o espaço horizontal em tablets e telefones landscape.
- **ForecastCard**: grid de 4 métricas era coluna única no mobile, 2-up em `sm:` — agora começa em `grid-cols-2` (2-up) direto e abre para 4-up em `lg:`.

## Test plan
- [ ] Abrir modal de transação em viewport < 640px — modal centrado verticalmente, não grudado no topo
- [ ] Botão fechar modal: ícone X (SVG) renderizado corretamente em claro e escuro
- [ ] Header em viewport 640px–1023px: título e botões na mesma linha (row), não empilhados
- [ ] ForecastCard em viewport < 640px: 4 tiles em 2 colunas (2×2), não 1 coluna vertical
- [ ] TypeScript: `tsc --noEmit` sem erros