### PR TITLE
test(imports): add negative-path coverage for all import parsers

### DIFF
--- a/apps/api/src/domain/imports/ofx-import.test.js
+++ b/apps/api/src/domain/imports/ofx-import.test.js
@@ -71,4 +71,43 @@ describe("ofx import parser", () => {
     expect(rows[0].raw.type).toBe("Saida");
     expect(rows[0].raw.value).toBe("99.90");
   });
+
+  it("lanca erro em buffer vazio — sem bloco STMTTRN", () => {
+    expect(() => parseOfxRows(Buffer.from("", "utf8"))).toThrow(
+      "Nenhuma transacao reconhecida no OFX.",
+    );
+  });
+
+  it("lanca erro em conteudo OFX sem transacoes validas", () => {
+    const garbage = "OFXHEADER:100\nDATA:OFXSGML\n<OFX>\n<BANKMSGSRSV1>\n</BANKMSGSRSV1>\n</OFX>";
+    expect(() => parseOfxRows(Buffer.from(garbage, "utf8"))).toThrow(
+      "Nenhuma transacao reconhecida no OFX.",
+    );
+  });
+
+  it("lanca erro quando TRNAMT esta ausente ou invalido", () => {
+    const content = [
+      "<STMTTRN>",
+      "<TRNTYPE>CREDIT",
+      "<DTPOSTED>20260205000000",
+      "<TRNAMT>abc",
+      "<MEMO>PGTO INVALIDO",
+      "</STMTTRN>",
+    ].join("\n");
+
+    expect(() => parseOfxRows(Buffer.from(content, "utf8"))).toThrow(
+      "Transacao OFX com valor invalido.",
+    );
+  });
+
+  it("lanca erro quando arquivo excede 2000 transacoes", () => {
+    const blocks = Array.from(
+      { length: 2001 },
+      (_, i) => `<STMTTRN>\n<TRNTYPE>CREDIT\n<TRNAMT>1.00\n<FITID>ID${i}\n</STMTTRN>`,
+    ).join("\n");
+
+    expect(() => parseOfxRows(Buffer.from(blocks, "utf8"))).toThrow(
+      "Arquivo excede o limite de 2000 linhas.",
+    );
+  });
 });

--- a/apps/api/src/domain/imports/pdf-ocr.test.js
+++ b/apps/api/src/domain/imports/pdf-ocr.test.js
@@ -67,6 +67,64 @@ describe("pdf OCR fallback", () => {
     expect(loadCreateWorkerFn).not.toHaveBeenCalled();
   });
 
+  it("propaga erro quando getText lanca e ainda destroi o parser", async () => {
+    const fakeParser = {
+      getText: vi.fn().mockRejectedValue(new Error("PDF corrompido")),
+      getScreenshot: vi.fn(),
+      destroy: vi.fn().mockResolvedValue(undefined),
+    };
+    const PDFParseCtor = vi.fn(() => fakeParser);
+
+    await expect(
+      extractTextFromPdfWithOcr(Buffer.from("fake-pdf"), { PDFParseCtor }),
+    ).rejects.toThrow("PDF corrompido");
+
+    expect(fakeParser.destroy).toHaveBeenCalled();
+    expect(fakeParser.getScreenshot).not.toHaveBeenCalled();
+  });
+
+  it("retorna texto direto quando getScreenshot retorna pages vazias", async () => {
+    const fakeParser = {
+      getText: vi.fn().mockResolvedValue({ text: "abc 123" }),
+      getScreenshot: vi.fn().mockResolvedValue({ pages: [] }),
+      destroy: vi.fn().mockResolvedValue(undefined),
+    };
+    const PDFParseCtor = vi.fn(() => fakeParser);
+
+    const text = await extractTextFromPdfWithOcr(Buffer.from("fake-pdf"), {
+      PDFParseCtor,
+      ocrEnabled: true,
+    });
+
+    expect(text).toBe("abc 123");
+    expect(fakeParser.getScreenshot).toHaveBeenCalled();
+  });
+
+  it("usa texto direto como fallback quando OCR retorna texto vazio", async () => {
+    const fakeParser = {
+      getText: vi.fn().mockResolvedValue({ text: "abc 123" }),
+      getScreenshot: vi.fn().mockResolvedValue({
+        pages: [{ data: Buffer.from("fake-page") }],
+      }),
+      destroy: vi.fn().mockResolvedValue(undefined),
+    };
+    const fakeWorker = {
+      recognize: vi.fn().mockResolvedValue({ data: { text: "" } }),
+      terminate: vi.fn().mockResolvedValue(undefined),
+    };
+    const PDFParseCtor = vi.fn(() => fakeParser);
+    const createWorkerFn = vi.fn().mockResolvedValue(fakeWorker);
+
+    const text = await extractTextFromPdfWithOcr(Buffer.from("fake-pdf"), {
+      PDFParseCtor,
+      createWorkerFn,
+      ocrEnabled: true,
+    });
+
+    expect(text).toBe("abc 123");
+    expect(fakeWorker.terminate).toHaveBeenCalled();
+  });
+
   it("usa OCR como fallback quando texto direto nao e suficiente", async () => {
     const fakeParser = {
       getText: vi.fn().mockResolvedValue({ text: "abc 123" }),

--- a/apps/api/src/domain/imports/statement-import.test.js
+++ b/apps/api/src/domain/imports/statement-import.test.js
@@ -43,6 +43,18 @@ describe("statement import parser", () => {
     ]);
   });
 
+  it("lanca erro em CSV com header mas sem linhas de dados", () => {
+    const csvContent = "Data;Historico;Valor\n";
+    expect(() => parseStatementCsvRows(Buffer.from(csvContent, "utf8"))).toThrow("CSV vazio.");
+  });
+
+  it("lanca erro quando colunas do CSV nao sao reconheciveis", () => {
+    const csvContent = "Coluna1;Coluna2;Coluna3\nA;B;C\n";
+    expect(() => parseStatementCsvRows(Buffer.from(csvContent, "utf8"))).toThrow(
+      "Nao foi possivel reconhecer as colunas do extrato.",
+    );
+  });
+
   it("orienta OFX ou CSV quando o PDF nao tem texto util e OCR esta desligado", () => {
     expect(getPdfImportGuidanceError("abc 123", false)).toBe(
       "PDF sem texto reconhecivel. Tente OFX ou CSV.",

--- a/apps/api/src/domain/imports/transaction-classifier.test.js
+++ b/apps/api/src/domain/imports/transaction-classifier.test.js
@@ -72,6 +72,22 @@ describe("transaction classifier", () => {
     expect(classificationIndex.keywordMapsByType.get("Entrada")).toBeInstanceOf(Map);
   });
 
+  it("retorna string vazia quando lista de categorias e vazia", () => {
+    const category = suggestCategoryNameForImportedRow(
+      { type: "Saida", description: "PIX QRS UBER DO BRA", notes: "", category: "" },
+      [],
+    );
+    expect(category).toBe("");
+  });
+
+  it("retorna string vazia quando descricao nao casa com nenhuma categoria", () => {
+    const category = suggestCategoryNameForImportedRow(
+      { type: "Saida", description: "LANCAMENTO CONTABIL ZZZ", notes: "", category: "" },
+      categories,
+    );
+    expect(category).toBe("");
+  });
+
   it("aplica sugestao no shape das linhas importadas", () => {
     const rows = applySmartClassification(
       [
@@ -91,5 +107,10 @@ describe("transaction classifier", () => {
     );
 
     expect(rows[0].raw.category).toBe("Transporte");
+  });
+
+  it("retorna array vazio sem crash quando rows e vazio", () => {
+    const rows = applySmartClassification([], categories);
+    expect(rows).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- **OFX**: empty buffer → throw; content without `<STMTTRN>` → throw; invalid `TRNAMT` → throw; >2000 rows → throw limit error
- **PDF OCR**: `getText()` throws → error propagates + `destroy()` still called; `getScreenshot()` returns empty pages → returns direct text; `recognize()` returns empty text → falls back to direct text
- **CSV**: header-only file → throw "CSV vazio."; unrecognised column names → throw
- **Classifier**: empty categories list → returns ""; description with no keyword match → returns ""; `applySmartClassification` with empty rows → returns []

Importation is the critical data-entry path for the personal finance ERP — silent failures here corrupt forecasts, categories, and everything downstream.

## Test plan

- [ ] 516/516 API tests passing (+12 new tests)
- [ ] All 4 parser test files pass in isolation