### PR TITLE
refactor(upgrade-modal): daily price anchor, contextual CTA, explicit dismiss

### DIFF
--- a/apps/web/src/components/UpgradeModal.tsx
+++ b/apps/web/src/components/UpgradeModal.tsx
@@ -51,6 +51,8 @@ const UpgradeModal = ({ isOpen, reason, onClose }: UpgradeModalProps) => {
   const subtitle = isTrialExpired
     ? "Continue com acesso total por menos de R$ 0,33 por dia."
     : reason;
+  const ctaLabel = isTrialExpired ? "Reativar acesso Pro" : "Começar meu plano Pro";
+  const dismissLabel = isTrialExpired ? "Agora não" : "Continuar no plano gratuito";
 
   const handleUpgrade = () => {
     onClose();
@@ -91,6 +93,7 @@ const UpgradeModal = ({ isOpen, reason, onClose }: UpgradeModalProps) => {
             </span>
             <span className="text-sm text-cf-text-secondary">/mês</span>
           </div>
+          <p className="mt-0.5 text-xs text-cf-text-secondary">≈ R$ 0,33 por dia — menos que um café</p>
         </div>
 
         {/* Benefits */}
@@ -138,7 +141,7 @@ const UpgradeModal = ({ isOpen, reason, onClose }: UpgradeModalProps) => {
             onClick={handleUpgrade}
             className="w-full rounded bg-brand-1 px-4 py-2.5 text-sm font-semibold text-white hover:bg-brand-2"
           >
-            Começar meu plano Pro
+            {ctaLabel}
           </button>
           <p className="text-center text-xs text-cf-text-secondary">
             Cancele quando quiser. Sem fidelidade.
@@ -148,7 +151,7 @@ const UpgradeModal = ({ isOpen, reason, onClose }: UpgradeModalProps) => {
             onClick={onClose}
             className="text-center text-xs text-cf-text-secondary hover:text-cf-text-primary"
           >
-            Agora não
+            {dismissLabel}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
Three targeted copy/UX changes to increase upgrade conversion:

**1. Daily cost anchor**
Adds `"≈ R$ 0,33 por dia — menos que um café"` below `R$ 9,90/mês`.
Reframes the decision from a monthly cost to a daily one — cognitively easier to approve.

**2. Contextual CTA label**
| Context | Before | After |
|---|---|---|
| Feature gate | "Começar meu plano Pro" | "Começar meu plano Pro" (unchanged) |
| Trial expired | "Começar meu plano Pro" | "Reativar acesso Pro" |

"Reativar" is specific: the user had access, lost it, and can recover it. More accurate frame.

**3. Explicit dismiss label**
| Context | Before | After |
|---|---|---|
| Feature gate | "Agora não" | "Continuar no plano gratuito" |
| Trial expired | "Agora não" | "Agora não" (unchanged) |

Naming the choice ("plano gratuito") creates a small, legitimate cognitive moment without dark-pattern pressure. Trial expiry keeps "Agora não" because the user has no active plan to "continue".

## Test plan
- [ ] Feature gate flow (e.g. trigger CSV export on free plan) → modal shows "Começar meu plano Pro" / "Continuar no plano gratuito" / daily anchor visible
- [ ] Trial expiry flow → modal shows "Reativar acesso Pro" / "Agora não" / daily anchor visible  
- [ ] Dismiss button on both paths closes modal without navigating
- [ ] CTA button navigates to `/app/settings/billing` and closes modal
- [ ] `tsc --noEmit` zero errors