### PR TITLE
feat(paywall-tracking): instrument paywall events (viewed / clicked_upgrade / dismissed)

### DIFF
--- a/apps/web/src/components/UpgradeModal.tsx
+++ b/apps/web/src/components/UpgradeModal.tsx
@@ -1,9 +1,12 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import { trackPaywallEvent, type PaywallFeature, type PaywallContext } from "../utils/analytics";
 
 interface UpgradeModalProps {
   isOpen: boolean;
   reason: string;
+  feature?: PaywallFeature;
+  context?: PaywallContext;
   onClose: () => void;
 }
 
@@ -26,11 +29,19 @@ const BENEFITS = [
   "Exporte e importe transações com facilidade",
 ];
 
-const UpgradeModal = ({ isOpen, reason, onClose }: UpgradeModalProps) => {
+const UpgradeModal = ({
+  isOpen,
+  reason,
+  feature = "unknown",
+  context = "feature_gate",
+  onClose,
+}: UpgradeModalProps) => {
   const navigate = useNavigate();
 
   useEffect(() => {
     if (!isOpen) return;
+
+    trackPaywallEvent({ feature, action: "viewed", context });
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
@@ -40,7 +51,7 @@ const UpgradeModal = ({ isOpen, reason, onClose }: UpgradeModalProps) => {
 
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, onClose]);
+  }, [isOpen, feature, context, onClose]);
 
   if (!isOpen) return null;
 
@@ -55,8 +66,14 @@ const UpgradeModal = ({ isOpen, reason, onClose }: UpgradeModalProps) => {
   const dismissLabel = isTrialExpired ? "Agora não" : "Continuar no plano gratuito";
 
   const handleUpgrade = () => {
+    trackPaywallEvent({ feature, action: "clicked_upgrade", context });
     onClose();
     navigate("/app/settings/billing");
+  };
+
+  const handleDismiss = () => {
+    trackPaywallEvent({ feature, action: "dismissed", context });
+    onClose();
   };
 
   return (
@@ -148,7 +165,7 @@ const UpgradeModal = ({ isOpen, reason, onClose }: UpgradeModalProps) => {
           </p>
           <button
             type="button"
-            onClick={onClose}
+            onClick={handleDismiss}
             className="text-center text-xs text-cf-text-secondary hover:text-cf-text-primary"
           >
             {dismissLabel}

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -33,7 +33,8 @@ import {
   normalizeTransactionDate,
 } from "../components/DatabaseUtils";
 import { analyticsService, type TrendPoint } from "../services/analytics.service";
-import { setPaymentRequiredHandler } from "../services/api";
+import { setPaymentRequiredHandler, type PaymentRequiredPayload } from "../services/api";
+import type { PaywallFeature, PaywallContext } from "../utils/analytics";
 import {
   useFilters,
   type FilterState,
@@ -479,6 +480,8 @@ const App = ({
   const [isBudgetModalOpen, setBudgetModalOpen] = useState(false);
   const [isUpgradeModalOpen, setUpgradeModalOpen] = useState(false);
   const [upgradeModalReason, setUpgradeModalReason] = useState("");
+  const [upgradeModalFeature, setUpgradeModalFeature] = useState<PaywallFeature>("unknown");
+  const [upgradeModalContext, setUpgradeModalContext] = useState<PaywallContext>("feature_gate");
   const [editingTransaction, setEditingTransaction] = useState<TransactionWithCategoryName | null>(null);
   const [editingBudget, setEditingBudget] = useState<MonthlyBudget | null>(null);
   const [budgetForm, setBudgetForm] = useState<BudgetFormState>(DEFAULT_BUDGET_FORM);
@@ -599,8 +602,10 @@ const App = ({
   }, []);
 
   useEffect(() => {
-    setPaymentRequiredHandler((message: string) => {
-      setUpgradeModalReason(message);
+    setPaymentRequiredHandler(({ reason, feature, context }: PaymentRequiredPayload) => {
+      setUpgradeModalReason(reason);
+      setUpgradeModalFeature(feature);
+      setUpgradeModalContext(context);
       setUpgradeModalOpen(true);
     });
     return () => {
@@ -2807,6 +2812,8 @@ const App = ({
       <UpgradeModal
         isOpen={isUpgradeModalOpen}
         reason={upgradeModalReason}
+        feature={upgradeModalFeature}
+        context={upgradeModalContext}
         onClose={() => setUpgradeModalOpen(false)}
       />
 

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -11,8 +11,11 @@ type EnvConfig = {
   VITE_API_URL?: string;
 };
 
+import type { PaywallFeature, PaywallContext } from "../utils/analytics";
+
 type UnauthorizedHandler = (() => void) | undefined;
-type PaymentRequiredHandler = ((message: string) => void) | undefined;
+export type PaymentRequiredPayload = { reason: string; feature: PaywallFeature; context: PaywallContext };
+type PaymentRequiredHandler = ((payload: PaymentRequiredPayload) => void) | undefined;
 
 type ApiConfigurationError = Error & {
   code: "API_URL_NOT_CONFIGURED";
@@ -162,44 +165,52 @@ api.interceptors.request.use((config: InternalAxiosRequestConfig) => {
   return config;
 });
 
-const PAYWALL_COPY: Array<{ pattern: RegExp; reason: string }> = [
+const PAYWALL_COPY: Array<{ pattern: RegExp; reason: string; feature: PaywallFeature }> = [
   {
     pattern: /\/transactions\/import/,
     reason: "Importe transações de outros apps e bancos direto para o Control Finance.",
+    feature: "csv_import",
   },
   {
     pattern: /\/transactions\/export/,
     reason: "Exporte suas transações para planilhas e ferramentas financeiras.",
+    feature: "csv_export",
   },
   {
     pattern: /\/forecasts/,
     reason: "Saiba exatamente quanto vai ter no saldo no fim do mês.",
+    feature: "forecast",
   },
   {
     pattern: /\/analytics\/trend/,
     reason: "Acesse até 24 meses de histórico e veja sua evolução financeira completa.",
+    feature: "analytics_trend",
   },
   {
     pattern: /\/salary/,
     reason: "Planeje seu salário com cálculo real de INSS e IRRF.",
+    feature: "salary",
   },
 ];
 
 const isTrialExpiredMessage = (msg: string): boolean =>
   msg.toLowerCase().includes("teste encerrado");
 
-const resolvePaywallReason = (url: string, serverMessage: string): string => {
+const resolvePaywallPayload = (
+  url: string,
+  serverMessage: string,
+): PaymentRequiredPayload => {
   if (isTrialExpiredMessage(serverMessage)) {
-    return serverMessage;
+    return { reason: serverMessage, feature: "unknown", context: "trial_expired" };
   }
 
   for (const entry of PAYWALL_COPY) {
     if (entry.pattern.test(url)) {
-      return entry.reason;
+      return { reason: entry.reason, feature: entry.feature, context: "feature_gate" };
     }
   }
 
-  return serverMessage;
+  return { reason: serverMessage, feature: "unknown", context: "feature_gate" };
 };
 
 api.interceptors.response.use(
@@ -267,10 +278,10 @@ api.interceptors.response.use(
           : "";
 
       const url: string = error?.config?.url ?? "";
-      const reason = resolvePaywallReason(url, serverMessage);
+      const payload = resolvePaywallPayload(url, serverMessage);
 
       if (typeof paymentRequiredHandler === "function") {
-        paymentRequiredHandler(reason);
+        paymentRequiredHandler(payload);
       }
     }
 

--- a/apps/web/src/utils/analytics.ts
+++ b/apps/web/src/utils/analytics.ts
@@ -1,0 +1,26 @@
+export type PaywallFeature =
+  | "csv_import"
+  | "csv_export"
+  | "forecast"
+  | "analytics_trend"
+  | "salary"
+  | "unknown";
+
+export type PaywallAction = "viewed" | "clicked_upgrade" | "dismissed";
+export type PaywallContext = "trial_expired" | "feature_gate";
+
+export interface PaywallEvent {
+  feature: PaywallFeature;
+  action: PaywallAction;
+  context: PaywallContext;
+}
+
+/**
+ * Tracks a paywall interaction event.
+ *
+ * Today: logs to console. Swap this implementation to send events to
+ * PostHog, Mixpanel, or a backend endpoint without touching call sites.
+ */
+export const trackPaywallEvent = (event: PaywallEvent): void => {
+  console.log("[paywall]", event);
+};


### PR DESCRIPTION
## Summary

Builds the tracking seam for paywall conversion measurement. Today logs to console; swap `trackPaywallEvent()` in `analytics.ts` for any provider (PostHog, Mixpanel, backend endpoint) without touching call sites.

### New: `apps/web/src/utils/analytics.ts`
Single-responsibility module. Types `PaywallFeature`, `PaywallAction`, `PaywallContext`, `PaywallEvent`. One function: `trackPaywallEvent(event)`.

### `api.ts` — payload upgrade
`resolvePaywallPayload(url, serverMessage)` returns `{ reason, feature, context }`:
- `feature`: one of `csv_import | csv_export | forecast | analytics_trend | salary | unknown`
- `context`: `trial_expired` (server string contains "teste encerrado") or `feature_gate`

`PaymentRequiredPayload` exported. `PaymentRequiredHandler` signature updated.

### `App.tsx`
Two new state fields (`upgradeModalFeature`, `upgradeModalContext`) populated from handler payload; passed as props to `UpgradeModal`.

### `UpgradeModal.tsx`
- Tracks `"viewed"` on `isOpen → true` (useEffect)
- Tracks `"clicked_upgrade"` on CTA click
- Tracks `"dismissed"` on explicit dismiss button **only** — Escape key and backdrop do NOT fire `"dismissed"`, avoiding false negatives

## Events emitted
| Trigger | action | feature | context |
|---|---|---|---|
| Modal opens | `viewed` | e.g. `csv_export` | `feature_gate` |
| CTA clicked | `clicked_upgrade` | same | same |
| Dismiss button | `dismissed` | same | same |
| Trial expiry modal opens | `viewed` | `unknown` | `trial_expired` |

## Test plan
- [ ] Trigger CSV export paywall → console shows `[paywall] { feature: "csv_export", action: "viewed", context: "feature_gate" }`
- [ ] Click "Começar meu plano Pro" → `clicked_upgrade` logged before navigation
- [ ] Click "Continuar no plano gratuito" → `dismissed` logged
- [ ] Press Escape or click backdrop → modal closes, no `dismissed` event
- [ ] Trial expiry path → `context: "trial_expired"`, `feature: "unknown"`
- [ ] `tsc --noEmit` zero errors