### PR TITLE
feat(web): proactive negative-balance alert banner (D1)

### DIFF
--- a/apps/web/src/components/FinancialAlertBanner.test.tsx
+++ b/apps/web/src/components/FinancialAlertBanner.test.tsx
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import FinancialAlertBanner from "./FinancialAlertBanner";
+
+vi.mock("../services/forecast.service", () => ({
+  forecastService: {
+    getCurrent: vi.fn(),
+  },
+}));
+
+import { forecastService } from "../services/forecast.service";
+
+const buildForecast = (adjustedProjectedBalance: number, month = "2026-03") => ({
+  month,
+  projectedBalance: adjustedProjectedBalance,
+  adjustedProjectedBalance,
+  spendingToDate: 500,
+  dailyAvgSpending: 20,
+  daysRemaining: 10,
+  flipDetected: false,
+  flipDirection: null,
+  engineVersion: "v1",
+  incomeExpected: null,
+  billsPendingTotal: 0,
+  billsPendingCount: 0,
+});
+
+describe("FinancialAlertBanner", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    sessionStorage.clear();
+  });
+
+  it("nao exibe nada quando projecao e null (sem forecast ainda)", async () => {
+    (forecastService.getCurrent as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    await act(async () => {
+      render(<FinancialAlertBanner />);
+    });
+
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("nao exibe nada quando saldo projetado e positivo", async () => {
+    (forecastService.getCurrent as ReturnType<typeof vi.fn>).mockResolvedValue(
+      buildForecast(250),
+    );
+
+    await act(async () => {
+      render(<FinancialAlertBanner />);
+    });
+
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("nao exibe nada quando saldo projetado e zero", async () => {
+    (forecastService.getCurrent as ReturnType<typeof vi.fn>).mockResolvedValue(
+      buildForecast(0),
+    );
+
+    await act(async () => {
+      render(<FinancialAlertBanner />);
+    });
+
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("exibe alerta quando saldo projetado e negativo", async () => {
+    (forecastService.getCurrent as ReturnType<typeof vi.fn>).mockResolvedValue(
+      buildForecast(-320.5, "2026-03"),
+    );
+
+    await act(async () => {
+      render(<FinancialAlertBanner />);
+    });
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByRole("alert").textContent).toContain("2026-03");
+  });
+
+  it("botao fechar oculta o alerta e persiste no sessionStorage", async () => {
+    (forecastService.getCurrent as ReturnType<typeof vi.fn>).mockResolvedValue(
+      buildForecast(-100),
+    );
+
+    await act(async () => {
+      render(<FinancialAlertBanner />);
+    });
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /fechar alerta/i }));
+
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(sessionStorage.getItem("cf.forecast_alert.dismissed_v1")).toBe("1");
+  });
+
+  it("nao exibe alerta se ja foi dispensado via sessionStorage", async () => {
+    sessionStorage.setItem("cf.forecast_alert.dismissed_v1", "1");
+    (forecastService.getCurrent as ReturnType<typeof vi.fn>).mockResolvedValue(
+      buildForecast(-200),
+    );
+
+    await act(async () => {
+      render(<FinancialAlertBanner />);
+    });
+
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});

--- a/apps/web/src/components/FinancialAlertBanner.tsx
+++ b/apps/web/src/components/FinancialAlertBanner.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from "react";
+import { forecastService } from "../services/forecast.service";
+import { formatCurrency } from "../utils/formatCurrency";
+
+const DISMISS_KEY = "cf.forecast_alert.dismissed_v1";
+
+const FinancialAlertBanner = (): JSX.Element | null => {
+  const [projectedBalance, setProjectedBalance] = useState<number | null>(null);
+  const [month, setMonth] = useState<string>("");
+  const [dismissed, setDismissed] = useState(() => {
+    try {
+      return sessionStorage.getItem(DISMISS_KEY) === "1";
+    } catch {
+      return false;
+    }
+  });
+
+  useEffect(() => {
+    void forecastService.getCurrent().then((forecast) => {
+      if (forecast !== null) {
+        setProjectedBalance(forecast.adjustedProjectedBalance);
+        setMonth(forecast.month);
+      }
+    });
+  }, []);
+
+  if (dismissed || projectedBalance === null || projectedBalance >= 0) {
+    return null;
+  }
+
+  const handleDismiss = () => {
+    try {
+      sessionStorage.setItem(DISMISS_KEY, "1");
+    } catch {
+      // Ignore storage errors (private mode / quotas)
+    }
+    setDismissed(true);
+  };
+
+  return (
+    <div
+      role="alert"
+      className="flex items-start justify-between rounded border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-700 dark:border-red-400/30 dark:bg-red-400/10 dark:text-red-400"
+    >
+      <span>
+        Atenção: a projeção de saldo para {month} está em{" "}
+        <strong>{formatCurrency(projectedBalance)}</strong>. Revise seus gastos para evitar saldo
+        negativo.
+      </span>
+      <button
+        type="button"
+        onClick={handleDismiss}
+        className="ml-4 shrink-0 opacity-60 hover:opacity-100"
+        aria-label="Fechar alerta"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="h-4 w-4"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            fillRule="evenodd"
+            d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </button>
+    </div>
+  );
+};
+
+export default FinancialAlertBanner;

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -7,6 +7,7 @@ import ImportCsvModal from "../components/ImportCsvModal";
 import ImportHistoryModal from "../components/ImportHistoryModal";
 import UpgradeModal from "../components/UpgradeModal";
 import ForecastCard from "../components/ForecastCard";
+import FinancialAlertBanner from "../components/FinancialAlertBanner";
 import BillsSummaryWidget from "../components/BillsSummaryWidget";
 import SalaryWidget from "../components/SalaryWidget";
 import TransactionList from "../components/TransactionList";
@@ -1883,6 +1884,8 @@ const App = ({
             </button>
           </div>
         )}
+
+        <FinancialAlertBanner />
 
         <section ref={filtersPanelRef}>
           <div className="space-y-4 rounded border border-cf-border bg-cf-surface p-4">


### PR DESCRIPTION
## Summary

- New `FinancialAlertBanner` component: self-contained, fetches `forecastService.getCurrent()` on mount
- Renders a dismissible red alert when `adjustedProjectedBalance < 0`, with month and formatted balance
- Dismiss persists to `sessionStorage` — banner re-appears on next login session but not during navigation
- Placed in `App.tsx` between the activation banner and the financial summary section

## Test plan

- [ ] 5 unit tests: null forecast → no render, positive/zero balance → no render, negative balance → renders with month, dismiss button → hides + sets sessionStorage, pre-dismissed → no render
- [ ] `App.test.jsx` continues to pass unchanged (forecastService.getCurrent already mocked → null, banner invisible in all existing tests)
- [ ] 191/191 web tests green