### PR TITLE
chore(income-sources): remove sortOrder from deduction contract

### DIFF
--- a/apps/api/src/services/income-sources.service.js
+++ b/apps/api/src/services/income-sources.service.js
@@ -170,7 +170,6 @@ const mapDeductionRow = (row) => ({
   amount: toMoney(row.amount),
   isVariable: Boolean(row.is_variable),
   isActive: Boolean(row.is_active),
-  sortOrder: Number(row.sort_order),
   createdAt: toISODateTime(row.created_at),
   updatedAt: toISODateTime(row.updated_at),
 });
@@ -342,14 +341,13 @@ export const createDeductionForSource = async (userId, sourceId, payload) => {
   const label = normalizeDeductionLabel(payload.label);
   const amount = normalizeDeductionAmount(payload.amount);
   const isVariable = Boolean(payload.isVariable);
-  const sortOrder = payload.sortOrder != null ? Number(payload.sortOrder) : 0;
 
   const { rows } = await dbQuery(
     `INSERT INTO income_deductions
-       (income_source_id, label, amount, is_variable, sort_order)
-     VALUES ($1, $2, $3, $4, $5)
+       (income_source_id, label, amount, is_variable)
+     VALUES ($1, $2, $3, $4)
      RETURNING *`,
-    [sid, label, amount, isVariable, sortOrder],
+    [sid, label, amount, isVariable],
   );
   return mapDeductionRow(rows[0]);
 };
@@ -379,11 +377,6 @@ export const updateDeductionForSource = async (userId, deductionId, payload) => 
     params.push(Boolean(payload.isActive));
     setClauses.push(`is_active = $${params.length}`);
   }
-  if (payload.sortOrder !== undefined) {
-    params.push(Number(payload.sortOrder));
-    setClauses.push(`sort_order = $${params.length}`);
-  }
-
   if (setClauses.length === 0) {
     const { rows } = await dbQuery(`SELECT * FROM income_deductions WHERE id = $1`, [did]);
     return mapDeductionRow(rows[0]);

--- a/apps/web/src/pages/IncomeSourcesPage.test.tsx
+++ b/apps/web/src/pages/IncomeSourcesPage.test.tsx
@@ -45,7 +45,6 @@ const buildDeduction = (overrides: Partial<IncomeDeduction> = {}): IncomeDeducti
   amount: 300,
   isVariable: false,
   isActive: true,
-  sortOrder: 0,
   createdAt: "2026-01-01T00:00:00.000Z",
   updatedAt: "2026-01-01T00:00:00.000Z",
   ...overrides,

--- a/apps/web/src/services/incomeSources.service.ts
+++ b/apps/web/src/services/incomeSources.service.ts
@@ -20,7 +20,6 @@ export interface IncomeDeduction {
   amount: number;
   isVariable: boolean;
   isActive: boolean;
-  sortOrder: number;
   createdAt: string;
   updatedAt: string;
 }
@@ -111,7 +110,6 @@ interface RawDeduction {
   amount?: unknown;
   isVariable?: unknown;
   isActive?: unknown;
-  sortOrder?: unknown;
   createdAt?: unknown;
   updatedAt?: unknown;
 }
@@ -171,7 +169,6 @@ const normalizeDeduction = (raw: RawDeduction): IncomeDeduction => ({
   amount: Number(raw.amount) || 0,
   isVariable: Boolean(raw.isVariable),
   isActive: raw.isActive !== false,
-  sortOrder: Number(raw.sortOrder) || 0,
   createdAt: normalizeISOString(raw.createdAt),
   updatedAt: normalizeISOString(raw.updatedAt),
 });


### PR DESCRIPTION
## Summary

- `sortOrder` was stored in the DB, mapped on read, and accepted by the backend — but the frontend never sent it and `IncomeSourcesPage` has no reorder UI
- Removes the field from `mapDeductionRow`, the `INSERT` statement, the `updateDeductionForSource` SET builder, `IncomeDeduction` interface, `RawDeduction`, and `normalizeDeduction`
- The `sort_order` DB column (DEFAULT 0) stays in place as latent infra for future drag-and-drop

## Test plan

- [ ] 504/504 API tests passing
- [ ] 183/183 web tests passing
- [ ] No TypeScript errors