### PR TITLE
feat(analytics): persist paywall events to Postgres via POST /analytics/paywall

### DIFF
--- a/apps/api/src/analytics.paywall.test.js
+++ b/apps/api/src/analytics.paywall.test.js
@@ -1,0 +1,132 @@
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import app from "./app.js";
+import { clearDbClientForTests, dbQuery } from "./db/index.js";
+import { resetLoginProtectionState } from "./middlewares/login-protection.middleware.js";
+import { resetImportRateLimiterState, resetWriteRateLimiterState } from "./middlewares/rate-limit.middleware.js";
+import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
+import { registerAndLogin, setupTestDb } from "./test-helpers.js";
+
+describe("POST /analytics/paywall", () => {
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  afterAll(async () => {
+    await clearDbClientForTests();
+  });
+
+  beforeEach(async () => {
+    resetLoginProtectionState();
+    resetImportRateLimiterState();
+    resetWriteRateLimiterState();
+    resetHttpMetricsForTests();
+    await dbQuery("DELETE FROM paywall_events");
+    await dbQuery("DELETE FROM refresh_tokens");
+    await dbQuery("DELETE FROM users");
+  });
+
+  it("retorna 401 sem autenticacao", async () => {
+    const response = await request(app)
+      .post("/analytics/paywall")
+      .send({ feature: "csv_export", action: "viewed", context: "feature_gate" });
+
+    expect(response.status).toBe(401);
+  });
+
+  it("registra evento valido e retorna 201", async () => {
+    const token = await registerAndLogin("user@test.com");
+
+    const response = await request(app)
+      .post("/analytics/paywall")
+      .set("Cookie", [`cf_access=${token}`])
+      .send({ feature: "csv_export", action: "viewed", context: "feature_gate" });
+
+    expect(response.status).toBe(201);
+    expect(response.body).toMatchObject({
+      feature: "csv_export",
+      action: "viewed",
+      context: "feature_gate",
+    });
+    expect(response.body.id).toBeDefined();
+    expect(response.body.created_at).toBeDefined();
+  });
+
+  it("aceita todos os valores validos de feature", async () => {
+    const token = await registerAndLogin("user2@test.com");
+    const features = ["csv_import", "csv_export", "forecast", "analytics_trend", "salary", "unknown"];
+
+    for (const feature of features) {
+      const response = await request(app)
+        .post("/analytics/paywall")
+        .set("Cookie", [`cf_access=${token}`])
+        .send({ feature, action: "viewed", context: "feature_gate" });
+
+      expect(response.status).toBe(201);
+    }
+  });
+
+  it("aceita todas as actions validas", async () => {
+    const token = await registerAndLogin("user3@test.com");
+    const actions = ["viewed", "clicked_upgrade", "dismissed"];
+
+    for (const action of actions) {
+      const response = await request(app)
+        .post("/analytics/paywall")
+        .set("Cookie", [`cf_access=${token}`])
+        .send({ feature: "forecast", action, context: "feature_gate" });
+
+      expect(response.status).toBe(201);
+    }
+  });
+
+  it("retorna 400 para feature invalida", async () => {
+    const token = await registerAndLogin("user4@test.com");
+
+    const response = await request(app)
+      .post("/analytics/paywall")
+      .set("Cookie", [`cf_access=${token}`])
+      .send({ feature: "invalid_feature", action: "viewed", context: "feature_gate" });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("retorna 400 para action invalida", async () => {
+    const token = await registerAndLogin("user5@test.com");
+
+    const response = await request(app)
+      .post("/analytics/paywall")
+      .set("Cookie", [`cf_access=${token}`])
+      .send({ feature: "csv_export", action: "invalid_action", context: "feature_gate" });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("retorna 400 para context invalido", async () => {
+    const token = await registerAndLogin("user6@test.com");
+
+    const response = await request(app)
+      .post("/analytics/paywall")
+      .set("Cookie", [`cf_access=${token}`])
+      .send({ feature: "csv_export", action: "viewed", context: "invalid_context" });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("persiste o user_id correto no banco", async () => {
+    const token = await registerAndLogin("user7@test.com");
+
+    await request(app)
+      .post("/analytics/paywall")
+      .set("Cookie", [`cf_access=${token}`])
+      .send({ feature: "salary", action: "clicked_upgrade", context: "trial_expired" });
+
+    const result = await dbQuery(
+      "SELECT * FROM paywall_events WHERE feature = 'salary' AND action = 'clicked_upgrade'",
+    );
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].context).toBe("trial_expired");
+    expect(result.rows[0].user_id).toBeGreaterThan(0);
+  });
+});

--- a/apps/api/src/db/migrations/026_create_paywall_events.sql
+++ b/apps/api/src/db/migrations/026_create_paywall_events.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS paywall_events (
+  id         SERIAL       PRIMARY KEY,
+  user_id    INTEGER      NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  feature    VARCHAR(50)  NOT NULL,
+  action     VARCHAR(50)  NOT NULL,
+  context    VARCHAR(50)  NOT NULL,
+  created_at TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_paywall_events_user_id
+  ON paywall_events(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_paywall_events_feature_action
+  ON paywall_events(feature, action);

--- a/apps/api/src/routes/analytics.routes.js
+++ b/apps/api/src/routes/analytics.routes.js
@@ -2,15 +2,29 @@ import { Router } from "express";
 import { authMiddleware } from "../middlewares/auth.middleware.js";
 import { attachEntitlements, requireActiveTrialOrPaidPlan } from "../middlewares/entitlement.middleware.js";
 import { getMonthlyTrendForUser } from "../services/analytics.service.js";
+import { recordPaywallEvent } from "../services/paywall-events.service.js";
 
 const router = Router();
 
 const DEFAULT_MONTHS = 6;
 const MAX_MONTHS = 24;
 
-router.use(authMiddleware, requireActiveTrialOrPaidPlan);
+router.post("/paywall", authMiddleware, async (req, res, next) => {
+  try {
+    const { feature, action, context } = req.body ?? {};
+    const event = await recordPaywallEvent({
+      userId: req.user.id,
+      feature,
+      action,
+      context,
+    });
+    res.status(201).json(event);
+  } catch (error) {
+    next(error);
+  }
+});
 
-router.get("/trend", attachEntitlements, async (req, res, next) => {
+router.get("/trend", authMiddleware, requireActiveTrialOrPaidPlan, attachEntitlements, async (req, res, next) => {
   try {
     const cap = req.entitlements.analytics_months_max;
     const rawMonths = req.query?.months;

--- a/apps/api/src/services/paywall-events.service.js
+++ b/apps/api/src/services/paywall-events.service.js
@@ -1,0 +1,43 @@
+import { dbQuery } from "../db/index.js";
+
+const VALID_FEATURES = new Set([
+  "csv_import",
+  "csv_export",
+  "forecast",
+  "analytics_trend",
+  "salary",
+  "unknown",
+]);
+
+const VALID_ACTIONS = new Set(["viewed", "clicked_upgrade", "dismissed"]);
+
+const VALID_CONTEXTS = new Set(["trial_expired", "feature_gate"]);
+
+const createError = (status, message) => {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+};
+
+export const recordPaywallEvent = async ({ userId, feature, action, context }) => {
+  if (!VALID_FEATURES.has(feature)) {
+    throw createError(400, "feature invalido.");
+  }
+
+  if (!VALID_ACTIONS.has(action)) {
+    throw createError(400, "action invalido.");
+  }
+
+  if (!VALID_CONTEXTS.has(context)) {
+    throw createError(400, "context invalido.");
+  }
+
+  const result = await dbQuery(
+    `INSERT INTO paywall_events (user_id, feature, action, context)
+     VALUES ($1, $2, $3, $4)
+     RETURNING id, user_id, feature, action, context, created_at`,
+    [userId, feature, action, context],
+  );
+
+  return result.rows[0];
+};

--- a/apps/web/src/utils/analytics.ts
+++ b/apps/web/src/utils/analytics.ts
@@ -17,10 +17,12 @@ export interface PaywallEvent {
 
 /**
  * Tracks a paywall interaction event.
- *
- * Today: logs to console. Swap this implementation to send events to
- * PostHog, Mixpanel, or a backend endpoint without touching call sites.
+ * Fire-and-forget: never blocks the UI, never throws.
  */
 export const trackPaywallEvent = (event: PaywallEvent): void => {
-  console.log("[paywall]", event);
+  import("../services/api").then(({ api }) => {
+    void api.post("/analytics/paywall", event).catch(() => {
+      // Silently discard — tracking must never degrade the user experience
+    });
+  });
 };


### PR DESCRIPTION
## Summary

Closes the tracking loop: paywall events now persist to Postgres instead of staying in console. No new dependency — uses the Axios instance and Postgres already in place.

## Backend

**Migration 026** — `paywall_events` table:
- `user_id INTEGER REFERENCES users(id) ON DELETE CASCADE`
- `feature VARCHAR(50)`, `action VARCHAR(50)`, `context VARCHAR(50)`
- Indexes on `user_id` and `(feature, action)` for future aggregation queries

**`paywall-events.service.js`** — `recordPaywallEvent({ userId, feature, action, context })`:
- Allowlist validation via `Set` — returns 400 for unknown enum values
- Returns the inserted row

**`analytics.routes.js`** — `POST /analytics/paywall`:
- Auth-only (no plan gate — event fires when user IS blocked)
- `router.use(authMiddleware, requireActiveTrialOrPaidPlan)` replaced with inline middleware on `/trend` to avoid blocking the new route

## Frontend

**`analytics.ts`** — `trackPaywallEvent` now calls `api.post("/analytics/paywall", event)`:
- Dynamic import to avoid circular dependency
- Fire-and-forget: `.catch(() => {})` — tracking silently discards errors, never breaks the UI

## Tests

8 API tests in `analytics.paywall.test.js`:
- 401 without auth
- 201 with valid payload + response shape
- All 6 valid feature values → 201
- All 3 valid action values → 201  
- 400 for invalid feature / action / context
- DB persistence: `user_id` and `context` stored correctly

## What you can now query

```sql
-- Which feature generates most interest?
SELECT feature, COUNT(*) AS views
FROM paywall_events WHERE action = 'viewed'
GROUP BY feature ORDER BY views DESC;

-- Conversion rate per feature
SELECT feature,
  COUNT(*) FILTER (WHERE action = 'clicked_upgrade')::float /
  NULLIF(COUNT(*) FILTER (WHERE action = 'viewed'), 0) AS conversion_rate
FROM paywall_events GROUP BY feature;

-- Trial vs feature gate conversion
SELECT context,
  COUNT(*) FILTER (WHERE action = 'clicked_upgrade')::float /
  NULLIF(COUNT(*) FILTER (WHERE action = 'viewed'), 0) AS conversion_rate
FROM paywall_events GROUP BY context;
```