### PR TITLE
feat(billing): expose trial/grace/prepaid states in subscription summary

### DIFF
--- a/apps/api/src/billing.test.js
+++ b/apps/api/src/billing.test.js
@@ -79,6 +79,40 @@ describe("billing", () => {
     });
   });
 
+  it("GET /billing/subscription retorna entitlementSource=trial para usuario em trial ativo", async () => {
+    const token = await registerAndLogin("billing-sub-trial@controlfinance.dev");
+
+    const response = await request(app)
+      .get("/billing/subscription")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.plan).toBe("free");
+    expect(response.body.entitlementSource).toBe("trial");
+    expect(typeof response.body.trialEndsAt).toBe("string");
+    expect(response.body.subscription).toBeNull();
+  });
+
+  it("GET /billing/subscription retorna entitlementSource=free com trialExpired=true para trial vencido", async () => {
+    const email = "billing-sub-trial-expired@controlfinance.dev";
+    const token = await registerAndLogin(email);
+    const userId = await getUserIdByEmail(email);
+
+    await dbQuery(
+      `UPDATE users SET trial_ends_at = NOW() - INTERVAL '1 day' WHERE id = $1`,
+      [userId],
+    );
+
+    const response = await request(app)
+      .get("/billing/subscription")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.entitlementSource).toBe("free");
+    expect(response.body.trialExpired).toBe(true);
+    expect(response.body.subscription).toBeNull();
+  });
+
   it("GET /billing/entitlement retorna source=trial para usuario novo", async () => {
     const email = "billing-entitlement-trial@controlfinance.dev";
     const token = await registerAndLogin(email);

--- a/apps/api/src/services/billing.service.js
+++ b/apps/api/src/services/billing.service.js
@@ -176,6 +176,7 @@ export const resolveEntitlement = async (userId) => {
       trialEndsAt: null,
       proExpiresAt: null,
       graceEndsAt: null,
+      trialExpired: false,
       subscription: activeSubscription,
     };
   }
@@ -193,6 +194,7 @@ export const resolveEntitlement = async (userId) => {
         trialEndsAt: null,
         proExpiresAt: null,
         graceEndsAt,
+        trialExpired: false,
         subscription: activeSubscription,
       };
     }
@@ -212,6 +214,7 @@ export const resolveEntitlement = async (userId) => {
       trialEndsAt: null,
       proExpiresAt,
       graceEndsAt: pastDueContext?.graceEndsAt ?? null,
+      trialExpired: false,
       subscription: pastDueContext?.subscription ?? null,
     };
   }
@@ -224,6 +227,7 @@ export const resolveEntitlement = async (userId) => {
       trialEndsAt,
       proExpiresAt: null,
       graceEndsAt: pastDueContext?.graceEndsAt ?? null,
+      trialExpired: false,
       subscription: pastDueContext?.subscription ?? null,
     };
   }
@@ -235,6 +239,7 @@ export const resolveEntitlement = async (userId) => {
     trialEndsAt: null,
     proExpiresAt: null,
     graceEndsAt: pastDueContext?.graceEndsAt ?? null,
+    trialExpired: trialEndsAt !== null,
     subscription: pastDueContext?.subscription ?? null,
   };
 };
@@ -335,13 +340,24 @@ export const getSubscriptionSummaryForUser = async (userId) => {
 
   const freePlan = await getFreePlan();
 
+  if (entitlement.plan === "trial") {
+    return {
+      plan: freePlan.name,
+      displayName: freePlan.displayName,
+      features: freePlan.features,
+      subscription: null,
+      entitlementSource: "trial",
+      trialEndsAt: toIsoOrNull(entitlement.trialEndsAt),
+    };
+  }
+
   return {
     plan: freePlan.name,
     displayName: freePlan.displayName,
     features: freePlan.features,
     subscription: null,
     entitlementSource: "free",
-    proExpiresAt: null,
+    trialExpired: entitlement.trialExpired ?? false,
   };
 };
 

--- a/apps/web/src/pages/BillingSettings.tsx
+++ b/apps/web/src/pages/BillingSettings.tsx
@@ -21,22 +21,59 @@ const resolveCheckoutStatus = (): string => {
   return params.get("checkout")?.trim().toLowerCase() || "";
 };
 
-const STATUS_LABELS: Record<string, string> = {
-  active: "Ativo",
-  prepaid_active: "Ativo (pre-pago)",
-  trialing: "Em teste",
-  past_due: "Pagamento pendente",
-  canceled: "Cancelado",
-  unpaid: "Não pago",
+const daysRemaining = (isoDate: string | null | undefined): number => {
+  if (!isoDate) return 0;
+  const ms = new Date(isoDate).getTime() - Date.now();
+  return Math.max(0, Math.ceil(ms / (1000 * 60 * 60 * 24)));
 };
 
-const STATUS_CLASSES: Record<string, string> = {
-  active: "border-green-200 bg-green-50 text-green-700",
-  prepaid_active: "border-green-200 bg-green-50 text-green-700",
-  trialing: "border-blue-200 bg-blue-50 text-blue-700",
-  past_due: "border-amber-200 bg-amber-50 text-amber-700",
-  canceled: "border-gray-200 bg-gray-50 text-gray-600",
-  unpaid: "border-red-200 bg-red-50 text-red-700",
+type PlanBadge = { label: string; className: string };
+
+const resolvePlanBadge = (summary: import("../services/billing.service").SubscriptionSummary): PlanBadge => {
+  const source = summary.entitlementSource;
+
+  if (source === "trial") {
+    const days = daysRemaining(summary.trialEndsAt);
+    return {
+      label: `Trial — ${days} dia${days !== 1 ? "s" : ""} restante${days !== 1 ? "s" : ""}`,
+      className: "border-blue-200 bg-blue-50 text-blue-700",
+    };
+  }
+
+  if (source === "subscription") {
+    const canceling = Boolean(summary.subscription?.cancelAtPeriodEnd);
+    const date = formatDate(summary.subscription?.currentPeriodEnd);
+    return canceling
+      ? { label: `Pro ativo — acesso até ${date}`, className: "border-amber-200 bg-amber-50 text-amber-700" }
+      : { label: `Pro ativo — renova em ${date}`, className: "border-green-200 bg-green-50 text-green-700" };
+  }
+
+  if (source === "subscription_grace") {
+    return {
+      label: `Pagamento pendente — acesso até ${formatDate(summary.graceEndsAt)}`,
+      className: "border-amber-200 bg-amber-50 text-amber-700",
+    };
+  }
+
+  if (source === "prepaid") {
+    return {
+      label: `Pro prepago — válido até ${formatDate(summary.proExpiresAt)}`,
+      className: "border-green-200 bg-green-50 text-green-700",
+    };
+  }
+
+  // source === "free"
+  if (summary.trialExpired) {
+    return {
+      label: "Trial encerrado",
+      className: "border-amber-200 bg-amber-50 text-amber-700",
+    };
+  }
+
+  return {
+    label: "Gratuito",
+    className: "border-cf-border bg-cf-bg-subtle text-cf-text-secondary",
+  };
 };
 
 interface BillingSettingsProps {
@@ -108,13 +145,9 @@ const BillingSettings = ({
     }
   };
 
-  const isPro = Boolean(summary?.subscription);
-  const statusKey = summary?.subscription?.status ?? "";
-  const statusLabel = STATUS_LABELS[statusKey] ?? "";
-  const statusClass = STATUS_CLASSES[statusKey] ?? "";
-  const isPrepaid = statusKey === "prepaid_active";
-  const periodEnd = summary?.subscription?.currentPeriodEnd;
-  const cancelAtPeriodEnd = summary?.subscription?.cancelAtPeriodEnd;
+  const source = summary?.entitlementSource ?? "free";
+  const isPro = source === "subscription" || source === "subscription_grace" || source === "prepaid";
+  const planBadge = summary ? resolvePlanBadge(summary) : null;
   const checkoutStatus = resolveCheckoutStatus();
   const showCheckoutPendingNotice =
     checkoutStatus === "success" && !isLoading && !loadError && !isPro;
@@ -200,30 +233,16 @@ const BillingSettings = ({
                     <p className="mt-0.5 text-lg font-bold text-cf-text-primary">
                       {summary.displayName}
                     </p>
-                    {isPro && statusLabel ? (
+                    {planBadge ? (
                       <span
-                        className={`mt-1 inline-block rounded border px-2 py-0.5 text-xs font-semibold ${statusClass}`}
+                        className={`mt-1 inline-block rounded border px-2 py-0.5 text-xs font-semibold ${planBadge.className}`}
                       >
-                        {statusLabel}
-                      </span>
-                    ) : null}
-                    {!isPro ? (
-                      <span className="mt-1 inline-block rounded border border-cf-border px-2 py-0.5 text-xs font-semibold text-cf-text-secondary">
-                        Gratuito
+                        {planBadge.label}
                       </span>
                     ) : null}
                   </div>
 
-                  {!isPro ? (
-                    <button
-                      type="button"
-                      onClick={handleSubscribe}
-                      disabled={isActionLoading}
-                      className="rounded bg-brand-1 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-2 disabled:cursor-not-allowed disabled:opacity-60"
-                    >
-                      {isActionLoading ? "Aguarde..." : "Assinar PRO"}
-                    </button>
-                  ) : (
+                  {isPro ? (
                     <button
                       type="button"
                       onClick={handleManage}
@@ -232,18 +251,24 @@ const BillingSettings = ({
                     >
                       {isActionLoading ? "Aguarde..." : "Gerenciar assinatura"}
                     </button>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={handleSubscribe}
+                      disabled={isActionLoading}
+                      className="rounded bg-brand-1 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-2 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {isActionLoading
+                        ? "Aguarde..."
+                        : source === "trial"
+                        ? "Assinar PRO agora"
+                        : source === "free" && summary?.trialExpired
+                        ? "Reativar acesso Pro"
+                        : "Assinar PRO"}
+                    </button>
                   )}
                 </div>
 
-                {isPro && periodEnd ? (
-                  <p className="mt-3 text-xs text-cf-text-secondary">
-                    {isPrepaid
-                      ? `Expira em: ${formatDate(periodEnd)}`
-                      : cancelAtPeriodEnd
-                      ? `Cancela em: ${formatDate(periodEnd)}`
-                      : `Renovacao em: ${formatDate(periodEnd)}`}
-                  </p>
-                ) : null}
               </div>
 
               {actionError ? (

--- a/apps/web/src/services/billing.service.ts
+++ b/apps/web/src/services/billing.service.ts
@@ -6,11 +6,23 @@ export interface SubscriptionDetail {
   cancelAtPeriodEnd: boolean;
 }
 
+export type EntitlementSource =
+  | "free"
+  | "trial"
+  | "subscription"
+  | "subscription_grace"
+  | "prepaid";
+
 export interface SubscriptionSummary {
   plan: string;
   displayName: string;
   features: Record<string, unknown>;
   subscription: SubscriptionDetail | null;
+  entitlementSource: EntitlementSource;
+  trialEndsAt?: string | null;
+  trialExpired?: boolean;
+  proExpiresAt?: string | null;
+  graceEndsAt?: string | null;
 }
 
 export const billingService = {


### PR DESCRIPTION
## Summary
- `getSubscriptionSummaryForUser` now handles all 6 billing states: free, trial, trial-expired, subscription, subscription_grace, prepaid
- `resolveEntitlement` returns `trialExpired` in all shapes — consumed by the free fallback
- `SubscriptionSummary` TS type expanded with `entitlementSource`, `trialEndsAt`, `trialExpired`, `proExpiresAt`, `graceEndsAt`
- `BillingSettings` replaces `Boolean(subscription)` with `entitlementSource`-based rendering via `resolvePlanBadge()`
- CTA copy adapts per state: "Assinar PRO agora" (trial), "Reativar acesso Pro" (trial expired), "Assinar PRO" (free), "Gerenciar assinatura" (pro/grace/prepaid)

## State → badge mapping
| entitlementSource | Badge |
|---|---|
| `trial` | "Trial — N dias restantes" (blue) |
| `free` + trialExpired | "Trial encerrado" (amber) |
| `free` | "Gratuito" (neutral) |
| `subscription` (renewing) | "Pro ativo — renova em X" (green) |
| `subscription` (canceling) | "Pro ativo — acesso até X" (amber) |
| `subscription_grace` | "Pagamento pendente — acesso até X" (amber) |
| `prepaid` | "Pro prepago — válido até X" (green) |

## Test plan
- [ ] 501 API tests passing (2 new billing tests)
- [ ] 183 web tests passing
- [ ] TypeScript typecheck clean