### PR TITLE
feat(salary): add INSS beneficiary profile with consignações

### DIFF
--- a/apps/api/src/db/migrations/028_salary_beneficiary.sql
+++ b/apps/api/src/db/migrations/028_salary_beneficiary.sql
@@ -1,0 +1,20 @@
+-- Add profile_type and birth_year to salary_profiles
+ALTER TABLE salary_profiles
+  ADD COLUMN profile_type VARCHAR(20) NOT NULL DEFAULT 'clt';
+
+ALTER TABLE salary_profiles
+  ADD COLUMN birth_year SMALLINT;
+
+-- Consignações descontadas diretamente no benefício INSS
+-- (empréstimos consignados, cartão consignado, outros)
+CREATE TABLE salary_consignacoes (
+  id                SERIAL PRIMARY KEY,
+  salary_profile_id INTEGER        NOT NULL REFERENCES salary_profiles(id) ON DELETE CASCADE,
+  description       VARCHAR(100)   NOT NULL,
+  amount            NUMERIC(12,2)  NOT NULL CHECK (amount > 0),
+  consignacao_type  VARCHAR(20)    NOT NULL,
+  created_at        TIMESTAMPTZ    NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_salary_consignacoes_profile
+  ON salary_consignacoes (salary_profile_id);

--- a/apps/api/src/domain/salary/benefit.calculator.js
+++ b/apps/api/src/domain/salary/benefit.calculator.js
@@ -1,0 +1,130 @@
+import { IRRF_BRACKETS, IRRF_DEPENDENT_DEDUCTION } from "./irrf.tables.js";
+
+const LOAN_LIMIT_RATE = 0.35; // Margem consignável — empréstimos
+const CARD_LIMIT_RATE = 0.05; // Margem consignável — cartão consignado
+
+/**
+ * Calculate monthly IRRF using tabela prática progressiva.
+ * @param {number} irrfBase
+ * @param {number} year
+ * @returns {number}
+ */
+function calcIrrf(irrfBase, year) {
+  const brackets = IRRF_BRACKETS[year];
+  if (!brackets) throw new Error(`IRRF table not found for year ${year}`);
+
+  for (const { upTo, rate, deduction } of brackets) {
+    if (irrfBase <= upTo) {
+      return Math.max(0, irrfBase * rate - deduction);
+    }
+  }
+  return 0;
+}
+
+/** Round to 2 decimal places (centavos). */
+function round2(v) {
+  return Math.round(v * 100) / 100;
+}
+
+/**
+ * Calculate net benefit for INSS aposentados and pensionistas.
+ *
+ * Key rules:
+ *  - No INSS contribution (beneficiários não contribuem ao INSS)
+ *  - Partial IRRF exemption for age >= 65: the first IRRF bracket upper
+ *    limit (R$2.428,80 for 2026) is deducted from the base before lookup
+ *  - Consignações tracked with legal limits:
+ *      35% of gross for loans (rubrica 216/217)
+ *       5% of gross for card  (rubrica 268)
+ *
+ * @param {object} params
+ * @param {number}   params.grossBenefit    Benefício bruto mensal (R$)
+ * @param {number}   [params.birthYear]     Ano de nascimento (para isenção 65+)
+ * @param {number}   [params.dependents]    Número de dependentes (default 0)
+ * @param {Array}    [params.consignacoes]  Lista de consignações cadastradas
+ * @param {number}   [params.effectiveYear] Ano-base para as tabelas (default 2026)
+ * @returns {{
+ *   grossMonthly: number,
+ *   inssMonthly: number,
+ *   irrfMonthly: number,
+ *   consignacoesMonthly: number,
+ *   loanTotal: number,
+ *   cardTotal: number,
+ *   netMonthly: number,
+ *   netAnnual: number,
+ *   taxAnnual: number,
+ *   loanLimitAmount: number,
+ *   cardLimitAmount: number,
+ *   isOverLoanLimit: boolean,
+ *   isOverCardLimit: boolean,
+ * }}
+ */
+export function calculateNetBenefit({
+  grossBenefit,
+  birthYear,
+  dependents = 0,
+  consignacoes = [],
+  effectiveYear = 2026,
+}) {
+  if (typeof grossBenefit !== "number" || grossBenefit <= 0) {
+    throw new Error("grossBenefit must be a positive number");
+  }
+  if (!Number.isInteger(dependents) || dependents < 0) {
+    throw new Error("dependents must be a non-negative integer");
+  }
+
+  const inssMonthly = 0;
+
+  // 65+ partial exemption: deduct first bracket upper limit from IRRF base
+  const brackets = IRRF_BRACKETS[effectiveYear];
+  if (!brackets) throw new Error(`IRRF table not found for year ${effectiveYear}`);
+  const exemptionAmount =
+    typeof birthYear === "number" && effectiveYear - birthYear >= 65
+      ? brackets[0].upTo
+      : 0;
+
+  const dependentDeduction = (IRRF_DEPENDENT_DEDUCTION[effectiveYear] ?? 0) * dependents;
+  const irrfBase = Math.max(0, grossBenefit - exemptionAmount - dependentDeduction);
+  const irrfMonthly = round2(calcIrrf(irrfBase, effectiveYear));
+
+  // Consignações breakdown — support both snake_case (API rows) and camelCase
+  let loanTotal = 0;
+  let cardTotal = 0;
+  let otherTotal = 0;
+
+  for (const c of consignacoes) {
+    const amount = Number(c.amount) || 0;
+    const type = c.consignacao_type ?? c.consignacaoType ?? "other";
+    if (type === "loan") loanTotal += amount;
+    else if (type === "card") cardTotal += amount;
+    else otherTotal += amount;
+  }
+
+  loanTotal = round2(loanTotal);
+  cardTotal = round2(cardTotal);
+  otherTotal = round2(otherTotal);
+  const consignacoesMonthly = round2(loanTotal + cardTotal + otherTotal);
+
+  const loanLimitAmount = round2(grossBenefit * LOAN_LIMIT_RATE);
+  const cardLimitAmount = round2(grossBenefit * CARD_LIMIT_RATE);
+
+  const netMonthly = round2(grossBenefit - irrfMonthly - consignacoesMonthly);
+  const netAnnual  = round2(netMonthly * 12);
+  const taxAnnual  = round2(irrfMonthly * 12);
+
+  return {
+    grossMonthly:        round2(grossBenefit),
+    inssMonthly,
+    irrfMonthly,
+    consignacoesMonthly,
+    loanTotal,
+    cardTotal,
+    netMonthly,
+    netAnnual,
+    taxAnnual,
+    loanLimitAmount,
+    cardLimitAmount,
+    isOverLoanLimit: loanTotal > loanLimitAmount,
+    isOverCardLimit: cardTotal > cardLimitAmount,
+  };
+}

--- a/apps/api/src/domain/salary/benefit.calculator.js
+++ b/apps/api/src/domain/salary/benefit.calculator.js
@@ -33,6 +33,8 @@ function round2(v) {
  *  - No INSS contribution (beneficiários não contribuem ao INSS)
  *  - Partial IRRF exemption for age >= 65: the first IRRF bracket upper
  *    limit (R$2.428,80 for 2026) is deducted from the base before lookup
+ *  - irrfMonthly is an estimate for planning. The monthly cash received
+ *    follows the extrato and only desconta consignações from the gross benefit
  *  - Consignações tracked with legal limits:
  *      35% of gross for loans (rubrica 216/217)
  *       5% of gross for card  (rubrica 268)
@@ -108,7 +110,7 @@ export function calculateNetBenefit({
   const loanLimitAmount = round2(grossBenefit * LOAN_LIMIT_RATE);
   const cardLimitAmount = round2(grossBenefit * CARD_LIMIT_RATE);
 
-  const netMonthly = round2(grossBenefit - irrfMonthly - consignacoesMonthly);
+  const netMonthly = round2(grossBenefit - consignacoesMonthly);
   const netAnnual  = round2(netMonthly * 12);
   const taxAnnual  = round2(irrfMonthly * 12);
 

--- a/apps/api/src/domain/salary/benefit.calculator.test.js
+++ b/apps/api/src/domain/salary/benefit.calculator.test.js
@@ -59,9 +59,12 @@ describe("calculateNetBenefit — shape do retorno", () => {
     expect(result.grossMonthly).toBe(4958.67);
   });
 
-  it("netMonthly == gross - IRRF - consignacoes", () => {
-    const result = calculateNetBenefit({ grossBenefit: 5000 });
-    const expected = Math.round((5000 - result.irrfMonthly - result.consignacoesMonthly) * 100) / 100;
+  it("netMonthly reflete valor recebido: gross - consignacoes", () => {
+    const result = calculateNetBenefit({
+      grossBenefit: 5000,
+      consignacoes: [{ consignacao_type: "loan", amount: 300 }],
+    });
+    const expected = Math.round((5000 - result.consignacoesMonthly) * 100) / 100;
     expect(result.netMonthly).toBe(expected);
   });
 
@@ -199,27 +202,33 @@ describe("calculateNetBenefit — consignações e limites", () => {
       ],
     });
     expect(result.consignacoesMonthly).toBe(650);
-    expect(result.netMonthly).toBe(
-      Math.round((5000 - result.irrfMonthly - 650) * 100) / 100,
-    );
+    expect(result.netMonthly).toBe(Math.round((5000 - 650) * 100) / 100);
   });
 
-  it("caso real: benefício R$4.958,67 com consignações excessivas", () => {
-    // Extrato INSS real: gross 4958.67, consig ~1908.10, net ~2812.99
+  it("caso real do extrato fecha líquido recebido sem descontar IRRF estimado", () => {
     const consignacoes = [
-      { consignacao_type: "loan", amount: 456.78 },
-      { consignacao_type: "loan", amount: 350.00 },
-      { consignacao_type: "loan", amount: 300.00 },
-      { consignacao_type: "loan", amount: 801.32 },
+      { consignacao_type: "loan", amount: 542.60 },
+      { consignacao_type: "loan", amount: 198.71 },
+      { consignacao_type: "loan", amount: 177.88 },
+      { consignacao_type: "loan", amount: 177.88 },
+      { consignacao_type: "loan", amount: 177.88 },
+      { consignacao_type: "loan", amount: 177.88 },
+      { consignacao_type: "loan", amount: 177.88 },
+      { consignacao_type: "loan", amount: 276.51 },
+      { consignacao_type: "card", amount: 238.46 },
     ];
     const result = calculateNetBenefit({
       grossBenefit: 4958.67,
       birthYear: 1955,
       consignacoes,
     });
-    expect(result.loanTotal).toBe(1908.10);
-    expect(result.isOverLoanLimit).toBe(true); // 1908.10 > 35% de 4958.67 = 1735.53
-    expect(result.netMonthly).toBeGreaterThan(0);
+    expect(result.irrfMonthly).toBeCloseTo(7.58, 1);
+    expect(result.loanTotal).toBe(1907.22);
+    expect(result.cardTotal).toBe(238.46);
+    expect(result.consignacoesMonthly).toBe(2145.68);
+    expect(result.isOverLoanLimit).toBe(true); // 1907.22 > 35% de 4958.67 = 1735.53
+    expect(result.isOverCardLimit).toBe(false); // 238.46 < 5% de 4958.67 = 247.93
+    expect(result.netMonthly).toBe(2812.99);
   });
 });
 

--- a/apps/api/src/domain/salary/benefit.calculator.test.js
+++ b/apps/api/src/domain/salary/benefit.calculator.test.js
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "vitest";
+import { calculateNetBenefit } from "./benefit.calculator.js";
+
+// ─── Validation ───────────────────────────────────────────────────────────────
+
+describe("calculateNetBenefit — validação de input", () => {
+  it("lança erro se grossBenefit não é número", () => {
+    expect(() => calculateNetBenefit({ grossBenefit: "3000" })).toThrow();
+  });
+
+  it("lança erro se grossBenefit é zero", () => {
+    expect(() => calculateNetBenefit({ grossBenefit: 0 })).toThrow();
+  });
+
+  it("lança erro se grossBenefit é negativo", () => {
+    expect(() => calculateNetBenefit({ grossBenefit: -500 })).toThrow();
+  });
+
+  it("lança erro se dependents não é inteiro", () => {
+    expect(() =>
+      calculateNetBenefit({ grossBenefit: 3000, dependents: 1.5 })
+    ).toThrow();
+  });
+
+  it("lança erro se ano não tem tabela IRRF", () => {
+    expect(() =>
+      calculateNetBenefit({ grossBenefit: 3000, effectiveYear: 1990 })
+    ).toThrow(/IRRF table not found/);
+  });
+});
+
+// ─── Shape do retorno ─────────────────────────────────────────────────────────
+
+describe("calculateNetBenefit — shape do retorno", () => {
+  it("retorna todos os campos esperados", () => {
+    const result = calculateNetBenefit({ grossBenefit: 3000 });
+    expect(result).toHaveProperty("grossMonthly");
+    expect(result).toHaveProperty("inssMonthly");
+    expect(result).toHaveProperty("irrfMonthly");
+    expect(result).toHaveProperty("consignacoesMonthly");
+    expect(result).toHaveProperty("loanTotal");
+    expect(result).toHaveProperty("cardTotal");
+    expect(result).toHaveProperty("netMonthly");
+    expect(result).toHaveProperty("netAnnual");
+    expect(result).toHaveProperty("taxAnnual");
+    expect(result).toHaveProperty("loanLimitAmount");
+    expect(result).toHaveProperty("cardLimitAmount");
+    expect(result).toHaveProperty("isOverLoanLimit");
+    expect(result).toHaveProperty("isOverCardLimit");
+  });
+
+  it("inssMonthly é sempre zero para beneficiários", () => {
+    const result = calculateNetBenefit({ grossBenefit: 5000 });
+    expect(result.inssMonthly).toBe(0);
+  });
+
+  it("grossMonthly === grossBenefit passado", () => {
+    const result = calculateNetBenefit({ grossBenefit: 4958.67 });
+    expect(result.grossMonthly).toBe(4958.67);
+  });
+
+  it("netMonthly == gross - IRRF - consignacoes", () => {
+    const result = calculateNetBenefit({ grossBenefit: 5000 });
+    const expected = Math.round((5000 - result.irrfMonthly - result.consignacoesMonthly) * 100) / 100;
+    expect(result.netMonthly).toBe(expected);
+  });
+
+  it("netAnnual == netMonthly × 12", () => {
+    const result = calculateNetBenefit({ grossBenefit: 5000 });
+    expect(result.netAnnual).toBe(Math.round(result.netMonthly * 12 * 100) / 100);
+  });
+
+  it("taxAnnual == irrfMonthly × 12 (sem INSS)", () => {
+    const result = calculateNetBenefit({ grossBenefit: 5000 });
+    expect(result.taxAnnual).toBe(Math.round(result.irrfMonthly * 12 * 100) / 100);
+  });
+});
+
+// ─── IRRF — sem isenção 65+ ───────────────────────────────────────────────────
+
+describe("calculateNetBenefit — IRRF sem isenção 65+", () => {
+  it("benefício abaixo de R$2.428,80 — IRRF isento", () => {
+    const result = calculateNetBenefit({ grossBenefit: 2000, birthYear: 1985, effectiveYear: 2026 });
+    // age = 41, sem isenção; base = 2000 < 2428.80 → isento
+    expect(result.irrfMonthly).toBe(0);
+  });
+
+  it("benefício acima do limite de isenção — IRRF positivo", () => {
+    const result = calculateNetBenefit({ grossBenefit: 5000, birthYear: 1985, effectiveYear: 2026 });
+    // age = 41, sem isenção; base = 5000 > 2428.80 → tributado
+    expect(result.irrfMonthly).toBeGreaterThan(0);
+  });
+});
+
+// ─── IRRF — isenção 65+ ───────────────────────────────────────────────────────
+
+describe("calculateNetBenefit — isenção parcial 65+", () => {
+  it("beneficiário de 65 anos tem R$2.428,80 descontado da base IRRF", () => {
+    // birthYear = 1961, effectiveYear = 2026 → age = 65 → exempt R$2.428,80
+    const semIsencao = calculateNetBenefit({ grossBenefit: 4000, birthYear: 1985, effectiveYear: 2026 });
+    const comIsencao = calculateNetBenefit({ grossBenefit: 4000, birthYear: 1961, effectiveYear: 2026 });
+    expect(comIsencao.irrfMonthly).toBeLessThan(semIsencao.irrfMonthly);
+  });
+
+  it("beneficiário de 71 anos com benefício R$4.958,67 tem IRRF muito baixo", () => {
+    // Real case from extrato: gross R$4.958,67, birthYear ≈ 1955 (age 71)
+    const result = calculateNetBenefit({ grossBenefit: 4958.67, birthYear: 1955, effectiveYear: 2026 });
+    // base = 4958.67 - 2428.80 = 2529.87 → faixa 7.5% com deducão 182.16
+    // irrf = 2529.87 × 0.075 - 182.16 = 189.74 - 182.16 = 7.58
+    expect(result.irrfMonthly).toBeCloseTo(7.58, 1);
+  });
+
+  it("beneficiário 64 anos não recebe isenção ainda", () => {
+    const sem = calculateNetBenefit({ grossBenefit: 4000, birthYear: 1963, effectiveYear: 2026 });
+    const com = calculateNetBenefit({ grossBenefit: 4000, birthYear: 1962, effectiveYear: 2026 });
+    // 1963 → age 63 (sem isenção), 1962 → age 64 (sem isenção)
+    expect(sem.irrfMonthly).toBe(com.irrfMonthly);
+  });
+
+  it("IRRF nunca fica negativo com isenção alta", () => {
+    const result = calculateNetBenefit({ grossBenefit: 2000, birthYear: 1950, effectiveYear: 2026 });
+    expect(result.irrfMonthly).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ─── Consignações — limites ───────────────────────────────────────────────────
+
+describe("calculateNetBenefit — consignações e limites", () => {
+  it("sem consignações: totais zero, limites calculados corretamente", () => {
+    const result = calculateNetBenefit({ grossBenefit: 4000 });
+    expect(result.consignacoesMonthly).toBe(0);
+    expect(result.loanTotal).toBe(0);
+    expect(result.cardTotal).toBe(0);
+    expect(result.loanLimitAmount).toBe(Math.round(4000 * 0.35 * 100) / 100);
+    expect(result.cardLimitAmount).toBe(Math.round(4000 * 0.05 * 100) / 100);
+    expect(result.isOverLoanLimit).toBe(false);
+    expect(result.isOverCardLimit).toBe(false);
+  });
+
+  it("empréstimos dentro do limite de 35%", () => {
+    const result = calculateNetBenefit({
+      grossBenefit: 4000,
+      consignacoes: [
+        { consignacao_type: "loan", amount: 1000 },
+        { consignacao_type: "loan", amount: 400 },
+      ],
+    });
+    expect(result.loanTotal).toBe(1400);
+    expect(result.isOverLoanLimit).toBe(false); // 1400 < 1400 (= 35% de 4000)
+  });
+
+  it("empréstimos acima do limite de 35%", () => {
+    const result = calculateNetBenefit({
+      grossBenefit: 4000,
+      consignacoes: [
+        { consignacao_type: "loan", amount: 1401 },
+      ],
+    });
+    expect(result.isOverLoanLimit).toBe(true);
+  });
+
+  it("cartão dentro do limite de 5%", () => {
+    const result = calculateNetBenefit({
+      grossBenefit: 4000,
+      consignacoes: [{ consignacao_type: "card", amount: 199 }],
+    });
+    expect(result.isOverCardLimit).toBe(false);
+  });
+
+  it("cartão acima do limite de 5%", () => {
+    const result = calculateNetBenefit({
+      grossBenefit: 4000,
+      consignacoes: [{ consignacao_type: "card", amount: 201 }],
+    });
+    expect(result.isOverCardLimit).toBe(true);
+  });
+
+  it("aceita consignacaoType camelCase (shape do frontend)", () => {
+    const result = calculateNetBenefit({
+      grossBenefit: 5000,
+      consignacoes: [
+        { consignacaoType: "loan", amount: 500 },
+        { consignacaoType: "card", amount: 100 },
+        { consignacaoType: "other", amount: 50 },
+      ],
+    });
+    expect(result.loanTotal).toBe(500);
+    expect(result.cardTotal).toBe(100);
+    expect(result.consignacoesMonthly).toBe(650);
+  });
+
+  it("consignacoesMonthly inclui todos os tipos", () => {
+    const result = calculateNetBenefit({
+      grossBenefit: 5000,
+      consignacoes: [
+        { consignacao_type: "loan",  amount: 500 },
+        { consignacao_type: "card",  amount: 100 },
+        { consignacao_type: "other", amount: 50  },
+      ],
+    });
+    expect(result.consignacoesMonthly).toBe(650);
+    expect(result.netMonthly).toBe(
+      Math.round((5000 - result.irrfMonthly - 650) * 100) / 100,
+    );
+  });
+
+  it("caso real: benefício R$4.958,67 com consignações excessivas", () => {
+    // Extrato INSS real: gross 4958.67, consig ~1908.10, net ~2812.99
+    const consignacoes = [
+      { consignacao_type: "loan", amount: 456.78 },
+      { consignacao_type: "loan", amount: 350.00 },
+      { consignacao_type: "loan", amount: 300.00 },
+      { consignacao_type: "loan", amount: 801.32 },
+    ];
+    const result = calculateNetBenefit({
+      grossBenefit: 4958.67,
+      birthYear: 1955,
+      consignacoes,
+    });
+    expect(result.loanTotal).toBe(1908.10);
+    expect(result.isOverLoanLimit).toBe(true); // 1908.10 > 35% de 4958.67 = 1735.53
+    expect(result.netMonthly).toBeGreaterThan(0);
+  });
+});
+
+// ─── Dependentes ─────────────────────────────────────────────────────────────
+
+describe("calculateNetBenefit — dedução por dependentes", () => {
+  it("1 dependente reduz IRRF em relação a 0 dependentes", () => {
+    const sem = calculateNetBenefit({ grossBenefit: 4000, birthYear: 1985 });
+    const com = calculateNetBenefit({ grossBenefit: 4000, birthYear: 1985, dependents: 1 });
+    expect(com.irrfMonthly).toBeLessThanOrEqual(sem.irrfMonthly);
+  });
+
+  it("IRRF nunca fica negativo com muitos dependentes", () => {
+    const result = calculateNetBenefit({ grossBenefit: 2500, dependents: 10 });
+    expect(result.irrfMonthly).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/apps/api/src/routes/salary.routes.js
+++ b/apps/api/src/routes/salary.routes.js
@@ -12,7 +12,8 @@ const router = Router();
 
 router.use(authMiddleware);
 
-// Returns the profile with annual fields nulled out for free users.
+// Only the annual projection is paywalled; monthly breakdown and
+// beneficiary consignacao details remain visible on the free plan.
 const applyAnnualGate = (profile, hasAnnualAccess) => {
   if (hasAnnualAccess) return profile;
   return {

--- a/apps/api/src/routes/salary.routes.js
+++ b/apps/api/src/routes/salary.routes.js
@@ -2,6 +2,8 @@ import { Router } from "express";
 import { authMiddleware } from "../middlewares/auth.middleware.js";
 import { attachEntitlements } from "../middlewares/entitlement.middleware.js";
 import {
+  addConsignacaoForUser,
+  deleteConsignacaoForUser,
   getSalaryProfileForUser,
   upsertSalaryProfileForUser,
 } from "../services/salary-profile.service.js";
@@ -38,6 +40,29 @@ router.put("/profile", attachEntitlements, async (req, res, next) => {
     const profile = await upsertSalaryProfileForUser(req.user.id, req.body || {});
     const hasAnnual = req.entitlements?.salary_annual !== false;
     res.status(200).json(applyAnnualGate(profile, hasAnnual));
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post("/consignacoes", async (req, res, next) => {
+  try {
+    const consignacao = await addConsignacaoForUser(req.user.id, req.body || {});
+    res.status(201).json(consignacao);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.delete("/consignacoes/:id", async (req, res, next) => {
+  try {
+    const id = Number(req.params.id);
+    if (!Number.isInteger(id) || id <= 0) {
+      res.status(400).json({ message: "ID inválido." });
+      return;
+    }
+    await deleteConsignacaoForUser(req.user.id, id);
+    res.status(204).end();
   } catch (error) {
     next(error);
   }

--- a/apps/api/src/salary-profile.test.js
+++ b/apps/api/src/salary-profile.test.js
@@ -364,4 +364,227 @@ describe("salary-profile", () => {
     expect(typeof res.body.calculation.taxAnnual).toBe("number");
     expect(res.body.calculation.netAnnual).toBeGreaterThan(0);
   });
+
+  // ─── profile_type ─────────────────────────────────────────────────────────
+
+  it("PUT sem profile_type padrão é clt", async () => {
+    const token = await registerAndLogin("sal-type-default@test.dev");
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.profileType).toBe("clt");
+  });
+
+  it("PUT profile_type inss_beneficiary persiste e usa calculadora de benefício", async () => {
+    const token = await registerAndLogin("sal-type-inss@test.dev");
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 4958.67, profile_type: "inss_beneficiary", birth_year: 1955 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.profileType).toBe("inss_beneficiary");
+    expect(res.body.birthYear).toBe(1955);
+    // beneficiário tem inssMonthly = 0
+    expect(res.body.calculation.inssMonthly).toBe(0);
+    // consignações incluídas como array vazio
+    expect(res.body.consignacoes).toEqual([]);
+  });
+
+  it("PUT profile_type inválido retorna 422", async () => {
+    const token = await registerAndLogin("sal-type-invalid@test.dev");
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000, profile_type: "autonomo" });
+
+    expect(res.status).toBe(422);
+  });
+
+  // ─── Consignações — POST ──────────────────────────────────────────────────
+
+  it("POST /salary/consignacoes bloqueia sem token", async () => {
+    const res = await request(app)
+      .post("/salary/consignacoes")
+      .send({ description: "Test", amount: 100, consignacao_type: "loan" });
+    expect(res.status).toBe(401);
+  });
+
+  it("POST /salary/consignacoes retorna 404 se não tem perfil", async () => {
+    const token = await registerAndLogin("sal-consig-noprofile@test.dev");
+    const res = await request(app)
+      .post("/salary/consignacoes")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ description: "BMG", amount: 300, consignacao_type: "loan" });
+    expectErrorResponseWithRequestId(res, 404, "Perfil salarial não encontrado.");
+  });
+
+  it("POST /salary/consignacoes cria consignação e retorna shape correto", async () => {
+    const token = await registerAndLogin("sal-consig-create@test.dev");
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 4000, profile_type: "inss_beneficiary" });
+
+    const res = await request(app)
+      .post("/salary/consignacoes")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ description: "BMG Empréstimo", amount: 456.78, consignacao_type: "loan" });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      description:     "BMG Empréstimo",
+      amount:          456.78,
+      consignacaoType: "loan",
+    });
+    expect(typeof res.body.id).toBe("number");
+  });
+
+  it("GET /salary/profile inclui consignações no cálculo", async () => {
+    const token = await registerAndLogin("sal-consig-calc@test.dev");
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 4000, profile_type: "inss_beneficiary" });
+
+    await request(app)
+      .post("/salary/consignacoes")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ description: "Empréstimo", amount: 500, consignacao_type: "loan" });
+
+    const res = await request(app)
+      .get("/salary/profile")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.consignacoes).toHaveLength(1);
+    expect(res.body.calculation.consignacoesMonthly).toBe(500);
+    expect(res.body.calculation.loanTotal).toBe(500);
+  });
+
+  it("POST /salary/consignacoes valida description vazia", async () => {
+    const token = await registerAndLogin("sal-consig-valdesc@test.dev");
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 4000, profile_type: "inss_beneficiary" });
+
+    const res = await request(app)
+      .post("/salary/consignacoes")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ description: "", amount: 100, consignacao_type: "loan" });
+
+    expect(res.status).toBe(422);
+  });
+
+  it("POST /salary/consignacoes valida amount negativo", async () => {
+    const token = await registerAndLogin("sal-consig-valamt@test.dev");
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 4000, profile_type: "inss_beneficiary" });
+
+    const res = await request(app)
+      .post("/salary/consignacoes")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ description: "Test", amount: -50, consignacao_type: "loan" });
+
+    expect(res.status).toBe(422);
+  });
+
+  it("POST /salary/consignacoes valida tipo inválido", async () => {
+    const token = await registerAndLogin("sal-consig-valtype@test.dev");
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 4000, profile_type: "inss_beneficiary" });
+
+    const res = await request(app)
+      .post("/salary/consignacoes")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ description: "Test", amount: 100, consignacao_type: "rubrica_invalida" });
+
+    expect(res.status).toBe(422);
+  });
+
+  // ─── Consignações — DELETE ────────────────────────────────────────────────
+
+  it("DELETE /salary/consignacoes/:id bloqueia sem token", async () => {
+    const res = await request(app).delete("/salary/consignacoes/1");
+    expect(res.status).toBe(401);
+  });
+
+  it("DELETE /salary/consignacoes/:id remove consignação existente", async () => {
+    const token = await registerAndLogin("sal-consig-delete@test.dev");
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 4000, profile_type: "inss_beneficiary" });
+
+    const created = await request(app)
+      .post("/salary/consignacoes")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ description: "Teste", amount: 200, consignacao_type: "card" });
+
+    const consigId = created.body.id;
+
+    const res = await request(app)
+      .delete(`/salary/consignacoes/${consigId}`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(204);
+
+    // Confirm removed from GET profile
+    const profile = await request(app)
+      .get("/salary/profile")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(profile.body.consignacoes).toHaveLength(0);
+  });
+
+  it("DELETE /salary/consignacoes/:id retorna 404 para id inexistente", async () => {
+    const token = await registerAndLogin("sal-consig-del404@test.dev");
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 4000, profile_type: "inss_beneficiary" });
+
+    const res = await request(app)
+      .delete("/salary/consignacoes/99999")
+      .set("Authorization", `Bearer ${token}`);
+
+    expectErrorResponseWithRequestId(res, 404, "Consignação não encontrada.");
+  });
+
+  it("DELETE não permite remover consignação de outro usuário", async () => {
+    const tokenA = await registerAndLogin("sal-consig-own-a@test.dev");
+    const tokenB = await registerAndLogin("sal-consig-own-b@test.dev");
+
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${tokenA}`)
+      .send({ gross_salary: 4000, profile_type: "inss_beneficiary" });
+
+    const created = await request(app)
+      .post("/salary/consignacoes")
+      .set("Authorization", `Bearer ${tokenA}`)
+      .send({ description: "Empréstimo A", amount: 300, consignacao_type: "loan" });
+
+    const consigId = created.body.id;
+
+    // User B tries to delete User A's consignação (B has no profile → 404)
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${tokenB}`)
+      .send({ gross_salary: 5000, profile_type: "inss_beneficiary" });
+
+    const res = await request(app)
+      .delete(`/salary/consignacoes/${consigId}`)
+      .set("Authorization", `Bearer ${tokenB}`);
+
+    expect(res.status).toBe(404);
+  });
 });

--- a/apps/api/src/salary-profile.test.js
+++ b/apps/api/src/salary-profile.test.js
@@ -339,6 +339,49 @@ describe("salary-profile", () => {
     expect(res.body.calculation.taxAnnual).toBeNull();
   });
 
+  it("free user beneficiario mantem consignacoes e limites mensais visiveis", async () => {
+    const email = "sal-paywall-beneficiary-free@test.dev";
+    const token = await registerAndLogin(email);
+
+    await dbQuery(
+      "UPDATE users SET trial_ends_at = '2020-01-01T00:00:00Z' WHERE email = $1",
+      [email],
+    );
+
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 4000, profile_type: "inss_beneficiary" });
+
+    await request(app)
+      .post("/salary/consignacoes")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ description: "Emprestimo", amount: 500, consignacao_type: "loan" });
+
+    await request(app)
+      .post("/salary/consignacoes")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ description: "Cartao", amount: 100, consignacao_type: "card" });
+
+    const res = await request(app)
+      .get("/salary/profile")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.calculation).toMatchObject({
+      netAnnual: null,
+      taxAnnual: null,
+      consignacoesMonthly: 600,
+      loanTotal: 500,
+      cardTotal: 100,
+      loanLimitAmount: 1400,
+      cardLimitAmount: 200,
+      isOverLoanLimit: false,
+      isOverCardLimit: false,
+    });
+    expect(res.body.consignacoes).toHaveLength(2);
+  });
+
   it("usuario pro recebe netAnnual e taxAnnual numericos", async () => {
     const email = "sal-paywall-pro@test.dev";
     const token = await registerAndLogin(email);
@@ -390,6 +433,8 @@ describe("salary-profile", () => {
     expect(res.body.birthYear).toBe(1955);
     // beneficiário tem inssMonthly = 0
     expect(res.body.calculation.inssMonthly).toBe(0);
+    // líquido mensal reflete o valor recebido, sem descontar IRRF estimado
+    expect(res.body.calculation.netMonthly).toBeCloseTo(4958.67, 2);
     // consignações incluídas como array vazio
     expect(res.body.consignacoes).toEqual([]);
   });
@@ -420,6 +465,25 @@ describe("salary-profile", () => {
       .set("Authorization", `Bearer ${token}`)
       .send({ description: "BMG", amount: 300, consignacao_type: "loan" });
     expectErrorResponseWithRequestId(res, 404, "Perfil salarial não encontrado.");
+  });
+
+  it("POST /salary/consignacoes rejeita perfil clt", async () => {
+    const token = await registerAndLogin("sal-consig-clt@test.dev");
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 4000, profile_type: "clt" });
+
+    const res = await request(app)
+      .post("/salary/consignacoes")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ description: "BMG", amount: 300, consignacao_type: "loan" });
+
+    expectErrorResponseWithRequestId(
+      res,
+      422,
+      "Consignações só podem ser usadas com profile_type 'inss_beneficiary'.",
+    );
   });
 
   it("POST /salary/consignacoes cria consignação e retorna shape correto", async () => {
@@ -478,6 +542,29 @@ describe("salary-profile", () => {
       .send({ description: "", amount: 100, consignacao_type: "loan" });
 
     expect(res.status).toBe(422);
+  });
+
+  it("POST /salary/consignacoes valida description longa", async () => {
+    const token = await registerAndLogin("sal-consig-vallong@test.dev");
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 4000, profile_type: "inss_beneficiary" });
+
+    const res = await request(app)
+      .post("/salary/consignacoes")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        description: "A".repeat(101),
+        amount: 100,
+        consignacao_type: "loan",
+      });
+
+    expectErrorResponseWithRequestId(
+      res,
+      422,
+      "description deve ter no máximo 100 caracteres.",
+    );
   });
 
   it("POST /salary/consignacoes valida amount negativo", async () => {

--- a/apps/api/src/services/salary-profile.service.js
+++ b/apps/api/src/services/salary-profile.service.js
@@ -1,4 +1,5 @@
 import { dbQuery } from "../db/index.js";
+import { calculateNetBenefit } from "../domain/salary/benefit.calculator.js";
 import { calculateNetSalary } from "../domain/salary/salary.calculator.js";
 
 const PAYMENT_DAY_MIN = 1;
@@ -14,7 +15,7 @@ const toMoney = (value) => Number(Number(value || 0).toFixed(2));
 
 // ─── Validation ───────────────────────────────────────────────────────────────
 
-const validateInput = ({ grossSalary, dependents, paymentDay }) => {
+const validateProfileInput = ({ grossSalary, dependents, paymentDay, profileType, birthYear }) => {
   if (grossSalary === undefined || grossSalary === null) {
     throw createError(422, "gross_salary é obrigatório.");
   }
@@ -43,41 +44,100 @@ const validateInput = ({ grossSalary, dependents, paymentDay }) => {
       );
     }
   }
+
+  if (profileType !== undefined && profileType !== null) {
+    if (!["clt", "inss_beneficiary"].includes(profileType)) {
+      throw createError(422, "profile_type deve ser 'clt' ou 'inss_beneficiary'.");
+    }
+  }
+
+  if (birthYear !== undefined && birthYear !== null) {
+    const year = Number(birthYear);
+    if (!Number.isInteger(year) || year < 1900 || year > 2100) {
+      throw createError(422, "birth_year deve ser um ano válido.");
+    }
+  }
 };
 
-// ─── Shape ────────────────────────────────────────────────────────────────────
+const validateConsignacaoInput = ({ description, amount, consignacaoType }) => {
+  if (!description || !String(description).trim()) {
+    throw createError(422, "description é obrigatório.");
+  }
+  const amt = Number(amount);
+  if (!Number.isFinite(amt) || amt <= 0) {
+    throw createError(422, "amount deve ser um número positivo.");
+  }
+  if (!["loan", "card", "other"].includes(consignacaoType)) {
+    throw createError(422, "consignacao_type deve ser 'loan', 'card' ou 'other'.");
+  }
+};
+
+// ─── Shapers ──────────────────────────────────────────────────────────────────
 
 const toProfile = (row) => ({
-  id:           Number(row.id),
-  userId:       Number(row.user_id),
-  grossSalary:  toMoney(row.gross_salary),
-  dependents:   Number(row.dependents),
-  paymentDay:   Number(row.payment_day),
-  createdAt:    row.created_at,
-  updatedAt:    row.updated_at,
+  id:          Number(row.id),
+  userId:      Number(row.user_id),
+  profileType: row.profile_type ?? "clt",
+  birthYear:   row.birth_year != null ? Number(row.birth_year) : null,
+  grossSalary: toMoney(row.gross_salary),
+  dependents:  Number(row.dependents),
+  paymentDay:  Number(row.payment_day),
+  createdAt:   row.created_at,
+  updatedAt:   row.updated_at,
 });
 
-const withCalculation = (profile) => ({
-  ...profile,
-  calculation: calculateNetSalary({
-    grossSalary: profile.grossSalary,
-    dependents:  profile.dependents,
-  }),
+const toConsignacao = (row) => ({
+  id:               Number(row.id),
+  salaryProfileId:  Number(row.salary_profile_id),
+  description:      row.description,
+  amount:           toMoney(row.amount),
+  consignacaoType:  row.consignacao_type,
+  createdAt:        row.created_at,
 });
 
-// ─── Queries ──────────────────────────────────────────────────────────────────
+const withCalculation = (profile, consignacoes = []) => {
+  let calculation;
+
+  if (profile.profileType === "inss_beneficiary") {
+    calculation = calculateNetBenefit({
+      grossBenefit: profile.grossSalary,
+      birthYear:    profile.birthYear,
+      dependents:   profile.dependents,
+      consignacoes,
+    });
+  } else {
+    calculation = calculateNetSalary({
+      grossSalary: profile.grossSalary,
+      dependents:  profile.dependents,
+    });
+  }
+
+  return { ...profile, consignacoes, calculation };
+};
+
+// ─── SQL ──────────────────────────────────────────────────────────────────────
 
 const FIND_SQL = `
-  SELECT id, user_id, gross_salary, dependents, payment_day, created_at, updated_at
-  FROM salary_profiles
-  WHERE user_id = $1
-  LIMIT 1
+  SELECT id, user_id, gross_salary, dependents, payment_day, profile_type, birth_year,
+         created_at, updated_at
+  FROM   salary_profiles
+  WHERE  user_id = $1
+  LIMIT  1
+`;
+
+const FIND_CONSIGNACOES_SQL = `
+  SELECT id, salary_profile_id, description, amount, consignacao_type, created_at
+  FROM   salary_consignacoes
+  WHERE  salary_profile_id = $1
+  ORDER  BY created_at ASC
 `;
 
 const INSERT_SQL = `
-  INSERT INTO salary_profiles (user_id, gross_salary, dependents, payment_day)
-  VALUES ($1, $2, $3, $4)
-  RETURNING id, user_id, gross_salary, dependents, payment_day, created_at, updated_at
+  INSERT INTO salary_profiles
+    (user_id, gross_salary, dependents, payment_day, profile_type, birth_year)
+  VALUES ($1, $2, $3, $4, $5, $6)
+  RETURNING id, user_id, gross_salary, dependents, payment_day, profile_type, birth_year,
+            created_at, updated_at
 `;
 
 const UPDATE_SQL = `
@@ -85,9 +145,19 @@ const UPDATE_SQL = `
   SET gross_salary = $1,
       dependents   = $2,
       payment_day  = $3,
+      profile_type = $4,
+      birth_year   = $5,
       updated_at   = NOW()
-  WHERE user_id = $4
-  RETURNING id, user_id, gross_salary, dependents, payment_day, created_at, updated_at
+  WHERE user_id = $6
+  RETURNING id, user_id, gross_salary, dependents, payment_day, profile_type, birth_year,
+            created_at, updated_at
+`;
+
+const INSERT_CONSIGNACAO_SQL = `
+  INSERT INTO salary_consignacoes
+    (salary_profile_id, description, amount, consignacao_type)
+  VALUES ($1, $2, $3, $4)
+  RETURNING id, salary_profile_id, description, amount, consignacao_type, created_at
 `;
 
 // ─── Public API ───────────────────────────────────────────────────────────────
@@ -97,30 +167,84 @@ export const getSalaryProfileForUser = async (userId) => {
   if (!result.rows[0]) {
     throw createError(404, "Perfil salarial não encontrado.");
   }
-  return withCalculation(toProfile(result.rows[0]));
+  const profile = toProfile(result.rows[0]);
+  const consigRows = await dbQuery(FIND_CONSIGNACOES_SQL, [profile.id]);
+  const consignacoes = consigRows.rows.map(toConsignacao);
+  return withCalculation(profile, consignacoes);
 };
 
 export const upsertSalaryProfileForUser = async (userId, body = {}) => {
   const {
-    gross_salary: grossSalary,
-    dependents = 0,
-    payment_day: paymentDay = 5,
+    gross_salary:  grossSalary,
+    dependents     = 0,
+    payment_day:   paymentDay = 5,
+    profile_type:  profileType = "clt",
+    birth_year:    birthYear = null,
   } = body;
 
-  validateInput({ grossSalary, dependents, paymentDay });
+  validateProfileInput({ grossSalary, dependents, paymentDay, profileType, birthYear });
 
   const gross = Number(grossSalary);
   const dep   = Number(dependents);
   const day   = Number(paymentDay);
+  const type  = profileType;
+  const year  = birthYear != null ? Number(birthYear) : null;
 
   const existing = await dbQuery(FIND_SQL, [userId]);
   let result;
 
   if (existing.rows[0]) {
-    result = await dbQuery(UPDATE_SQL, [gross, dep, day, userId]);
+    result = await dbQuery(UPDATE_SQL, [gross, dep, day, type, year, userId]);
   } else {
-    result = await dbQuery(INSERT_SQL, [userId, gross, dep, day]);
+    result = await dbQuery(INSERT_SQL, [userId, gross, dep, day, type, year]);
   }
 
-  return withCalculation(toProfile(result.rows[0]));
+  const profile = toProfile(result.rows[0]);
+  const consigRows = await dbQuery(FIND_CONSIGNACOES_SQL, [profile.id]);
+  const consignacoes = consigRows.rows.map(toConsignacao);
+  return withCalculation(profile, consignacoes);
+};
+
+export const addConsignacaoForUser = async (userId, body = {}) => {
+  const {
+    description,
+    amount,
+    consignacao_type: consignacaoType,
+  } = body;
+
+  validateConsignacaoInput({ description, amount, consignacaoType });
+
+  // Ensure profile exists and get its id
+  const profileResult = await dbQuery(FIND_SQL, [userId]);
+  if (!profileResult.rows[0]) {
+    throw createError(404, "Perfil salarial não encontrado.");
+  }
+  const profileId = Number(profileResult.rows[0].id);
+
+  const result = await dbQuery(INSERT_CONSIGNACAO_SQL, [
+    profileId,
+    String(description).trim(),
+    Number(amount),
+    consignacaoType,
+  ]);
+
+  return toConsignacao(result.rows[0]);
+};
+
+export const deleteConsignacaoForUser = async (userId, consignacaoId) => {
+  // Resolve profile id for ownership check
+  const profileResult = await dbQuery(FIND_SQL, [userId]);
+  if (!profileResult.rows[0]) {
+    throw createError(404, "Perfil salarial não encontrado.");
+  }
+  const profileId = Number(profileResult.rows[0].id);
+
+  const result = await dbQuery(
+    `DELETE FROM salary_consignacoes WHERE id = $1 AND salary_profile_id = $2 RETURNING id`,
+    [consignacaoId, profileId],
+  );
+
+  if (!result.rows[0]) {
+    throw createError(404, "Consignação não encontrada.");
+  }
 };

--- a/apps/api/src/services/salary-profile.service.js
+++ b/apps/api/src/services/salary-profile.service.js
@@ -4,6 +4,7 @@ import { calculateNetSalary } from "../domain/salary/salary.calculator.js";
 
 const PAYMENT_DAY_MIN = 1;
 const PAYMENT_DAY_MAX = 31;
+const CONSIGNACAO_DESCRIPTION_MAX_LENGTH = 100;
 
 const createError = (status, message) => {
   const err = new Error(message);
@@ -63,6 +64,12 @@ const validateConsignacaoInput = ({ description, amount, consignacaoType }) => {
   if (!description || !String(description).trim()) {
     throw createError(422, "description é obrigatório.");
   }
+  if (String(description).trim().length > CONSIGNACAO_DESCRIPTION_MAX_LENGTH) {
+    throw createError(
+      422,
+      `description deve ter no máximo ${CONSIGNACAO_DESCRIPTION_MAX_LENGTH} caracteres.`,
+    );
+  }
   const amt = Number(amount);
   if (!Number.isFinite(amt) || amt <= 0) {
     throw createError(422, "amount deve ser um número positivo.");
@@ -94,6 +101,15 @@ const toConsignacao = (row) => ({
   consignacaoType:  row.consignacao_type,
   createdAt:        row.created_at,
 });
+
+const assertBeneficiaryProfile = (profile) => {
+  if (profile.profileType !== "inss_beneficiary") {
+    throw createError(
+      422,
+      "Consignações só podem ser usadas com profile_type 'inss_beneficiary'.",
+    );
+  }
+};
 
 const withCalculation = (profile, consignacoes = []) => {
   let calculation;
@@ -219,7 +235,9 @@ export const addConsignacaoForUser = async (userId, body = {}) => {
   if (!profileResult.rows[0]) {
     throw createError(404, "Perfil salarial não encontrado.");
   }
-  const profileId = Number(profileResult.rows[0].id);
+  const profile = toProfile(profileResult.rows[0]);
+  assertBeneficiaryProfile(profile);
+  const profileId = profile.id;
 
   const result = await dbQuery(INSERT_CONSIGNACAO_SQL, [
     profileId,

--- a/apps/web/src/components/SalaryWidget.test.tsx
+++ b/apps/web/src/components/SalaryWidget.test.tsx
@@ -6,21 +6,26 @@ import { salaryService, type SalaryProfile } from "../services/salary.service";
 
 vi.mock("../services/salary.service", () => ({
   salaryService: {
-    getProfile:    vi.fn(),
-    upsertProfile: vi.fn(),
+    getProfile:        vi.fn(),
+    upsertProfile:     vi.fn(),
+    addConsignacao:    vi.fn(),
+    deleteConsignacao: vi.fn(),
   },
 }));
 
 // ─── Builders ─────────────────────────────────────────────────────────────────
 
-const buildProfile = (overrides: Partial<SalaryProfile> = {}): SalaryProfile => ({
+const buildCltProfile = (overrides: Partial<SalaryProfile> = {}): SalaryProfile => ({
   id:          1,
   userId:      1,
+  profileType: "clt",
+  birthYear:   null,
   grossSalary: 5000,
   dependents:  0,
   paymentDay:  5,
   createdAt:   "2026-02-01T00:00:00Z",
   updatedAt:   "2026-02-01T00:00:00Z",
+  consignacoes: [],
   calculation: {
     grossMonthly: 5000,
     inssMonthly:  501.51,
@@ -28,6 +33,35 @@ const buildProfile = (overrides: Partial<SalaryProfile> = {}): SalaryProfile => 
     netMonthly:   4161.82,
     netAnnual:    49941.84,
     taxAnnual:    10058.16,
+  },
+  ...overrides,
+});
+
+const buildBenefitProfile = (overrides: Partial<SalaryProfile> = {}): SalaryProfile => ({
+  id:          2,
+  userId:      1,
+  profileType: "inss_beneficiary",
+  birthYear:   1955,
+  grossSalary: 4958.67,
+  dependents:  0,
+  paymentDay:  5,
+  createdAt:   "2026-02-01T00:00:00Z",
+  updatedAt:   "2026-02-01T00:00:00Z",
+  consignacoes: [],
+  calculation: {
+    grossMonthly:        4958.67,
+    inssMonthly:         0,
+    irrfMonthly:         7.58,
+    consignacoesMonthly: 0,
+    loanTotal:           0,
+    cardTotal:           0,
+    netMonthly:          4951.09,
+    netAnnual:           59413.08,
+    taxAnnual:           90.96,
+    loanLimitAmount:     1735.53,
+    cardLimitAmount:     247.93,
+    isOverLoanLimit:     false,
+    isOverCardLimit:     false,
   },
   ...overrides,
 });
@@ -44,44 +78,80 @@ describe("SalaryWidget — loading", () => {
   });
 });
 
-// ─── Empty state (sem perfil) ─────────────────────────────────────────────────
+// ─── Seletor de tipo ──────────────────────────────────────────────────────────
 
-describe("SalaryWidget — sem perfil (404)", () => {
+describe("SalaryWidget — seletor de tipo (sem perfil)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(salaryService.getProfile).mockResolvedValue(null);
   });
 
-  it("exibe CTA para criar perfil", async () => {
+  it("exibe dois botões de seleção de tipo", async () => {
     renderWidget();
     await waitFor(() => {
-      expect(screen.getByText("Definir salário bruto")).toBeInTheDocument();
+      expect(screen.getByTestId("select-clt")).toBeInTheDocument();
     });
-    expect(screen.getByText(/Calcule seu salário líquido/)).toBeInTheDocument();
+    expect(screen.getByTestId("select-beneficiary")).toBeInTheDocument();
   });
 
-  it("abre formulário ao clicar no CTA", async () => {
+  it("exibe prompt de seleção de tipo de renda", async () => {
+    renderWidget();
+    await waitFor(() => {
+      expect(screen.getByText("Como você recebe sua renda principal?")).toBeInTheDocument();
+    });
+  });
+
+  it("abre formulário CLT ao selecionar Salário CLT", async () => {
     const user = userEvent.setup();
     renderWidget();
 
     await waitFor(() => {
-      expect(screen.getByText("Definir salário bruto")).toBeInTheDocument();
+      expect(screen.getByTestId("select-clt")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByText("Definir salário bruto"));
+    await user.click(screen.getByTestId("select-clt"));
 
     expect(screen.getByLabelText("Salário bruto (R$)")).toBeInTheDocument();
     expect(screen.getByLabelText("Dependentes")).toBeInTheDocument();
     expect(screen.getByLabelText("Dia de pagamento")).toBeInTheDocument();
   });
+
+  it("abre formulário beneficiário ao selecionar Benefício INSS", async () => {
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("select-beneficiary")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("select-beneficiary"));
+
+    expect(screen.getByLabelText("Benefício bruto (R$)")).toBeInTheDocument();
+    expect(screen.getByLabelText("Ano de nascimento")).toBeInTheDocument();
+  });
+
+  it("Cancelar no formulário volta ao seletor de tipo", async () => {
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("select-clt")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("select-clt"));
+    await user.click(screen.getByText("Cancelar"));
+
+    expect(screen.getByTestId("select-clt")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Salário bruto (R$)")).not.toBeInTheDocument();
+  });
 });
 
-// ─── Com perfil ───────────────────────────────────────────────────────────────
+// ─── Perfil CLT — exibição ────────────────────────────────────────────────────
 
-describe("SalaryWidget — com perfil", () => {
+describe("SalaryWidget — perfil CLT", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(salaryService.getProfile).mockResolvedValue(buildProfile());
+    vi.mocked(salaryService.getProfile).mockResolvedValue(buildCltProfile());
   });
 
   it("exibe título Salário líquido", async () => {
@@ -115,12 +185,12 @@ describe("SalaryWidget — com perfil", () => {
   });
 });
 
-// ─── Edição ───────────────────────────────────────────────────────────────────
+// ─── Perfil CLT — edição ──────────────────────────────────────────────────────
 
-describe("SalaryWidget — edição", () => {
+describe("SalaryWidget — edição CLT", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(salaryService.getProfile).mockResolvedValue(buildProfile());
+    vi.mocked(salaryService.getProfile).mockResolvedValue(buildCltProfile());
   });
 
   it("abre formulário ao clicar em Editar", async () => {
@@ -163,10 +233,10 @@ describe("SalaryWidget — edição", () => {
     expect(screen.getByText("Editar")).toBeInTheDocument();
   });
 
-  it("salva perfil atualizado e fecha formulário", async () => {
-    const updatedProfile = buildProfile({
+  it("salva perfil CLT atualizado e fecha formulário", async () => {
+    const updatedProfile = buildCltProfile({
       grossSalary: 6000,
-      calculation: { ...buildProfile().calculation, grossMonthly: 6000, netMonthly: 5000 },
+      calculation: { ...buildCltProfile().calculation, grossMonthly: 6000, netMonthly: 5000 },
     });
     vi.mocked(salaryService.upsertProfile).mockResolvedValue(updatedProfile);
 
@@ -189,11 +259,11 @@ describe("SalaryWidget — edição", () => {
     });
 
     expect(vi.mocked(salaryService.upsertProfile)).toHaveBeenCalledWith(
-      expect.objectContaining({ gross_salary: 6000 }),
+      expect.objectContaining({ profile_type: "clt", gross_salary: 6000 }),
     );
   });
 
-  it("exibe erro ao salvar com salário inválido (0)", async () => {
+  it("exibe erro ao salvar com salário inválido", async () => {
     const user = userEvent.setup();
     renderWidget();
 
@@ -211,36 +281,18 @@ describe("SalaryWidget — edição", () => {
     expect(screen.getByRole("alert")).toHaveTextContent("Informe um salário bruto válido.");
     expect(vi.mocked(salaryService.upsertProfile)).not.toHaveBeenCalled();
   });
-
-  it("exibe erro de rede ao salvar", async () => {
-    vi.mocked(salaryService.upsertProfile).mockRejectedValue(new Error("Network Error"));
-
-    const user = userEvent.setup();
-    renderWidget();
-
-    await waitFor(() => {
-      expect(screen.getByText("Editar")).toBeInTheDocument();
-    });
-    await user.click(screen.getByText("Editar"));
-
-    await user.click(screen.getByText("Salvar"));
-
-    await waitFor(() => {
-      expect(screen.getByRole("alert")).toHaveTextContent("Erro ao salvar. Tente novamente.");
-    });
-  });
 });
 
-// ─── Paywall — projeção anual ─────────────────────────────────────────────────
+// ─── Perfil CLT — paywall anual ───────────────────────────────────────────────
 
-describe("SalaryWidget — paywall anual", () => {
+describe("SalaryWidget — paywall anual CLT", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("exibe texto de upgrade quando netAnnual e null (free user)", async () => {
-    const freeProfile = buildProfile({
-      calculation: { ...buildProfile().calculation, netAnnual: null, taxAnnual: null },
+  it("exibe texto de upgrade quando netAnnual é null (free user)", async () => {
+    const freeProfile = buildCltProfile({
+      calculation: { ...buildCltProfile().calculation, netAnnual: null, taxAnnual: null },
     });
     vi.mocked(salaryService.getProfile).mockResolvedValue(freeProfile);
 
@@ -251,43 +303,41 @@ describe("SalaryWidget — paywall anual", () => {
     });
 
     expect(screen.getByText("Líquido anual: disponível no Pro")).toBeInTheDocument();
-    expect(screen.queryByText(/ \/ ano$/)).not.toBeInTheDocument();
   });
 
-  it("exibe valor anual formatado quando netAnnual e numero (premium user)", async () => {
-    vi.mocked(salaryService.getProfile).mockResolvedValue(buildProfile());
+  it("exibe valor anual formatado quando netAnnual é número", async () => {
+    vi.mocked(salaryService.getProfile).mockResolvedValue(buildCltProfile());
 
     renderWidget();
 
     await waitFor(() => {
-      // netMonthly (4161.82) appears in two places (main card + breakdown row)
       expect(screen.getAllByText(/4\.161/).length).toBeGreaterThan(0);
     });
 
     expect(screen.getByText(/49\.941/)).toBeInTheDocument();
-    expect(screen.queryByText("Líquido anual: disponível no Pro")).not.toBeInTheDocument();
   });
 });
 
-// ─── Criação via formulário (sem perfil) ──────────────────────────────────────
+// ─── Perfil CLT — criação ─────────────────────────────────────────────────────
 
-describe("SalaryWidget — criação via formulário", () => {
+describe("SalaryWidget — criação CLT", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(salaryService.getProfile).mockResolvedValue(null);
   });
 
-  it("cria perfil e exibe breakdown após salvar", async () => {
-    const newProfile = buildProfile({ grossSalary: 3000 });
+  it("cria perfil CLT e exibe breakdown após salvar", async () => {
+    const newProfile = buildCltProfile({ grossSalary: 3000 });
     vi.mocked(salaryService.upsertProfile).mockResolvedValue(newProfile);
 
     const user = userEvent.setup();
     renderWidget();
 
     await waitFor(() => {
-      expect(screen.getByText("Definir salário bruto")).toBeInTheDocument();
+      expect(screen.getByTestId("select-clt")).toBeInTheDocument();
     });
-    await user.click(screen.getByText("Definir salário bruto"));
+
+    await user.click(screen.getByTestId("select-clt"));
 
     const grossInput = screen.getByLabelText("Salário bruto (R$)");
     await user.clear(grossInput);
@@ -300,5 +350,267 @@ describe("SalaryWidget — criação via formulário", () => {
     });
 
     expect(screen.getByText("Editar")).toBeInTheDocument();
+  });
+});
+
+// ─── Perfil beneficiário — exibição ──────────────────────────────────────────
+
+describe("SalaryWidget — perfil beneficiário INSS", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(salaryService.getProfile).mockResolvedValue(buildBenefitProfile());
+  });
+
+  it("exibe título Benefício líquido", async () => {
+    renderWidget();
+    await waitFor(() => {
+      expect(screen.getByText("Benefício líquido")).toBeInTheDocument();
+    });
+  });
+
+  it("exibe breakdown: Benefício bruto, IRRF, Consignações", async () => {
+    renderWidget();
+    await waitFor(() => {
+      expect(screen.getByText("Benefício bruto")).toBeInTheDocument();
+    });
+    expect(screen.getByText("(-) IRRF")).toBeInTheDocument();
+    expect(screen.getByText("(-) Consignações")).toBeInTheDocument();
+  });
+
+  it("exibe alertas de limite de empréstimos e cartão", async () => {
+    renderWidget();
+    await waitFor(() => {
+      expect(screen.getByText("Empréstimos")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Cartão consignado")).toBeInTheDocument();
+  });
+
+  it("exibe mensagem de nenhum desconto quando consignações estão vazias", async () => {
+    renderWidget();
+    await waitFor(() => {
+      expect(screen.getByText("Nenhum desconto cadastrado.")).toBeInTheDocument();
+    });
+  });
+
+  it("exibe botão Editar", async () => {
+    renderWidget();
+    await waitFor(() => {
+      expect(screen.getByText("Editar")).toBeInTheDocument();
+    });
+  });
+});
+
+// ─── Perfil beneficiário — com consignações ───────────────────────────────────
+
+describe("SalaryWidget — beneficiário com consignações", () => {
+  const profileWithConsig = buildBenefitProfile({
+    consignacoes: [
+      { id: 1, salaryProfileId: 2, description: "BMG Empréstimo", amount: 456.78, consignacaoType: "loan", createdAt: "2026-01-01T00:00:00Z" },
+      { id: 2, salaryProfileId: 2, description: "Cartão Banco X",  amount: 100.00, consignacaoType: "card", createdAt: "2026-01-02T00:00:00Z" },
+    ],
+    calculation: {
+      ...buildBenefitProfile().calculation,
+      consignacoesMonthly: 556.78,
+      loanTotal:           456.78,
+      cardTotal:           100.00,
+      isOverLoanLimit:     false,
+      isOverCardLimit:     false,
+    },
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(salaryService.getProfile).mockResolvedValue(profileWithConsig);
+  });
+
+  it("exibe lista de consignações cadastradas", async () => {
+    renderWidget();
+    await waitFor(() => {
+      expect(screen.getByText("BMG Empréstimo")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Cartão Banco X")).toBeInTheDocument();
+  });
+
+  it("exibe badge de tipo para cada consignação", async () => {
+    renderWidget();
+    await waitFor(() => {
+      expect(screen.getByText("BMG Empréstimo")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Empréstimo")).toBeInTheDocument();
+    expect(screen.getByText("Cartão")).toBeInTheDocument();
+  });
+});
+
+// ─── Perfil beneficiário — alerta de limite excedido ─────────────────────────
+
+describe("SalaryWidget — alertas de limite de consignação", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("exibe aviso quando empréstimos excedem 35% do benefício", async () => {
+    const overLimitProfile = buildBenefitProfile({
+      calculation: {
+        ...buildBenefitProfile().calculation,
+        loanTotal:       1908.10,
+        isOverLoanLimit: true,
+        loanLimitAmount: 1735.53,
+      },
+    });
+    vi.mocked(salaryService.getProfile).mockResolvedValue(overLimitProfile);
+
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText(/acima do limite 35%/)).toBeInTheDocument();
+    });
+  });
+
+  it("não exibe aviso quando dentro dos limites", async () => {
+    vi.mocked(salaryService.getProfile).mockResolvedValue(buildBenefitProfile());
+
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText("Empréstimos")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText(/acima do limite/)).not.toBeInTheDocument();
+  });
+});
+
+// ─── Perfil beneficiário — adicionar consignação ──────────────────────────────
+
+describe("SalaryWidget — adicionar consignação", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(salaryService.getProfile).mockResolvedValue(buildBenefitProfile());
+  });
+
+  it("exibe formulário ao clicar em Adicionar", async () => {
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("add-consignacao-btn")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("add-consignacao-btn"));
+
+    expect(screen.getByLabelText("Descrição")).toBeInTheDocument();
+    expect(screen.getByLabelText("Valor (R$)")).toBeInTheDocument();
+    expect(screen.getByLabelText("Tipo")).toBeInTheDocument();
+  });
+
+  it("salva consignação e atualiza perfil", async () => {
+    const updatedProfile = buildBenefitProfile({
+      consignacoes: [
+        { id: 10, salaryProfileId: 2, description: "BMG", amount: 300, consignacaoType: "loan", createdAt: "2026-01-01T00:00:00Z" },
+      ],
+      calculation: { ...buildBenefitProfile().calculation, loanTotal: 300, consignacoesMonthly: 300 },
+    });
+    vi.mocked(salaryService.addConsignacao).mockResolvedValue({
+      id: 10, salaryProfileId: 2, description: "BMG", amount: 300, consignacaoType: "loan", createdAt: "2026-01-01T00:00:00Z",
+    });
+    vi.mocked(salaryService.getProfile).mockResolvedValueOnce(buildBenefitProfile()).mockResolvedValue(updatedProfile);
+
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("add-consignacao-btn")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("add-consignacao-btn"));
+    await user.type(screen.getByLabelText("Descrição"), "BMG");
+    await user.type(screen.getByLabelText("Valor (R$)"), "300");
+    await user.click(screen.getByText("Salvar"));
+
+    await waitFor(() => {
+      expect(vi.mocked(salaryService.addConsignacao)).toHaveBeenCalledWith(
+        expect.objectContaining({ description: "BMG", amount: 300, consignacao_type: "loan" }),
+      );
+    });
+  });
+
+  it("exibe erro de validação ao tentar salvar sem descrição", async () => {
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("add-consignacao-btn")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("add-consignacao-btn"));
+    await user.type(screen.getByLabelText("Valor (R$)"), "200");
+    await user.click(screen.getByText("Salvar"));
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Informe a descrição.");
+    expect(vi.mocked(salaryService.addConsignacao)).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Perfil beneficiário — edição ─────────────────────────────────────────────
+
+describe("SalaryWidget — edição perfil beneficiário", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(salaryService.getProfile).mockResolvedValue(buildBenefitProfile());
+  });
+
+  it("abre formulário beneficiário ao clicar em Editar", async () => {
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText("Editar")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("Editar"));
+
+    expect(screen.getByLabelText("Benefício bruto (R$)")).toBeInTheDocument();
+    expect(screen.getByLabelText("Ano de nascimento")).toBeInTheDocument();
+  });
+
+  it("formulário pré-preenchido com benefício atual", async () => {
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText("Editar")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("Editar"));
+
+    const benefitInput = screen.getByLabelText("Benefício bruto (R$)") as HTMLInputElement;
+    expect(benefitInput.value).toBe("4958.67");
+
+    const birthYearInput = screen.getByLabelText("Ano de nascimento") as HTMLInputElement;
+    expect(birthYearInput.value).toBe("1955");
+  });
+
+  it("salva perfil beneficiário com profile_type correto", async () => {
+    vi.mocked(salaryService.upsertProfile).mockResolvedValue(buildBenefitProfile({ grossSalary: 5200 }));
+
+    const user = userEvent.setup();
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText("Editar")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("Editar"));
+
+    const benefitInput = screen.getByLabelText("Benefício bruto (R$)");
+    await user.clear(benefitInput);
+    await user.type(benefitInput, "5200");
+
+    await user.click(screen.getByText("Salvar"));
+
+    await waitFor(() => {
+      expect(vi.mocked(salaryService.upsertProfile)).toHaveBeenCalledWith(
+        expect.objectContaining({ profile_type: "inss_beneficiary", gross_salary: 5200 }),
+      );
+    });
   });
 });

--- a/apps/web/src/components/SalaryWidget.test.tsx
+++ b/apps/web/src/components/SalaryWidget.test.tsx
@@ -55,8 +55,8 @@ const buildBenefitProfile = (overrides: Partial<SalaryProfile> = {}): SalaryProf
     consignacoesMonthly: 0,
     loanTotal:           0,
     cardTotal:           0,
-    netMonthly:          4951.09,
-    netAnnual:           59413.08,
+    netMonthly:          4958.67,
+    netAnnual:           59504.04,
     taxAnnual:           90.96,
     loanLimitAmount:     1735.53,
     cardLimitAmount:     247.93,
@@ -368,12 +368,12 @@ describe("SalaryWidget — perfil beneficiário INSS", () => {
     });
   });
 
-  it("exibe breakdown: Benefício bruto, IRRF, Consignações", async () => {
+  it("exibe breakdown: Benefício bruto, IRRF estimado e Consignações", async () => {
     renderWidget();
     await waitFor(() => {
       expect(screen.getByText("Benefício bruto")).toBeInTheDocument();
     });
-    expect(screen.getByText("(-) IRRF")).toBeInTheDocument();
+    expect(screen.getByText("IRRF estimado")).toBeInTheDocument();
     expect(screen.getByText("(-) Consignações")).toBeInTheDocument();
   });
 
@@ -413,6 +413,7 @@ describe("SalaryWidget — beneficiário com consignações", () => {
       consignacoesMonthly: 556.78,
       loanTotal:           456.78,
       cardTotal:           100.00,
+      netMonthly:          4401.89,
       isOverLoanLimit:     false,
       isOverCardLimit:     false,
     },
@@ -498,6 +499,7 @@ describe("SalaryWidget — adicionar consignação", () => {
     await user.click(screen.getByTestId("add-consignacao-btn"));
 
     expect(screen.getByLabelText("Descrição")).toBeInTheDocument();
+    expect(screen.getByLabelText("Descrição")).toHaveAttribute("maxLength", "100");
     expect(screen.getByLabelText("Valor (R$)")).toBeInTheDocument();
     expect(screen.getByLabelText("Tipo")).toBeInTheDocument();
   });

--- a/apps/web/src/components/SalaryWidget.tsx
+++ b/apps/web/src/components/SalaryWidget.tsx
@@ -1,24 +1,45 @@
 import { useEffect, useState } from "react";
-import { salaryService, type SalaryProfile } from "../services/salary.service";
+import {
+  salaryService,
+  type Consignacao,
+  type ConsignacaoType,
+  type ProfileType,
+  type SalaryProfile,
+} from "../services/salary.service";
 import { formatCurrency } from "../utils/formatCurrency";
 
-// ─── Form state ───────────────────────────────────────────────────────────────
+// ─── Form state types ──────────────────────────────────────────────────────────
 
-interface FormState {
+interface CltFormState {
   grossSalary: string;
   dependents: string;
   paymentDay: string;
 }
 
-const EMPTY_FORM: FormState = { grossSalary: "", dependents: "0", paymentDay: "5" };
+interface BenefitFormState {
+  grossBenefit: string;
+  birthYear: string;
+  dependents: string;
+  paymentDay: string;
+}
 
-const profileToForm = (p: SalaryProfile): FormState => ({
+const EMPTY_CLT: CltFormState = { grossSalary: "", dependents: "0", paymentDay: "5" };
+const EMPTY_BENEFIT: BenefitFormState = { grossBenefit: "", birthYear: "", dependents: "0", paymentDay: "5" };
+
+const profileToCltForm = (p: SalaryProfile): CltFormState => ({
   grossSalary: String(p.grossSalary),
   dependents:  String(p.dependents),
   paymentDay:  String(p.paymentDay),
 });
 
-// ─── Sub-components ───────────────────────────────────────────────────────────
+const profileToBenefitForm = (p: SalaryProfile): BenefitFormState => ({
+  grossBenefit: String(p.grossSalary),
+  birthYear:    p.birthYear != null ? String(p.birthYear) : "",
+  dependents:   String(p.dependents),
+  paymentDay:   String(p.paymentDay),
+});
+
+// ─── Shared sub-components ────────────────────────────────────────────────────
 
 function BreakdownRow({
   label,
@@ -47,7 +68,205 @@ function BreakdownRow({
   );
 }
 
-function ProfileView({
+// ─── CLT form ─────────────────────────────────────────────────────────────────
+
+function CltForm({
+  initial,
+  onSave,
+  onCancel,
+  saving,
+  error,
+}: {
+  initial: CltFormState;
+  onSave: (form: CltFormState) => void;
+  onCancel: () => void;
+  saving: boolean;
+  error: string | null;
+}) {
+  const [form, setForm] = useState<CltFormState>(initial);
+  const set = (field: keyof CltFormState) => (e: React.ChangeEvent<HTMLInputElement>) =>
+    setForm((prev) => ({ ...prev, [field]: e.target.value }));
+
+  return (
+    <form onSubmit={(e) => { e.preventDefault(); onSave(form); }} noValidate>
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-medium text-cf-text-primary">Salário líquido</h3>
+      </div>
+
+      <div className="space-y-3">
+        <div>
+          <label htmlFor="sw-gross" className="mb-1 block text-xs font-medium text-cf-text-secondary">
+            Salário bruto (R$)
+          </label>
+          <input
+            id="sw-gross"
+            type="number" min="0.01" step="0.01" required
+            value={form.grossSalary}
+            onChange={set("grossSalary")}
+            placeholder="Ex: 5000"
+            className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label htmlFor="sw-dep" className="mb-1 block text-xs font-medium text-cf-text-secondary">
+              Dependentes
+            </label>
+            <input
+              id="sw-dep"
+              type="number" min="0" step="1"
+              value={form.dependents}
+              onChange={set("dependents")}
+              className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary focus:outline-none focus:ring-1 focus:ring-brand-1"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="sw-day" className="mb-1 block text-xs font-medium text-cf-text-secondary">
+              Dia de pagamento
+            </label>
+            <input
+              id="sw-day"
+              type="number" min="1" max="31" step="1"
+              value={form.paymentDay}
+              onChange={set("paymentDay")}
+              className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary focus:outline-none focus:ring-1 focus:ring-brand-1"
+            />
+          </div>
+        </div>
+
+        {error ? (
+          <p role="alert" className="text-xs text-red-500">{error}</p>
+        ) : null}
+
+        <div className="flex gap-2 pt-1">
+          <button
+            type="submit" disabled={saving}
+            className="flex-1 rounded bg-brand-1 px-3 py-1.5 text-xs font-semibold text-white hover:opacity-90 disabled:opacity-50"
+          >
+            {saving ? "Salvando..." : "Salvar"}
+          </button>
+          <button
+            type="button" onClick={onCancel} disabled={saving}
+            className="flex-1 rounded border border-cf-border px-3 py-1.5 text-xs font-medium text-cf-text-secondary hover:bg-cf-bg-subtle disabled:opacity-50"
+          >
+            Cancelar
+          </button>
+        </div>
+      </div>
+    </form>
+  );
+}
+
+// ─── Beneficiary form ─────────────────────────────────────────────────────────
+
+function BenefitForm({
+  initial,
+  onSave,
+  onCancel,
+  saving,
+  error,
+}: {
+  initial: BenefitFormState;
+  onSave: (form: BenefitFormState) => void;
+  onCancel: () => void;
+  saving: boolean;
+  error: string | null;
+}) {
+  const [form, setForm] = useState<BenefitFormState>(initial);
+  const set = (field: keyof BenefitFormState) => (e: React.ChangeEvent<HTMLInputElement>) =>
+    setForm((prev) => ({ ...prev, [field]: e.target.value }));
+
+  return (
+    <form onSubmit={(e) => { e.preventDefault(); onSave(form); }} noValidate>
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-medium text-cf-text-primary">Benefício líquido</h3>
+      </div>
+
+      <div className="space-y-3">
+        <div>
+          <label htmlFor="sw-gross-b" className="mb-1 block text-xs font-medium text-cf-text-secondary">
+            Benefício bruto (R$)
+          </label>
+          <input
+            id="sw-gross-b"
+            type="number" min="0.01" step="0.01" required
+            value={form.grossBenefit}
+            onChange={set("grossBenefit")}
+            placeholder="Ex: 4958.67"
+            className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label htmlFor="sw-birthyear" className="mb-1 block text-xs font-medium text-cf-text-secondary">
+              Ano de nascimento
+            </label>
+            <input
+              id="sw-birthyear"
+              type="number" min="1900" max="2100" step="1"
+              value={form.birthYear}
+              onChange={set("birthYear")}
+              placeholder="Ex: 1955"
+              className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="sw-dep-b" className="mb-1 block text-xs font-medium text-cf-text-secondary">
+              Dependentes
+            </label>
+            <input
+              id="sw-dep-b"
+              type="number" min="0" step="1"
+              value={form.dependents}
+              onChange={set("dependents")}
+              className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary focus:outline-none focus:ring-1 focus:ring-brand-1"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="sw-day-b" className="mb-1 block text-xs font-medium text-cf-text-secondary">
+            Dia de recebimento
+          </label>
+          <input
+            id="sw-day-b"
+            type="number" min="1" max="31" step="1"
+            value={form.paymentDay}
+            onChange={set("paymentDay")}
+            className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary focus:outline-none focus:ring-1 focus:ring-brand-1"
+          />
+        </div>
+
+        {error ? (
+          <p role="alert" className="text-xs text-red-500">{error}</p>
+        ) : null}
+
+        <div className="flex gap-2 pt-1">
+          <button
+            type="submit" disabled={saving}
+            className="flex-1 rounded bg-brand-1 px-3 py-1.5 text-xs font-semibold text-white hover:opacity-90 disabled:opacity-50"
+          >
+            {saving ? "Salvando..." : "Salvar"}
+          </button>
+          <button
+            type="button" onClick={onCancel} disabled={saving}
+            className="flex-1 rounded border border-cf-border px-3 py-1.5 text-xs font-medium text-cf-text-secondary hover:bg-cf-bg-subtle disabled:opacity-50"
+          >
+            Cancelar
+          </button>
+        </div>
+      </div>
+    </form>
+  );
+}
+
+// ─── CLT profile view ─────────────────────────────────────────────────────────
+
+function CltProfileView({
   profile,
   onEdit,
 }: {
@@ -59,20 +278,14 @@ function ProfileView({
     <>
       <div className="mb-3 flex items-center justify-between">
         <h3 className="text-sm font-medium text-cf-text-primary">Salário líquido</h3>
-        <button
-          type="button"
-          onClick={onEdit}
-          className="text-xs text-brand-1 hover:underline"
-        >
+        <button type="button" onClick={onEdit} className="text-xs text-brand-1 hover:underline">
           Editar
         </button>
       </div>
 
       <div className="mb-3 rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
         <p className="text-xs text-cf-text-secondary">Líquido mensal</p>
-        <p className="text-lg font-bold text-cf-text-primary">
-          {formatCurrency(calculation.netMonthly)}
-        </p>
+        <p className="text-lg font-bold text-cf-text-primary">{formatCurrency(calculation.netMonthly)}</p>
         <p className="text-xs text-cf-text-secondary">
           {calculation.netAnnual == null
             ? "Líquido anual: disponível no Pro"
@@ -91,120 +304,278 @@ function ProfileView({
   );
 }
 
-function ProfileForm({
-  initial,
-  onSave,
-  onCancel,
-  saving,
-  error,
+// ─── Consignação type labels ──────────────────────────────────────────────────
+
+const CONSIG_TYPE_LABEL: Record<ConsignacaoType, string> = {
+  loan:  "Empréstimo",
+  card:  "Cartão",
+  other: "Outro",
+};
+
+const CONSIG_TYPE_CLASS: Record<ConsignacaoType, string> = {
+  loan:  "border-orange-200 bg-orange-50 text-orange-700",
+  card:  "border-blue-200 bg-blue-50 text-blue-700",
+  other: "border-cf-border bg-cf-bg-subtle text-cf-text-secondary",
+};
+
+// ─── Beneficiary profile view ─────────────────────────────────────────────────
+
+function BenefitProfileView({
+  profile,
+  onEdit,
+  onProfileUpdate,
 }: {
-  initial: FormState;
-  onSave: (form: FormState) => void;
-  onCancel: () => void;
-  saving: boolean;
-  error: string | null;
+  profile: SalaryProfile;
+  onEdit: () => void;
+  onProfileUpdate: (updated: SalaryProfile) => void;
 }) {
-  const [form, setForm] = useState<FormState>(initial);
+  const { calculation, consignacoes } = profile;
+  const loanLimit = calculation.loanLimitAmount ?? 0;
+  const cardLimit = calculation.cardLimitAmount ?? 0;
+  const loanTotal = calculation.loanTotal ?? 0;
+  const cardTotal = calculation.cardTotal ?? 0;
 
-  const set = (field: keyof FormState) => (e: React.ChangeEvent<HTMLInputElement>) =>
-    setForm((prev) => ({ ...prev, [field]: e.target.value }));
+  const [addingConsig, setAddingConsig] = useState(false);
+  const [consigForm, setConsigForm] = useState({ description: "", amount: "", consignacaoType: "loan" as ConsignacaoType });
+  const [savingConsig, setSavingConsig] = useState(false);
+  const [consigError, setConsigError] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<number | null>(null);
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    onSave(form);
+  const handleAddConsig = async () => {
+    const amt = Number(consigForm.amount);
+    if (!consigForm.description.trim()) {
+      setConsigError("Informe a descrição.");
+      return;
+    }
+    if (!amt || amt <= 0) {
+      setConsigError("Informe um valor positivo.");
+      return;
+    }
+
+    setSavingConsig(true);
+    setConsigError(null);
+    try {
+      await salaryService.addConsignacao({
+        description:      consigForm.description.trim(),
+        amount:           amt,
+        consignacao_type: consigForm.consignacaoType,
+      });
+      const updated = await salaryService.getProfile();
+      if (updated) onProfileUpdate(updated);
+      setAddingConsig(false);
+      setConsigForm({ description: "", amount: "", consignacaoType: "loan" });
+    } catch {
+      setConsigError("Erro ao salvar. Tente novamente.");
+    } finally {
+      setSavingConsig(false);
+    }
+  };
+
+  const handleDeleteConsig = async (c: Consignacao) => {
+    setDeletingId(c.id);
+    try {
+      await salaryService.deleteConsignacao(c.id);
+      const updated = await salaryService.getProfile();
+      if (updated) onProfileUpdate(updated);
+    } catch {
+      // no-op: UI stays intact, user can retry
+    } finally {
+      setDeletingId(null);
+    }
   };
 
   return (
-    <form onSubmit={handleSubmit} noValidate>
+    <>
       <div className="mb-3 flex items-center justify-between">
-        <h3 className="text-sm font-medium text-cf-text-primary">Salário líquido</h3>
+        <h3 className="text-sm font-medium text-cf-text-primary">Benefício líquido</h3>
+        <button type="button" onClick={onEdit} className="text-xs text-brand-1 hover:underline">
+          Editar
+        </button>
       </div>
 
-      <div className="space-y-3">
-        <div>
-          <label
-            htmlFor="sw-gross"
-            className="mb-1 block text-xs font-medium text-cf-text-secondary"
-          >
-            Salário bruto (R$)
-          </label>
-          <input
-            id="sw-gross"
-            type="number"
-            min="0.01"
-            step="0.01"
-            required
-            value={form.grossSalary}
-            onChange={set("grossSalary")}
-            placeholder="Ex: 5000"
-            className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
-          />
+      {/* Main card */}
+      <div className="mb-3 rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
+        <p className="text-xs text-cf-text-secondary">Líquido mensal</p>
+        <p className="text-lg font-bold text-cf-text-primary">
+          {formatCurrency(calculation.netMonthly)}
+        </p>
+        <p className="text-xs text-cf-text-secondary">
+          {calculation.netAnnual == null
+            ? "Líquido anual: disponível no Pro"
+            : `${formatCurrency(calculation.netAnnual)} / ano`}
+        </p>
+      </div>
+
+      {/* Breakdown */}
+      <div className="space-y-1.5">
+        <BreakdownRow label="Benefício bruto"       value={calculation.grossMonthly}                           highlight />
+        <BreakdownRow label="(-) IRRF"              value={calculation.irrfMonthly}                            negative />
+        <BreakdownRow label="(-) Consignações"      value={calculation.consignacoesMonthly ?? 0}               negative />
+        <div className="my-1.5 border-t border-cf-border" />
+        <BreakdownRow label="= Líquido mensal"      value={calculation.netMonthly}                             highlight />
+      </div>
+
+      {/* Margin alerts */}
+      <div className="mt-3 space-y-1.5">
+        <div className={`flex items-center justify-between rounded border px-2.5 py-1.5 text-xs ${
+          calculation.isOverLoanLimit
+            ? "border-red-200 bg-red-50 text-red-700"
+            : "border-cf-border bg-cf-bg-subtle text-cf-text-secondary"
+        }`}>
+          <span>Empréstimos</span>
+          <span>
+            {formatCurrency(loanTotal)} / {formatCurrency(loanLimit)}
+            {calculation.isOverLoanLimit ? (
+              <span className="ml-1 font-semibold">⚠ acima do limite 35%</span>
+            ) : (
+              <span className="ml-1 text-cf-text-secondary">máx 35%</span>
+            )}
+          </span>
         </div>
 
-        <div className="grid grid-cols-2 gap-3">
-          <div>
-            <label
-              htmlFor="sw-dep"
-              className="mb-1 block text-xs font-medium text-cf-text-secondary"
-            >
-              Dependentes
-            </label>
-            <input
-              id="sw-dep"
-              type="number"
-              min="0"
-              step="1"
-              value={form.dependents}
-              onChange={set("dependents")}
-              className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary focus:outline-none focus:ring-1 focus:ring-brand-1"
-            />
-          </div>
+        <div className={`flex items-center justify-between rounded border px-2.5 py-1.5 text-xs ${
+          calculation.isOverCardLimit
+            ? "border-red-200 bg-red-50 text-red-700"
+            : "border-cf-border bg-cf-bg-subtle text-cf-text-secondary"
+        }`}>
+          <span>Cartão consignado</span>
+          <span>
+            {formatCurrency(cardTotal)} / {formatCurrency(cardLimit)}
+            {calculation.isOverCardLimit ? (
+              <span className="ml-1 font-semibold">⚠ acima do limite 5%</span>
+            ) : (
+              <span className="ml-1 text-cf-text-secondary">máx 5%</span>
+            )}
+          </span>
+        </div>
+      </div>
 
-          <div>
-            <label
-              htmlFor="sw-day"
-              className="mb-1 block text-xs font-medium text-cf-text-secondary"
+      {/* Consignações list */}
+      <div className="mt-4">
+        <div className="mb-2 flex items-center justify-between">
+          <p className="text-xs font-medium text-cf-text-primary">Descontos consignados</p>
+          {!addingConsig ? (
+            <button
+              type="button"
+              onClick={() => setAddingConsig(true)}
+              className="text-xs text-brand-1 hover:underline"
+              data-testid="add-consignacao-btn"
             >
-              Dia de pagamento
-            </label>
-            <input
-              id="sw-day"
-              type="number"
-              min="1"
-              max="31"
-              step="1"
-              value={form.paymentDay}
-              onChange={set("paymentDay")}
-              className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary focus:outline-none focus:ring-1 focus:ring-brand-1"
-            />
-          </div>
+              + Adicionar
+            </button>
+          ) : null}
         </div>
 
-        {error ? (
-          <p role="alert" className="text-xs text-red-500">
-            {error}
-          </p>
+        {consignacoes.length === 0 && !addingConsig ? (
+          <p className="text-xs text-cf-text-secondary">Nenhum desconto cadastrado.</p>
         ) : null}
 
-        <div className="flex gap-2 pt-1">
-          <button
-            type="submit"
-            disabled={saving}
-            className="flex-1 rounded bg-brand-1 px-3 py-1.5 text-xs font-semibold text-white hover:opacity-90 disabled:opacity-50"
-          >
-            {saving ? "Salvando..." : "Salvar"}
-          </button>
-          <button
-            type="button"
-            onClick={onCancel}
-            disabled={saving}
-            className="flex-1 rounded border border-cf-border px-3 py-1.5 text-xs font-medium text-cf-text-secondary hover:bg-cf-bg-subtle disabled:opacity-50"
-          >
-            Cancelar
-          </button>
-        </div>
+        {consignacoes.length > 0 ? (
+          <ul className="space-y-1.5">
+            {consignacoes.map((c) => (
+              <li
+                key={c.id}
+                className="flex items-center justify-between gap-2 rounded border border-cf-border bg-cf-surface px-2.5 py-1.5"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-xs text-cf-text-primary">{c.description}</p>
+                  <span className={`inline-block rounded border px-1.5 py-0.5 text-xs ${CONSIG_TYPE_CLASS[c.consignacaoType]}`}>
+                    {CONSIG_TYPE_LABEL[c.consignacaoType]}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-xs font-medium text-cf-text-primary">{formatCurrency(c.amount)}</span>
+                  <button
+                    type="button"
+                    disabled={deletingId === c.id}
+                    onClick={() => void handleDeleteConsig(c)}
+                    className="text-xs text-red-500 hover:text-red-700 disabled:opacity-50"
+                    aria-label={`Remover ${c.description}`}
+                  >
+                    {deletingId === c.id ? "..." : "✕"}
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+
+        {addingConsig ? (
+          <div className="mt-2 rounded border border-cf-border bg-cf-bg-subtle p-3">
+            <div className="space-y-2">
+              <div>
+                <label htmlFor="consig-desc" className="mb-0.5 block text-xs font-medium text-cf-text-secondary">
+                  Descrição
+                </label>
+                <input
+                  id="consig-desc"
+                  type="text"
+                  value={consigForm.description}
+                  onChange={(e) => setConsigForm((f) => ({ ...f, description: e.target.value }))}
+                  placeholder="Ex: BMG Empréstimo"
+                  className="w-full rounded border border-cf-border-input bg-cf-surface px-2.5 py-1 text-xs text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-2">
+                <div>
+                  <label htmlFor="consig-amt" className="mb-0.5 block text-xs font-medium text-cf-text-secondary">
+                    Valor (R$)
+                  </label>
+                  <input
+                    id="consig-amt"
+                    type="number" min="0.01" step="0.01"
+                    value={consigForm.amount}
+                    onChange={(e) => setConsigForm((f) => ({ ...f, amount: e.target.value }))}
+                    placeholder="0,00"
+                    className="w-full rounded border border-cf-border-input bg-cf-surface px-2.5 py-1 text-xs text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
+                  />
+                </div>
+
+                <div>
+                  <label htmlFor="consig-type" className="mb-0.5 block text-xs font-medium text-cf-text-secondary">
+                    Tipo
+                  </label>
+                  <select
+                    id="consig-type"
+                    value={consigForm.consignacaoType}
+                    onChange={(e) => setConsigForm((f) => ({ ...f, consignacaoType: e.target.value as ConsignacaoType }))}
+                    className="w-full rounded border border-cf-border-input bg-cf-surface px-2.5 py-1 text-xs text-cf-text-primary focus:outline-none focus:ring-1 focus:ring-brand-1"
+                  >
+                    <option value="loan">Empréstimo</option>
+                    <option value="card">Cartão</option>
+                    <option value="other">Outro</option>
+                  </select>
+                </div>
+              </div>
+
+              {consigError ? (
+                <p role="alert" className="text-xs text-red-500">{consigError}</p>
+              ) : null}
+
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  disabled={savingConsig}
+                  onClick={() => void handleAddConsig()}
+                  className="flex-1 rounded bg-brand-1 px-2.5 py-1 text-xs font-semibold text-white hover:opacity-90 disabled:opacity-50"
+                >
+                  {savingConsig ? "Salvando..." : "Salvar"}
+                </button>
+                <button
+                  type="button"
+                  disabled={savingConsig}
+                  onClick={() => { setAddingConsig(false); setConsigError(null); }}
+                  className="flex-1 rounded border border-cf-border px-2.5 py-1 text-xs font-medium text-cf-text-secondary hover:bg-cf-surface disabled:opacity-50"
+                >
+                  Cancelar
+                </button>
+              </div>
+            </div>
+          </div>
+        ) : null}
       </div>
-    </form>
+    </>
   );
 }
 
@@ -214,6 +585,7 @@ const SalaryWidget = (): JSX.Element | null => {
   const [profile, setProfile] = useState<SalaryProfile | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [editing, setEditing] = useState(false);
+  const [pendingType, setPendingType] = useState<ProfileType | null>(null);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
 
@@ -225,7 +597,20 @@ const SalaryWidget = (): JSX.Element | null => {
       .finally(() => setIsLoading(false));
   }, []);
 
-  const handleSave = async (form: FormState) => {
+  // Derived mode
+  const activeType: ProfileType | null = editing
+    ? (profile?.profileType ?? pendingType ?? "clt")
+    : pendingType;
+  const inForm      = editing || pendingType !== null;
+  const inTypeSelect = !profile && !editing && pendingType === null;
+
+  const handleCancel = () => {
+    setEditing(false);
+    setPendingType(null);
+    setSaveError(null);
+  };
+
+  const handleSaveClt = async (form: CltFormState) => {
     const gross = Number(form.grossSalary);
     const dep   = Number(form.dependents);
     const day   = Number(form.paymentDay);
@@ -237,15 +622,16 @@ const SalaryWidget = (): JSX.Element | null => {
 
     setSaving(true);
     setSaveError(null);
-
     try {
       const updated = await salaryService.upsertProfile({
+        profile_type: "clt",
         gross_salary: gross,
         dependents:   dep,
         payment_day:  day,
       });
       setProfile(updated);
       setEditing(false);
+      setPendingType(null);
     } catch {
       setSaveError("Erro ao salvar. Tente novamente.");
     } finally {
@@ -253,9 +639,35 @@ const SalaryWidget = (): JSX.Element | null => {
     }
   };
 
-  const handleCancel = () => {
-    setEditing(false);
+  const handleSaveBenefit = async (form: BenefitFormState) => {
+    const gross = Number(form.grossBenefit);
+    const dep   = Number(form.dependents);
+    const day   = Number(form.paymentDay);
+    const year  = form.birthYear ? Number(form.birthYear) : null;
+
+    if (!gross || gross <= 0) {
+      setSaveError("Informe um valor de benefício válido.");
+      return;
+    }
+
+    setSaving(true);
     setSaveError(null);
+    try {
+      const updated = await salaryService.upsertProfile({
+        profile_type: "inss_beneficiary",
+        gross_salary: gross,
+        birth_year:   year,
+        dependents:   dep,
+        payment_day:  day,
+      });
+      setProfile(updated);
+      setEditing(false);
+      setPendingType(null);
+    } catch {
+      setSaveError("Erro ao salvar. Tente novamente.");
+    } finally {
+      setSaving(false);
+    }
   };
 
   if (isLoading) {
@@ -268,31 +680,69 @@ const SalaryWidget = (): JSX.Element | null => {
 
   return (
     <div className="rounded border border-cf-border bg-cf-surface p-4">
-      {editing || !profile ? (
-        <ProfileForm
-          initial={profile ? profileToForm(profile) : EMPTY_FORM}
-          onSave={handleSave}
+      {/* Type selector — no profile yet, no type chosen */}
+      {inTypeSelect ? (
+        <div>
+          <p className="mb-3 text-xs text-cf-text-secondary">
+            Como você recebe sua renda principal?
+          </p>
+          <div className="grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              onClick={() => { setPendingType("clt"); setEditing(true); }}
+              className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5 text-left hover:border-brand-1 hover:bg-cf-surface"
+              data-testid="select-clt"
+            >
+              <p className="text-xs font-semibold text-cf-text-primary">Salário CLT</p>
+              <p className="mt-0.5 text-xs text-cf-text-secondary">Empregado com carteira assinada</p>
+            </button>
+            <button
+              type="button"
+              onClick={() => { setPendingType("inss_beneficiary"); setEditing(true); }}
+              className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5 text-left hover:border-brand-1 hover:bg-cf-surface"
+              data-testid="select-beneficiary"
+            >
+              <p className="text-xs font-semibold text-cf-text-primary">Benefício INSS</p>
+              <p className="mt-0.5 text-xs text-cf-text-secondary">Aposentado ou pensionista</p>
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {/* CLT form */}
+      {inForm && activeType === "clt" ? (
+        <CltForm
+          initial={profile?.profileType === "clt" ? profileToCltForm(profile) : EMPTY_CLT}
+          onSave={handleSaveClt}
           onCancel={handleCancel}
           saving={saving}
           error={saveError}
         />
-      ) : (
-        <ProfileView profile={profile} onEdit={() => setEditing(true)} />
-      )}
+      ) : null}
 
-      {!profile && !editing ? (
-        <div className="text-center">
-          <p className="mb-2 text-xs text-cf-text-secondary">
-            Calcule seu salário líquido (CLT) com INSS e IRRF 2026.
-          </p>
-          <button
-            type="button"
-            onClick={() => setEditing(true)}
-            className="rounded bg-brand-1 px-4 py-1.5 text-xs font-semibold text-white hover:opacity-90"
-          >
-            Definir salário bruto
-          </button>
-        </div>
+      {/* Benefit form */}
+      {inForm && activeType === "inss_beneficiary" ? (
+        <BenefitForm
+          initial={profile?.profileType === "inss_beneficiary" ? profileToBenefitForm(profile) : EMPTY_BENEFIT}
+          onSave={handleSaveBenefit}
+          onCancel={handleCancel}
+          saving={saving}
+          error={saveError}
+        />
+      ) : null}
+
+      {/* CLT profile view */}
+      {!inForm && profile?.profileType === "clt" ? (
+        <CltProfileView profile={profile} onEdit={() => setEditing(true)} />
+      ) : null}
+
+      {/* Beneficiary profile view */}
+      {!inForm && profile?.profileType === "inss_beneficiary" ? (
+        <BenefitProfileView
+          profile={profile}
+          onEdit={() => setEditing(true)}
+          onProfileUpdate={setProfile}
+        />
       ) : null}
     </div>
   );

--- a/apps/web/src/components/SalaryWidget.tsx
+++ b/apps/web/src/components/SalaryWidget.tsx
@@ -25,6 +25,7 @@ interface BenefitFormState {
 
 const EMPTY_CLT: CltFormState = { grossSalary: "", dependents: "0", paymentDay: "5" };
 const EMPTY_BENEFIT: BenefitFormState = { grossBenefit: "", birthYear: "", dependents: "0", paymentDay: "5" };
+const CONSIGNACAO_DESCRIPTION_MAX_LENGTH = 100;
 
 const profileToCltForm = (p: SalaryProfile): CltFormState => ({
   grossSalary: String(p.grossSalary),
@@ -347,6 +348,10 @@ function BenefitProfileView({
       setConsigError("Informe a descrição.");
       return;
     }
+    if (consigForm.description.trim().length > CONSIGNACAO_DESCRIPTION_MAX_LENGTH) {
+      setConsigError(`Descrição deve ter no máximo ${CONSIGNACAO_DESCRIPTION_MAX_LENGTH} caracteres.`);
+      return;
+    }
     if (!amt || amt <= 0) {
       setConsigError("Informe um valor positivo.");
       return;
@@ -409,10 +414,10 @@ function BenefitProfileView({
       {/* Breakdown */}
       <div className="space-y-1.5">
         <BreakdownRow label="Benefício bruto"       value={calculation.grossMonthly}                           highlight />
-        <BreakdownRow label="(-) IRRF"              value={calculation.irrfMonthly}                            negative />
         <BreakdownRow label="(-) Consignações"      value={calculation.consignacoesMonthly ?? 0}               negative />
         <div className="my-1.5 border-t border-cf-border" />
         <BreakdownRow label="= Líquido mensal"      value={calculation.netMonthly}                             highlight />
+        <BreakdownRow label="IRRF estimado"         value={calculation.irrfMonthly} />
       </div>
 
       {/* Margin alerts */}
@@ -510,6 +515,7 @@ function BenefitProfileView({
                 <input
                   id="consig-desc"
                   type="text"
+                  maxLength={CONSIGNACAO_DESCRIPTION_MAX_LENGTH}
                   value={consigForm.description}
                   onChange={(e) => setConsigForm((f) => ({ ...f, description: e.target.value }))}
                   placeholder="Ex: BMG Empréstimo"

--- a/apps/web/src/services/salary.service.ts
+++ b/apps/web/src/services/salary.service.ts
@@ -2,6 +2,9 @@ import { api } from "./api";
 
 // ─── Public types ─────────────────────────────────────────────────────────────
 
+export type ProfileType = "clt" | "inss_beneficiary";
+export type ConsignacaoType = "loan" | "card" | "other";
+
 export interface SalaryCalculation {
   grossMonthly: number;
   inssMonthly: number;
@@ -9,44 +12,93 @@ export interface SalaryCalculation {
   netMonthly: number;
   netAnnual: number | null;  // null for free-plan users
   taxAnnual: number | null;  // null for free-plan users
+  // INSS beneficiary extras (present when profileType === 'inss_beneficiary')
+  consignacoesMonthly?: number;
+  loanTotal?: number;
+  cardTotal?: number;
+  loanLimitAmount?: number;
+  cardLimitAmount?: number;
+  isOverLoanLimit?: boolean;
+  isOverCardLimit?: boolean;
+}
+
+export interface Consignacao {
+  id: number;
+  salaryProfileId: number;
+  description: string;
+  amount: number;
+  consignacaoType: ConsignacaoType;
+  createdAt: string;
 }
 
 export interface SalaryProfile {
   id: number;
   userId: number;
+  profileType: ProfileType;
+  birthYear: number | null;
   grossSalary: number;
   dependents: number;
   paymentDay: number;
   createdAt: string;
   updatedAt: string;
+  consignacoes: Consignacao[];
   calculation: SalaryCalculation;
 }
 
 export interface UpsertSalaryProfilePayload {
+  profile_type?: ProfileType;
   gross_salary: number;
+  birth_year?: number | null;
   dependents?: number;
   payment_day?: number;
+}
+
+export interface AddConsignacaoPayload {
+  description: string;
+  amount: number;
+  consignacao_type: ConsignacaoType;
 }
 
 // ─── Normalization ────────────────────────────────────────────────────────────
 
 const normalizeCalculation = (raw: Record<string, unknown>): SalaryCalculation => ({
-  grossMonthly: Number(raw.grossMonthly) || 0,
-  inssMonthly:  Number(raw.inssMonthly)  || 0,
-  irrfMonthly:  Number(raw.irrfMonthly)  || 0,
-  netMonthly:   Number(raw.netMonthly)   || 0,
-  netAnnual:    raw.netAnnual == null ? null : Number(raw.netAnnual) || 0,
-  taxAnnual:    raw.taxAnnual == null ? null : Number(raw.taxAnnual) || 0,
+  grossMonthly:        Number(raw.grossMonthly)        || 0,
+  inssMonthly:         Number(raw.inssMonthly)         || 0,
+  irrfMonthly:         Number(raw.irrfMonthly)         || 0,
+  netMonthly:          Number(raw.netMonthly)          || 0,
+  netAnnual:           raw.netAnnual  == null ? null : Number(raw.netAnnual)  || 0,
+  taxAnnual:           raw.taxAnnual  == null ? null : Number(raw.taxAnnual)  || 0,
+  consignacoesMonthly: raw.consignacoesMonthly != null ? Number(raw.consignacoesMonthly) : undefined,
+  loanTotal:           raw.loanTotal           != null ? Number(raw.loanTotal)           : undefined,
+  cardTotal:           raw.cardTotal           != null ? Number(raw.cardTotal)           : undefined,
+  loanLimitAmount:     raw.loanLimitAmount     != null ? Number(raw.loanLimitAmount)     : undefined,
+  cardLimitAmount:     raw.cardLimitAmount     != null ? Number(raw.cardLimitAmount)     : undefined,
+  isOverLoanLimit:     raw.isOverLoanLimit     != null ? Boolean(raw.isOverLoanLimit)    : undefined,
+  isOverCardLimit:     raw.isOverCardLimit     != null ? Boolean(raw.isOverCardLimit)    : undefined,
+});
+
+const normalizeConsignacao = (raw: Record<string, unknown>): Consignacao => ({
+  id:              Number(raw.id)              || 0,
+  salaryProfileId: Number(raw.salaryProfileId) || 0,
+  description:     typeof raw.description === "string" ? raw.description : "",
+  amount:          Number(raw.amount)          || 0,
+  consignacaoType: (raw.consignacaoType as ConsignacaoType) ?? "other",
+  createdAt:       typeof raw.createdAt === "string" ? raw.createdAt : "",
 });
 
 const normalizeProfile = (raw: Record<string, unknown>): SalaryProfile => ({
-  id:          Number(raw.id) || 0,
-  userId:      Number(raw.userId) || 0,
+  id:          Number(raw.id)          || 0,
+  userId:      Number(raw.userId)      || 0,
+  profileType: (raw.profileType as ProfileType) ?? "clt",
+  birthYear:   raw.birthYear != null ? Number(raw.birthYear) : null,
   grossSalary: Number(raw.grossSalary) || 0,
-  dependents:  Number(raw.dependents) || 0,
-  paymentDay:  Number(raw.paymentDay) || 5,
+  dependents:  Number(raw.dependents)  || 0,
+  paymentDay:  Number(raw.paymentDay)  || 5,
   createdAt:   typeof raw.createdAt === "string" ? raw.createdAt : "",
   updatedAt:   typeof raw.updatedAt === "string" ? raw.updatedAt : "",
+  consignacoes: Array.isArray(raw.consignacoes)
+    ? (raw.consignacoes as Record<string, unknown>[]).map(normalizeConsignacao)
+    : [],
   calculation: normalizeCalculation(
     (raw.calculation as Record<string, unknown>) ?? {},
   ),
@@ -69,5 +121,14 @@ export const salaryService = {
   upsertProfile: async (payload: UpsertSalaryProfilePayload): Promise<SalaryProfile> => {
     const { data } = await api.put("/salary/profile", payload);
     return normalizeProfile(data as Record<string, unknown>);
+  },
+
+  addConsignacao: async (payload: AddConsignacaoPayload): Promise<Consignacao> => {
+    const { data } = await api.post("/salary/consignacoes", payload);
+    return normalizeConsignacao(data as Record<string, unknown>);
+  },
+
+  deleteConsignacao: async (id: number): Promise<void> => {
+    await api.delete(`/salary/consignacoes/${id}`);
   },
 };


### PR DESCRIPTION
## Summary

Adds a new `inss_beneficiary` salary profile alongside the existing CLT flow.

This PR includes:
- beneficiary-specific calculation via `calculateNetBenefit`
- 65+ IRRF partial exemption handling as an informational estimate
- consignações CRUD with loan/card limit flags
- salary widget support for CLT vs INSS beneficiary flows
- gating preserved for annual-only fields on free plans

## Follow-up Fix Included

This branch also includes the review follow-up that:
- aligns `netMonthly` with the amount effectively received
- keeps `irrfMonthly` informational for beneficiary profiles
- blocks consignações on CLT profiles
- enforces the 100-character description limit in backend and UI

## Validation

Validated with focused salary domain, profile integration, and widget test suites.
