### PR TITLE
feat(web): badge Revisar em linhas importadas sem categoria (D2)

### DIFF
--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -292,7 +292,18 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
                         </td>
                         <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">{row.raw.date || "-"}</td>
                         <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
-                          {row.raw.category || "Sem categoria"}
+                          {row.raw.category ? (
+                            row.raw.category
+                          ) : row.status === "valid" ? (
+                            <span className="inline-flex items-center gap-1.5">
+                              <span className="rounded border border-amber-300 bg-amber-50 px-1.5 py-0.5 text-xs font-medium text-amber-700">
+                                Revisar
+                              </span>
+                              <span className="text-cf-text-secondary">Sem categoria</span>
+                            </span>
+                          ) : (
+                            "—"
+                          )}
                         </td>
                         <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
                           {row.errors.length > 0

--- a/apps/web/src/components/ImportCsvModal.test.jsx
+++ b/apps/web/src/components/ImportCsvModal.test.jsx
@@ -113,6 +113,60 @@ describe("ImportCsvModal", () => {
     });
   });
 
+  it("exibe badge Revisar para linha valida sem categoria", async () => {
+    const file = new File(["date,type,value"], "import.csv", { type: "text/csv" });
+    transactionsService.dryRunImportCsv.mockResolvedValueOnce(
+      buildDryRunResponse({
+        rows: [
+          {
+            line: 2,
+            status: "valid",
+            raw: {
+              date: "2026-02-21",
+              type: "Entrada",
+              value: "100",
+              description: "PIX SEM CATEGORIA",
+              notes: "",
+              category: "",
+            },
+            normalized: {
+              date: "2026-02-21",
+              type: "Entrada",
+              value: 100,
+              description: "PIX SEM CATEGORIA",
+              notes: "",
+              categoryId: null,
+            },
+            errors: [],
+          },
+        ],
+      }),
+    );
+
+    render(<ImportCsvModal isOpen onClose={vi.fn()} />);
+    await userEvent.upload(screen.getByLabelText("Arquivo do extrato"), file);
+    await userEvent.click(screen.getByRole("button", { name: "Pré-visualizar" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Revisar")).toBeInTheDocument();
+    });
+  });
+
+  it("nao exibe badge Revisar quando linha valida ja tem categoria", async () => {
+    const file = new File(["date,type,value"], "import.csv", { type: "text/csv" });
+    transactionsService.dryRunImportCsv.mockResolvedValueOnce(buildDryRunResponse());
+
+    render(<ImportCsvModal isOpen onClose={vi.fn()} />);
+    await userEvent.upload(screen.getByLabelText("Arquivo do extrato"), file);
+    await userEvent.click(screen.getByRole("button", { name: "Pré-visualizar" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Trabalho")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Revisar")).not.toBeInTheDocument();
+  });
+
   it("shows expired session message on commit error", async () => {
     const file = new File(["date,type,value"], "import.csv", { type: "text/csv" });
 


### PR DESCRIPTION
## Summary

- In the dry-run preview table of `ImportCsvModal`, valid rows with no classified category now show an amber **Revisar** badge next to "Sem categoria"
- Invalid rows (won't be imported) show "—" — badge only surfaces where it matters
- No backend changes: the signal was already present in the contract (`row.status === "valid" && row.raw.category === ""`)

## Test plan

- [ ] `exibe badge Revisar para linha valida sem categoria` — dry run response with `category: ""` renders the amber badge
- [ ] `nao exibe badge Revisar quando linha valida ja tem categoria` — dry run with `category: "Trabalho"` shows no badge
- [ ] All 193 web tests green, zero regressions