### PR TITLE
feat(web): HealthOverview — gauge de dinheiro livre + trajetória do mês (D4-lite + D5)

### DIFF
--- a/apps/web/src/components/HealthOverview.test.tsx
+++ b/apps/web/src/components/HealthOverview.test.tsx
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import HealthOverview, { generateTrajectory } from "./HealthOverview";
+
+vi.mock("recharts", () => ({
+  AreaChart: ({ data }: { data: unknown[] }) => (
+    <div data-testid="area-chart" data-points={data.length} />
+  ),
+  Area: () => null,
+  XAxis: () => null,
+  Tooltip: () => null,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ReferenceLine: () => null,
+}));
+
+vi.mock("../services/forecast.service", () => ({
+  forecastService: { getCurrent: vi.fn() },
+}));
+
+import { forecastService } from "../services/forecast.service";
+
+const buildForecast = (overrides = {}) => ({
+  month: "2026-03",
+  projectedBalance: 1200,
+  adjustedProjectedBalance: 1200,
+  spendingToDate: 500,
+  dailyAvgSpending: 50,
+  daysRemaining: 10,
+  flipDetected: false,
+  flipDirection: null,
+  engineVersion: "v1",
+  incomeExpected: 3000,
+  billsPendingTotal: 0,
+  billsPendingCount: 0,
+  ...overrides,
+});
+
+describe("generateTrajectory", () => {
+  it("retorna array vazio quando daysRemaining e zero", () => {
+    expect(generateTrajectory(buildForecast({ daysRemaining: 0 }) as never)).toEqual([]);
+  });
+
+  it("primeiro ponto e Hoje, ultimo ponto e Fim", () => {
+    const points = generateTrajectory(buildForecast({ daysRemaining: 5 }) as never);
+    expect(points[0].day).toBe("Hoje");
+    expect(points[points.length - 1].day).toBe("Fim");
+  });
+
+  it("gera daysRemaining+1 pontos", () => {
+    const points = generateTrajectory(buildForecast({ daysRemaining: 8 }) as never);
+    expect(points).toHaveLength(9);
+  });
+
+  it("ultimo ponto e igual ao adjustedProjectedBalance", () => {
+    const forecast = buildForecast({ adjustedProjectedBalance: 800, dailyAvgSpending: 40, daysRemaining: 5 });
+    const points = generateTrajectory(forecast as never);
+    expect(points[points.length - 1].balance).toBe(800);
+  });
+
+  it("saldo decai diariamente pelo dailyAvgSpending", () => {
+    const forecast = buildForecast({ adjustedProjectedBalance: 1000, dailyAvgSpending: 100, daysRemaining: 3 });
+    const points = generateTrajectory(forecast as never);
+    expect(points[0].balance).toBe(1300); // 1000 + 100*3
+    expect(points[1].balance).toBe(1200);
+    expect(points[2].balance).toBe(1100);
+    expect(points[3].balance).toBe(1000);
+  });
+});
+
+describe("HealthOverview", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("retorna null quando forecast e null", async () => {
+    (forecastService.getCurrent as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    await act(async () => {
+      render(<HealthOverview />);
+    });
+    expect(screen.queryByText("Saúde Financeira do Mês")).toBeNull();
+  });
+
+  it("retorna null quando daysRemaining e zero", async () => {
+    (forecastService.getCurrent as ReturnType<typeof vi.fn>).mockResolvedValue(
+      buildForecast({ daysRemaining: 0 }),
+    );
+    await act(async () => {
+      render(<HealthOverview />);
+    });
+    expect(screen.queryByText("Saúde Financeira do Mês")).toBeNull();
+  });
+
+  it("renderiza titulo e paineis quando forecast e valido", async () => {
+    (forecastService.getCurrent as ReturnType<typeof vi.fn>).mockResolvedValue(buildForecast());
+    await act(async () => {
+      render(<HealthOverview />);
+    });
+    expect(screen.getByText("Saúde Financeira do Mês")).toBeInTheDocument();
+    expect(screen.getByText("Dinheiro Livre")).toBeInTheDocument();
+    expect(screen.getByText("Trajetória do Mês")).toBeInTheDocument();
+  });
+
+  it("renderiza AreaChart com daysRemaining+1 pontos na trajetoria", async () => {
+    (forecastService.getCurrent as ReturnType<typeof vi.fn>).mockResolvedValue(
+      buildForecast({ daysRemaining: 5 }),
+    );
+    await act(async () => {
+      render(<HealthOverview />);
+    });
+    expect(Number(screen.getByTestId("area-chart").dataset.points)).toBe(6);
+  });
+
+  it("exibe mensagem de risco quando saldo projetado e negativo", async () => {
+    (forecastService.getCurrent as ReturnType<typeof vi.fn>).mockResolvedValue(
+      buildForecast({ adjustedProjectedBalance: -200 }),
+    );
+    await act(async () => {
+      render(<HealthOverview />);
+    });
+    expect(screen.getByText("Projeção negativa — revise seus gastos")).toBeInTheDocument();
+  });
+
+  it("exibe label positivo quando saldo projetado e positivo", async () => {
+    (forecastService.getCurrent as ReturnType<typeof vi.fn>).mockResolvedValue(buildForecast());
+    await act(async () => {
+      render(<HealthOverview />);
+    });
+    expect(screen.getByText("projetado ao fim do mês")).toBeInTheDocument();
+  });
+
+  it("renderiza gauge SVG quando incomeExpected esta disponivel", async () => {
+    (forecastService.getCurrent as ReturnType<typeof vi.fn>).mockResolvedValue(buildForecast());
+    await act(async () => {
+      render(<HealthOverview />);
+    });
+    expect(screen.getByRole("img", { name: /gauge/i })).toBeInTheDocument();
+  });
+
+  it("omite gauge SVG quando incomeExpected e null", async () => {
+    (forecastService.getCurrent as ReturnType<typeof vi.fn>).mockResolvedValue(
+      buildForecast({ incomeExpected: null }),
+    );
+    await act(async () => {
+      render(<HealthOverview />);
+    });
+    expect(screen.queryByRole("img", { name: /gauge/i })).toBeNull();
+  });
+});

--- a/apps/web/src/components/HealthOverview.tsx
+++ b/apps/web/src/components/HealthOverview.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useState } from "react";
+import {
+  Area,
+  AreaChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+} from "recharts";
+import { forecastService, type Forecast } from "../services/forecast.service";
+import { formatCurrency } from "../utils/formatCurrency";
+
+interface TrajectoryPoint {
+  day: string;
+  balance: number;
+}
+
+export const generateTrajectory = (forecast: Forecast): TrajectoryPoint[] => {
+  const { adjustedProjectedBalance, dailyAvgSpending, daysRemaining } = forecast;
+  if (daysRemaining <= 0) return [];
+
+  const startBalance = Number(
+    (adjustedProjectedBalance + dailyAvgSpending * daysRemaining).toFixed(2),
+  );
+
+  const points: TrajectoryPoint[] = [{ day: "Hoje", balance: startBalance }];
+
+  for (let i = 1; i <= daysRemaining; i++) {
+    points.push({
+      day: i === daysRemaining ? "Fim" : `+${i}`,
+      balance: Number((startBalance - dailyAvgSpending * i).toFixed(2)),
+    });
+  }
+
+  return points;
+};
+
+const gaugeColor = (balance: number, pct: number | null): string => {
+  if (balance <= 0) return "#ef4444";
+  if (pct !== null && pct < 15) return "#f59e0b";
+  return "#22c55e";
+};
+
+interface GaugeProps {
+  percentage: number;
+  color: string;
+}
+
+const Gauge = ({ percentage, color }: GaugeProps) => {
+  const clamped = Math.max(0, Math.min(100, percentage));
+  return (
+    <svg
+      viewBox="0 0 100 55"
+      role="img"
+      aria-label="Gauge de saúde financeira"
+      className="w-full max-w-[180px]"
+    >
+      <path
+        d="M 10 50 A 40 40 0 0 1 90 50"
+        fill="none"
+        stroke="#334155"
+        strokeWidth={10}
+        strokeLinecap="round"
+        pathLength={100}
+      />
+      <path
+        d="M 10 50 A 40 40 0 0 1 90 50"
+        fill="none"
+        stroke={color}
+        strokeWidth={10}
+        strokeLinecap="round"
+        pathLength={100}
+        strokeDasharray={`${clamped} 100`}
+      />
+    </svg>
+  );
+};
+
+const TrajectoryTooltip = ({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: { value: number; payload: TrajectoryPoint }[];
+}) => {
+  if (!active || !payload || payload.length === 0) return null;
+  return (
+    <div className="rounded border border-cf-border bg-cf-surface px-2 py-1 text-xs shadow-sm">
+      <p className="font-semibold text-cf-text-primary">{payload[0].payload.day}</p>
+      <p className="text-cf-text-secondary">{formatCurrency(payload[0].value)}</p>
+    </div>
+  );
+};
+
+const HealthOverview = (): JSX.Element | null => {
+  const [forecast, setForecast] = useState<Forecast | null>(null);
+
+  useEffect(() => {
+    void forecastService.getCurrent().then(setForecast).catch(() => undefined);
+  }, []);
+
+  if (forecast === null || forecast.daysRemaining <= 0) return null;
+
+  const trajectory = generateTrajectory(forecast);
+  const { adjustedProjectedBalance, incomeExpected } = forecast;
+  const gaugePct =
+    incomeExpected !== null && incomeExpected > 0
+      ? (adjustedProjectedBalance / incomeExpected) * 100
+      : null;
+  const color = gaugeColor(adjustedProjectedBalance, gaugePct);
+  const isAtRisk = adjustedProjectedBalance <= 0;
+
+  return (
+    <div className="rounded border border-cf-border bg-cf-surface p-4">
+      <h3 className="mb-4 text-sm font-semibold text-cf-text-primary">Saúde Financeira do Mês</h3>
+      <div className="grid gap-4 sm:grid-cols-2">
+        {/* D5 — Gauge */}
+        <div className="flex flex-col items-center justify-center gap-2 rounded border border-cf-border bg-cf-bg-subtle p-4">
+          <p className="text-xs font-medium uppercase text-cf-text-secondary">Dinheiro Livre</p>
+          {gaugePct !== null ? <Gauge percentage={gaugePct} color={color} /> : null}
+          <p className={`text-xl font-bold ${isAtRisk ? "text-red-600" : "text-cf-text-primary"}`}>
+            {formatCurrency(adjustedProjectedBalance)}
+          </p>
+          <p className="text-center text-xs text-cf-text-secondary">
+            {isAtRisk ? "Projeção negativa — revise seus gastos" : "projetado ao fim do mês"}
+          </p>
+        </div>
+
+        {/* D4-lite — Trajectory */}
+        <div className="rounded border border-cf-border bg-cf-bg-subtle p-4">
+          <p className="mb-2 text-xs font-medium uppercase text-cf-text-secondary">
+            Trajetória do Mês
+          </p>
+          {trajectory.length >= 2 ? (
+            <div className="h-40">
+              <ResponsiveContainer width="100%" height="100%">
+                <AreaChart data={trajectory} margin={{ top: 4, right: 4, left: 4, bottom: 0 }}>
+                  <defs>
+                    <linearGradient id="healthAreaGradient" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="5%" stopColor={color} stopOpacity={0.3} />
+                      <stop offset="95%" stopColor={color} stopOpacity={0} />
+                    </linearGradient>
+                  </defs>
+                  <XAxis
+                    dataKey="day"
+                    tick={{ fontSize: 10, fill: "#94A3B8" }}
+                    interval="preserveStartEnd"
+                    axisLine={false}
+                    tickLine={false}
+                  />
+                  <Tooltip content={<TrajectoryTooltip />} />
+                  <ReferenceLine
+                    y={0}
+                    stroke="#ef4444"
+                    strokeDasharray="3 3"
+                    strokeOpacity={0.5}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="balance"
+                    stroke={color}
+                    fill="url(#healthAreaGradient)"
+                    strokeWidth={2}
+                    dot={false}
+                  />
+                </AreaChart>
+              </ResponsiveContainer>
+            </div>
+          ) : (
+            <p className="text-sm text-cf-text-secondary">Último dia do mês.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default HealthOverview;

--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -18,6 +18,10 @@ vi.mock("../components/UpgradeModal", () => ({
   default: () => null,
 }));
 
+vi.mock("../components/HealthOverview", () => ({
+  default: () => null,
+}));
+
 vi.mock("../components/TransactionChart", () => ({
   default: () => <div data-testid="transaction-chart" />,
 }));

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -53,6 +53,7 @@ import { formatCurrency } from "../utils/formatCurrency";
 
 const TransactionChart = lazy(() => import("../components/TransactionChart"));
 const TrendChart = lazy(() => import("../components/TrendChart"));
+const HealthOverview = lazy(() => import("../components/HealthOverview"));
 
 type SummaryMetricKey = "income" | "expense" | "balance";
 type MonthOverMonthDirection = "up" | "down" | "flat";
@@ -2346,6 +2347,10 @@ const App = ({
             ) : null}
           </section>
         <ForecastCard onOpenProfileSettings={onOpenProfileSettings} />
+
+        <Suspense fallback={null}>
+          <HealthOverview />
+        </Suspense>
 
         <BillsSummaryWidget onOpenBills={handleOpenBills} />
 


### PR DESCRIPTION
## Summary

Two financial health panels in a single self-contained component, placed between `ForecastCard` and `BillsSummaryWidget`:

**D5 — Gauge de Dinheiro Livre**
- Custom SVG semicircle arc using `pathLength={100}` + `strokeDasharray` — no extra dependency
- Shows `adjustedProjectedBalance / incomeExpected × 100%`
- Green ≥ 15%, amber < 15%, red ≤ 0; omitted when `incomeExpected` is null

**D4-lite — Trajetória do Mês (Landing Chart)**
- Recharts `AreaChart` with `daysRemaining + 1` data points
- `generateTrajectory()` (exported pure function): start = `adjustedProjectedBalance + dailyAvgSpending × daysRemaining`; each day subtracts `dailyAvgSpending`; final point lands exactly on `adjustedProjectedBalance`
- `ReferenceLine y={0}` marks the zero-crossing threshold
- Area gradient uses the same color as the gauge (green/amber/red)

Returns `null` silently when forecast is null or the month is over — no noise for new users.

## Test plan

- [ ] `generateTrajectory` (pure): empty on daysRemaining=0, correct length (N+1), first="Hoje"/last="Fim", math closes on adjustedProjectedBalance, daily decay
- [ ] Component: null when no forecast, null when daysRemaining=0, renders both panel titles, chart receives N+1 points, risk label on negative balance, gauge present/absent based on incomeExpected
- [ ] 198/198 web tests green