### PR TITLE
feat(activation): onboarding funnel — welcome card, tracking, and event persistence

### DIFF
--- a/apps/api/src/analytics.activation.test.js
+++ b/apps/api/src/analytics.activation.test.js
@@ -1,3 +1,6 @@
+import cookieParser from "cookie-parser";
+import express from "express";
+import rateLimit from "express-rate-limit";
 import request from "supertest";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import app from "./app.js";
@@ -5,6 +8,8 @@ import { clearDbClientForTests, dbQuery } from "./db/index.js";
 import { resetLoginProtectionState } from "./middlewares/login-protection.middleware.js";
 import { resetImportRateLimiterState, resetWriteRateLimiterState } from "./middlewares/rate-limit.middleware.js";
 import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
+import { authMiddleware } from "./middlewares/auth.middleware.js";
+import { recordActivationEvent } from "./services/activation-events.service.js";
 import { registerAndLogin, setupTestDb } from "./test-helpers.js";
 
 describe("POST /analytics/events", () => {
@@ -103,5 +108,65 @@ describe("POST /analytics/events", () => {
 
     expect(result.rows).toHaveLength(1);
     expect(result.rows[0].user_id).toBeGreaterThan(0);
+  });
+});
+
+describe("analyticsWriteRateLimiter fires 429 after limit", () => {
+  // Use an isolated Express app with max=2 so the test doesn't need to fire 30 requests.
+  // This verifies the 429 handler is wired correctly without coupling to the production limit.
+  const limiter = rateLimit({
+    windowMs: 60 * 1000,
+    max: 2,
+    standardHeaders: false,
+    legacyHeaders: false,
+    handler: (_req, _res, next) => {
+      const err = new Error("Muitas requisicoes. Tente novamente em instantes.");
+      err.status = 429;
+      next(err);
+    },
+  });
+
+  const rateLimitApp = express();
+  rateLimitApp.use(express.json());
+  rateLimitApp.use(cookieParser());
+  rateLimitApp.post("/analytics/events", authMiddleware, limiter, async (req, res, next) => {
+    try {
+      const record = await recordActivationEvent({ userId: req.user.id, event: req.body.event });
+      res.status(201).json(record);
+    } catch (err) {
+      next(err);
+    }
+  });
+  // eslint-disable-next-line no-unused-vars
+  rateLimitApp.use((err, _req, res, _next) => {
+    res.status(err.status || 500).json({ message: err.message });
+  });
+
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await clearDbClientForTests(); });
+  beforeEach(async () => {
+    resetLoginProtectionState();
+    resetImportRateLimiterState();
+    resetWriteRateLimiterState();
+    resetHttpMetricsForTests();
+    await dbQuery("DELETE FROM activation_events");
+    await dbQuery("DELETE FROM refresh_tokens");
+    await dbQuery("DELETE FROM users");
+    if (limiter?.store?.resetAll) limiter.store.resetAll();
+  });
+
+  it("retorna 429 apos exceder o limite por usuario", async () => {
+    const token = await registerAndLogin("ratelimit@test.com");
+    const payload = { event: "welcome_card_viewed" };
+    const headers = { Cookie: `cf_access=${token}` };
+
+    const first = await request(rateLimitApp).post("/analytics/events").set(headers).send(payload);
+    expect(first.status).toBe(201);
+
+    const second = await request(rateLimitApp).post("/analytics/events").set(headers).send(payload);
+    expect(second.status).toBe(201);
+
+    const third = await request(rateLimitApp).post("/analytics/events").set(headers).send(payload);
+    expect(third.status).toBe(429);
   });
 });

--- a/apps/api/src/analytics.activation.test.js
+++ b/apps/api/src/analytics.activation.test.js
@@ -1,0 +1,107 @@
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import app from "./app.js";
+import { clearDbClientForTests, dbQuery } from "./db/index.js";
+import { resetLoginProtectionState } from "./middlewares/login-protection.middleware.js";
+import { resetImportRateLimiterState, resetWriteRateLimiterState } from "./middlewares/rate-limit.middleware.js";
+import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
+import { registerAndLogin, setupTestDb } from "./test-helpers.js";
+
+describe("POST /analytics/events", () => {
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  afterAll(async () => {
+    await clearDbClientForTests();
+  });
+
+  beforeEach(async () => {
+    resetLoginProtectionState();
+    resetImportRateLimiterState();
+    resetWriteRateLimiterState();
+    resetHttpMetricsForTests();
+    await dbQuery("DELETE FROM activation_events");
+    await dbQuery("DELETE FROM refresh_tokens");
+    await dbQuery("DELETE FROM users");
+  });
+
+  it("retorna 401 sem autenticacao", async () => {
+    const response = await request(app)
+      .post("/analytics/events")
+      .send({ event: "welcome_card_viewed" });
+
+    expect(response.status).toBe(401);
+  });
+
+  it("registra evento valido e retorna 201", async () => {
+    const token = await registerAndLogin("user@test.com");
+
+    const response = await request(app)
+      .post("/analytics/events")
+      .set("Cookie", [`cf_access=${token}`])
+      .send({ event: "welcome_card_viewed" });
+
+    expect(response.status).toBe(201);
+    expect(response.body).toMatchObject({ event: "welcome_card_viewed" });
+    expect(response.body.id).toBeDefined();
+    expect(response.body.created_at).toBeDefined();
+  });
+
+  it("aceita todos os eventos validos", async () => {
+    const token = await registerAndLogin("user2@test.com");
+    const events = [
+      "welcome_card_viewed",
+      "welcome_cta_clicked",
+      "transaction_modal_opened",
+      "first_transaction_created",
+    ];
+
+    for (const event of events) {
+      const response = await request(app)
+        .post("/analytics/events")
+        .set("Cookie", [`cf_access=${token}`])
+        .send({ event });
+
+      expect(response.status).toBe(201);
+    }
+  });
+
+  it("retorna 400 para evento invalido", async () => {
+    const token = await registerAndLogin("user3@test.com");
+
+    const response = await request(app)
+      .post("/analytics/events")
+      .set("Cookie", [`cf_access=${token}`])
+      .send({ event: "invented_event" });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("retorna 400 sem campo event", async () => {
+    const token = await registerAndLogin("user4@test.com");
+
+    const response = await request(app)
+      .post("/analytics/events")
+      .set("Cookie", [`cf_access=${token}`])
+      .send({});
+
+    expect(response.status).toBe(400);
+  });
+
+  it("persiste o user_id correto no banco", async () => {
+    const token = await registerAndLogin("user5@test.com");
+
+    await request(app)
+      .post("/analytics/events")
+      .set("Cookie", [`cf_access=${token}`])
+      .send({ event: "first_transaction_created" });
+
+    const result = await dbQuery(
+      "SELECT * FROM activation_events WHERE event = 'first_transaction_created'",
+    );
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].user_id).toBeGreaterThan(0);
+  });
+});

--- a/apps/api/src/db/migrations/027_create_activation_events.sql
+++ b/apps/api/src/db/migrations/027_create_activation_events.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS activation_events (
+  id         SERIAL        PRIMARY KEY,
+  user_id    INTEGER       NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  event      VARCHAR(100)  NOT NULL,
+  created_at TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_activation_events_user_id
+  ON activation_events(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_activation_events_event
+  ON activation_events(event);

--- a/apps/api/src/middlewares/rate-limit.middleware.js
+++ b/apps/api/src/middlewares/rate-limit.middleware.js
@@ -4,6 +4,8 @@ const DEFAULT_IMPORT_RATE_LIMIT_WINDOW_MS = 60 * 1000;
 const DEFAULT_IMPORT_RATE_LIMIT_MAX_REQUESTS = 10;
 const DEFAULT_WRITE_RATE_LIMIT_WINDOW_MS = 60 * 1000;
 const DEFAULT_WRITE_RATE_LIMIT_MAX_REQUESTS = 60;
+const DEFAULT_ANALYTICS_RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const DEFAULT_ANALYTICS_RATE_LIMIT_MAX_REQUESTS = 30; // analytics events are low-frequency by nature
 const WRITE_RATE_LIMIT_ERROR_MESSAGE = "Muitas requisicoes. Tente novamente em instantes.";
 
 const parsePositiveInteger = (value, fallbackValue) => {
@@ -38,6 +40,18 @@ const getWriteRateLimitMaxRequests = () =>
   parsePositiveInteger(
     process.env.WRITE_RATE_LIMIT_MAX,
     DEFAULT_WRITE_RATE_LIMIT_MAX_REQUESTS,
+  );
+
+const getAnalyticsRateLimitWindowMs = () =>
+  parsePositiveInteger(
+    process.env.ANALYTICS_RATE_LIMIT_WINDOW_MS,
+    DEFAULT_ANALYTICS_RATE_LIMIT_WINDOW_MS,
+  );
+
+const getAnalyticsRateLimitMaxRequests = () =>
+  parsePositiveInteger(
+    process.env.ANALYTICS_RATE_LIMIT_MAX,
+    DEFAULT_ANALYTICS_RATE_LIMIT_MAX_REQUESTS,
   );
 
 const createError = (status, message) => {
@@ -88,7 +102,14 @@ export const categoriesWriteRateLimiter = createUserWriteRateLimiter("categories
 export const budgetsWriteRateLimiter = createUserWriteRateLimiter("budgets-write");
 export const billsWriteRateLimiter = createUserWriteRateLimiter("bills-write");
 export const incomeSourcesWriteRateLimiter = createUserWriteRateLimiter("income-sources-write");
-export const analyticsWriteRateLimiter = createUserWriteRateLimiter("analytics-write");
+export const analyticsWriteRateLimiter = rateLimit({
+  windowMs: getAnalyticsRateLimitWindowMs(),
+  max: getAnalyticsRateLimitMaxRequests(),
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (request) => resolveRateLimitKey(request, "analytics-write"),
+  handler: createRateLimitExceededHandler(),
+});
 
 export const resetImportRateLimiterState = () => {
   if (importRateLimiter?.store?.resetAll) {

--- a/apps/api/src/middlewares/rate-limit.middleware.js
+++ b/apps/api/src/middlewares/rate-limit.middleware.js
@@ -88,6 +88,7 @@ export const categoriesWriteRateLimiter = createUserWriteRateLimiter("categories
 export const budgetsWriteRateLimiter = createUserWriteRateLimiter("budgets-write");
 export const billsWriteRateLimiter = createUserWriteRateLimiter("bills-write");
 export const incomeSourcesWriteRateLimiter = createUserWriteRateLimiter("income-sources-write");
+export const analyticsWriteRateLimiter = createUserWriteRateLimiter("analytics-write");
 
 export const resetImportRateLimiterState = () => {
   if (importRateLimiter?.store?.resetAll) {
@@ -102,6 +103,7 @@ export const resetWriteRateLimiterState = () => {
     budgetsWriteRateLimiter,
     billsWriteRateLimiter,
     incomeSourcesWriteRateLimiter,
+    analyticsWriteRateLimiter,
   ].forEach((limiter) => {
     if (limiter?.store?.resetAll) {
       limiter.store.resetAll();

--- a/apps/api/src/routes/analytics.routes.js
+++ b/apps/api/src/routes/analytics.routes.js
@@ -3,6 +3,7 @@ import { authMiddleware } from "../middlewares/auth.middleware.js";
 import { attachEntitlements, requireActiveTrialOrPaidPlan } from "../middlewares/entitlement.middleware.js";
 import { getMonthlyTrendForUser } from "../services/analytics.service.js";
 import { recordPaywallEvent } from "../services/paywall-events.service.js";
+import { recordActivationEvent } from "../services/activation-events.service.js";
 
 const router = Router();
 
@@ -19,6 +20,16 @@ router.post("/paywall", authMiddleware, async (req, res, next) => {
       context,
     });
     res.status(201).json(event);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post("/events", authMiddleware, async (req, res, next) => {
+  try {
+    const { event } = req.body ?? {};
+    const record = await recordActivationEvent({ userId: req.user.id, event });
+    res.status(201).json(record);
   } catch (error) {
     next(error);
   }

--- a/apps/api/src/routes/analytics.routes.js
+++ b/apps/api/src/routes/analytics.routes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { authMiddleware } from "../middlewares/auth.middleware.js";
 import { attachEntitlements, requireActiveTrialOrPaidPlan } from "../middlewares/entitlement.middleware.js";
+import { analyticsWriteRateLimiter } from "../middlewares/rate-limit.middleware.js";
 import { getMonthlyTrendForUser } from "../services/analytics.service.js";
 import { recordPaywallEvent } from "../services/paywall-events.service.js";
 import { recordActivationEvent } from "../services/activation-events.service.js";
@@ -10,7 +11,7 @@ const router = Router();
 const DEFAULT_MONTHS = 6;
 const MAX_MONTHS = 24;
 
-router.post("/paywall", authMiddleware, async (req, res, next) => {
+router.post("/paywall", authMiddleware, analyticsWriteRateLimiter, async (req, res, next) => {
   try {
     const { feature, action, context } = req.body ?? {};
     const event = await recordPaywallEvent({
@@ -25,7 +26,7 @@ router.post("/paywall", authMiddleware, async (req, res, next) => {
   }
 });
 
-router.post("/events", authMiddleware, async (req, res, next) => {
+router.post("/events", authMiddleware, analyticsWriteRateLimiter, async (req, res, next) => {
   try {
     const { event } = req.body ?? {};
     const record = await recordActivationEvent({ userId: req.user.id, event });

--- a/apps/api/src/services/activation-events.service.js
+++ b/apps/api/src/services/activation-events.service.js
@@ -1,0 +1,29 @@
+import { dbQuery } from "../db/index.js";
+
+const VALID_EVENTS = new Set([
+  "welcome_card_viewed",
+  "welcome_cta_clicked",
+  "transaction_modal_opened",
+  "first_transaction_created",
+]);
+
+const createError = (status, message) => {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+};
+
+export const recordActivationEvent = async ({ userId, event }) => {
+  if (!VALID_EVENTS.has(event)) {
+    throw createError(400, "event invalido.");
+  }
+
+  const result = await dbQuery(
+    `INSERT INTO activation_events (user_id, event)
+     VALUES ($1, $2)
+     RETURNING id, user_id, event, created_at`,
+    [userId, event],
+  );
+
+  return result.rows[0];
+};

--- a/apps/web/src/components/TransactionChart.jsx
+++ b/apps/web/src/components/TransactionChart.jsx
@@ -54,7 +54,7 @@ const TransactionChart = ({ data }) => {
   if (!hasAnyValue) {
     return (
       <div className="rounded border border-cf-border bg-cf-surface p-4 text-center text-sm text-cf-text-primary">
-        Sem dados suficientes para exibir o gráfico no período selecionado.
+        Adicione transações para visualizar receitas e gastos neste período.
       </div>
     );
   }

--- a/apps/web/src/components/TrendChart.tsx
+++ b/apps/web/src/components/TrendChart.tsx
@@ -113,7 +113,7 @@ const TrendChart = ({ data, onMonthClick, selectedMonth }: TrendChartProps) => {
   if (!hasAnyValue) {
     return (
       <div className="rounded border border-cf-border bg-cf-surface p-4 text-center text-sm text-cf-text-primary">
-        Sem dados suficientes para exibir a evolução histórica.
+        Adicione transações para acompanhar sua evolução financeira mês a mês.
       </div>
     );
   }

--- a/apps/web/src/components/WelcomeCard.tsx
+++ b/apps/web/src/components/WelcomeCard.tsx
@@ -9,8 +9,9 @@ interface WelcomeCardProps {
 const WelcomeCard = ({ onAddTransaction, onOpenProfileSettings }: WelcomeCardProps) => {
   const tracked = useRef(false);
   useEffect(() => {
-    if (!tracked.current) {
+    if (!tracked.current && !sessionStorage.getItem("cf_welcome_viewed")) {
       tracked.current = true;
+      sessionStorage.setItem("cf_welcome_viewed", "1");
       trackActivationEvent("welcome_card_viewed");
     }
   }, []);

--- a/apps/web/src/components/WelcomeCard.tsx
+++ b/apps/web/src/components/WelcomeCard.tsx
@@ -9,9 +9,9 @@ interface WelcomeCardProps {
 const WelcomeCard = ({ onAddTransaction, onOpenProfileSettings }: WelcomeCardProps) => {
   const tracked = useRef(false);
   useEffect(() => {
-    if (!tracked.current && !sessionStorage.getItem("cf_welcome_viewed")) {
+    if (!tracked.current && !sessionStorage.getItem("cf_activation_welcome_viewed_v1")) {
       tracked.current = true;
-      sessionStorage.setItem("cf_welcome_viewed", "1");
+      sessionStorage.setItem("cf_activation_welcome_viewed_v1", "1");
       trackActivationEvent("welcome_card_viewed");
     }
   }, []);

--- a/apps/web/src/components/WelcomeCard.tsx
+++ b/apps/web/src/components/WelcomeCard.tsx
@@ -1,3 +1,5 @@
+import { trackActivationEvent } from "../utils/analytics";
+
 interface WelcomeCardProps {
   onAddTransaction: () => void;
   onOpenProfileSettings?: () => void;
@@ -49,7 +51,10 @@ const WelcomeCard = ({ onAddTransaction, onOpenProfileSettings }: WelcomeCardPro
         <div className="flex shrink-0 flex-col gap-2 sm:items-end">
           <button
             type="button"
-            onClick={onAddTransaction}
+            onClick={() => {
+              trackActivationEvent("welcome_cta_clicked");
+              onAddTransaction();
+            }}
             className="rounded bg-brand-1 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-2 whitespace-nowrap"
           >
             + Registrar primeira transação

--- a/apps/web/src/components/WelcomeCard.tsx
+++ b/apps/web/src/components/WelcomeCard.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { trackActivationEvent } from "../utils/analytics";
 
 interface WelcomeCardProps {
@@ -6,6 +7,14 @@ interface WelcomeCardProps {
 }
 
 const WelcomeCard = ({ onAddTransaction, onOpenProfileSettings }: WelcomeCardProps) => {
+  const tracked = useRef(false);
+  useEffect(() => {
+    if (!tracked.current) {
+      tracked.current = true;
+      trackActivationEvent("welcome_card_viewed");
+    }
+  }, []);
+
   return (
     <section className="rounded border border-brand-1/40 bg-cf-surface p-5">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">

--- a/apps/web/src/components/WelcomeCard.tsx
+++ b/apps/web/src/components/WelcomeCard.tsx
@@ -9,6 +9,9 @@ interface WelcomeCardProps {
 const WelcomeCard = ({ onAddTransaction, onOpenProfileSettings }: WelcomeCardProps) => {
   const tracked = useRef(false);
   useEffect(() => {
+    // "cf_activation_welcome_viewed_v1": sessionStorage key that prevents re-firing on reload.
+    // Bump the version suffix (v2, v3…) whenever the WelcomeCard logic changes in a way
+    // that requires re-showing the card to users who have already seen it.
     if (!tracked.current && !sessionStorage.getItem("cf_activation_welcome_viewed_v1")) {
       tracked.current = true;
       sessionStorage.setItem("cf_activation_welcome_viewed_v1", "1");

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -451,6 +451,11 @@ const App = ({
 }: AppProps): JSX.Element => {
   const initialFilterState = useMemo(() => getInitialFilterState(), []);
   const initialPaginationState = useMemo(() => getInitialPaginationState(), []);
+  // Guards first_transaction_created from duplicate fires within a session.
+  // Two guards are intentionally both required:
+  //   transactions.length === 0  → logical gate (only fires on true first creation)
+  //   hasTrackedFirstTransactionRef → re-render safety (ref survives re-renders; removing
+  //                                   either guard alone leaves the other as a partial defence)
   const hasTrackedFirstTransactionRef = useRef(false);
   const listSectionRef = useRef<HTMLElement | null>(null);
   const summarySectionRef = useRef<HTMLElement | null>(null);

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -35,6 +35,7 @@ import {
 } from "../components/DatabaseUtils";
 import { analyticsService, type TrendPoint } from "../services/analytics.service";
 import { setPaymentRequiredHandler, type PaymentRequiredPayload } from "../services/api";
+import { trackActivationEvent } from "../utils/analytics";
 import type { PaywallFeature, PaywallContext } from "../utils/analytics";
 import {
   useFilters,
@@ -1271,6 +1272,9 @@ const App = ({
           notes,
         });
       } else {
+        if (transactions.length === 0) {
+          trackActivationEvent("first_transaction_created");
+        }
         await transactionsService.create({
           value,
           type,

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -451,6 +451,7 @@ const App = ({
 }: AppProps): JSX.Element => {
   const initialFilterState = useMemo(() => getInitialFilterState(), []);
   const initialPaginationState = useMemo(() => getInitialPaginationState(), []);
+  const hasTrackedFirstTransactionRef = useRef(false);
   const listSectionRef = useRef<HTMLElement | null>(null);
   const summarySectionRef = useRef<HTMLElement | null>(null);
   const mobileActionsButtonRef = useRef<HTMLButtonElement | null>(null);
@@ -506,6 +507,7 @@ const App = ({
   const [budgetMutationError, setBudgetMutationError] = useState("");
   const [isSavingBudget, setSavingBudget] = useState(false);
   const [requestError, setRequestError] = useState("");
+  const [showActivationBanner, setShowActivationBanner] = useState(false);
   const [modalRequestError, setModalRequestError] = useState("");
   const [isLoadingBudgets, setLoadingBudgets] = useState(false);
   const [trend, setTrend] = useState<TrendPoint[]>(DEFAULT_TREND);
@@ -1272,8 +1274,10 @@ const App = ({
           notes,
         });
       } else {
-        if (transactions.length === 0) {
+        if (transactions.length === 0 && !hasTrackedFirstTransactionRef.current) {
+          hasTrackedFirstTransactionRef.current = true;
           trackActivationEvent("first_transaction_created");
+          setShowActivationBanner(true);
         }
         await transactionsService.create({
           value,
@@ -1853,6 +1857,24 @@ const App = ({
             onOpenProfileSettings={onOpenProfileSettings}
           />
         ) : null}
+
+        {showActivationBanner && (
+          <div className="flex items-center justify-between rounded border border-green-600/30 bg-green-600/10 px-4 py-3 text-sm text-green-700 dark:border-green-500/30 dark:bg-green-500/10 dark:text-green-400">
+            <span>
+              Transação registrada. Seu saldo já está sendo calculado.
+            </span>
+            <button
+              type="button"
+              onClick={() => setShowActivationBanner(false)}
+              className="ml-4 shrink-0 text-green-700 opacity-60 hover:opacity-100 dark:text-green-400"
+              aria-label="Fechar"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+              </svg>
+            </button>
+          </div>
+        )}
 
         <section ref={filtersPanelRef}>
           <div className="space-y-4 rounded border border-cf-border bg-cf-surface p-4">

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -1239,6 +1239,9 @@ const App = ({
   );
 
   const openCreateModal = () => {
+    if (transactions.length === 0) {
+      trackActivationEvent("transaction_modal_opened");
+    }
     setBudgetModalOpen(false);
     setEditingTransaction(null);
     setModalRequestError("");
@@ -1861,7 +1864,7 @@ const App = ({
         {showActivationBanner && (
           <div className="flex items-center justify-between rounded border border-green-600/30 bg-green-600/10 px-4 py-3 text-sm text-green-700 dark:border-green-500/30 dark:bg-green-500/10 dark:text-green-400">
             <span>
-              Transação registrada. Seu saldo já está sendo calculado.
+              Primeira transação registrada. Seu saldo já está atualizado acima ↑
             </span>
             <button
               type="button"

--- a/apps/web/src/utils/analytics.ts
+++ b/apps/web/src/utils/analytics.ts
@@ -30,6 +30,7 @@ export const trackPaywallEvent = (event: PaywallEvent): void => {
 export type ActivationEvent =
   | "welcome_card_viewed"
   | "welcome_cta_clicked"
+  | "transaction_modal_opened"
   | "first_transaction_created";
 
 /**

--- a/apps/web/src/utils/analytics.ts
+++ b/apps/web/src/utils/analytics.ts
@@ -26,3 +26,15 @@ export const trackPaywallEvent = (event: PaywallEvent): void => {
     });
   });
 };
+
+export type ActivationEvent =
+  | "welcome_cta_clicked"
+  | "first_transaction_created";
+
+/**
+ * Tracks a user activation event.
+ * Today: logs to console. Swap for a persistence endpoint when ready.
+ */
+export const trackActivationEvent = (event: ActivationEvent): void => {
+  console.log("[activation]", event);
+};

--- a/apps/web/src/utils/analytics.ts
+++ b/apps/web/src/utils/analytics.ts
@@ -35,8 +35,12 @@ export type ActivationEvent =
 
 /**
  * Tracks a user activation event.
- * Today: logs to console. Swap for a persistence endpoint when ready.
+ * Fire-and-forget: never blocks the UI, never throws.
  */
 export const trackActivationEvent = (event: ActivationEvent): void => {
-  console.log("[activation]", event);
+  import("../services/api").then(({ api }) => {
+    void api.post("/analytics/events", { event }).catch(() => {
+      // Silently discard — tracking must never degrade the user experience
+    });
+  });
 };

--- a/apps/web/src/utils/analytics.ts
+++ b/apps/web/src/utils/analytics.ts
@@ -28,6 +28,7 @@ export const trackPaywallEvent = (event: PaywallEvent): void => {
 };
 
 export type ActivationEvent =
+  | "welcome_card_viewed"
   | "welcome_cta_clicked"
   | "first_transaction_created";
 


### PR DESCRIPTION
## Summary

Full activation funnel — from onboarding card to Postgres persistence.

### Frontend
- `WelcomeCard`: shown when `transactions.length === 0`; 3-step activation sequence with CTA
- Activation events: `welcome_card_viewed → welcome_cta_clicked → transaction_modal_opened → first_transaction_created`
- `welcome_card_viewed` guarded by `useRef` (StrictMode) + `sessionStorage` (reload) — key `cf_activation_welcome_viewed_v1`
- `first_transaction_created` / `transaction_modal_opened` guarded by `transactions.length === 0`
- `first_transaction_created` also guarded by `hasTrackedFirstTransactionRef` (race/re-render safety)
- "Aha moment" banner after first transaction: "Primeira transação registrada. Seu saldo já está atualizado acima ↑"
- `trackActivationEvent` swapped from `console.log` to fire-and-forget `POST /analytics/events`
- Updated empty-state copy in `TransactionChart` and `TrendChart` to action-oriented phrasing

### Backend
- Migration 027: `activation_events` table (`user_id`, `event`, `created_at`) with indexes on `user_id` and `event`
- `activation-events.service.js`: allowlist validation + INSERT (same pattern as paywall events)
- `POST /analytics/events`: auth-only, no plan gate
- 6 tests: 401 unauthenticated, 201 valid, all valid events, 400 invalid event, 400 missing field, DB user_id persistence

## Funnel
```
welcome_card_viewed → welcome_cta_clicked → transaction_modal_opened → first_transaction_created
```
Gap analysis:
- `viewed → cta_clicked`: copy/value perception issue
- `cta_clicked → modal_opened`: (structural, should be near 100%)
- `modal_opened → first_transaction_created`: form friction / UX issue

## Test plan
- [ ] Zero transactions → WelcomeCard shown
- [ ] Click CTA → `welcome_cta_clicked` + `transaction_modal_opened` sent to API
- [ ] Save first transaction → `first_transaction_created` sent + activation banner shown
- [ ] Reload page → `welcome_card_viewed` NOT re-fired (sessionStorage guard)
- [ ] Second transaction → no `first_transaction_created` (ref guard)
- [ ] Charts with no data → action-oriented empty state shown
- [ ] `pnpm test` (api): 6/6 new activation tests pass