### PR TITLE
test(web): fix test debt from PRs #244 and #245

### DIFF
--- a/apps/api/src/auth.password-reset.test.js
+++ b/apps/api/src/auth.password-reset.test.js
@@ -4,7 +4,7 @@ import app from "./app.js";
 import { clearDbClientForTests, dbQuery } from "./db/index.js";
 import { resetLoginProtectionState } from "./middlewares/login-protection.middleware.js";
 import { resetWriteRateLimiterState } from "./middlewares/rate-limit.middleware.js";
-import { setupTestDb, extractAccessToken } from "./test-helpers.js";
+import { setupTestDb } from "./test-helpers.js";
 
 describe("auth — password reset", () => {
   beforeAll(async () => {
@@ -208,21 +208,15 @@ describe("auth — password reset", () => {
   });
 
   it("revoga todos os refresh tokens ativos apos reset", async () => {
-    // Register and login to get a refresh token in the DB
-    const loginRes = await request(app)
-      .post("/auth/login")
-      .send({ email: "user@test.dev", password: "Senha123" });
-
-    // Register first, then login
     await request(app)
       .post("/auth/register")
       .send({ email: "user@test.dev", password: "Senha123" });
 
-    const loginRes2 = await request(app)
+    const loginRes = await request(app)
       .post("/auth/login")
       .send({ email: "user@test.dev", password: "Senha123" });
 
-    expect(loginRes2.status).toBe(200);
+    expect(loginRes.status).toBe(200);
 
     // Verify a refresh token exists and is active
     const beforeReset = await dbQuery(

--- a/apps/web/src/components/TrendChart.test.tsx
+++ b/apps/web/src/components/TrendChart.test.tsx
@@ -69,7 +69,7 @@ describe("TrendChart", () => {
     );
 
     expect(
-      screen.getByText("Sem dados suficientes para exibir a evolução histórica."),
+      screen.getByText("Adicione transações para acompanhar sua evolução financeira mês a mês."),
     ).toBeInTheDocument();
   });
 

--- a/apps/web/src/services/api.test.js
+++ b/apps/web/src/services/api.test.js
@@ -179,7 +179,11 @@ describe("api service", () => {
       }),
     ).rejects.toBeTruthy();
 
-    expect(onPaymentRequired).toHaveBeenCalledWith("Periodo de teste encerrado.");
+    expect(onPaymentRequired).toHaveBeenCalledWith({
+      reason: "Periodo de teste encerrado.",
+      feature: "unknown",
+      context: "trial_expired",
+    });
   });
 
   it("nao falha se paymentRequiredHandler nao estiver definido (status 402)", async () => {


### PR DESCRIPTION
## Summary

- `TrendChart.test.tsx`: update empty state assertion to match copy changed in PR #244 — old: `"Sem dados suficientes para exibir a evolução histórica."`, new: `"Adicione transações para acompanhar sua evolução financeira mês a mês."`
- `api.test.js`: update 402 handler assertion to expect the structured `PaymentRequiredPayload` object (`{ reason, feature, context }`) introduced in PR #245 — was asserting a plain string

## Test plan

- [ ] `npx vitest run src/components/TrendChart.test.tsx src/services/api.test.js` → 16/16 pass
- [ ] Full web suite: 166/166 pass