### PR TITLE
chore: remove 5 dead exports

### DIFF
--- a/apps/api/src/db/index.js
+++ b/apps/api/src/db/index.js
@@ -183,15 +183,6 @@ export const withDbClient = async (callback) => {
   }
 };
 
-export const closePool = async () => {
-  if (!poolInstance) {
-    return;
-  }
-
-  await poolInstance.end();
-  poolInstance = undefined;
-};
-
 export const getDatabaseConnectionDiagnostics = () => {
   const connectionString = process.env.DATABASE_URL;
   const parsedDiagnostics = parseConnectionStringDiagnostics(connectionString);

--- a/apps/web/src/components/DatabaseUtils.jsx
+++ b/apps/web/src/components/DatabaseUtils.jsx
@@ -147,23 +147,6 @@ export const calculateBalance = (transactions) => {
   }, 0);
 };
 
-export const getTotalsByType = (transactions) => {
-  return transactions.reduce(
-    (totals, transaction) => {
-      if (transaction.type === CATEGORY_ENTRY) {
-        totals.entry += transaction.value;
-      }
-
-      if (transaction.type === CATEGORY_EXIT) {
-        totals.exit += transaction.value;
-      }
-
-      return totals;
-    },
-    { entry: 0, exit: 0 },
-  );
-};
-
 export const parseCurrencyInput = (rawValue) => {
   if (typeof rawValue !== "string") {
     return Number.NaN;

--- a/apps/web/src/features/filters/useFilters.ts
+++ b/apps/web/src/features/filters/useFilters.ts
@@ -88,10 +88,10 @@ export const isSelectedPeriod = (value: string | null): value is SelectedPeriod 
   value === "Últimos 30 dias" ||
   value === "Personalizado";
 
-export const isCompactFiltersPanelMode = (): boolean =>
+const isCompactFiltersPanelMode = (): boolean =>
   typeof window !== "undefined" && window.innerWidth < MOBILE_FILTERS_BREAKPOINT;
 
-export const hasInitialActiveFilters = (filters: FilterState): boolean =>
+const hasInitialActiveFilters = (filters: FilterState): boolean =>
   filters.selectedCategory !== CATEGORY_ALL ||
   filters.selectedPeriod !== PERIOD_ALL ||
   Boolean(filters.selectedTransactionCategoryId) ||

--- a/apps/web/src/services/billing.service.ts
+++ b/apps/web/src/services/billing.service.ts
@@ -24,11 +24,6 @@ export const billingService = {
     return data;
   },
 
-  createPrepaidCheckout: async (): Promise<{ url: string }> => {
-    const { data } = await api.post<{ url: string }>("/billing/checkout-prepaid");
-    return data;
-  },
-
   createPortal: async (): Promise<{ url: string }> => {
     const { data } = await api.post<{ url: string }>("/billing/portal");
     return data;


### PR DESCRIPTION
## Summary
- `billing.service.ts`: drop `createPrepaidCheckout` — no UI consumer
- `DatabaseUtils.jsx`: drop `getTotalsByType` — superseded by server-side aggregation
- `useFilters.ts`: unexport `isCompactFiltersPanelMode` + `hasInitialActiveFilters` — module-private helpers with no external imports
- `db/index.js`: drop `closePool` — never called; pool lifecycle managed by process exit

## Test plan
- [ ] 498 API + 183 web tests passing