### PR TITLE
feat(onboarding): WelcomeCard for zero-transaction users

### DIFF
--- a/apps/web/src/components/WelcomeCard.tsx
+++ b/apps/web/src/components/WelcomeCard.tsx
@@ -1,0 +1,72 @@
+interface WelcomeCardProps {
+  onAddTransaction: () => void;
+  onOpenProfileSettings?: () => void;
+}
+
+const WelcomeCard = ({ onAddTransaction, onOpenProfileSettings }: WelcomeCardProps) => {
+  return (
+    <section className="rounded border border-brand-1/40 bg-cf-surface p-5">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <h2 className="text-base font-semibold text-cf-text-primary">
+            Comece a organizar sua vida financeira
+          </h2>
+          <p className="mt-1 text-sm text-cf-text-secondary">
+            Registre sua primeira transação para visualizar seu saldo, gráficos e projeção de saldo ao fim do mês.
+          </p>
+
+          <ol className="mt-4 space-y-2">
+            <li className="flex items-start gap-2.5 text-sm text-cf-text-secondary">
+              <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-brand-1 text-xs font-bold text-white">
+                1
+              </span>
+              <span>
+                <strong className="font-semibold text-cf-text-primary">Registre uma transação</strong>
+                {" — "}uma entrada (salário, freelance) ou saída (conta, compra)
+              </span>
+            </li>
+            <li className="flex items-start gap-2.5 text-sm text-cf-text-secondary">
+              <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-brand-1/20 text-xs font-bold text-brand-1">
+                2
+              </span>
+              <span>
+                <strong className="font-semibold text-cf-text-primary">Veja seu saldo em tempo real</strong>
+                {" — "}entradas menos saídas calculadas automaticamente
+              </span>
+            </li>
+            <li className="flex items-start gap-2.5 text-sm text-cf-text-secondary">
+              <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-brand-1/20 text-xs font-bold text-brand-1">
+                3
+              </span>
+              <span>
+                <strong className="font-semibold text-cf-text-primary">Configure seu perfil</strong>
+                {" — "}salário e dia de pagamento para ativar a projeção de saldo
+              </span>
+            </li>
+          </ol>
+        </div>
+
+        <div className="flex shrink-0 flex-col gap-2 sm:items-end">
+          <button
+            type="button"
+            onClick={onAddTransaction}
+            className="rounded bg-brand-1 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-2 whitespace-nowrap"
+          >
+            + Registrar primeira transação
+          </button>
+          {onOpenProfileSettings ? (
+            <button
+              type="button"
+              onClick={onOpenProfileSettings}
+              className="rounded border border-cf-border px-4 py-2 text-sm font-semibold text-cf-text-secondary hover:bg-cf-bg-subtle whitespace-nowrap"
+            >
+              Configurar perfil
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default WelcomeCard;

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -1,6 +1,7 @@
 import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getApiErrorMessage } from "../utils/apiError";
 import ConfirmDialog from "../components/ConfirmDialog";
+import WelcomeCard from "../components/WelcomeCard";
 import Modal from "../components/Modal";
 import ImportCsvModal from "../components/ImportCsvModal";
 import ImportHistoryModal from "../components/ImportHistoryModal";
@@ -1842,6 +1843,13 @@ const App = ({
       </header>
 
       <main className="mx-auto mt-8 w-full max-w-6xl space-y-6 px-4 sm:mt-10 sm:px-6">
+        {!isLoadingTransactions && transactions.length === 0 ? (
+          <WelcomeCard
+            onAddTransaction={openCreateModal}
+            onOpenProfileSettings={onOpenProfileSettings}
+          />
+        ) : null}
+
         <section ref={filtersPanelRef}>
           <div className="space-y-4 rounded border border-cf-border bg-cf-surface p-4">
             <div className="flex items-start justify-between gap-3 rounded border border-cf-border bg-cf-bg-subtle px-3 py-2">


### PR DESCRIPTION
## The problem
A new user with zero data sees: zeros everywhere, empty lists, technical messages like "Sem dados suficientes". No orientation, no sequence, no value signal. They leave before their "aha moment".

## The fix
`WelcomeCard` — a single, contextual card that:
- **Appears** when `!isLoadingTransactions && transactions.length === 0`
- **Disappears** automatically after the first transaction is recorded (no dismiss button needed)
- **Shows a 3-step sequence** that mirrors the real activation path
- **Has two CTAs**: primary opens the transaction modal directly, secondary goes to profile settings

## What the user sees
```
Comece a organizar sua vida financeira
Registre sua primeira transação para visualizar seu saldo, gráficos e projeção...

① Registre uma transação — uma entrada (salário, freelance) ou saída (conta, compra)
② Veja seu saldo em tempo real — entradas menos saídas calculadas automaticamente  
③ Configure seu perfil — salário e dia de pagamento para ativar a projeção de saldo

[+ Registrar primeira transação]   [Configurar perfil]
```

## Design
- Border `border-brand-1/40` — subtle brand accent without being a modal/banner
- Step 1: filled `bg-brand-1` circle (active/priority)
- Steps 2–3: `bg-brand-1/20` circles (future steps, lighter)
- Responsive: stacked on mobile, side-by-side on `sm:`
- Zero new dependencies, consistent with existing `cf-*` token system

## Test plan
- [ ] New user (zero transactions) → WelcomeCard visible at top of dashboard
- [ ] Register first transaction → card disappears from dashboard
- [ ] "Registrar primeira transação" → opens transaction modal
- [ ] "Configurar perfil" → calls `onOpenProfileSettings` (only shown if prop is provided)
- [ ] User with existing transactions → card never appears
- [ ] App.test.jsx: 75/75 passing (no regression)