### PR TITLE
feat(paywall): contextual upgrade copy per blocked feature

### DIFF
--- a/apps/web/src/components/UpgradeModal.tsx
+++ b/apps/web/src/components/UpgradeModal.tsx
@@ -48,6 +48,9 @@ const UpgradeModal = ({ isOpen, reason, onClose }: UpgradeModalProps) => {
   const title = isTrialExpired
     ? "Seu período de teste encerrou"
     : "Desbloqueie o Control Finance Pro";
+  const subtitle = isTrialExpired
+    ? "Continue com acesso total por menos de R$ 0,33 por dia."
+    : reason;
 
   const handleUpgrade = () => {
     onClose();
@@ -73,8 +76,8 @@ const UpgradeModal = ({ isOpen, reason, onClose }: UpgradeModalProps) => {
         >
           {title}
         </h3>
-        {reason ? (
-          <p className="mt-1 text-sm text-cf-text-secondary">{reason}</p>
+        {subtitle ? (
+          <p className="mt-1 text-sm text-cf-text-secondary">{subtitle}</p>
         ) : null}
 
         {/* Price anchor */}

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -162,6 +162,46 @@ api.interceptors.request.use((config: InternalAxiosRequestConfig) => {
   return config;
 });
 
+const PAYWALL_COPY: Array<{ pattern: RegExp; reason: string }> = [
+  {
+    pattern: /\/transactions\/import/,
+    reason: "Importe transações de outros apps e bancos direto para o Control Finance.",
+  },
+  {
+    pattern: /\/transactions\/export/,
+    reason: "Exporte suas transações para planilhas e ferramentas financeiras.",
+  },
+  {
+    pattern: /\/forecasts/,
+    reason: "Saiba exatamente quanto vai ter no saldo no fim do mês.",
+  },
+  {
+    pattern: /\/analytics\/trend/,
+    reason: "Acesse até 24 meses de histórico e veja sua evolução financeira completa.",
+  },
+  {
+    pattern: /\/salary/,
+    reason: "Planeje seu salário com cálculo real de INSS e IRRF.",
+  },
+];
+
+const isTrialExpiredMessage = (msg: string): boolean =>
+  msg.toLowerCase().includes("teste encerrado");
+
+const resolvePaywallReason = (url: string, serverMessage: string): string => {
+  if (isTrialExpiredMessage(serverMessage)) {
+    return serverMessage;
+  }
+
+  for (const entry of PAYWALL_COPY) {
+    if (entry.pattern.test(url)) {
+      return entry.reason;
+    }
+  }
+
+  return serverMessage;
+};
+
 api.interceptors.response.use(
   (response) => response,
   async (error) => {
@@ -221,13 +261,16 @@ api.interceptors.response.use(
     }
 
     if (error?.response?.status === 402) {
-      const message: string =
+      const serverMessage: string =
         typeof error?.response?.data?.message === "string"
           ? error.response.data.message
           : "";
 
+      const url: string = error?.config?.url ?? "";
+      const reason = resolvePaywallReason(url, serverMessage);
+
       if (typeof paymentRequiredHandler === "function") {
-        paymentRequiredHandler(message);
+        paymentRequiredHandler(reason);
       }
     }
 


### PR DESCRIPTION
## Summary
- Add `resolvePaywallReason(url, serverMessage)` in the global 402 interceptor (`api.ts`) — maps request URL to benefit-oriented copy before opening `UpgradeModal`
- Trial-expiry path preserved: if backend message contains "teste encerrado", URL mapping is skipped so the trial flow stays intact
- `UpgradeModal`: replace raw trial-expiry backend string with concise cost anchor

## Before → After

| Feature blocked | Before | After |
|---|---|---|
| CSV Import | "Recurso disponivel apenas no plano Pro." | "Importe transações de outros apps e bancos direto para o Control Finance." |
| CSV Export | "Recurso disponivel apenas no plano Pro." | "Exporte suas transações para planilhas e ferramentas financeiras." |
| Forecast | "Recurso disponivel apenas no plano Pro." | "Saiba exatamente quanto vai ter no saldo no fim do mês." |
| Analytics trend | "Recurso disponivel apenas no plano Pro." | "Acesse até 24 meses de histórico e veja sua evolução financeira completa." |
| Salary | "Recurso disponivel apenas no plano Pro." | "Planeje seu salário com cálculo real de INSS e IRRF." |
| Trial expiry | "Periodo de teste encerrado. Ative seu plano..." | "Continue com acesso total por menos de R$ 0,33 por dia." |

## Test plan
- [ ] Trigger CSV export on free plan → modal subtitle shows export copy
- [ ] Trigger CSV import on free plan → modal subtitle shows import copy
- [ ] Trial expiry path → modal title "Seu período de teste encerrou" + subtitle "Continue com acesso total por menos de R$ 0,33 por dia."
- [ ] Unknown endpoint 402 → falls back to raw server message (no regression)
- [ ] `tsc --noEmit` zero errors