### PR TITLE
fix(billing): activate stripe_events idempotency guard

### DIFF
--- a/apps/api/src/services/stripe-webhook.service.js
+++ b/apps/api/src/services/stripe-webhook.service.js
@@ -398,7 +398,30 @@ export const handleInvoicePaymentFailed = async (invoice) => {
   );
 };
 
+const markStripeEventProcessed = async (stripeEventId, eventType) => {
+  if (!stripeEventId) return false;
+
+  const existing = await dbQuery(
+    `SELECT id FROM stripe_events WHERE stripe_event_id = $1 LIMIT 1`,
+    [stripeEventId],
+  );
+  if (existing.rows.length > 0) return true;
+
+  const inserted = await dbQuery(
+    `INSERT INTO stripe_events (stripe_event_id, event_type)
+     VALUES ($1, $2)
+     ON CONFLICT (stripe_event_id) DO NOTHING
+     RETURNING id`,
+    [stripeEventId, eventType ?? "unknown"],
+  );
+  // Empty RETURNING means a concurrent request won the race — treat as duplicate
+  return inserted.rows.length === 0;
+};
+
 export const processStripeEvent = async (event) => {
+  const alreadyProcessed = await markStripeEventProcessed(event?.id, event?.type);
+  if (alreadyProcessed) return;
+
   switch (event?.type) {
     case "checkout.session.completed":
       return handleCheckoutSessionCompleted(event.data?.object);

--- a/apps/api/src/stripe-webhooks.test.js
+++ b/apps/api/src/stripe-webhooks.test.js
@@ -65,6 +65,7 @@ describe("stripe webhooks", () => {
     await dbQuery("DELETE FROM subscriptions");
     await dbQuery("DELETE FROM transactions");
     await dbQuery("DELETE FROM users");
+    await dbQuery("DELETE FROM stripe_events");
   });
 
   it("retorna 400 sem header Stripe-Signature", async () => {
@@ -292,6 +293,42 @@ describe("stripe webhooks", () => {
       [userId],
     );
     expect(Number(count.rows[0].count)).toBe(1);
+  });
+
+  it("processStripeEvent ignora evento duplicado pelo stripe_event_id", async () => {
+    await registerAndLogin("webhook-event-dedup@controlfinance.dev");
+    const userId = await getUserIdByEmail("webhook-event-dedup@controlfinance.dev");
+
+    const event = {
+      id: "evt_dedup_001",
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          customer: "cus_dedup_001",
+          subscription: "sub_dedup_001",
+          metadata: { userId: String(userId) },
+        },
+      },
+    };
+
+    const first = await stripePost(event);
+    const second = await stripePost(event);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+
+    // Only one subscription row despite two identical events
+    const count = await dbQuery(
+      `SELECT COUNT(*) FROM subscriptions WHERE user_id = $1`,
+      [userId],
+    );
+    expect(Number(count.rows[0].count)).toBe(1);
+
+    // Event recorded exactly once in idempotency registry
+    const evtCount = await dbQuery(
+      `SELECT COUNT(*) FROM stripe_events WHERE stripe_event_id = 'evt_dedup_001'`,
+    );
+    expect(Number(evtCount.rows[0].count)).toBe(1);
   });
 
   it("customer.subscription.deleted marca status como canceled", async () => {


### PR DESCRIPTION
## Summary
- Wire the `stripe_events` table (already created in migration 022) into `processStripeEvent`
- `markStripeEventProcessed()`: SELECT + INSERT ON CONFLICT DO NOTHING — returns true if event already recorded (skip), false if first time
- Events without an `id` field bypass the guard (malformed/test payloads still work)
- Protects against Stripe at-least-once delivery: duplicate `checkout.session.completed` on timeout no longer creates a second subscription

## Test plan
- [ ] 499 API tests passing (includes new deduplication test)
- [ ] Verify `stripe_events` row created per unique event in staging