### PR TITLE
feat(import): import bank statements from OFX, CSV, and PDF

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,9 @@ DB_SSL=false
 # Aceita lista separada por virgula (ex.: local + Vercel):
 # CORS_ORIGIN=http://localhost:5173,https://control-finance-react-tail-wind.vercel.app
 CORS_ORIGIN=http://localhost:5173
+# OCR for low-signal statement PDFs. Keep disabled on small hosts.
+# Enable only on hosts with at least 1GB RAM available to the API service.
+IMPORT_OCR_ENABLED=false
 # Ops endpoint guard (non-production only; required for /ops/force-plan)
 # OPS_TOKEN=troque-isto-por-um-token-forte
 # Stripe checkout (billing)

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -28,6 +28,7 @@
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.0.2",
     "nodemailer": "^8.0.1",
+    "pdf-parse": "^2.4.5",
     "pg": "^8.16.3",
     "prom-client": "^15.1.3",
     "stripe": "^20.3.1"

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -31,7 +31,8 @@
     "pdf-parse": "^2.4.5",
     "pg": "^8.16.3",
     "prom-client": "^15.1.3",
-    "stripe": "^20.3.1"
+    "stripe": "^20.3.1",
+    "tesseract.js": "^7.0.0"
   },
   "devDependencies": {
     "eslint": "^8.57.1",

--- a/apps/api/src/domain/imports/ofx-import.js
+++ b/apps/api/src/domain/imports/ofx-import.js
@@ -1,0 +1,106 @@
+const TYPE_INCOME = "Entrada";
+const TYPE_EXPENSE = "Saida";
+const MAX_ROWS = 2000;
+
+const collapseWhitespace = (value) => String(value || "").replace(/\s+/g, " ").trim();
+
+const formatValue = (value) => Number(value).toFixed(2);
+
+const parseSignedAmount = (value) => {
+  const normalizedValue = collapseWhitespace(value).replace(",", ".");
+
+  if (!normalizedValue) {
+    return null;
+  }
+
+  const parsedValue = Number(normalizedValue);
+  if (!Number.isFinite(parsedValue)) {
+    return null;
+  }
+
+  return Number(parsedValue.toFixed(2));
+};
+
+const normalizeOfxDate = (value) => {
+  const normalizedValue = String(value || "").trim();
+  const compactValue = normalizedValue.replace(/[^0-9]/g, "");
+
+  if (compactValue.length < 8) {
+    return normalizedValue;
+  }
+
+  const year = compactValue.slice(0, 4);
+  const month = compactValue.slice(4, 6);
+  const day = compactValue.slice(6, 8);
+  return `${year}-${month}-${day}`;
+};
+
+const resolveTypeFromAmount = (amount) => (amount < 0 ? TYPE_EXPENSE : TYPE_INCOME);
+
+const resolveType = (trnType, amount) => {
+  const normalizedType = collapseWhitespace(trnType).toUpperCase();
+
+  if (["CREDIT", "DEP", "DIRECTDEP", "INT", "DIV", "CASH", "XFER"].includes(normalizedType)) {
+    return TYPE_INCOME;
+  }
+
+  if (
+    ["DEBIT", "PAYMENT", "CHECK", "ATM", "POS", "FEE", "SRVCHG", "XFER"].includes(normalizedType)
+  ) {
+    return amount < 0 ? TYPE_EXPENSE : TYPE_INCOME;
+  }
+
+  return resolveTypeFromAmount(amount);
+};
+
+const getOfxTagValue = (block, tagName) => {
+  const closedTagRegex = new RegExp(`<${tagName}>([\\s\\S]*?)</${tagName}>`, "i");
+  const closedTagMatch = block.match(closedTagRegex);
+
+  if (closedTagMatch) {
+    return collapseWhitespace(closedTagMatch[1]);
+  }
+
+  const openTagRegex = new RegExp(`<${tagName}>([^<\\r\\n]+)`, "i");
+  const openTagMatch = block.match(openTagRegex);
+  return openTagMatch ? collapseWhitespace(openTagMatch[1]) : "";
+};
+
+export const parseOfxRows = (buffer) => {
+  const content = Buffer.isBuffer(buffer) ? buffer.toString("utf8") : String(buffer || "");
+  const transactionBlocks = content.match(/<STMTTRN>([\s\S]*?)(?:<\/STMTTRN>|(?=<STMTTRN>)|$)/gi) || [];
+
+  if (transactionBlocks.length === 0) {
+    throw new Error("Nenhuma transacao reconhecida no OFX.");
+  }
+
+  if (transactionBlocks.length > MAX_ROWS) {
+    throw new Error(`Arquivo excede o limite de ${MAX_ROWS} linhas.`);
+  }
+
+  return transactionBlocks.map((block, index) => {
+    const amount = parseSignedAmount(getOfxTagValue(block, "TRNAMT"));
+    if (amount === null) {
+      throw new Error("Transacao OFX com valor invalido.");
+    }
+
+    const description =
+      getOfxTagValue(block, "MEMO") ||
+      getOfxTagValue(block, "NAME") ||
+      getOfxTagValue(block, "FITID") ||
+      `Transacao OFX ${index + 1}`;
+    const fitId = getOfxTagValue(block, "FITID");
+
+    return {
+      line: index + 1,
+      raw: {
+        date: normalizeOfxDate(getOfxTagValue(block, "DTPOSTED")),
+        type: resolveType(getOfxTagValue(block, "TRNTYPE"), amount),
+        value: formatValue(Math.abs(amount)),
+        description,
+        notes: fitId ? `FITID ${fitId}` : "",
+        category: "",
+      },
+    };
+  });
+};

--- a/apps/api/src/domain/imports/ofx-import.test.js
+++ b/apps/api/src/domain/imports/ofx-import.test.js
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { parseOfxRows } from "./ofx-import.js";
+
+describe("ofx import parser", () => {
+  it("extrai transacoes de OFX SGML", () => {
+    const content = [
+      "OFXHEADER:100",
+      "DATA:OFXSGML",
+      "<OFX>",
+      "<BANKMSGSRSV1>",
+      "<STMTTRNRS>",
+      "<STMTRS>",
+      "<BANKTRANLIST>",
+      "<STMTTRN>",
+      "<TRNTYPE>CREDIT",
+      "<DTPOSTED>20260205000000[-3:BRT]",
+      "<TRNAMT>2812.99",
+      "<FITID>ABC123",
+      "<MEMO>PGTO INSS 01776829899",
+      "</STMTTRN>",
+      "<STMTTRN>",
+      "<TRNTYPE>DEBIT",
+      "<DTPOSTED>20260206000000[-3:BRT]",
+      "<TRNAMT>-15.98",
+      "<FITID>XYZ456",
+      "<NAME>PIX QRS UBER DO BRA",
+      "</STMTTRN>",
+      "</BANKTRANLIST>",
+    ].join("\n");
+
+    const rows = parseOfxRows(Buffer.from(content, "utf8"));
+
+    expect(rows).toEqual([
+      {
+        line: 1,
+        raw: {
+          date: "2026-02-05",
+          type: "Entrada",
+          value: "2812.99",
+          description: "PGTO INSS 01776829899",
+          notes: "FITID ABC123",
+          category: "",
+        },
+      },
+      {
+        line: 2,
+        raw: {
+          date: "2026-02-06",
+          type: "Saida",
+          value: "15.98",
+          description: "PIX QRS UBER DO BRA",
+          notes: "FITID XYZ456",
+          category: "",
+        },
+      },
+    ]);
+  });
+
+  it("usa o sinal do valor quando o TRNTYPE nao ajuda", () => {
+    const content = [
+      "<STMTTRN>",
+      "<TRNTYPE>OTHER",
+      "<DTPOSTED>20260310000000",
+      "<TRNAMT>-99.90",
+      "<MEMO>TARIFA BANCARIA",
+      "</STMTTRN>",
+    ].join("\n");
+
+    const rows = parseOfxRows(Buffer.from(content, "utf8"));
+
+    expect(rows[0].raw.type).toBe("Saida");
+    expect(rows[0].raw.value).toBe("99.90");
+  });
+});

--- a/apps/api/src/domain/imports/pdf-ocr.js
+++ b/apps/api/src/domain/imports/pdf-ocr.js
@@ -1,7 +1,11 @@
 import { PDFParse } from "pdf-parse";
-import { createWorker } from "tesseract.js";
 
 const OCR_LANGUAGES = "por+eng";
+
+const loadCreateWorker = async () => {
+  const tesseractModule = await import("tesseract.js");
+  return tesseractModule.createWorker;
+};
 
 export const shouldRunPdfOcrFallback = (text) => {
   const normalizedText = String(text || "").replace(/\s+/g, " ").trim();
@@ -23,10 +27,10 @@ export const extractTextFromPdfWithOcr = async (
   buffer,
   dependencies = {
     PDFParseCtor: PDFParse,
-    createWorkerFn: createWorker,
+    loadCreateWorkerFn: loadCreateWorker,
   },
 ) => {
-  const { PDFParseCtor, createWorkerFn } = dependencies;
+  const { PDFParseCtor, createWorkerFn, loadCreateWorkerFn } = dependencies;
   const parser = new PDFParseCtor({ data: buffer });
 
   try {
@@ -49,7 +53,11 @@ export const extractTextFromPdfWithOcr = async (
       return directText;
     }
 
-    const worker = await createWorkerFn(OCR_LANGUAGES);
+    const resolvedCreateWorkerFn =
+      typeof createWorkerFn === "function"
+        ? createWorkerFn
+        : await loadCreateWorkerFn();
+    const worker = await resolvedCreateWorkerFn(OCR_LANGUAGES);
 
     try {
       const ocrTexts = [];

--- a/apps/api/src/domain/imports/pdf-ocr.js
+++ b/apps/api/src/domain/imports/pdf-ocr.js
@@ -7,6 +7,9 @@ const loadCreateWorker = async () => {
   return tesseractModule.createWorker;
 };
 
+export const isImportOcrEnabled = (value = process.env.IMPORT_OCR_ENABLED) =>
+  String(value || "").trim().toLowerCase() === "true";
+
 export const shouldRunPdfOcrFallback = (text) => {
   const normalizedText = String(text || "").replace(/\s+/g, " ").trim();
 
@@ -28,16 +31,22 @@ export const extractTextFromPdfWithOcr = async (
   dependencies = {
     PDFParseCtor: PDFParse,
     loadCreateWorkerFn: loadCreateWorker,
+    ocrEnabled: isImportOcrEnabled(),
   },
 ) => {
-  const { PDFParseCtor, createWorkerFn, loadCreateWorkerFn } = dependencies;
+  const {
+    PDFParseCtor,
+    createWorkerFn,
+    loadCreateWorkerFn,
+    ocrEnabled = isImportOcrEnabled(),
+  } = dependencies;
   const parser = new PDFParseCtor({ data: buffer });
 
   try {
     const textResult = await parser.getText();
     const directText = String(textResult?.text || "");
 
-    if (!shouldRunPdfOcrFallback(directText)) {
+    if (!shouldRunPdfOcrFallback(directText) || !ocrEnabled) {
       return directText;
     }
 

--- a/apps/api/src/domain/imports/pdf-ocr.js
+++ b/apps/api/src/domain/imports/pdf-ocr.js
@@ -1,0 +1,70 @@
+import { PDFParse } from "pdf-parse";
+import { createWorker } from "tesseract.js";
+
+const OCR_LANGUAGES = "por+eng";
+
+export const shouldRunPdfOcrFallback = (text) => {
+  const normalizedText = String(text || "").replace(/\s+/g, " ").trim();
+
+  if (!normalizedText || normalizedText.length < 60) {
+    return true;
+  }
+
+  const signalCount =
+    (normalizedText.match(/\d{2}\/\d{2}\/\d{4}/g) || []).length +
+    (normalizedText.match(/\d{2}\/\d{4}/g) || []).length +
+    (normalizedText.match(/R\$\s*[\d.,]+/g) || []).length +
+    (normalizedText.match(/\b\d[\d.]*,\d{2}\b/g) || []).length;
+
+  return signalCount < 3;
+};
+
+export const extractTextFromPdfWithOcr = async (
+  buffer,
+  dependencies = {
+    PDFParseCtor: PDFParse,
+    createWorkerFn: createWorker,
+  },
+) => {
+  const { PDFParseCtor, createWorkerFn } = dependencies;
+  const parser = new PDFParseCtor({ data: buffer });
+
+  try {
+    const textResult = await parser.getText();
+    const directText = String(textResult?.text || "");
+
+    if (!shouldRunPdfOcrFallback(directText)) {
+      return directText;
+    }
+
+    const screenshots = await parser.getScreenshot({
+      first: 3,
+      scale: 2,
+      imageDataUrl: false,
+      imageBuffer: true,
+    });
+    const pages = Array.isArray(screenshots?.pages) ? screenshots.pages : [];
+
+    if (pages.length === 0) {
+      return directText;
+    }
+
+    const worker = await createWorkerFn(OCR_LANGUAGES);
+
+    try {
+      const ocrTexts = [];
+
+      for (const page of pages) {
+        const result = await worker.recognize(page.data);
+        ocrTexts.push(String(result?.data?.text || ""));
+      }
+
+      const combinedOcrText = ocrTexts.join("\n").trim();
+      return combinedOcrText || directText;
+    } finally {
+      await worker.terminate();
+    }
+  } finally {
+    await parser.destroy();
+  }
+};

--- a/apps/api/src/domain/imports/pdf-ocr.test.js
+++ b/apps/api/src/domain/imports/pdf-ocr.test.js
@@ -1,7 +1,17 @@
 import { describe, expect, it, vi } from "vitest";
-import { extractTextFromPdfWithOcr, shouldRunPdfOcrFallback } from "./pdf-ocr.js";
+import {
+  extractTextFromPdfWithOcr,
+  isImportOcrEnabled,
+  shouldRunPdfOcrFallback,
+} from "./pdf-ocr.js";
 
 describe("pdf OCR fallback", () => {
+  it("IMPORT_OCR_ENABLED vem desligado por padrao", () => {
+    expect(isImportOcrEnabled(undefined)).toBe(false);
+    expect(isImportOcrEnabled("false")).toBe(false);
+    expect(isImportOcrEnabled("true")).toBe(true);
+  });
+
   it("nao roda OCR quando texto nativo do PDF ja parece utilizavel", () => {
     const shouldRun = shouldRunPdfOcrFallback(
       "05/02/2026 PGTO INSS 01776829899 2.812,99 06/02/2026 PIX QRS UBER DO BRA -15,98 R$ 2.812,99",
@@ -37,6 +47,26 @@ describe("pdf OCR fallback", () => {
     expect(loadCreateWorkerFn).not.toHaveBeenCalled();
   });
 
+  it("retorna texto direto sem tentar OCR quando a flag esta desligada", async () => {
+    const fakeParser = {
+      getText: vi.fn().mockResolvedValue({ text: "abc 123" }),
+      getScreenshot: vi.fn(),
+      destroy: vi.fn().mockResolvedValue(undefined),
+    };
+    const PDFParseCtor = vi.fn(() => fakeParser);
+    const loadCreateWorkerFn = vi.fn();
+
+    const text = await extractTextFromPdfWithOcr(Buffer.from("fake-pdf"), {
+      PDFParseCtor,
+      loadCreateWorkerFn,
+      ocrEnabled: false,
+    });
+
+    expect(text).toBe("abc 123");
+    expect(fakeParser.getScreenshot).not.toHaveBeenCalled();
+    expect(loadCreateWorkerFn).not.toHaveBeenCalled();
+  });
+
   it("usa OCR como fallback quando texto direto nao e suficiente", async () => {
     const fakeParser = {
       getText: vi.fn().mockResolvedValue({ text: "abc 123" }),
@@ -57,6 +87,7 @@ describe("pdf OCR fallback", () => {
     const text = await extractTextFromPdfWithOcr(Buffer.from("fake-pdf"), {
       PDFParseCtor,
       createWorkerFn,
+      ocrEnabled: true,
     });
 
     expect(text).toContain("PGTO INSS");

--- a/apps/api/src/domain/imports/pdf-ocr.test.js
+++ b/apps/api/src/domain/imports/pdf-ocr.test.js
@@ -16,6 +16,27 @@ describe("pdf OCR fallback", () => {
     expect(shouldRun).toBe(true);
   });
 
+  it("nao carrega o worker de OCR quando o texto direto ja resolve", async () => {
+    const fakeParser = {
+      getText: vi.fn().mockResolvedValue({
+        text: "05/02/2026 PGTO INSS 01776829899 2.812,99 06/02/2026 PIX QRS UBER DO BRA -15,98",
+      }),
+      getScreenshot: vi.fn(),
+      destroy: vi.fn().mockResolvedValue(undefined),
+    };
+    const PDFParseCtor = vi.fn(() => fakeParser);
+    const loadCreateWorkerFn = vi.fn();
+
+    const text = await extractTextFromPdfWithOcr(Buffer.from("fake-pdf"), {
+      PDFParseCtor,
+      loadCreateWorkerFn,
+    });
+
+    expect(text).toContain("PGTO INSS");
+    expect(fakeParser.getScreenshot).not.toHaveBeenCalled();
+    expect(loadCreateWorkerFn).not.toHaveBeenCalled();
+  });
+
   it("usa OCR como fallback quando texto direto nao e suficiente", async () => {
     const fakeParser = {
       getText: vi.fn().mockResolvedValue({ text: "abc 123" }),

--- a/apps/api/src/domain/imports/pdf-ocr.test.js
+++ b/apps/api/src/domain/imports/pdf-ocr.test.js
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { extractTextFromPdfWithOcr, shouldRunPdfOcrFallback } from "./pdf-ocr.js";
+
+describe("pdf OCR fallback", () => {
+  it("nao roda OCR quando texto nativo do PDF ja parece utilizavel", () => {
+    const shouldRun = shouldRunPdfOcrFallback(
+      "05/02/2026 PGTO INSS 01776829899 2.812,99 06/02/2026 PIX QRS UBER DO BRA -15,98 R$ 2.812,99",
+    );
+
+    expect(shouldRun).toBe(false);
+  });
+
+  it("roda OCR quando a extracao de texto vem pobre ou ilegivel", () => {
+    const shouldRun = shouldRunPdfOcrFallback("abc 123");
+
+    expect(shouldRun).toBe(true);
+  });
+
+  it("usa OCR como fallback quando texto direto nao e suficiente", async () => {
+    const fakeParser = {
+      getText: vi.fn().mockResolvedValue({ text: "abc 123" }),
+      getScreenshot: vi.fn().mockResolvedValue({
+        pages: [{ data: Buffer.from("fake-image") }],
+      }),
+      destroy: vi.fn().mockResolvedValue(undefined),
+    };
+    const fakeWorker = {
+      recognize: vi.fn().mockResolvedValue({
+        data: { text: "05/02/2026 PGTO INSS 01776829899 2.812,99" },
+      }),
+      terminate: vi.fn().mockResolvedValue(undefined),
+    };
+    const PDFParseCtor = vi.fn(() => fakeParser);
+    const createWorkerFn = vi.fn().mockResolvedValue(fakeWorker);
+
+    const text = await extractTextFromPdfWithOcr(Buffer.from("fake-pdf"), {
+      PDFParseCtor,
+      createWorkerFn,
+    });
+
+    expect(text).toContain("PGTO INSS");
+    expect(fakeParser.getScreenshot).toHaveBeenCalled();
+    expect(createWorkerFn).toHaveBeenCalled();
+    expect(fakeWorker.terminate).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/domain/imports/statement-import.js
+++ b/apps/api/src/domain/imports/statement-import.js
@@ -1,5 +1,9 @@
 import { parse as parseCsv } from "csv-parse/sync";
-import { extractTextFromPdfWithOcr } from "./pdf-ocr.js";
+import {
+  extractTextFromPdfWithOcr,
+  isImportOcrEnabled,
+  shouldRunPdfOcrFallback,
+} from "./pdf-ocr.js";
 
 const STATEMENT_ROW_MAX = 2000;
 const BALANCE_TERMS = [
@@ -39,6 +43,7 @@ const HEADER_ALIASES = {
   credit: ["credit", "credito", "entrada", "entradas", "valorentrada"],
   notes: ["notes", "nota", "notas", "observacao", "observacoes", "obs"],
 };
+const PDF_WITHOUT_TEXT_GUIDANCE_MESSAGE = "PDF sem texto reconhecivel. Tente OFX ou CSV.";
 
 const collapseWhitespace = (value) => String(value || "").replace(/\s+/g, " ").trim();
 
@@ -218,6 +223,18 @@ const finalizeStatementRows = (rows) => {
   }
 
   return rows;
+};
+
+export const getPdfImportGuidanceError = (text, ocrEnabled = isImportOcrEnabled()) => {
+  if (ocrEnabled) {
+    return "";
+  }
+
+  if (shouldRunPdfOcrFallback(text)) {
+    return PDF_WITHOUT_TEXT_GUIDANCE_MESSAGE;
+  }
+
+  return "";
 };
 
 export const parseStatementCsvRows = (buffer) => {
@@ -464,6 +481,12 @@ export const extractTextFromPdfBuffer = async (buffer) => extractTextFromPdfWith
 
 export const parseStatementPdfRows = async (buffer) => {
   const text = await extractTextFromPdfBuffer(buffer);
+  const pdfImportGuidanceError = getPdfImportGuidanceError(text);
+
+  if (pdfImportGuidanceError) {
+    throw new Error(pdfImportGuidanceError);
+  }
+
   const normalizedText = collapseWhitespace(text)
     .normalize("NFD")
     .replace(/[\u0300-\u036f]/g, "")

--- a/apps/api/src/domain/imports/statement-import.js
+++ b/apps/api/src/domain/imports/statement-import.js
@@ -1,0 +1,458 @@
+import { parse as parseCsv } from "csv-parse/sync";
+import { PDFParse } from "pdf-parse";
+
+const STATEMENT_ROW_MAX = 2000;
+const BALANCE_TERMS = [
+  "saldo do dia",
+  "saldo em conta",
+  "saldo total",
+  "saldo anterior",
+  "saldo final",
+  "saldo",
+];
+
+const HEADER_ALIASES = {
+  date: [
+    "date",
+    "data",
+    "datalancamento",
+    "datalanc",
+    "datamovimento",
+    "datamovimentacao",
+    "transactiondate",
+  ],
+  description: [
+    "description",
+    "descricao",
+    "descricaolancamento",
+    "historico",
+    "lancamento",
+    "detalhe",
+    "memo",
+    "estabelecimento",
+  ],
+  amount: ["value", "valor", "amount", "valorr", "valorr$", "quantia"],
+  type: ["type", "tipo", "natureza"],
+  debit: ["debit", "debito", "debtor", "saidas", "saida", "valorsaida"],
+  credit: ["credit", "credito", "entrada", "entradas", "valorentrada"],
+  notes: ["notes", "nota", "notas", "observacao", "observacoes", "obs"],
+};
+
+const collapseWhitespace = (value) => String(value || "").replace(/\s+/g, " ").trim();
+
+const normalizeHeaderAlias = (value) =>
+  collapseWhitespace(value)
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "");
+
+const normalizeAmountToken = (value) => collapseWhitespace(value).replace(/^R\$\s*/i, "");
+
+const formatValue = (value) => Number(value).toFixed(2);
+
+const detectCsvDelimiter = (content) => {
+  const firstLine = String(content || "").split(/\r?\n/, 1)[0] || "";
+
+  if (firstLine.includes(";")) {
+    return ";";
+  }
+
+  if (firstLine.includes("\t")) {
+    return "\t";
+  }
+
+  return ",";
+};
+
+const isBalanceDescription = (value) => {
+  const normalizedValue = collapseWhitespace(value)
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+
+  return BALANCE_TERMS.some((term) => normalizedValue.includes(term));
+};
+
+const parseSignedAmount = (value) => {
+  const normalizedValue = normalizeAmountToken(value).replace(/\s+/g, "");
+
+  if (!normalizedValue) {
+    return null;
+  }
+
+  let signal = 1;
+  let numericValue = normalizedValue;
+
+  if (/d$/i.test(numericValue)) {
+    signal = -1;
+    numericValue = numericValue.slice(0, -1);
+  } else if (/c$/i.test(numericValue)) {
+    signal = 1;
+    numericValue = numericValue.slice(0, -1);
+  }
+
+  if (numericValue.startsWith("-")) {
+    signal = -1;
+    numericValue = numericValue.slice(1);
+  } else if (numericValue.startsWith("+")) {
+    numericValue = numericValue.slice(1);
+  }
+
+  const hasComma = numericValue.includes(",");
+  const hasDot = numericValue.includes(".");
+  let normalizedNumericValue = numericValue;
+
+  if (hasComma && hasDot) {
+    const decimalSeparator =
+      numericValue.lastIndexOf(",") > numericValue.lastIndexOf(".") ? "," : ".";
+
+    normalizedNumericValue =
+      decimalSeparator === ","
+        ? numericValue.replace(/\./g, "").replace(",", ".")
+        : numericValue.replace(/,/g, "");
+  } else if (hasComma) {
+    normalizedNumericValue = numericValue.replace(/\./g, "").replace(",", ".");
+  }
+
+  const parsedValue = Number(normalizedNumericValue);
+
+  if (!Number.isFinite(parsedValue)) {
+    return null;
+  }
+
+  return Number((parsedValue * signal).toFixed(2));
+};
+
+const toIsoDateString = (value) => {
+  const normalizedValue = collapseWhitespace(value);
+
+  if (!normalizedValue) {
+    return "";
+  }
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(normalizedValue)) {
+    return normalizedValue;
+  }
+
+  const brDateMatch = normalizedValue.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+
+  if (!brDateMatch) {
+    return normalizedValue;
+  }
+
+  const [, dayPart, monthPart, yearPart] = brDateMatch;
+  return `${yearPart}-${monthPart}-${dayPart}`;
+};
+
+const toNormalizedType = (value) => {
+  const normalizedValue = collapseWhitespace(value)
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+
+  if (!normalizedValue) {
+    return "";
+  }
+
+  if (["entrada", "credito", "credit", "c"].includes(normalizedValue)) {
+    return "Entrada";
+  }
+
+  if (["saida", "debito", "debit", "d"].includes(normalizedValue)) {
+    return "Saida";
+  }
+
+  return String(value || "");
+};
+
+const findMappedHeader = (headers, aliases) => {
+  const aliasesSet = new Set(aliases);
+  return headers.find((header) => aliasesSet.has(normalizeHeaderAlias(header))) || null;
+};
+
+const buildRawRow = ({
+  date,
+  type,
+  value,
+  description,
+  notes = "",
+  category = "",
+}) => ({
+  date: String(date || ""),
+  type: String(type || ""),
+  value: String(value || ""),
+  description: String(description || ""),
+  notes: String(notes || ""),
+  category: String(category || ""),
+});
+
+const finalizeStatementRows = (rows) => {
+  if (rows.length > STATEMENT_ROW_MAX) {
+    throw new Error(`Arquivo excede o limite de ${STATEMENT_ROW_MAX} linhas.`);
+  }
+
+  if (rows.length === 0) {
+    throw new Error("Nenhuma transacao reconhecida no arquivo.");
+  }
+
+  return rows;
+};
+
+export const parseStatementCsvRows = (buffer) => {
+  const csvContent = Buffer.isBuffer(buffer) ? buffer.toString("utf8") : String(buffer || "");
+  let records;
+
+  try {
+    records = parseCsv(csvContent, {
+      bom: true,
+      columns: true,
+      delimiter: detectCsvDelimiter(csvContent),
+      skip_empty_lines: true,
+      relax_column_count: true,
+      trim: false,
+    });
+  } catch {
+    throw new Error("Nao foi possivel ler o CSV do extrato.");
+  }
+
+  if (!Array.isArray(records) || records.length === 0) {
+    throw new Error("CSV vazio.");
+  }
+
+  const headers = Object.keys(records[0] || {});
+  const mappedHeaders = {
+    date: findMappedHeader(headers, HEADER_ALIASES.date),
+    description: findMappedHeader(headers, HEADER_ALIASES.description),
+    amount: findMappedHeader(headers, HEADER_ALIASES.amount),
+    type: findMappedHeader(headers, HEADER_ALIASES.type),
+    debit: findMappedHeader(headers, HEADER_ALIASES.debit),
+    credit: findMappedHeader(headers, HEADER_ALIASES.credit),
+    notes: findMappedHeader(headers, HEADER_ALIASES.notes),
+  };
+
+  if (
+    !mappedHeaders.date ||
+    !mappedHeaders.description ||
+    (!mappedHeaders.amount && !mappedHeaders.debit && !mappedHeaders.credit)
+  ) {
+    throw new Error("Nao foi possivel reconhecer as colunas do extrato.");
+  }
+
+  const rows = records.reduce((accumulator, record, recordIndex) => {
+    const description = collapseWhitespace(record[mappedHeaders.description]);
+
+    if (!description || isBalanceDescription(description)) {
+      return accumulator;
+    }
+
+    const dateValue = toIsoDateString(record[mappedHeaders.date]);
+    const notes = mappedHeaders.notes ? collapseWhitespace(record[mappedHeaders.notes]) : "";
+    const explicitType = mappedHeaders.type
+      ? toNormalizedType(record[mappedHeaders.type])
+      : "";
+
+    let resolvedType = explicitType;
+    let resolvedValue = mappedHeaders.amount ? collapseWhitespace(record[mappedHeaders.amount]) : "";
+
+    if (mappedHeaders.amount) {
+      const parsedAmount = parseSignedAmount(record[mappedHeaders.amount]);
+
+      if (parsedAmount !== null) {
+        resolvedType = resolvedType || (parsedAmount < 0 ? "Saida" : "Entrada");
+        resolvedValue = formatValue(Math.abs(parsedAmount));
+      }
+    } else {
+      const parsedCredit = mappedHeaders.credit
+        ? parseSignedAmount(record[mappedHeaders.credit])
+        : null;
+      const parsedDebit = mappedHeaders.debit
+        ? parseSignedAmount(record[mappedHeaders.debit])
+        : null;
+
+      if (parsedCredit !== null && parsedCredit !== 0) {
+        resolvedType = "Entrada";
+        resolvedValue = formatValue(Math.abs(parsedCredit));
+      } else if (parsedDebit !== null && parsedDebit !== 0) {
+        resolvedType = "Saida";
+        resolvedValue = formatValue(Math.abs(parsedDebit));
+      } else {
+        resolvedValue = collapseWhitespace(
+          record[mappedHeaders.credit] || record[mappedHeaders.debit] || "",
+        );
+      }
+    }
+
+    accumulator.push({
+      line: recordIndex + 2,
+      raw: buildRawRow({
+        date: dateValue,
+        type: resolvedType,
+        value: resolvedValue,
+        description,
+        notes,
+      }),
+    });
+
+    return accumulator;
+  }, []);
+
+  return finalizeStatementRows(rows);
+};
+
+export const parseGenericBankStatementPdfText = (text) => {
+  const lines = String(text || "")
+    .replace(/\r/g, "")
+    .split("\n")
+    .map((line) => collapseWhitespace(line))
+    .filter(Boolean);
+
+  const rows = [];
+
+  lines.forEach((line, index) => {
+    const match = line.match(/^(\d{2}\/\d{2}\/\d{4})\s+(.+?)\s+(-?\d[\d.]*,\d{2})$/);
+
+    if (!match) {
+      return;
+    }
+
+    const [, datePart, descriptionPart, amountPart] = match;
+    const description = collapseWhitespace(descriptionPart);
+
+    if (!description || isBalanceDescription(description)) {
+      return;
+    }
+
+    const parsedAmount = parseSignedAmount(amountPart);
+    if (parsedAmount === null) {
+      return;
+    }
+
+    rows.push({
+      line: index + 1,
+      raw: buildRawRow({
+        date: toIsoDateString(datePart),
+        type: parsedAmount < 0 ? "Saida" : "Entrada",
+        value: formatValue(Math.abs(parsedAmount)),
+        description,
+      }),
+    });
+  });
+
+  return finalizeStatementRows(rows);
+};
+
+const parseRubricaTotal = (blockText, rubricaPattern) => {
+  const matches = blockText.matchAll(rubricaPattern);
+  let total = 0;
+
+  for (const match of matches) {
+    const parsedValue = parseSignedAmount(match[1]);
+    if (parsedValue !== null) {
+      total += Math.abs(parsedValue);
+    }
+  }
+
+  return Number(total.toFixed(2));
+};
+
+export const parseInssCreditHistoryPdfText = (text) => {
+  const lines = String(text || "")
+    .replace(/\r/g, "")
+    .split("\n")
+    .map((line) => collapseWhitespace(line))
+    .filter(Boolean);
+  const rows = [];
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const headerMatch = lines[lineIndex].match(/^(\d{2}\/\d{4})\s+R\$\s*([\d.,]+)/);
+
+    if (!headerMatch) {
+      continue;
+    }
+
+    const competence = headerMatch[1];
+    const liquidAmount = parseSignedAmount(headerMatch[2]);
+    const startLine = lineIndex + 1;
+    const blockLines = [lines[lineIndex]];
+    let nextIndex = lineIndex + 1;
+
+    while (nextIndex < lines.length && !/^\d{2}\/\d{4}\s+R\$\s*[\d.,]+/.test(lines[nextIndex])) {
+      blockLines.push(lines[nextIndex]);
+      nextIndex += 1;
+    }
+
+    lineIndex = nextIndex - 1;
+
+    if (liquidAmount === null) {
+      continue;
+    }
+
+    const blockText = blockLines.join(" ");
+    const paymentDates = blockText.match(/\d{2}\/\d{2}\/\d{4}/g) || [];
+    const paymentDate = paymentDates[paymentDates.length - 1] || "";
+    const grossMatch = blockText.match(/101 VALOR TOTAL DE MR DO PERIODO R\$\s*([\d.,]+)/i);
+    const grossAmount = grossMatch ? parseSignedAmount(grossMatch[1]) : null;
+    const loansTotal = parseRubricaTotal(
+      blockText,
+      /(?:216|217)\s+.*?R\$\s*([\d.,]+)/gi,
+    );
+    const cardTotal = parseRubricaTotal(blockText, /268\s+.*?R\$\s*([\d.,]+)/gi);
+    const notesParts = [];
+
+    if (grossAmount !== null) {
+      notesParts.push(`MR ${formatValue(Math.abs(grossAmount))}`);
+    }
+    if (loansTotal > 0) {
+      notesParts.push(`Emprestimos ${formatValue(loansTotal)}`);
+    }
+    if (cardTotal > 0) {
+      notesParts.push(`Cartao ${formatValue(cardTotal)}`);
+    }
+
+    rows.push({
+      line: startLine,
+      raw: buildRawRow({
+        date: paymentDate ? toIsoDateString(paymentDate) : competence,
+        type: "Entrada",
+        value: formatValue(Math.abs(liquidAmount)),
+        description: `Credito INSS ${competence}`,
+        notes: notesParts.join(" | "),
+      }),
+    });
+  }
+
+  return finalizeStatementRows(rows);
+};
+
+export const extractTextFromPdfBuffer = async (buffer) => {
+  const parser = new PDFParse({ data: buffer });
+
+  try {
+    const result = await parser.getText();
+    return String(result?.text || "");
+  } finally {
+    await parser.destroy();
+  }
+};
+
+export const parseStatementPdfRows = async (buffer) => {
+  const text = await extractTextFromPdfBuffer(buffer);
+  const normalizedText = collapseWhitespace(text)
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+
+  if (!normalizedText) {
+    throw new Error("Nao foi possivel extrair texto do PDF.");
+  }
+
+  if (
+    normalizedText.includes("historico de creditos") &&
+    normalizedText.includes("inss - instituto nacional do seguro social")
+  ) {
+    return parseInssCreditHistoryPdfText(text);
+  }
+
+  return parseGenericBankStatementPdfText(text);
+};

--- a/apps/api/src/domain/imports/statement-import.js
+++ b/apps/api/src/domain/imports/statement-import.js
@@ -1,5 +1,5 @@
 import { parse as parseCsv } from "csv-parse/sync";
-import { PDFParse } from "pdf-parse";
+import { extractTextFromPdfWithOcr } from "./pdf-ocr.js";
 
 const STATEMENT_ROW_MAX = 2000;
 const BALANCE_TERMS = [
@@ -10,6 +10,8 @@ const BALANCE_TERMS = [
   "saldo final",
   "saldo",
 ];
+const MONTH_NAME_REGEX =
+  /\b(jan|fev|mar|abr|mai|jun|jul|ago|set|out|nov|dez)[a-z]*\s+(\d{4})\b/i;
 
 const HEADER_ALIASES = {
   date: [
@@ -90,6 +92,9 @@ const parseSignedAmount = (value) => {
   } else if (/c$/i.test(numericValue)) {
     signal = 1;
     numericValue = numericValue.slice(0, -1);
+  } else if (numericValue.endsWith("-")) {
+    signal = -1;
+    numericValue = numericValue.slice(0, -1);
   }
 
   if (numericValue.startsWith("-")) {
@@ -124,7 +129,18 @@ const parseSignedAmount = (value) => {
   return Number((parsedValue * signal).toFixed(2));
 };
 
-const toIsoDateString = (value) => {
+const detectStatementYear = (text) => {
+  const monthHeaderMatch = String(text || "").match(MONTH_NAME_REGEX);
+
+  if (monthHeaderMatch) {
+    return monthHeaderMatch[2];
+  }
+
+  const fullDateMatch = String(text || "").match(/\b\d{2}\/\d{2}\/(\d{4})\b/);
+  return fullDateMatch ? fullDateMatch[1] : "";
+};
+
+const toIsoDateString = (value, fallbackYear = "") => {
   const normalizedValue = collapseWhitespace(value);
 
   if (!normalizedValue) {
@@ -136,13 +152,18 @@ const toIsoDateString = (value) => {
   }
 
   const brDateMatch = normalizedValue.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
-
-  if (!brDateMatch) {
-    return normalizedValue;
+  if (brDateMatch) {
+    const [, dayPart, monthPart, yearPart] = brDateMatch;
+    return `${yearPart}-${monthPart}-${dayPart}`;
   }
 
-  const [, dayPart, monthPart, yearPart] = brDateMatch;
-  return `${yearPart}-${monthPart}-${dayPart}`;
+  const shortDateMatch = normalizedValue.match(/^(\d{2})\/(\d{2})$/);
+  if (shortDateMatch && fallbackYear) {
+    const [, dayPart, monthPart] = shortDateMatch;
+    return `${fallbackYear}-${monthPart}-${dayPart}`;
+  }
+
+  return normalizedValue;
 };
 
 const toNormalizedType = (value) => {
@@ -308,15 +329,26 @@ export const parseGenericBankStatementPdfText = (text) => {
     .filter(Boolean);
 
   const rows = [];
+  const statementYear = detectStatementYear(text);
+  let currentDate = "";
 
   lines.forEach((line, index) => {
-    const match = line.match(/^(\d{2}\/\d{2}\/\d{4})\s+(.+?)\s+(-?\d[\d.]*,\d{2})$/);
+    const datedMatch = line.match(/^(\d{2}\/\d{2}(?:\/\d{4})?)\s+(.+?)\s+(-?\d[\d.]*,\d{2}-?)$/);
+    const continuedMatch = !datedMatch ? line.match(/^(.+?)\s+(-?\d[\d.]*,\d{2}-?)$/) : null;
+    let datePart = "";
+    let descriptionPart = "";
+    let amountPart = "";
 
-    if (!match) {
+    if (datedMatch) {
+      [, datePart, descriptionPart, amountPart] = datedMatch;
+      currentDate = datePart;
+    } else if (continuedMatch && currentDate) {
+      [, descriptionPart, amountPart] = continuedMatch;
+      datePart = currentDate;
+    } else {
       return;
     }
 
-    const [, datePart, descriptionPart, amountPart] = match;
     const description = collapseWhitespace(descriptionPart);
 
     if (!description || isBalanceDescription(description)) {
@@ -331,7 +363,7 @@ export const parseGenericBankStatementPdfText = (text) => {
     rows.push({
       line: index + 1,
       raw: buildRawRow({
-        date: toIsoDateString(datePart),
+        date: toIsoDateString(datePart, statementYear),
         type: parsedAmount < 0 ? "Saida" : "Entrada",
         value: formatValue(Math.abs(parsedAmount)),
         description,
@@ -389,7 +421,10 @@ export const parseInssCreditHistoryPdfText = (text) => {
     }
 
     const blockText = blockLines.join(" ");
-    const paymentDates = blockText.match(/\d{2}\/\d{2}\/\d{4}/g) || [];
+    const paymentDates = blockLines
+      .slice(0, 4)
+      .join(" ")
+      .match(/\d{2}\/\d{2}\/\d{4}/g) || [];
     const paymentDate = paymentDates[paymentDates.length - 1] || "";
     const grossMatch = blockText.match(/101 VALOR TOTAL DE MR DO PERIODO R\$\s*([\d.,]+)/i);
     const grossAmount = grossMatch ? parseSignedAmount(grossMatch[1]) : null;
@@ -425,16 +460,7 @@ export const parseInssCreditHistoryPdfText = (text) => {
   return finalizeStatementRows(rows);
 };
 
-export const extractTextFromPdfBuffer = async (buffer) => {
-  const parser = new PDFParse({ data: buffer });
-
-  try {
-    const result = await parser.getText();
-    return String(result?.text || "");
-  } finally {
-    await parser.destroy();
-  }
-};
+export const extractTextFromPdfBuffer = async (buffer) => extractTextFromPdfWithOcr(buffer);
 
 export const parseStatementPdfRows = async (buffer) => {
   const text = await extractTextFromPdfBuffer(buffer);

--- a/apps/api/src/domain/imports/statement-import.test.js
+++ b/apps/api/src/domain/imports/statement-import.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  getPdfImportGuidanceError,
   parseGenericBankStatementPdfText,
   parseInssCreditHistoryPdfText,
   parseStatementCsvRows,
@@ -40,6 +41,12 @@ describe("statement import parser", () => {
         },
       },
     ]);
+  });
+
+  it("orienta OFX ou CSV quando o PDF nao tem texto util e OCR esta desligado", () => {
+    expect(getPdfImportGuidanceError("abc 123", false)).toBe(
+      "PDF sem texto reconhecivel. Tente OFX ou CSV.",
+    );
   });
 
   it("extrai linhas de PDF de extrato bancario e ignora saldo do dia", () => {

--- a/apps/api/src/domain/imports/statement-import.test.js
+++ b/apps/api/src/domain/imports/statement-import.test.js
@@ -89,6 +89,66 @@ describe("statement import parser", () => {
     ]);
   });
 
+  it("entende extrato mensal com data curta e sinal negativo no fim", () => {
+    const text = [
+      "extrato mensal ag 3380 cc 59974-0 dez 2022",
+      "06/12 Sispag Salários 960.903,71-",
+      "Sispag Diversos TED 13.624,52-",
+      "Sispag 2250JUCEMG 664.659,76",
+      "Sispag 2250JUCEMG 314.143,10",
+      "Saldo em C/C 0,00",
+    ].join("\n");
+
+    const rows = parseGenericBankStatementPdfText(text);
+
+    expect(rows).toEqual([
+      {
+        line: 2,
+        raw: {
+          date: "2022-12-06",
+          type: "Saida",
+          value: "960903.71",
+          description: "Sispag Salários",
+          notes: "",
+          category: "",
+        },
+      },
+      {
+        line: 3,
+        raw: {
+          date: "2022-12-06",
+          type: "Saida",
+          value: "13624.52",
+          description: "Sispag Diversos TED",
+          notes: "",
+          category: "",
+        },
+      },
+      {
+        line: 4,
+        raw: {
+          date: "2022-12-06",
+          type: "Entrada",
+          value: "664659.76",
+          description: "Sispag 2250JUCEMG",
+          notes: "",
+          category: "",
+        },
+      },
+      {
+        line: 5,
+        raw: {
+          date: "2022-12-06",
+          type: "Entrada",
+          value: "314143.10",
+          description: "Sispag 2250JUCEMG",
+          notes: "",
+          category: "",
+        },
+      },
+    ]);
+  });
+
   it("extrai creditos do INSS com liquido e resumo de consignacoes nas notas", () => {
     const text = [
       "INSS - INSTITUTO NACIONAL DO SEGURO SOCIAL",

--- a/apps/api/src/domain/imports/statement-import.test.js
+++ b/apps/api/src/domain/imports/statement-import.test.js
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseGenericBankStatementPdfText,
+  parseInssCreditHistoryPdfText,
+  parseStatementCsvRows,
+} from "./statement-import.js";
+
+describe("statement import parser", () => {
+  it("normaliza CSV de extrato bancario com colunas flexiveis e ignora saldo", () => {
+    const csvContent = [
+      "Data;Historico;Valor",
+      "05/02/2026;PGTO INSS 01776829899;2812,99",
+      "05/02/2026;SALDO DO DIA;2411,37",
+      "06/02/2026;PIX QRS UBER DO BRA;-15,98",
+    ].join("\n");
+
+    const rows = parseStatementCsvRows(Buffer.from(csvContent, "utf8"));
+
+    expect(rows).toEqual([
+      {
+        line: 2,
+        raw: {
+          date: "2026-02-05",
+          type: "Entrada",
+          value: "2812.99",
+          description: "PGTO INSS 01776829899",
+          notes: "",
+          category: "",
+        },
+      },
+      {
+        line: 4,
+        raw: {
+          date: "2026-02-06",
+          type: "Saida",
+          value: "15.98",
+          description: "PIX QRS UBER DO BRA",
+          notes: "",
+          category: "",
+        },
+      },
+    ]);
+  });
+
+  it("extrai linhas de PDF de extrato bancario e ignora saldo do dia", () => {
+    const text = [
+      "05/02/2026 PGTO INSS 01776829899 2.812,99",
+      "05/02/2026 SALDO DO DIA 2.411,37",
+      "06/02/2026 PIX QRS UBER DO BRA -15,98",
+      "06/02/2026 PIX TRANSF ZAINE S11/02 95,00",
+    ].join("\n");
+
+    const rows = parseGenericBankStatementPdfText(text);
+
+    expect(rows).toEqual([
+      {
+        line: 1,
+        raw: {
+          date: "2026-02-05",
+          type: "Entrada",
+          value: "2812.99",
+          description: "PGTO INSS 01776829899",
+          notes: "",
+          category: "",
+        },
+      },
+      {
+        line: 3,
+        raw: {
+          date: "2026-02-06",
+          type: "Saida",
+          value: "15.98",
+          description: "PIX QRS UBER DO BRA",
+          notes: "",
+          category: "",
+        },
+      },
+      {
+        line: 4,
+        raw: {
+          date: "2026-02-06",
+          type: "Entrada",
+          value: "95.00",
+          description: "PIX TRANSF ZAINE S11/02",
+          notes: "",
+          category: "",
+        },
+      },
+    ]);
+  });
+
+  it("extrai creditos do INSS com liquido e resumo de consignacoes nas notas", () => {
+    const text = [
+      "INSS - INSTITUTO NACIONAL DO SEGURO SOCIAL",
+      "Historico de Creditos",
+      "01/2026 R$ 2.812,99 CCF - CONTA-CORRENTE Pago 05/02/2026 Nao Nao 01/01/2026 a 31/01/2026 05/02/2026",
+      "Banco: 341 - ITAU",
+      "101 VALOR TOTAL DE MR DO PERIODO R$ 4.958,67",
+      "216 CONSIGNACAO EMPRESTIMO BANCARIO R$ 156,00",
+      "216 CONSIGNACAO EMPRESTIMO BANCARIO R$ 90,30",
+      "217 EMPRESTIMO SOBRE A RMC R$ 238,00",
+      "268 CONSIGNACAO - CARTAO R$ 238,46",
+      "02/2026 R$ 2.803,52 CCF - CONTA-CORRENTE Nao Nao 01/02/2026 a 28/02/2026 05/03/2026",
+      "Banco: 341 - ITAU",
+      "101 VALOR TOTAL DE MR DO PERIODO R$ 4.958,67",
+      "216 CONSIGNACAO EMPRESTIMO BANCARIO R$ 542,60",
+      "268 CONSIGNACAO - CARTAO R$ 247,93",
+    ].join("\n");
+
+    const rows = parseInssCreditHistoryPdfText(text);
+
+    expect(rows).toEqual([
+      {
+        line: 3,
+        raw: {
+          date: "2026-02-05",
+          type: "Entrada",
+          value: "2812.99",
+          description: "Credito INSS 01/2026",
+          notes: "MR 4958.67 | Emprestimos 484.30 | Cartao 238.46",
+          category: "",
+        },
+      },
+      {
+        line: 10,
+        raw: {
+          date: "2026-03-05",
+          type: "Entrada",
+          value: "2803.52",
+          description: "Credito INSS 02/2026",
+          notes: "MR 4958.67 | Emprestimos 542.60 | Cartao 247.93",
+          category: "",
+        },
+      },
+    ]);
+  });
+});

--- a/apps/api/src/domain/imports/transaction-classifier.js
+++ b/apps/api/src/domain/imports/transaction-classifier.js
@@ -1,0 +1,146 @@
+import { normalizeCategoryNameKey } from "../../services/categories-normalization.js";
+
+const normalizeText = (value) =>
+  String(value || "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+
+const CATEGORY_GROUPS = [
+  {
+    aliases: ["transporte", "mobilidade", "combustivel", "locomocao"],
+    keywords: [
+      "uber",
+      "99",
+      "taxi",
+      "autopass",
+      "top sp",
+      "metro",
+      "buson",
+      "posto",
+      "ipiranga",
+      "shell",
+      "ale combustiveis",
+      "estacionamento",
+    ],
+    types: ["Saida"],
+  },
+  {
+    aliases: ["alimentacao", "mercado", "supermercado", "restaurante", "delivery"],
+    keywords: [
+      "ifood",
+      "mercado",
+      "supermercado",
+      "restaurante",
+      "padaria",
+      "carrefour",
+      "atacadao",
+      "nagumo",
+      "oxxo",
+      "pao de",
+      "lanche",
+    ],
+    types: ["Saida"],
+  },
+  {
+    aliases: ["saude", "farmacia", "medicamentos"],
+    keywords: ["raia", "drogaria", "droga", "farmacia", "medic"],
+    types: ["Saida"],
+  },
+  {
+    aliases: ["moradia", "casa", "contas", "servicos", "utilities"],
+    keywords: ["neoenergia", "sabesp", "enel", "tim", "claro", "vivo", "embratel", "energia"],
+    types: ["Saida"],
+  },
+  {
+    aliases: ["salario", "renda", "beneficios", "beneficio", "receitas", "recebimentos", "clientes"],
+    keywords: ["salario", "pgto inss", "credito inss", "deposito", "recebimento", "cliente"],
+    types: ["Entrada"],
+  },
+];
+
+const scoreCategoryAgainstGroup = (categoryKey, group, description, type) => {
+  if (Array.isArray(group.types) && !group.types.includes(type)) {
+    return 0;
+  }
+
+  const aliasMatched = group.aliases.some((alias) => categoryKey === normalizeCategoryNameKey(alias));
+  if (!aliasMatched) {
+    return 0;
+  }
+
+  const keywordMatches = group.keywords.filter((keyword) => description.includes(keyword)).length;
+  return keywordMatches > 0 ? 3 + keywordMatches : 0;
+};
+
+export const suggestCategoryNameForImportedRow = (rawRow, categories = []) => {
+  if (!rawRow || rawRow.category) {
+    return rawRow?.category || "";
+  }
+
+  const description = normalizeText(`${rawRow.description || ""} ${rawRow.notes || ""}`);
+  const type = String(rawRow.type || "").trim();
+
+  if (!description || !type) {
+    return "";
+  }
+
+  let bestCandidate = null;
+
+  categories.forEach((category) => {
+    const categoryName = String(category?.name || "").trim();
+    const categoryKey = normalizeCategoryNameKey(categoryName);
+
+    if (!categoryName || !categoryKey) {
+      return;
+    }
+
+    let score = 0;
+
+    if (categoryKey.length >= 4 && description.includes(categoryKey)) {
+      score += 2;
+    }
+
+    CATEGORY_GROUPS.forEach((group) => {
+      score += scoreCategoryAgainstGroup(categoryKey, group, description, type);
+    });
+
+    if (score <= 0) {
+      return;
+    }
+
+    if (!bestCandidate || score > bestCandidate.score) {
+      bestCandidate = { name: categoryName, score, tied: false };
+      return;
+    }
+
+    if (bestCandidate && score === bestCandidate.score && bestCandidate.name !== categoryName) {
+      bestCandidate.tied = true;
+    }
+  });
+
+  if (!bestCandidate || bestCandidate.tied) {
+    return "";
+  }
+
+  return bestCandidate.name;
+};
+
+export const applySmartClassification = (rows = [], categories = []) =>
+  rows.map((row) => {
+    const suggestedCategoryName = suggestCategoryNameForImportedRow(row.raw, categories);
+
+    if (!suggestedCategoryName) {
+      return row;
+    }
+
+    return {
+      ...row,
+      raw: {
+        ...row.raw,
+        category: suggestedCategoryName,
+      },
+    };
+  });

--- a/apps/api/src/domain/imports/transaction-classifier.js
+++ b/apps/api/src/domain/imports/transaction-classifier.js
@@ -8,6 +8,10 @@ const normalizeText = (value) =>
     .replace(/\s+/g, " ")
     .trim();
 
+const DIRECT_CATEGORY_SCORE = 2;
+const GROUP_MATCH_BONUS = 3;
+const GROUP_KEYWORD_SCORE = 1;
+
 const CATEGORY_GROUPS = [
   {
     aliases: ["transporte", "mobilidade", "combustivel", "locomocao"],
@@ -61,33 +65,36 @@ const CATEGORY_GROUPS = [
   },
 ];
 
-const scoreCategoryAgainstGroup = (categoryKey, group, description, type) => {
-  if (Array.isArray(group.types) && !group.types.includes(type)) {
-    return 0;
+const addCategoryToIndex = (index, keyword, categoryName) => {
+  const normalizedKeyword = normalizeText(keyword);
+
+  if (!normalizedKeyword || !categoryName) {
+    return;
   }
 
-  const aliasMatched = group.aliases.some((alias) => categoryKey === normalizeCategoryNameKey(alias));
-  if (!aliasMatched) {
-    return 0;
+  const existingBucket = index.get(normalizedKeyword);
+
+  if (!existingBucket) {
+    index.set(normalizedKeyword, [categoryName]);
+    return;
   }
 
-  const keywordMatches = group.keywords.filter((keyword) => description.includes(keyword)).length;
-  return keywordMatches > 0 ? 3 + keywordMatches : 0;
+  if (!existingBucket.includes(categoryName)) {
+    existingBucket.push(categoryName);
+  }
 };
 
-export const suggestCategoryNameForImportedRow = (rawRow, categories = []) => {
-  if (!rawRow || rawRow.category) {
-    return rawRow?.category || "";
-  }
+const findCategoryGroup = (categoryKey) =>
+  CATEGORY_GROUPS.find((group) =>
+    group.aliases.some((alias) => categoryKey === normalizeCategoryNameKey(alias))
+  ) || null;
 
-  const description = normalizeText(`${rawRow.description || ""} ${rawRow.notes || ""}`);
-  const type = String(rawRow.type || "").trim();
-
-  if (!description || !type) {
-    return "";
-  }
-
-  let bestCandidate = null;
+export const createClassificationIndex = (categories = []) => {
+  const directCategoryMap = new Map();
+  const keywordMapsByType = new Map([
+    ["Entrada", new Map()],
+    ["Saida", new Map()],
+  ]);
 
   categories.forEach((category) => {
     const categoryName = String(category?.name || "").trim();
@@ -97,26 +104,49 @@ export const suggestCategoryNameForImportedRow = (rawRow, categories = []) => {
       return;
     }
 
-    let score = 0;
-
-    if (categoryKey.length >= 4 && description.includes(categoryKey)) {
-      score += 2;
+    if (categoryKey.length >= 4) {
+      addCategoryToIndex(directCategoryMap, categoryKey, categoryName);
     }
 
-    CATEGORY_GROUPS.forEach((group) => {
-      score += scoreCategoryAgainstGroup(categoryKey, group, description, type);
+    const matchingGroup = findCategoryGroup(categoryKey);
+
+    if (!matchingGroup) {
+      return;
+    }
+
+    (matchingGroup.types || []).forEach((type) => {
+      const typeKeywordMap = keywordMapsByType.get(type);
+
+      if (!typeKeywordMap) {
+        return;
+      }
+
+      matchingGroup.keywords.forEach((keyword) => {
+        addCategoryToIndex(typeKeywordMap, keyword, categoryName);
+      });
     });
+  });
 
-    if (score <= 0) {
-      return;
-    }
+  return {
+    directCategoryMap,
+    keywordMapsByType,
+  };
+};
 
+const addScore = (scoreMap, categoryName, amount) => {
+  scoreMap.set(categoryName, (scoreMap.get(categoryName) || 0) + amount);
+};
+
+const findBestCandidate = (scoreMap) => {
+  let bestCandidate = null;
+
+  scoreMap.forEach((score, name) => {
     if (!bestCandidate || score > bestCandidate.score) {
-      bestCandidate = { name: categoryName, score, tied: false };
+      bestCandidate = { name, score, tied: false };
       return;
     }
 
-    if (bestCandidate && score === bestCandidate.score && bestCandidate.name !== categoryName) {
+    if (bestCandidate && score === bestCandidate.score && bestCandidate.name !== name) {
       bestCandidate.tied = true;
     }
   });
@@ -128,9 +158,64 @@ export const suggestCategoryNameForImportedRow = (rawRow, categories = []) => {
   return bestCandidate.name;
 };
 
-export const applySmartClassification = (rows = [], categories = []) =>
-  rows.map((row) => {
-    const suggestedCategoryName = suggestCategoryNameForImportedRow(row.raw, categories);
+export const suggestCategoryNameForImportedRow = (rawRow, categoriesOrIndex = []) => {
+  if (!rawRow || rawRow.category) {
+    return rawRow?.category || "";
+  }
+
+  const description = normalizeText(`${rawRow.description || ""} ${rawRow.notes || ""}`);
+  const type = String(rawRow.type || "").trim();
+
+  if (!description || !type) {
+    return "";
+  }
+
+  const classificationIndex = Array.isArray(categoriesOrIndex)
+    ? createClassificationIndex(categoriesOrIndex)
+    : categoriesOrIndex;
+  const scoreMap = new Map();
+
+  classificationIndex.directCategoryMap.forEach((categoryNames, keyword) => {
+    if (!description.includes(keyword)) {
+      return;
+    }
+
+    categoryNames.forEach((categoryName) => {
+      addScore(scoreMap, categoryName, DIRECT_CATEGORY_SCORE);
+    });
+  });
+
+  const keywordMap = classificationIndex.keywordMapsByType.get(type) || new Map();
+  const categoriesWithKeywordHits = new Set();
+
+  keywordMap.forEach((categoryNames, keyword) => {
+    if (!description.includes(keyword)) {
+      return;
+    }
+
+    categoryNames.forEach((categoryName) => {
+      addScore(scoreMap, categoryName, GROUP_KEYWORD_SCORE);
+      categoriesWithKeywordHits.add(categoryName);
+    });
+  });
+
+  categoriesWithKeywordHits.forEach((categoryName) => {
+    addScore(scoreMap, categoryName, GROUP_MATCH_BONUS);
+  });
+
+  return findBestCandidate(scoreMap);
+};
+
+export const applySmartClassification = (rows = [], categories = []) => {
+  const classificationIndex = Array.isArray(categories)
+    ? createClassificationIndex(categories)
+    : categories;
+
+  return rows.map((row) => {
+    const suggestedCategoryName = suggestCategoryNameForImportedRow(
+      row.raw,
+      classificationIndex,
+    );
 
     if (!suggestedCategoryName) {
       return row;
@@ -144,3 +229,4 @@ export const applySmartClassification = (rows = [], categories = []) =>
       },
     };
   });
+};

--- a/apps/api/src/domain/imports/transaction-classifier.test.js
+++ b/apps/api/src/domain/imports/transaction-classifier.test.js
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  applySmartClassification,
+  suggestCategoryNameForImportedRow,
+} from "./transaction-classifier.js";
+
+describe("transaction classifier", () => {
+  const categories = [
+    { id: 1, name: "Transporte" },
+    { id: 2, name: "Alimentacao" },
+    { id: 3, name: "Saude" },
+    { id: 4, name: "Beneficios" },
+  ];
+
+  it("sugere categoria existente para saida de mobilidade", () => {
+    const category = suggestCategoryNameForImportedRow(
+      {
+        type: "Saida",
+        description: "PIX QRS UBER DO BRA",
+        notes: "",
+        category: "",
+      },
+      categories,
+    );
+
+    expect(category).toBe("Transporte");
+  });
+
+  it("sugere categoria existente para entrada de beneficio", () => {
+    const category = suggestCategoryNameForImportedRow(
+      {
+        type: "Entrada",
+        description: "PGTO INSS 01776829899",
+        notes: "Credito mensal",
+        category: "",
+      },
+      categories,
+    );
+
+    expect(category).toBe("Beneficios");
+  });
+
+  it("preserva categoria informada manualmente", () => {
+    const category = suggestCategoryNameForImportedRow(
+      {
+        type: "Saida",
+        description: "MERCADO CENTRAL",
+        notes: "",
+        category: "Alimentacao",
+      },
+      categories,
+    );
+
+    expect(category).toBe("Alimentacao");
+  });
+
+  it("aplica sugestao no shape das linhas importadas", () => {
+    const rows = applySmartClassification(
+      [
+        {
+          line: 1,
+          raw: {
+            date: "2026-02-05",
+            type: "Saida",
+            value: "15.98",
+            description: "PIX QRS UBER DO BRA",
+            notes: "",
+            category: "",
+          },
+        },
+      ],
+      categories,
+    );
+
+    expect(rows[0].raw.category).toBe("Transporte");
+  });
+});

--- a/apps/api/src/domain/imports/transaction-classifier.test.js
+++ b/apps/api/src/domain/imports/transaction-classifier.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   applySmartClassification,
+  createClassificationIndex,
   suggestCategoryNameForImportedRow,
 } from "./transaction-classifier.js";
 
@@ -52,6 +53,23 @@ describe("transaction classifier", () => {
     );
 
     expect(category).toBe("Alimentacao");
+  });
+
+  it("pre-computa indice uma vez e reutiliza nas sugestoes", () => {
+    const classificationIndex = createClassificationIndex(categories);
+
+    const category = suggestCategoryNameForImportedRow(
+      {
+        type: "Entrada",
+        description: "PGTO INSS 01776829899",
+        notes: "Credito mensal",
+        category: "",
+      },
+      classificationIndex,
+    );
+
+    expect(category).toBe("Beneficios");
+    expect(classificationIndex.keywordMapsByType.get("Entrada")).toBeInstanceOf(Map);
   });
 
   it("aplica sugestao no shape das linhas importadas", () => {

--- a/apps/api/src/import.test.js
+++ b/apps/api/src/import.test.js
@@ -302,10 +302,10 @@ describe("transaction imports", () => {
       .post("/transactions/import/dry-run")
       .set("Authorization", `Bearer ${token}`);
 
-    expectErrorResponseWithRequestId(response, 400, "Arquivo CSV (file) e obrigatorio.");
+    expectErrorResponseWithRequestId(response, 400, "Arquivo do extrato (file) e obrigatorio.");
   });
 
-  it("POST /transactions/import/dry-run retorna 400 para arquivo sem formato CSV", async () => {
+  it("POST /transactions/import/dry-run retorna 400 para arquivo sem formato suportado", async () => {
     const token = await registerAndLogin("import-arquivo-invalido@controlfinance.dev");
     await makeProUser("import-arquivo-invalido@controlfinance.dev");
     const invalidFile = csvFile("conteudo sem cabecalho", "import.txt");
@@ -318,7 +318,7 @@ describe("transaction imports", () => {
         contentType: "text/plain",
       });
 
-    expectErrorResponseWithRequestId(response, 400, "Arquivo invalido. Envie um CSV.");
+    expectErrorResponseWithRequestId(response, 400, "Arquivo invalido. Envie um CSV ou PDF de extrato.");
   });
 
   it("POST /transactions/import/dry-run retorna 413 quando arquivo excede limite", async () => {
@@ -392,7 +392,7 @@ describe("transaction imports", () => {
     );
   });
 
-  it("POST /transactions/import/dry-run retorna 400 para cabecalho invalido", async () => {
+  it("POST /transactions/import/dry-run retorna 400 para arquivo nao reconhecido", async () => {
     const token = await registerAndLogin("import-cabecalho@controlfinance.dev");
     await makeProUser("import-cabecalho@controlfinance.dev");
     const invalidHeaderCsv = csvFile("tipo,valor,descricao\nSaida,100,Mercado");
@@ -408,8 +408,83 @@ describe("transaction imports", () => {
     expectErrorResponseWithRequestId(
       response,
       400,
-      "CSV invalido. Cabecalho esperado: date,type,value,description,notes,category",
+      "Arquivo nao reconhecido. Envie um CSV manual com cabecalho date,type,value,description,notes,category ou um CSV/PDF de extrato.",
     );
+  });
+
+  it("POST /transactions/import/dry-run aceita CSV de extrato bancario com colunas flexiveis", async () => {
+    const token = await registerAndLogin("import-bank-csv@controlfinance.dev");
+    await makeProUser("import-bank-csv@controlfinance.dev");
+    const statementCsv = csvFile(
+      [
+        "Data;Historico;Valor",
+        "05/02/2026;PGTO INSS 01776829899;2812,99",
+        "05/02/2026;SALDO DO DIA;2411,37",
+        "06/02/2026;PIX QRS UBER DO BRA;-15,98",
+      ].join("\n"),
+      "itau-extrato.csv",
+    );
+
+    const response = await request(app)
+      .post("/transactions/import/dry-run")
+      .set("Authorization", `Bearer ${token}`)
+      .attach("file", statementCsv.buffer, {
+        filename: statementCsv.fileName,
+        contentType: "text/csv",
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.summary).toEqual({
+      totalRows: 2,
+      validRows: 2,
+      invalidRows: 0,
+      income: 2812.99,
+      expense: 15.98,
+    });
+    expect(response.body.rows).toEqual([
+      {
+        line: 2,
+        status: "valid",
+        raw: {
+          date: "2026-02-05",
+          type: "Entrada",
+          value: "2812.99",
+          description: "PGTO INSS 01776829899",
+          notes: "",
+          category: "",
+        },
+        normalized: {
+          date: "2026-02-05",
+          type: "Entrada",
+          value: 2812.99,
+          description: "PGTO INSS 01776829899",
+          notes: "",
+          categoryId: null,
+        },
+        errors: [],
+      },
+      {
+        line: 4,
+        status: "valid",
+        raw: {
+          date: "2026-02-06",
+          type: "Saida",
+          value: "15.98",
+          description: "PIX QRS UBER DO BRA",
+          notes: "",
+          category: "",
+        },
+        normalized: {
+          date: "2026-02-06",
+          type: "Saida",
+          value: 15.98,
+          description: "PIX QRS UBER DO BRA",
+          notes: "",
+          categoryId: null,
+        },
+        errors: [],
+      },
+    ]);
   });
 
   it("POST /transactions/import/dry-run valida linhas e persiste sessao", async () => {

--- a/apps/api/src/import.test.js
+++ b/apps/api/src/import.test.js
@@ -318,7 +318,11 @@ describe("transaction imports", () => {
         contentType: "text/plain",
       });
 
-    expectErrorResponseWithRequestId(response, 400, "Arquivo invalido. Envie um CSV ou PDF de extrato.");
+    expectErrorResponseWithRequestId(
+      response,
+      400,
+      "Arquivo invalido. Envie um CSV, OFX ou PDF de extrato.",
+    );
   });
 
   it("POST /transactions/import/dry-run retorna 413 quando arquivo excede limite", async () => {
@@ -408,8 +412,55 @@ describe("transaction imports", () => {
     expectErrorResponseWithRequestId(
       response,
       400,
-      "Arquivo nao reconhecido. Envie um CSV manual com cabecalho date,type,value,description,notes,category ou um CSV/PDF de extrato.",
+      "Arquivo nao reconhecido. Envie um CSV manual com cabecalho date,type,value,description,notes,category ou um CSV, OFX ou PDF de extrato.",
     );
+  });
+
+  it("POST /transactions/import/dry-run aceita OFX como formato preferencial de extrato", async () => {
+    const token = await registerAndLogin("import-bank-ofx@controlfinance.dev");
+    await makeProUser("import-bank-ofx@controlfinance.dev");
+    const ofxFile = csvFile(
+      [
+        "OFXHEADER:100",
+        "DATA:OFXSGML",
+        "<OFX>",
+        "<BANKTRANLIST>",
+        "<STMTTRN>",
+        "<TRNTYPE>CREDIT",
+        "<DTPOSTED>20260205000000[-3:BRT]",
+        "<TRNAMT>2812.99",
+        "<FITID>ABC123",
+        "<MEMO>PGTO INSS 01776829899",
+        "</STMTTRN>",
+        "<STMTTRN>",
+        "<TRNTYPE>DEBIT",
+        "<DTPOSTED>20260206000000[-3:BRT]",
+        "<TRNAMT>-15.98",
+        "<FITID>XYZ456",
+        "<NAME>PIX QRS UBER DO BRA",
+        "</STMTTRN>",
+      ].join("\n"),
+      "itau-extrato.ofx",
+    );
+
+    const response = await request(app)
+      .post("/transactions/import/dry-run")
+      .set("Authorization", `Bearer ${token}`)
+      .attach("file", ofxFile.buffer, {
+        filename: ofxFile.fileName,
+        contentType: "application/ofx",
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.summary).toEqual({
+      totalRows: 2,
+      validRows: 2,
+      invalidRows: 0,
+      income: 2812.99,
+      expense: 15.98,
+    });
+    expect(response.body.rows[0].raw.description).toBe("PGTO INSS 01776829899");
+    expect(response.body.rows[1].raw.description).toBe("PIX QRS UBER DO BRA");
   });
 
   it("POST /transactions/import/dry-run aceita CSV de extrato bancario com colunas flexiveis", async () => {
@@ -485,6 +536,44 @@ describe("transaction imports", () => {
         errors: [],
       },
     ]);
+  });
+
+  it("POST /transactions/import/dry-run auto-classifica extrato usando categorias existentes", async () => {
+    const token = await registerAndLogin("import-bank-smart-category@controlfinance.dev");
+    await makeProUser("import-bank-smart-category@controlfinance.dev");
+
+    const benefitsCategory = await request(app)
+      .post("/categories")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Beneficios" });
+
+    const transportCategory = await request(app)
+      .post("/categories")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Transporte" });
+
+    const statementCsv = csvFile(
+      [
+        "Data;Historico;Valor",
+        "05/02/2026;PGTO INSS 01776829899;2812,99",
+        "06/02/2026;PIX QRS UBER DO BRA;-15,98",
+      ].join("\n"),
+      "itau-extrato.csv",
+    );
+
+    const response = await request(app)
+      .post("/transactions/import/dry-run")
+      .set("Authorization", `Bearer ${token}`)
+      .attach("file", statementCsv.buffer, {
+        filename: statementCsv.fileName,
+        contentType: "text/csv",
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.rows[0].raw.category).toBe("Beneficios");
+    expect(response.body.rows[0].normalized.categoryId).toBe(benefitsCategory.body.id);
+    expect(response.body.rows[1].raw.category).toBe("Transporte");
+    expect(response.body.rows[1].normalized.categoryId).toBe(transportCategory.body.id);
   });
 
   it("POST /transactions/import/dry-run valida linhas e persiste sessao", async () => {

--- a/apps/api/src/routes/transactions.routes.js
+++ b/apps/api/src/routes/transactions.routes.js
@@ -63,15 +63,26 @@ const ensureValidImportFile = (file) => {
   const mimeType = String(file.mimetype || "").toLowerCase();
   const hasCsvExtension = extension === ".csv";
   const hasPdfExtension = extension === ".pdf";
+  const hasOfxExtension = extension === ".ofx";
   const hasCsvMimeType = ["text/csv", "application/csv", "application/vnd.ms-excel"].includes(mimeType);
   const hasPdfMimeType = ["application/pdf"].includes(mimeType);
+  const hasOfxMimeType = ["application/ofx", "application/x-ofx", "application/octet-stream"].includes(
+    mimeType,
+  );
 
   if (
-    (!hasCsvExtension && !hasCsvMimeType && !hasPdfExtension && !hasPdfMimeType) ||
+    (
+      !hasCsvExtension &&
+      !hasCsvMimeType &&
+      !hasPdfExtension &&
+      !hasPdfMimeType &&
+      !hasOfxExtension &&
+      !hasOfxMimeType
+    ) ||
     !file.buffer ||
     file.buffer.length === 0
   ) {
-    throw createError(400, "Arquivo invalido. Envie um CSV ou PDF de extrato.");
+    throw createError(400, "Arquivo invalido. Envie um CSV, OFX ou PDF de extrato.");
   }
 };
 

--- a/apps/api/src/routes/transactions.routes.js
+++ b/apps/api/src/routes/transactions.routes.js
@@ -32,13 +32,15 @@ import {
 } from "../services/transactions-import.service.js";
 
 const router = Router();
-const CSV_MAX_FILE_SIZE_BYTES = Number(process.env.IMPORT_CSV_MAX_FILE_SIZE_BYTES || 2 * 1024 * 1024);
+const IMPORT_MAX_FILE_SIZE_BYTES = Number(
+  process.env.IMPORT_CSV_MAX_FILE_SIZE_BYTES || 2 * 1024 * 1024,
+);
 const upload = multer({
   storage: multer.memoryStorage(),
   limits: {
     fileSize:
-      Number.isInteger(CSV_MAX_FILE_SIZE_BYTES) && CSV_MAX_FILE_SIZE_BYTES > 0
-        ? CSV_MAX_FILE_SIZE_BYTES
+      Number.isInteger(IMPORT_MAX_FILE_SIZE_BYTES) && IMPORT_MAX_FILE_SIZE_BYTES > 0
+        ? IMPORT_MAX_FILE_SIZE_BYTES
         : 2 * 1024 * 1024,
   },
 });
@@ -51,21 +53,25 @@ const createError = (status, message) => {
   return error;
 };
 
-const ensureValidCsvFile = (file) => {
+const ensureValidImportFile = (file) => {
   if (!file) {
-    throw createError(400, "Arquivo CSV (file) e obrigatorio.");
+    throw createError(400, "Arquivo do extrato (file) e obrigatorio.");
   }
 
   const originalName = String(file.originalname || "");
   const extension = path.extname(originalName).toLowerCase();
   const mimeType = String(file.mimetype || "").toLowerCase();
   const hasCsvExtension = extension === ".csv";
-  const hasCsvMimeType = ["text/csv", "application/csv", "application/vnd.ms-excel"].includes(
-    mimeType,
-  );
+  const hasPdfExtension = extension === ".pdf";
+  const hasCsvMimeType = ["text/csv", "application/csv", "application/vnd.ms-excel"].includes(mimeType);
+  const hasPdfMimeType = ["application/pdf"].includes(mimeType);
 
-  if ((!hasCsvExtension && !hasCsvMimeType) || !file.buffer || file.buffer.length === 0) {
-    throw createError(400, "Arquivo invalido. Envie um CSV.");
+  if (
+    (!hasCsvExtension && !hasCsvMimeType && !hasPdfExtension && !hasPdfMimeType) ||
+    !file.buffer ||
+    file.buffer.length === 0
+  ) {
+    throw createError(400, "Arquivo invalido. Envie um CSV ou PDF de extrato.");
   }
 };
 
@@ -295,8 +301,8 @@ router.post("/import/dry-run", importRateLimiter, requireFeature("csv_import"), 
     }
 
     try {
-      ensureValidCsvFile(req.file);
-      const dryRunResult = await dryRunTransactionsImportForUser(req.user.id, req.file.buffer);
+      ensureValidImportFile(req.file);
+      const dryRunResult = await dryRunTransactionsImportForUser(req.user.id, req.file);
       const rowsTotal = Number(dryRunResult.summary?.totalRows) || 0;
       const validRows = Number(dryRunResult.summary?.validRows) || 0;
       const invalidRows = Number(dryRunResult.summary?.invalidRows) || 0;

--- a/apps/api/src/services/transactions-import.service.js
+++ b/apps/api/src/services/transactions-import.service.js
@@ -7,9 +7,13 @@ import {
   TRANSACTION_TYPE_EXIT,
 } from "../constants/transaction-types.js";
 import {
+  parseOfxRows,
+} from "../domain/imports/ofx-import.js";
+import {
   parseStatementCsvRows,
   parseStatementPdfRows,
 } from "../domain/imports/statement-import.js";
+import { applySmartClassification } from "../domain/imports/transaction-classifier.js";
 import { normalizeCategoryNameKey } from "./categories-normalization.js";
 
 const CATEGORY_ENTRY = TRANSACTION_TYPE_ENTRY;
@@ -26,7 +30,7 @@ const ALLOWED_HEADERS = new Set([...REQUIRED_HEADERS, ...OPTIONAL_HEADERS]);
 const HEADER_ERROR_MESSAGE =
   "CSV invalido. Cabecalho esperado: date,type,value,description,notes,category";
 const IMPORT_FORMAT_ERROR_MESSAGE =
-  "Arquivo nao reconhecido. Envie um CSV manual com cabecalho date,type,value,description,notes,category ou um CSV/PDF de extrato.";
+  "Arquivo nao reconhecido. Envie um CSV manual com cabecalho date,type,value,description,notes,category ou um CSV, OFX ou PDF de extrato.";
 
 const createError = (status, message) => {
   const error = new Error(message);
@@ -239,6 +243,14 @@ const parseImportFileRows = async (importFile) => {
     }
   }
 
+  if (extension === ".ofx") {
+    try {
+      return parseOfxRows(fileBuffer);
+    } catch (error) {
+      throw createError(400, error.message || "Nao foi possivel reconhecer transacoes no OFX.");
+    }
+  }
+
   try {
     return parseCsvFileRows(fileBuffer);
   } catch (error) {
@@ -361,7 +373,7 @@ const resolveCategoryId = (value, categoryMap) => {
 const loadCategoryMapForUser = async (userId) => {
   const result = await dbQuery(
     `
-      SELECT id, normalized_name
+      SELECT id, name, normalized_name
       FROM categories
       WHERE user_id = $1
         AND deleted_at IS NULL
@@ -373,6 +385,24 @@ const loadCategoryMapForUser = async (userId) => {
     categoryMap.set(normalizeCategoryNameKey(row.normalized_name), Number(row.id));
     return categoryMap;
   }, new Map());
+};
+
+const loadCategoriesForUser = async (userId) => {
+  const result = await dbQuery(
+    `
+      SELECT id, name, normalized_name
+      FROM categories
+      WHERE user_id = $1
+        AND deleted_at IS NULL
+    `,
+    [userId],
+  );
+
+  return result.rows.map((row) => ({
+    id: Number(row.id),
+    name: row.name,
+    normalizedName: row.normalized_name,
+  }));
 };
 
 const normalizeCsvRow = (rawRow, categoryMap) => {
@@ -541,8 +571,12 @@ const assertSessionReadyForCommit = (session, userId) => {
 
 export const dryRunTransactionsImportForUser = async (userId, importFile) => {
   const parsedRows = await parseImportFileRows(importFile);
-  const categoryMap = await loadCategoryMapForUser(userId);
-  const rows = parsedRows.map((row) => {
+  const [categoryMap, categories] = await Promise.all([
+    loadCategoryMapForUser(userId),
+    loadCategoriesForUser(userId),
+  ]);
+  const classifiedRows = applySmartClassification(parsedRows, categories);
+  const rows = classifiedRows.map((row) => {
     const normalizedRow = normalizeCsvRow(row.raw, categoryMap);
 
     return {

--- a/apps/api/src/services/transactions-import.service.js
+++ b/apps/api/src/services/transactions-import.service.js
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { randomUUID } from "node:crypto";
 import { parse as parseCsv } from "csv-parse/sync";
 import { dbQuery, withDbTransaction } from "../db/index.js";
@@ -5,6 +6,10 @@ import {
   TRANSACTION_TYPE_ENTRY,
   TRANSACTION_TYPE_EXIT,
 } from "../constants/transaction-types.js";
+import {
+  parseStatementCsvRows,
+  parseStatementPdfRows,
+} from "../domain/imports/statement-import.js";
 import { normalizeCategoryNameKey } from "./categories-normalization.js";
 
 const CATEGORY_ENTRY = TRANSACTION_TYPE_ENTRY;
@@ -20,6 +25,8 @@ const OPTIONAL_HEADERS = ["notes", "category"];
 const ALLOWED_HEADERS = new Set([...REQUIRED_HEADERS, ...OPTIONAL_HEADERS]);
 const HEADER_ERROR_MESSAGE =
   "CSV invalido. Cabecalho esperado: date,type,value,description,notes,category";
+const IMPORT_FORMAT_ERROR_MESSAGE =
+  "Arquivo nao reconhecido. Envie um CSV manual com cabecalho date,type,value,description,notes,category ou um CSV/PDF de extrato.";
 
 const createError = (status, message) => {
   const error = new Error(message);
@@ -214,6 +221,43 @@ const parseCsvFileRows = (fileBuffer) => {
       raw: buildRawRow(rowObject),
     };
   });
+};
+
+const parseImportFileRows = async (importFile) => {
+  const fileBuffer = importFile?.buffer;
+  const extension = path.extname(String(importFile?.originalname || "")).toLowerCase();
+
+  if (!Buffer.isBuffer(fileBuffer) || fileBuffer.length === 0) {
+    throw createError(400, "Arquivo do extrato (file) e obrigatorio.");
+  }
+
+  if (extension === ".pdf") {
+    try {
+      return await parseStatementPdfRows(fileBuffer);
+    } catch (error) {
+      throw createError(400, error.message || "Nao foi possivel reconhecer transacoes no PDF.");
+    }
+  }
+
+  try {
+    return parseCsvFileRows(fileBuffer);
+  } catch (error) {
+    if (error?.message !== HEADER_ERROR_MESSAGE) {
+      throw error;
+    }
+  }
+
+  try {
+    return parseStatementCsvRows(fileBuffer);
+  } catch (error) {
+    if (
+      error?.message === `Arquivo excede o limite de ${getImportCsvMaxRows()} linhas.`
+    ) {
+      throw createError(400, error.message);
+    }
+
+    throw createError(400, IMPORT_FORMAT_ERROR_MESSAGE);
+  }
 };
 
 const normalizeDate = (value) => {
@@ -495,8 +539,8 @@ const assertSessionReadyForCommit = (session, userId) => {
   }
 };
 
-export const dryRunTransactionsImportForUser = async (userId, csvFileBuffer) => {
-  const parsedRows = parseCsvFileRows(csvFileBuffer);
+export const dryRunTransactionsImportForUser = async (userId, importFile) => {
+  const parsedRows = await parseImportFileRows(importFile);
   const categoryMap = await loadCategoryMapForUser(userId);
   const rows = parsedRows.map((row) => {
     const normalizedRow = normalizeCsvRow(row.raw, categoryMap);

--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -55,7 +55,7 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
 
   const handleDryRun = async () => {
     if (!selectedFile) {
-      setErrorMessage("Selecione um arquivo CSV ou PDF.");
+      setErrorMessage("Selecione um arquivo CSV, OFX ou PDF.");
       setSuccessMessage("");
       return;
     }
@@ -148,7 +148,7 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
         </div>
 
         <p className="mb-4 text-sm text-cf-text-secondary">
-          Envie um CSV ou PDF de extrato para pré-visualizar as transações válidas antes de importar.
+          Envie um CSV, OFX ou PDF de extrato para pré-visualizar as transações válidas antes de importar.
         </p>
 
         <div className="rounded border border-cf-border bg-cf-surface p-3">
@@ -162,7 +162,7 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
             ref={fileInputRef}
             id="csv-file-input"
             type="file"
-            accept=".csv,.pdf,text/csv,application/pdf"
+            accept=".csv,.ofx,.pdf,text/csv,application/ofx,application/pdf"
             onChange={(event) => {
               const nextFile = event.target.files?.[0] || null;
               setSelectedFile(nextFile);
@@ -173,7 +173,10 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
             className="block w-full text-sm text-cf-text-primary file:mr-3 file:rounded file:border file:border-cf-border file:bg-cf-bg-subtle file:px-3 file:py-1 file:text-sm file:font-semibold file:text-cf-text-primary hover:file:bg-cf-border"
           />
           <p className="mt-2 text-xs text-cf-text-secondary">
-            Suporta CSV manual, CSV exportado por banco e PDF com texto selecionável.
+            OFX é o formato preferencial quando o banco oferecer. CSV manual, CSV exportado por banco e PDF com OCR assistido entram como alternativas.
+          </p>
+          <p className="mt-1 text-xs text-cf-text-secondary">
+            Quando possível, a plataforma sugere automaticamente categorias com base nas descrições e nas categorias já cadastradas.
           </p>
         </div>
 

--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -55,7 +55,7 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
 
   const handleDryRun = async () => {
     if (!selectedFile) {
-      setErrorMessage("Selecione um arquivo CSV.");
+      setErrorMessage("Selecione um arquivo CSV ou PDF.");
       setSuccessMessage("");
       return;
     }
@@ -69,7 +69,7 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
       setDryRunResult(result);
     } catch (error) {
       setDryRunResult(null);
-      setErrorMessage(getApiErrorMessage(error, "Não foi possível processar o arquivo CSV."));
+      setErrorMessage(getApiErrorMessage(error, "Não foi possível processar o arquivo do extrato."));
     } finally {
       setIsDryRunning(false);
     }
@@ -135,31 +135,34 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
       >
         <div className="mb-4 flex items-center justify-between">
           <h2 id="import-csv-modal-title" className="text-lg font-semibold text-cf-text-primary">
-            Importar CSV
+            Importar extrato
           </h2>
           <button
             type="button"
             onClick={onClose}
             className="text-ui-200 transition-colors hover:text-ui-100"
-            aria-label="Fechar modal de importação CSV"
+            aria-label="Fechar modal de importação de extrato"
           >
             X
           </button>
         </div>
 
         <p className="mb-4 text-sm text-cf-text-secondary">
-          Envie um CSV para pré-visualizar as linhas válidas e confirmar a importação.
+          Envie um CSV ou PDF de extrato para pré-visualizar as transações válidas antes de importar.
         </p>
 
         <div className="rounded border border-cf-border bg-cf-surface p-3">
-          <label htmlFor="csv-file-input" className="mb-1 block text-sm font-medium text-cf-text-primary">
-            Arquivo CSV
+          <label
+            htmlFor="csv-file-input"
+            className="mb-1 block text-sm font-medium text-cf-text-primary"
+          >
+            Arquivo do extrato
           </label>
           <input
             ref={fileInputRef}
             id="csv-file-input"
             type="file"
-            accept=".csv,text/csv"
+            accept=".csv,.pdf,text/csv,application/pdf"
             onChange={(event) => {
               const nextFile = event.target.files?.[0] || null;
               setSelectedFile(nextFile);
@@ -169,6 +172,9 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
             }}
             className="block w-full text-sm text-cf-text-primary file:mr-3 file:rounded file:border file:border-cf-border file:bg-cf-bg-subtle file:px-3 file:py-1 file:text-sm file:font-semibold file:text-cf-text-primary hover:file:bg-cf-border"
           />
+          <p className="mt-2 text-xs text-cf-text-secondary">
+            Suporta CSV manual, CSV exportado por banco e PDF com texto selecionável.
+          </p>
         </div>
 
         <div className="mt-3 flex flex-wrap items-center gap-2">

--- a/apps/web/src/components/ImportCsvModal.test.jsx
+++ b/apps/web/src/components/ImportCsvModal.test.jsx
@@ -62,7 +62,7 @@ describe("ImportCsvModal", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "Pré-visualizar" }));
 
-    expect(screen.getByText("Selecione um arquivo CSV.")).toBeInTheDocument();
+    expect(screen.getByText("Selecione um arquivo CSV ou PDF.")).toBeInTheDocument();
     expect(transactionsService.dryRunImportCsv).not.toHaveBeenCalled();
   });
 
@@ -72,7 +72,7 @@ describe("ImportCsvModal", () => {
 
     render(<ImportCsvModal isOpen onClose={vi.fn()} />);
 
-    await userEvent.upload(screen.getByLabelText("Arquivo CSV"), file);
+    await userEvent.upload(screen.getByLabelText("Arquivo do extrato"), file);
     await userEvent.click(screen.getByRole("button", { name: "Pré-visualizar" }));
 
     await waitFor(() => {
@@ -98,7 +98,7 @@ describe("ImportCsvModal", () => {
 
     render(<ImportCsvModal isOpen onClose={vi.fn()} onImported={onImported} />);
 
-    await userEvent.upload(screen.getByLabelText("Arquivo CSV"), file);
+    await userEvent.upload(screen.getByLabelText("Arquivo do extrato"), file);
     await userEvent.click(screen.getByRole("button", { name: "Pré-visualizar" }));
 
     await waitFor(() => {
@@ -123,7 +123,7 @@ describe("ImportCsvModal", () => {
 
     render(<ImportCsvModal isOpen onClose={vi.fn()} />);
 
-    await userEvent.upload(screen.getByLabelText("Arquivo CSV"), file);
+    await userEvent.upload(screen.getByLabelText("Arquivo do extrato"), file);
     await userEvent.click(screen.getByRole("button", { name: "Pré-visualizar" }));
 
     await waitFor(() => {

--- a/apps/web/src/components/ImportCsvModal.test.jsx
+++ b/apps/web/src/components/ImportCsvModal.test.jsx
@@ -62,7 +62,7 @@ describe("ImportCsvModal", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "Pré-visualizar" }));
 
-    expect(screen.getByText("Selecione um arquivo CSV ou PDF.")).toBeInTheDocument();
+    expect(screen.getByText("Selecione um arquivo CSV, OFX ou PDF.")).toBeInTheDocument();
     expect(transactionsService.dryRunImportCsv).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -2023,7 +2023,7 @@ describe("App", () => {
     }
   });
 
-  it("abre importacao CSV, processa dry-run e exibe preview", async () => {
+  it("abre importacao de extrato, processa dry-run e exibe preview", async () => {
     const user = userEvent.setup();
     const csvFile = new File(
       ["date,type,value,description\n2026-03-01,Entrada,100,Salario"],
@@ -2035,8 +2035,8 @@ describe("App", () => {
 
     render(<App />);
 
-    await user.click(screen.getByRole("button", { name: "Importar CSV" }));
-    await user.upload(screen.getByLabelText("Arquivo CSV"), csvFile);
+    await user.click(screen.getByRole("button", { name: "Importar extrato" }));
+    await user.upload(screen.getByLabelText("Arquivo do extrato"), csvFile);
     await user.click(screen.getByRole("button", { name: "Pré-visualizar" }));
 
     expect(transactionsService.dryRunImportCsv).toHaveBeenCalledTimes(1);
@@ -2069,14 +2069,14 @@ describe("App", () => {
 
     render(<App />);
 
-    await user.click(screen.getByRole("button", { name: "Importar CSV" }));
-    await user.upload(screen.getByLabelText("Arquivo CSV"), csvFile);
+    await user.click(screen.getByRole("button", { name: "Importar extrato" }));
+    await user.upload(screen.getByLabelText("Arquivo do extrato"), csvFile);
     await user.click(screen.getByRole("button", { name: "Pré-visualizar" }));
     expect(await screen.findByText("Cafe")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Importar" })).toBeDisabled();
   });
 
-  it("confirma importacao CSV e recarrega listagem e resumo", async () => {
+  it("confirma importacao de extrato e recarrega listagem e resumo", async () => {
     const user = userEvent.setup();
     const csvFile = new File(
       ["date,type,value,description\n2026-03-01,Entrada,100,Salario"],
@@ -2089,8 +2089,8 @@ describe("App", () => {
 
     render(<App />);
 
-    await user.click(screen.getByRole("button", { name: "Importar CSV" }));
-    await user.upload(screen.getByLabelText("Arquivo CSV"), csvFile);
+    await user.click(screen.getByRole("button", { name: "Importar extrato" }));
+    await user.upload(screen.getByLabelText("Arquivo do extrato"), csvFile);
     await user.click(screen.getByRole("button", { name: "Pré-visualizar" }));
     await screen.findByText("Salario");
     await user.click(screen.getByRole("button", { name: "Importar" }));
@@ -2104,7 +2104,7 @@ describe("App", () => {
       expect(transactionsService.getMonthlySummaryCompare).toHaveBeenCalledTimes(2);
     });
 
-    expect(screen.queryByLabelText("Arquivo CSV")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Arquivo do extrato")).not.toBeInTheDocument();
   });
 
   it("exibe mensagem de erro quando dry-run falha", async () => {
@@ -2117,16 +2117,16 @@ describe("App", () => {
       },
     );
     transactionsService.dryRunImportCsv.mockRejectedValueOnce({
-      response: { data: { message: "Arquivo invalido. Envie um CSV." } },
+      response: { data: { message: "Arquivo invalido. Envie um CSV ou PDF de extrato." } },
     });
 
     render(<App />);
 
-    await user.click(screen.getByRole("button", { name: "Importar CSV" }));
-    await user.upload(screen.getByLabelText("Arquivo CSV"), csvFile);
+    await user.click(screen.getByRole("button", { name: "Importar extrato" }));
+    await user.upload(screen.getByLabelText("Arquivo do extrato"), csvFile);
     await user.click(screen.getByRole("button", { name: "Pré-visualizar" }));
 
-    expect(await screen.findByText("Arquivo invalido. Envie um CSV.")).toBeInTheDocument();
+    expect(await screen.findByText("Arquivo invalido. Envie um CSV ou PDF de extrato.")).toBeInTheDocument();
   });
 
   it("exibe orientacao para sessao expirada durante commit", async () => {
@@ -2145,8 +2145,8 @@ describe("App", () => {
 
     render(<App />);
 
-    await user.click(screen.getByRole("button", { name: "Importar CSV" }));
-    await user.upload(screen.getByLabelText("Arquivo CSV"), csvFile);
+    await user.click(screen.getByRole("button", { name: "Importar extrato" }));
+    await user.upload(screen.getByLabelText("Arquivo do extrato"), csvFile);
     await user.click(screen.getByRole("button", { name: "Pré-visualizar" }));
     await screen.findByText("Salario");
     await user.click(screen.getByRole("button", { name: "Importar" }));

--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -2117,7 +2117,7 @@ describe("App", () => {
       },
     );
     transactionsService.dryRunImportCsv.mockRejectedValueOnce({
-      response: { data: { message: "Arquivo invalido. Envie um CSV ou PDF de extrato." } },
+      response: { data: { message: "Arquivo invalido. Envie um CSV, OFX ou PDF de extrato." } },
     });
 
     render(<App />);
@@ -2126,7 +2126,7 @@ describe("App", () => {
     await user.upload(screen.getByLabelText("Arquivo do extrato"), csvFile);
     await user.click(screen.getByRole("button", { name: "Pré-visualizar" }));
 
-    expect(await screen.findByText("Arquivo invalido. Envie um CSV ou PDF de extrato.")).toBeInTheDocument();
+    expect(await screen.findByText("Arquivo invalido. Envie um CSV, OFX ou PDF de extrato.")).toBeInTheDocument();
   });
 
   it("exibe orientacao para sessao expirada durante commit", async () => {

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -1650,7 +1650,7 @@ const App = ({
                       onClick={handleOpenImportModal}
                       className="rounded px-2 py-2 text-left text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                     >
-                      Importar CSV
+                      Importar extrato
                     </button>
                     <button
                       type="button"
@@ -1740,7 +1740,7 @@ const App = ({
                   onClick={handleOpenImportModal}
                   className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                 >
-                  Importar CSV
+                  Importar extrato
                 </button>
                 <button
                   type="button"

--- a/docs/deployment/monorepo-render-vercel.md
+++ b/docs/deployment/monorepo-render-vercel.md
@@ -42,6 +42,7 @@ Se o service estiver com Root Directory no root do monorepo:
 - `JWT_EXPIRES_IN` (ex.: `24h`)
 - `CORS_ORIGIN` (ex.: `http://localhost:5173,https://<seu-vercel>.vercel.app`)
 - `TRUST_PROXY=1`
+- `IMPORT_OCR_ENABLED=false` por padrao; habilite apenas se o host da API tiver pelo menos 1GB de RAM disponivel
 - `APP_VERSION` (opcional para override; por padrao, `/health.version` usa `apps/api/package.json`)
 - `APP_COMMIT` (opcional; `RENDER_GIT_COMMIT` continua prioridade no `/health.commit`)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.2",
         "nodemailer": "^8.0.1",
+        "pdf-parse": "^2.4.5",
         "pg": "^8.16.3",
         "prom-client": "^15.1.3",
         "stripe": "^20.3.1"
@@ -1191,6 +1192,190 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.80.tgz",
+      "integrity": "sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==",
+      "license": "MIT",
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-x64": "0.1.80",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.80",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.80",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.80"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.80.tgz",
+      "integrity": "sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.80.tgz",
+      "integrity": "sha512-O64APRTXRUiAz0P8gErkfEr3lipLJgM6pjATwavZ22ebhjYl/SUbpgM0xcWPQBNMP1n29afAC/Us5PX1vg+JNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.80.tgz",
+      "integrity": "sha512-FqqSU7qFce0Cp3pwnTjVkKjjOtxMqRe6lmINxpIZYaZNnVI0H5FtsaraZJ36SiTHNjZlUB69/HhxNDT1Aaa9vA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.80.tgz",
+      "integrity": "sha512-eyWz0ddBDQc7/JbAtY4OtZ5SpK8tR4JsCYEZjCE3dI8pqoWUC8oMwYSBGCYfsx2w47cQgQCgMVRVTFiiO38hHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.80.tgz",
+      "integrity": "sha512-qwA63t8A86bnxhuA/GwOkK3jvb+XTQaTiVML0vAWoHyoZYTjNs7BzoOONDgTnNtr8/yHrq64XXzUoLqDzU+Uuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.80.tgz",
+      "integrity": "sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.80.tgz",
+      "integrity": "sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.80.tgz",
+      "integrity": "sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.80.tgz",
+      "integrity": "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.80.tgz",
+      "integrity": "sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@noble/hashes": {
@@ -6890,6 +7075,38 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"
+      }
+    },
+    "node_modules/pdf-parse": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-2.4.5.tgz",
+      "integrity": "sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@napi-rs/canvas": "0.1.80",
+        "pdfjs-dist": "5.4.296"
+      },
+      "bin": {
+        "pdf-parse": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.16.0 <21 || >=22.3.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/mehmet-kozan"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.4.296",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
+      "integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.80"
       }
     },
     "node_modules/pg": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,8 @@
         "pdf-parse": "^2.4.5",
         "pg": "^8.16.3",
         "prom-client": "^15.1.3",
-        "stripe": "^20.3.1"
+        "stripe": "^20.3.1",
+        "tesseract.js": "^7.0.0"
       },
       "devDependencies": {
         "eslint": "^8.57.1",
@@ -2946,6 +2947,12 @@
       "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
       "license": "MIT"
     },
+    "node_modules/bmp-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
@@ -5489,6 +5496,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/ignore": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
@@ -5969,6 +5982,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
     },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
@@ -6894,6 +6913,15 @@
       "dev": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "license": "MIT",
+      "bin": {
+        "opencollective-postinstall": "index.js"
       }
     },
     "node_modules/optionator": {
@@ -7930,6 +7958,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -8991,6 +9025,72 @@
         "bintrees": "1.0.2"
       }
     },
+    "node_modules/tesseract.js": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-7.0.0.tgz",
+      "integrity": "sha512-exPBkd+z+wM1BuMkx/Bjv43OeLBxhL5kKWsz/9JY+DXcXdiBjiAch0V49QR3oAJqCaL5qURE0vx9Eo+G5YE7mA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bmp-js": "^0.1.0",
+        "idb-keyval": "^6.2.0",
+        "is-url": "^1.2.4",
+        "node-fetch": "^2.6.9",
+        "opencollective-postinstall": "^2.0.3",
+        "regenerator-runtime": "^0.13.3",
+        "tesseract.js-core": "^7.0.0",
+        "wasm-feature-detect": "^1.8.0",
+        "zlibjs": "^0.3.1"
+      }
+    },
+    "node_modules/tesseract.js-core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-7.0.0.tgz",
+      "integrity": "sha512-WnNH518NzmbSq9zgTPeoF8c+xmilS8rFIl1YKbk/ptuuc7p6cLNELNuPAzcmsYw450ca6bLa8j3t0VAtq435Vw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/tesseract.js/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tesseract.js/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tesseract.js/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/tesseract.js/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -9699,6 +9799,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+      "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -10120,6 +10226,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zlibjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     }
   }


### PR DESCRIPTION
## Summary

Adds a bank statement import pipeline for multiple input formats with preview-before-commit.

Supported flows now shipping:
- OFX
- bank-exported CSV
- manual CSV
- text-based PDF

OCR support remains implemented in code, but is disabled by default behind `IMPORT_OCR_ENABLED=false` so the feature can ship safely on the current host tier.

This PR also adds smart category suggestions based on the user's existing categories.

## What Changed

### API
- OFX parser for `<STMTTRN>` blocks
- bank statement CSV normalization
- PDF statement parsing for text-based PDFs
- OCR fallback path kept in place behind an explicit feature flag
- dry-run import pipeline extended to accept CSV, OFX, and PDF
- smart auto-classification before normalization
- OCR worker loading moved to the real fallback path only
- classification now reuses a precomputed keyword index before mapping rows

### Web
- import modal updated from CSV-only to statement import
- accepted formats expanded to CSV, OFX, and PDF
- helper copy updated to position OFX as the preferred format when available

## Validation

Validated with:
- API lint
- Web lint
- parser and import integration suites
- import modal and App suites

## Deployment Note

- `IMPORT_OCR_ENABLED` defaults to `false`
- this means OFX, CSV, and text-based PDF import are safe to merge on the current Render Free host
- enable OCR only on API hosts with at least 1GB RAM available

## Notes

The repository documents the production API target as Render in [docs/runbooks/release-production-checklist.md](/f:/devprojects/Control-Finance-React-TailWind-bank-import/docs/runbooks/release-production-checklist.md#L8). OCR stays ready in code for a future host upgrade without changing the import contract again.
