### PR TITLE
fix(observability): log silent failures in cleanup job and unknown Stripe events

### DIFF
--- a/apps/api/src/jobs/import-sessions-cleanup.job.js
+++ b/apps/api/src/jobs/import-sessions-cleanup.job.js
@@ -1,4 +1,5 @@
 import { dbQuery } from "../db/index.js";
+import { logError } from "../observability/logger.js";
 
 const DEFAULT_IMPORT_SESSION_CLEANUP_INTERVAL_MINUTES = 30;
 const DEFAULT_IMPORT_SESSION_KEEP_COMMITTED_DAYS = 7;
@@ -52,8 +53,12 @@ export const startImportSessionsCleanupJob = () => {
   const runCleanup = async () => {
     try {
       await cleanupImportSessions();
-    } catch {
-      // no-op: cleanup failures should not crash API runtime
+    } catch (err) {
+      logError({
+        event: "import_sessions.cleanup.failed",
+        message: "Import sessions cleanup job encountered an error.",
+        errorMessage: err?.message ?? "Unexpected error.",
+      });
     }
   };
 

--- a/apps/api/src/services/stripe-webhook.service.js
+++ b/apps/api/src/services/stripe-webhook.service.js
@@ -1,4 +1,5 @@
 import { dbQuery } from "../db/index.js";
+import { logWarn } from "../observability/logger.js";
 
 const PREPAID_PRO_ENTITLEMENT_KEYS = new Set(["pro_12_months", "pro_6_months"]);
 const LEGACY_PREPAID_ENTITLEMENT_KEY = "pro_6_months";
@@ -415,7 +416,12 @@ export const processStripeEvent = async (event) => {
     case "invoice.payment_failed":
       return handleInvoicePaymentFailed(event.data?.object);
     default:
-      // Unknown event type — silently ignored
+      logWarn({
+        event: "stripe.webhook.unhandled_event",
+        message: "Received a Stripe event with no registered handler.",
+        stripeEventType: event?.type ?? "unknown",
+        stripeEventId: event?.id ?? "unknown",
+      });
       break;
   }
 };


### PR DESCRIPTION
## Summary
- `import-sessions-cleanup.job.js`: empty `catch {}` → structured `logError` with event key and error message
- `stripe-webhook.service.js`: unknown Stripe event types now emit `logWarn` instead of silently dropping

## Test plan
- [ ] 498 API tests passing
- [ ] Verify structured log output in staging