### PR TITLE
feat(ops): expose migration status in GET /health response

### DIFF
--- a/apps/api/src/db/migrate.js
+++ b/apps/api/src/db/migrate.js
@@ -82,6 +82,24 @@ export const runMigrations = async () => {
   });
 };
 
+export const getMigrationStatus = async () => {
+  try {
+    return await withDbClient(async (client) => {
+      const { rows } = await client.query(
+        `SELECT name FROM ${MIGRATIONS_TABLE} ORDER BY executed_at DESC LIMIT 1`,
+      );
+      const countResult = await client.query(`SELECT COUNT(*) AS total FROM ${MIGRATIONS_TABLE}`);
+      return {
+        applied: Number(countResult.rows[0].total),
+        latest: rows[0]?.name ?? null,
+      };
+    });
+  } catch {
+    // DB unavailable or schema_migrations doesn't exist yet
+    return { applied: 0, latest: null };
+  }
+};
+
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   runMigrations()
     .then(() => {

--- a/apps/api/src/health-observability.test.js
+++ b/apps/api/src/health-observability.test.js
@@ -77,6 +77,7 @@ describe("health and observability", () => {
       expect(typeof response.body.requestId).toBe("string");
       expect(response.body.requestId.length).toBeGreaterThan(0);
       expect(response.body.requestId).toBe(response.headers["x-request-id"]);
+      expect(response.body.migrations).toEqual({ applied: 0, latest: null });
     } finally {
       setDbClientForTests(testDbPool);
     }

--- a/apps/api/src/health-observability.test.js
+++ b/apps/api/src/health-observability.test.js
@@ -53,6 +53,10 @@ describe("health and observability", () => {
     expect(typeof response.body.requestId).toBe("string");
     expect(response.body.requestId.length).toBeGreaterThan(0);
     expect(response.body.requestId).toBe(response.headers["x-request-id"]);
+    expect(typeof response.body.migrations).toBe("object");
+    expect(typeof response.body.migrations.applied).toBe("number");
+    expect(response.body.migrations.applied).toBeGreaterThan(0);
+    expect(typeof response.body.migrations.latest).toBe("string");
   });
 
   it("GET /health retorna ok=false e status 503 quando DB falha", async () => {

--- a/apps/api/src/routes/health.routes.js
+++ b/apps/api/src/routes/health.routes.js
@@ -5,12 +5,16 @@ import {
   resolveApiVersion,
 } from "../config/version.js";
 import { checkDatabaseHealth } from "../db/index.js";
+import { getMigrationStatus } from "../db/migrate.js";
 
 const router = Router();
 
 router.get("/", async (req, res, next) => {
   try {
-    const db = await checkDatabaseHealth();
+    const [db, migrations] = await Promise.all([
+      checkDatabaseHealth(),
+      getMigrationStatus(),
+    ]);
     const responsePayload = {
       ok: db.status === "ok",
       version: resolveApiVersion(),
@@ -18,6 +22,7 @@ router.get("/", async (req, res, next) => {
       buildTimestamp: resolveApiBuildTimestamp(),
       uptimeSeconds: Math.floor(process.uptime()),
       db,
+      migrations,
       requestId: req.requestId || null,
     };
 


### PR DESCRIPTION
## Problem

After deploying a release that includes new migrations, there was no way to verify
from the outside that the migrations actually ran without direct DB access.
`runMigrations()` runs synchronously at startup — if it fails the server doesn't
come up — but the migration state wasn't observable through any endpoint.

## Solution

`GET /health` now includes a `migrations` field:

```json
{
  "ok": true,
  "version": "1.30.0",
  "db": { "status": "ok" },
  "migrations": {
    "applied": 27,
    "latest": "027_create_activation_events.sql"
  }
}
```

`getMigrationStatus()` queries `schema_migrations` in parallel with `checkDatabaseHealth()`
via `Promise.all` — no added latency. If the DB is unavailable it returns
`{ applied: 0, latest: null }` instead of throwing (same graceful degradation as the db field).

## Post-deploy verification

After deploying the #244 release:
```
curl https://your-api/health | jq '.migrations'
# expect: { "applied": 27, "latest": "027_create_activation_events.sql" }
```

## Test plan

- [ ] `GET /health` returns `migrations.applied > 0` and `migrations.latest` is a string
- [ ] DB-unavailable test still returns 503 (getMigrationStatus swallows its own error)
- [ ] `health-observability.test.js` 9/9 pass