### PR TITLE
feat(goals): Saving Goals full-stack + alertas de risco + contribuição rápida

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -39,3 +39,9 @@ AUTH_RATE_LIMIT_MAX_REQUESTS=20
 AUTH_BRUTE_FORCE_WINDOW_MS=900000
 AUTH_BRUTE_FORCE_MAX_ATTEMPTS=5
 AUTH_BRUTE_FORCE_LOCK_MS=900000
+# AI Insight (Claude Haiku via Anthropic SDK)
+# Obtenha em: https://console.anthropic.com/settings/keys
+# ANTHROPIC_API_KEY=sk-ant-...
+# Rate limit: chamadas ao /ai/insight por usuário (padrão: 10 calls / 10 min)
+# AI_RATE_LIMIT_MAX=10
+# AI_RATE_LIMIT_WINDOW_MS=600000

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,6 +17,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.80.0",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",

--- a/apps/api/src/ai.test.js
+++ b/apps/api/src/ai.test.js
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+import request from "supertest";
+import app from "./app.js";
+import { clearDbClientForTests, dbQuery } from "./db/index.js";
+import {
+  setupTestDb,
+  registerAndLogin,
+  expectErrorResponseWithRequestId,
+} from "./test-helpers.js";
+import { resetLoginProtectionState } from "./middlewares/login-protection.middleware.js";
+import { resetImportRateLimiterState, resetWriteRateLimiterState } from "./middlewares/rate-limit.middleware.js";
+import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
+
+// Stable reference to the mock fn — hoisted so it's available inside vi.mock factory
+const mockCreate = vi.hoisted(() => vi.fn());
+
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: vi.fn(() => ({ messages: { create: mockCreate } })),
+}));
+
+const buildMockAnthropicResponse = (text) => ({
+  content: [{ type: "text", text }],
+});
+
+const resetState = async () => {
+  resetLoginProtectionState();
+  resetImportRateLimiterState();
+  resetWriteRateLimiterState();
+  resetHttpMetricsForTests();
+  mockCreate.mockReset();
+  await dbQuery("DELETE FROM user_forecasts");
+  await dbQuery("DELETE FROM user_profiles");
+  await dbQuery("DELETE FROM transactions");
+  await dbQuery("DELETE FROM categories");
+  await dbQuery("DELETE FROM user_identities");
+  await dbQuery("DELETE FROM users");
+};
+
+const insertForecast = async (userId, overrides = {}) => {
+  const now = new Date();
+  const mStart = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}-01`;
+  const defaults = {
+    projected_balance: 800,
+    income_expected: 3000,
+    spending_to_date: 1200,
+    daily_avg_spending: 60,
+    days_remaining: 10,
+  };
+  const v = { ...defaults, ...overrides };
+  await dbQuery(
+    `INSERT INTO user_forecasts
+       (user_id, month, engine_version, projected_balance, income_expected,
+        spending_to_date, daily_avg_spending, days_remaining,
+        flip_detected, flip_direction, generated_at)
+     VALUES ($1, $2, 'v1', $3, $4, $5, $6, $7, false, null, NOW())`,
+    [userId, mStart, v.projected_balance, v.income_expected, v.spending_to_date, v.daily_avg_spending, v.days_remaining],
+  );
+  return mStart;
+};
+
+const getUserId = async (email) => {
+  const r = await dbQuery("SELECT id FROM users WHERE email = $1 LIMIT 1", [email]);
+  return r.rows[0].id;
+};
+
+describe("GET /ai/insight", () => {
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await clearDbClientForTests(); });
+  beforeEach(resetState);
+
+  it("retorna 401 sem token", async () => {
+    const res = await request(app).get("/ai/insight");
+    expectErrorResponseWithRequestId(res, 401, "Token de autenticacao ausente ou invalido.");
+  });
+
+  it("retorna null quando nao ha forecast para o mes", async () => {
+    const token = await registerAndLogin("ai-no-forecast@test.dev");
+
+    const res = await request(app)
+      .get("/ai/insight")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toBeNull();
+  });
+
+  it("retorna null quando forecast tem daysRemaining zero", async () => {
+    const token = await registerAndLogin("ai-zero-days@test.dev");
+    const userId = await getUserId("ai-zero-days@test.dev");
+    await insertForecast(userId, { days_remaining: 0 });
+
+    const res = await request(app)
+      .get("/ai/insight")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toBeNull();
+  });
+
+  it("retorna insight estruturado quando forecast valido e LLM responde", async () => {
+    const token = await registerAndLogin("ai-valid@test.dev");
+    const userId = await getUserId("ai-valid@test.dev");
+    await insertForecast(userId);
+
+    mockCreate.mockResolvedValueOnce(
+      buildMockAnthropicResponse("Seu saldo está saudável. Considere reservar R$ 200 para uma meta de emergência.")
+    );
+
+    const res = await request(app)
+      .get("/ai/insight")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      type: "success",
+      title: "Dica do Especialista",
+      message: "Seu saldo está saudável. Considere reservar R$ 200 para uma meta de emergência.",
+      action_label: "Ver detalhes",
+    });
+    expect(typeof res.body.id).toBe("string");
+    expect(mockCreate).toHaveBeenCalledOnce();
+  });
+
+  it("retorna type warning quando adjustedProjectedBalance e negativo", async () => {
+    const token = await registerAndLogin("ai-negative@test.dev");
+    const userId = await getUserId("ai-negative@test.dev");
+    await insertForecast(userId, { projected_balance: -300 });
+
+    mockCreate.mockResolvedValueOnce(
+      buildMockAnthropicResponse("Projeção negativa. Corte gastos em Lazer para equilibrar o mês.")
+    );
+
+    const res = await request(app)
+      .get("/ai/insight")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.type).toBe("warning");
+  });
+
+  it("retorna null silenciosamente quando LLM falha", async () => {
+    const token = await registerAndLogin("ai-llm-fail@test.dev");
+    const userId = await getUserId("ai-llm-fail@test.dev");
+    await insertForecast(userId);
+
+    mockCreate.mockRejectedValueOnce(new Error("Network error"));
+
+    const res = await request(app)
+      .get("/ai/insight")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toBeNull();
+  });
+
+  it("passa top_categories ao LLM quando existem transacoes de saida", async () => {
+    const token = await registerAndLogin("ai-categories@test.dev");
+    const userId = await getUserId("ai-categories@test.dev");
+    await insertForecast(userId);
+
+    const catResult = await dbQuery(
+      `INSERT INTO categories (user_id, name, normalized_name) VALUES ($1, 'Alimentacao', 'alimentacao') RETURNING id`,
+      [userId],
+    );
+    const catId = catResult.rows[0].id;
+    const now = new Date();
+    const txDate = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}-01`;
+    await dbQuery(
+      `INSERT INTO transactions (user_id, description, value, type, date, category_id)
+       VALUES ($1, 'Supermercado', 400, 'Saida', $2, $3)`,
+      [userId, txDate, catId],
+    );
+
+    mockCreate.mockResolvedValueOnce(
+      buildMockAnthropicResponse("Alimentacao é seu maior gasto. Reduza em R$ 100 para melhorar a projeção.")
+    );
+
+    await request(app)
+      .get("/ai/insight")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(mockCreate).toHaveBeenCalledOnce();
+    const callArg = mockCreate.mock.calls[0][0];
+    const userContent = JSON.parse(callArg.messages[0].content);
+    expect(userContent.top_categories[0].name).toBe("Alimentacao");
+    expect(userContent.top_categories[0].expense).toBe(400);
+  });
+});

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -18,6 +18,7 @@ import incomeSourcesRoutes from "./routes/income-sources.routes.js";
 import salaryRoutes from "./routes/salary.routes.js";
 import opsRoutes from "./routes/ops.routes.js";
 import aiRoutes from "./routes/ai.routes.js";
+import goalsRoutes from "./routes/goals.routes.js";
 import { notFoundHandler, errorHandler } from "./middlewares/error.middleware.js";
 import { requestIdMiddleware } from "./middlewares/request-id.middleware.js";
 import { requestLoggingMiddleware } from "./middlewares/request-logging.middleware.js";
@@ -98,6 +99,7 @@ app.use("/income-sources", incomeSourcesRoutes);
 app.use("/salary", salaryRoutes);
 app.use("/ops", opsRoutes);
 app.use("/ai", aiRoutes);
+app.use("/goals", goalsRoutes);
 
 app.use(notFoundHandler);
 app.use(errorHandler);

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -17,6 +17,7 @@ import billsRoutes from "./routes/bills.routes.js";
 import incomeSourcesRoutes from "./routes/income-sources.routes.js";
 import salaryRoutes from "./routes/salary.routes.js";
 import opsRoutes from "./routes/ops.routes.js";
+import aiRoutes from "./routes/ai.routes.js";
 import { notFoundHandler, errorHandler } from "./middlewares/error.middleware.js";
 import { requestIdMiddleware } from "./middlewares/request-id.middleware.js";
 import { requestLoggingMiddleware } from "./middlewares/request-logging.middleware.js";
@@ -96,6 +97,7 @@ app.use("/bills", billsRoutes);
 app.use("/income-sources", incomeSourcesRoutes);
 app.use("/salary", salaryRoutes);
 app.use("/ops", opsRoutes);
+app.use("/ai", aiRoutes);
 
 app.use(notFoundHandler);
 app.use(errorHandler);

--- a/apps/api/src/db/migrations/030_create_user_goals.sql
+++ b/apps/api/src/db/migrations/030_create_user_goals.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS user_goals (
+  id             SERIAL PRIMARY KEY,
+  user_id        INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  title          TEXT NOT NULL,
+  target_amount  NUMERIC(15,2) NOT NULL,
+  current_amount NUMERIC(15,2) NOT NULL DEFAULT 0,
+  target_date    DATE NOT NULL,
+  icon           TEXT NOT NULL DEFAULT 'target',
+  notes          TEXT,
+  deleted_at     TIMESTAMPTZ,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_goals_user_deleted
+  ON user_goals (user_id, deleted_at);

--- a/apps/api/src/goals.test.js
+++ b/apps/api/src/goals.test.js
@@ -1,0 +1,294 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import request from "supertest";
+import app from "./app.js";
+import { clearDbClientForTests, dbQuery } from "./db/index.js";
+import {
+  setupTestDb,
+  registerAndLogin,
+  expectErrorResponseWithRequestId,
+} from "./test-helpers.js";
+import { resetLoginProtectionState } from "./middlewares/login-protection.middleware.js";
+import { resetImportRateLimiterState, resetWriteRateLimiterState } from "./middlewares/rate-limit.middleware.js";
+import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
+import { calcMonthlyNeeded } from "./services/goals.service.js";
+
+const resetState = async () => {
+  resetLoginProtectionState();
+  resetImportRateLimiterState();
+  resetWriteRateLimiterState();
+  resetHttpMetricsForTests();
+  await dbQuery("DELETE FROM user_goals");
+  await dbQuery("DELETE FROM user_identities");
+  await dbQuery("DELETE FROM users");
+};
+
+const BASE_GOAL = {
+  title: "Viagem Japão",
+  target_amount: 15000,
+  current_amount: 1000,
+  target_date: "2027-10-01",
+  icon: "plane",
+};
+
+// ─── Unit tests: calcMonthlyNeeded ───────────────────────────────────────────
+
+describe("calcMonthlyNeeded", () => {
+  const NOW = new Date("2026-03-25T12:00:00Z");
+
+  it("retorna zero quando meta ja foi atingida", () => {
+    expect(calcMonthlyNeeded(1000, 1000, "2026-06-01", NOW)).toBe(0);
+  });
+
+  it("retorna zero quando current supera target", () => {
+    expect(calcMonthlyNeeded(1000, 1200, "2026-06-01", NOW)).toBe(0);
+  });
+
+  it("retorna remaining quando data ja passou (0 meses)", () => {
+    // target_date in the past: months = 0 → returns full remaining
+    expect(calcMonthlyNeeded(1000, 0, "2026-02-01", NOW)).toBe(1000);
+  });
+
+  it("divide remaining pelo numero de meses corretamente", () => {
+    // NOW = 2026-03-25; target = 2026-09-01 → 6 meses; remaining = 1200
+    const result = calcMonthlyNeeded(1200, 0, "2026-09-01", NOW);
+    expect(result).toBe(200); // 1200 / 6
+  });
+
+  it("arredonda em duas casas decimais", () => {
+    // remaining = 100; months = 3 → 33.33
+    const result = calcMonthlyNeeded(100, 0, "2026-06-01", NOW);
+    expect(result).toBe(33.33);
+  });
+});
+
+// ─── HTTP endpoint tests ──────────────────────────────────────────────────────
+
+describe("Goals API", () => {
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await clearDbClientForTests(); });
+  beforeEach(resetState);
+
+  // ── Auth ──────────────────────────────────────────────────────────────────
+
+  it("GET /goals — retorna 401 sem token", async () => {
+    const res = await request(app).get("/goals");
+    expectErrorResponseWithRequestId(res, 401, "Token de autenticacao ausente ou invalido.");
+  });
+
+  it("POST /goals — retorna 401 sem token", async () => {
+    const res = await request(app).post("/goals").send(BASE_GOAL);
+    expectErrorResponseWithRequestId(res, 401, "Token de autenticacao ausente ou invalido.");
+  });
+
+  // ── List ──────────────────────────────────────────────────────────────────
+
+  it("GET /goals — retorna lista vazia quando sem metas", async () => {
+    const token = await registerAndLogin("goals-list-empty@test.dev");
+
+    const res = await request(app)
+      .get("/goals")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it("GET /goals — retorna apenas metas do usuario autenticado", async () => {
+    const token1 = await registerAndLogin("goals-isolation-a@test.dev");
+    const token2 = await registerAndLogin("goals-isolation-b@test.dev");
+
+    await request(app).post("/goals").set("Authorization", `Bearer ${token1}`).send(BASE_GOAL);
+
+    const res = await request(app)
+      .get("/goals")
+      .set("Authorization", `Bearer ${token2}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(0);
+  });
+
+  // ── Create ────────────────────────────────────────────────────────────────
+
+  it("POST /goals — cria meta com campos validos", async () => {
+    const token = await registerAndLogin("goals-create@test.dev");
+
+    const res = await request(app)
+      .post("/goals")
+      .set("Authorization", `Bearer ${token}`)
+      .send(BASE_GOAL);
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      title: "Viagem Japão",
+      targetAmount: 15000,
+      currentAmount: 1000,
+      targetDate: "2027-10-01",
+      icon: "plane",
+    });
+    expect(typeof res.body.monthlyNeeded).toBe("number");
+    expect(res.body.monthlyNeeded).toBeGreaterThan(0);
+  });
+
+  it("POST /goals — cria meta sem current_amount (default 0)", async () => {
+    const token = await registerAndLogin("goals-create-noamt@test.dev");
+
+    const res = await request(app)
+      .post("/goals")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ title: "Reserva", target_amount: 5000, target_date: "2026-12-01" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.currentAmount).toBe(0);
+    expect(res.body.icon).toBe("target");
+  });
+
+  it("POST /goals — retorna 400 quando title e vazio", async () => {
+    const token = await registerAndLogin("goals-val-title@test.dev");
+
+    const res = await request(app)
+      .post("/goals")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ ...BASE_GOAL, title: "" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /goals — retorna 400 quando target_amount e zero", async () => {
+    const token = await registerAndLogin("goals-val-target@test.dev");
+
+    const res = await request(app)
+      .post("/goals")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ ...BASE_GOAL, target_amount: 0 });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /goals — retorna 400 quando current_amount supera target_amount", async () => {
+    const token = await registerAndLogin("goals-val-current@test.dev");
+
+    const res = await request(app)
+      .post("/goals")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ ...BASE_GOAL, current_amount: 20000 });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /goals — retorna 400 quando target_date e invalido", async () => {
+    const token = await registerAndLogin("goals-val-date@test.dev");
+
+    const res = await request(app)
+      .post("/goals")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ ...BASE_GOAL, target_date: "nao-e-data" });
+
+    expect(res.status).toBe(400);
+  });
+
+  // ── Update ────────────────────────────────────────────────────────────────
+
+  it("PATCH /goals/:id — atualiza campos parcialmente", async () => {
+    const token = await registerAndLogin("goals-update@test.dev");
+
+    const created = await request(app)
+      .post("/goals")
+      .set("Authorization", `Bearer ${token}`)
+      .send(BASE_GOAL);
+
+    const res = await request(app)
+      .patch(`/goals/${created.body.id}`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ current_amount: 5000 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.currentAmount).toBe(5000);
+    expect(res.body.title).toBe("Viagem Japão"); // outros campos mantidos
+  });
+
+  it("PATCH /goals/:id — retorna 404 para meta de outro usuario", async () => {
+    const tokenA = await registerAndLogin("goals-patch-a@test.dev");
+    const tokenB = await registerAndLogin("goals-patch-b@test.dev");
+
+    const created = await request(app)
+      .post("/goals")
+      .set("Authorization", `Bearer ${tokenA}`)
+      .send(BASE_GOAL);
+
+    const res = await request(app)
+      .patch(`/goals/${created.body.id}`)
+      .set("Authorization", `Bearer ${tokenB}`)
+      .send({ current_amount: 5000 });
+
+    expect(res.status).toBe(404);
+  });
+
+  // ── Delete ────────────────────────────────────────────────────────────────
+
+  it("DELETE /goals/:id — soft-deleta meta e retorna 204", async () => {
+    const token = await registerAndLogin("goals-delete@test.dev");
+
+    const created = await request(app)
+      .post("/goals")
+      .set("Authorization", `Bearer ${token}`)
+      .send(BASE_GOAL);
+
+    const del = await request(app)
+      .delete(`/goals/${created.body.id}`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(del.status).toBe(204);
+
+    const list = await request(app).get("/goals").set("Authorization", `Bearer ${token}`);
+    expect(list.body).toHaveLength(0);
+  });
+
+  it("DELETE /goals/:id — retorna 404 para meta ja deletada", async () => {
+    const token = await registerAndLogin("goals-delete-twice@test.dev");
+
+    const created = await request(app)
+      .post("/goals")
+      .set("Authorization", `Bearer ${token}`)
+      .send(BASE_GOAL);
+
+    await request(app).delete(`/goals/${created.body.id}`).set("Authorization", `Bearer ${token}`);
+
+    const res = await request(app)
+      .delete(`/goals/${created.body.id}`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  it("DELETE /goals/:id — retorna 404 para meta de outro usuario", async () => {
+    const tokenA = await registerAndLogin("goals-del-a@test.dev");
+    const tokenB = await registerAndLogin("goals-del-b@test.dev");
+
+    const created = await request(app)
+      .post("/goals")
+      .set("Authorization", `Bearer ${tokenA}`)
+      .send(BASE_GOAL);
+
+    const res = await request(app)
+      .delete(`/goals/${created.body.id}`)
+      .set("Authorization", `Bearer ${tokenB}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  // ── monthlyNeeded ─────────────────────────────────────────────────────────
+
+  it("GET /goals — monthlyNeeded e calculado e retornado", async () => {
+    const token = await registerAndLogin("goals-monthly@test.dev");
+
+    await request(app)
+      .post("/goals")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ title: "Meta", target_amount: 1200, current_amount: 0, target_date: "2026-09-01" });
+
+    const res = await request(app).get("/goals").set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body[0].monthlyNeeded).toBeGreaterThan(0);
+  });
+});

--- a/apps/api/src/middlewares/rate-limit.middleware.js
+++ b/apps/api/src/middlewares/rate-limit.middleware.js
@@ -6,6 +6,8 @@ const DEFAULT_WRITE_RATE_LIMIT_WINDOW_MS = 60 * 1000;
 const DEFAULT_WRITE_RATE_LIMIT_MAX_REQUESTS = 60;
 const DEFAULT_ANALYTICS_RATE_LIMIT_WINDOW_MS = 60 * 1000;
 const DEFAULT_ANALYTICS_RATE_LIMIT_MAX_REQUESTS = 30; // analytics events are low-frequency by nature
+const DEFAULT_AI_RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000; // 10 minutes
+const DEFAULT_AI_RATE_LIMIT_MAX_REQUESTS = 10; // LLM calls are expensive
 const WRITE_RATE_LIMIT_ERROR_MESSAGE = "Muitas requisicoes. Tente novamente em instantes.";
 
 const parsePositiveInteger = (value, fallbackValue) => {
@@ -52,6 +54,18 @@ const getAnalyticsRateLimitMaxRequests = () =>
   parsePositiveInteger(
     process.env.ANALYTICS_RATE_LIMIT_MAX,
     DEFAULT_ANALYTICS_RATE_LIMIT_MAX_REQUESTS,
+  );
+
+const getAiRateLimitWindowMs = () =>
+  parsePositiveInteger(
+    process.env.AI_RATE_LIMIT_WINDOW_MS,
+    DEFAULT_AI_RATE_LIMIT_WINDOW_MS,
+  );
+
+const getAiRateLimitMaxRequests = () =>
+  parsePositiveInteger(
+    process.env.AI_RATE_LIMIT_MAX,
+    DEFAULT_AI_RATE_LIMIT_MAX_REQUESTS,
   );
 
 const createError = (status, message) => {
@@ -108,6 +122,15 @@ export const analyticsWriteRateLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   keyGenerator: (request) => resolveRateLimitKey(request, "analytics-write"),
+  handler: createRateLimitExceededHandler(),
+});
+
+export const aiRateLimiter = rateLimit({
+  windowMs: getAiRateLimitWindowMs(),
+  max: getAiRateLimitMaxRequests(),
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (request) => resolveRateLimitKey(request, "ai"),
   handler: createRateLimitExceededHandler(),
 });
 

--- a/apps/api/src/middlewares/rate-limit.middleware.js
+++ b/apps/api/src/middlewares/rate-limit.middleware.js
@@ -116,6 +116,7 @@ export const categoriesWriteRateLimiter = createUserWriteRateLimiter("categories
 export const budgetsWriteRateLimiter = createUserWriteRateLimiter("budgets-write");
 export const billsWriteRateLimiter = createUserWriteRateLimiter("bills-write");
 export const incomeSourcesWriteRateLimiter = createUserWriteRateLimiter("income-sources-write");
+export const goalsWriteRateLimiter = createUserWriteRateLimiter("goals-write");
 export const analyticsWriteRateLimiter = rateLimit({
   windowMs: getAnalyticsRateLimitWindowMs(),
   max: getAnalyticsRateLimitMaxRequests(),

--- a/apps/api/src/routes/ai.routes.js
+++ b/apps/api/src/routes/ai.routes.js
@@ -1,0 +1,20 @@
+import { Router } from "express";
+import { authMiddleware } from "../middlewares/auth.middleware.js";
+import { requireActiveTrialOrPaidPlan } from "../middlewares/entitlement.middleware.js";
+import { aiRateLimiter } from "../middlewares/rate-limit.middleware.js";
+import { generateFinancialInsight } from "../services/ai.service.js";
+
+const router = Router();
+
+// GET /ai/insight — generates a Claude Haiku financial insight for the current user.
+// Returns null when no forecast exists or AI call fails (never 500 from LLM errors).
+router.get("/insight", authMiddleware, requireActiveTrialOrPaidPlan, aiRateLimiter, async (req, res, next) => {
+  try {
+    const insight = await generateFinancialInsight(req.user.id);
+    res.status(200).json(insight);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/apps/api/src/routes/goals.routes.js
+++ b/apps/api/src/routes/goals.routes.js
@@ -1,0 +1,56 @@
+import { Router } from "express";
+import { authMiddleware } from "../middlewares/auth.middleware.js";
+import { requireActiveTrialOrPaidPlan } from "../middlewares/entitlement.middleware.js";
+import { goalsWriteRateLimiter } from "../middlewares/rate-limit.middleware.js";
+import {
+  listGoalsForUser,
+  createGoalForUser,
+  updateGoalForUser,
+  deleteGoalForUser,
+} from "../services/goals.service.js";
+
+const router = Router();
+
+router.use(authMiddleware, requireActiveTrialOrPaidPlan);
+
+// GET /goals
+router.get("/", async (req, res, next) => {
+  try {
+    const goals = await listGoalsForUser(req.user.id);
+    res.status(200).json(goals);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /goals
+router.post("/", goalsWriteRateLimiter, async (req, res, next) => {
+  try {
+    const goal = await createGoalForUser(req.user.id, req.body ?? {});
+    res.status(201).json(goal);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// PATCH /goals/:id
+router.patch("/:id", goalsWriteRateLimiter, async (req, res, next) => {
+  try {
+    const goal = await updateGoalForUser(req.user.id, req.params.id, req.body ?? {});
+    res.status(200).json(goal);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// DELETE /goals/:id
+router.delete("/:id", goalsWriteRateLimiter, async (req, res, next) => {
+  try {
+    await deleteGoalForUser(req.user.id, req.params.id);
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/apps/api/src/services/ai.service.js
+++ b/apps/api/src/services/ai.service.js
@@ -5,7 +5,7 @@ import { dbQuery } from "../db/index.js";
 import { logInfo, logWarn, logError } from "../observability/logger.js";
 
 const SYSTEM_PROMPT =
-  "Você é o Especialista Financeiro do app Control Finance. Analise os dados JSON fornecidos e retorne um único insight acionável de no máximo 180 caracteres. Seja pragmático. Se os dados forem positivos, parabenize e sugira uma meta de reserva. Se forem negativos, aponte a categoria culpada e sugira um corte específico. Retorne APENAS o texto do insight, sem formatação, sem aspas, sem JSON.";
+  "Você é o Especialista Financeiro do app Control Finance. Analise os dados JSON e retorne um único insight acionável de no máximo 180 caracteres. Prioridade: se alguma meta tiver monthly_needed maior que o balance, alerte que o plano está inviável e sugira qual gasto cortar. Se os dados forem negativos sem metas, aponte a categoria culpada. Se forem positivos, parabenize e reforce a meta mais próxima do prazo. Retorne APENAS o texto do insight, sem formatação, sem aspas, sem JSON.";
 
 const monthStartStr = (now) => {
   const y = now.getUTCFullYear();

--- a/apps/api/src/services/ai.service.js
+++ b/apps/api/src/services/ai.service.js
@@ -1,0 +1,99 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { getLatestForecast } from "./forecast.service.js";
+import { dbQuery } from "../db/index.js";
+
+const SYSTEM_PROMPT =
+  "Você é o Especialista Financeiro do app Control Finance. Analise os dados JSON fornecidos e retorne um único insight acionável de no máximo 180 caracteres. Seja pragmático. Se os dados forem positivos, parabenize e sugira uma meta de reserva. Se forem negativos, aponte a categoria culpada e sugira um corte específico. Retorne APENAS o texto do insight, sem formatação, sem aspas, sem JSON.";
+
+const monthStartStr = (now) => {
+  const y = now.getUTCFullYear();
+  const m = String(now.getUTCMonth() + 1).padStart(2, "0");
+  return `${y}-${m}-01`;
+};
+
+const monthEndStr = (now) => {
+  const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 0));
+  return d.toISOString().slice(0, 10);
+};
+
+const getTopExpenseCategories = async (userId, now = new Date()) => {
+  const result = await dbQuery(
+    `SELECT
+       MIN(c.name) AS category_name,
+       COALESCE(SUM(t.value), 0)::numeric AS expense
+     FROM transactions t
+     LEFT JOIN categories c
+       ON c.id = t.category_id
+      AND c.user_id = $1
+     WHERE t.user_id = $1
+       AND t.deleted_at IS NULL
+       AND t.type = 'Saida'
+       AND t.date >= $2
+       AND t.date <= $3
+     GROUP BY t.category_id
+     ORDER BY expense DESC
+     LIMIT 3`,
+    [userId, monthStartStr(now), monthEndStr(now)],
+  );
+
+  return result.rows.map((r) => ({
+    name: r.category_name || "Sem categoria",
+    expense: Number(r.expense),
+  }));
+};
+
+const resolveInsightType = (adjustedBalance, incomeExpected) => {
+  if (adjustedBalance <= 0) return "warning";
+  const pct = incomeExpected != null && incomeExpected > 0
+    ? (adjustedBalance / incomeExpected) * 100
+    : null;
+  if (pct !== null && pct < 15) return "info";
+  return "success";
+};
+
+/**
+ * Generates a Claude Haiku financial insight for the given user.
+ * Returns null when no forecast exists, daysRemaining <= 0, or the LLM call fails.
+ *
+ * @param {number} userId
+ * @param {{ now?: Date, anthropicClient?: Anthropic }} options
+ */
+export const generateFinancialInsight = async (userId, { now = new Date(), anthropicClient } = {}) => {
+  const forecast = await getLatestForecast(userId, { now });
+  if (!forecast || forecast.daysRemaining <= 0) return null;
+
+  const topCategories = await getTopExpenseCategories(userId, now);
+
+  const context = {
+    balance: forecast.adjustedProjectedBalance,
+    burn_rate: forecast.dailyAvgSpending,
+    runway: forecast.daysRemaining,
+    health_score: forecast.adjustedProjectedBalance > 0 ? "positive" : "negative",
+    top_categories: topCategories,
+  };
+
+  const client = anthropicClient ?? new Anthropic();
+
+  let insightText;
+  try {
+    const response = await client.messages.create({
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 256,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: "user", content: JSON.stringify(context) }],
+    });
+    insightText = response.content[0]?.text?.trim() || null;
+  } catch {
+    return null;
+  }
+
+  if (!insightText) return null;
+
+  return {
+    id: `insight_${userId}_${Date.now()}`,
+    type: resolveInsightType(forecast.adjustedProjectedBalance, forecast.incomeExpected),
+    title: "Dica do Especialista",
+    message: insightText,
+    action_label: "Ver detalhes",
+  };
+};

--- a/apps/api/src/services/ai.service.js
+++ b/apps/api/src/services/ai.service.js
@@ -1,6 +1,7 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { getLatestForecast } from "./forecast.service.js";
 import { dbQuery } from "../db/index.js";
+import { logInfo, logWarn, logError } from "../observability/logger.js";
 
 const SYSTEM_PROMPT =
   "Você é o Especialista Financeiro do app Control Finance. Analise os dados JSON fornecidos e retorne um único insight acionável de no máximo 180 caracteres. Seja pragmático. Se os dados forem positivos, parabenize e sugira uma meta de reserva. Se forem negativos, aponte a categoria culpada e sugira um corte específico. Retorne APENAS o texto do insight, sem formatação, sem aspas, sem JSON.";
@@ -75,6 +76,7 @@ export const generateFinancialInsight = async (userId, { now = new Date(), anthr
   const client = anthropicClient ?? new Anthropic();
 
   let insightText;
+  const callStart = Date.now();
   try {
     const response = await client.messages.create({
       model: "claude-haiku-4-5-20251001",
@@ -83,15 +85,34 @@ export const generateFinancialInsight = async (userId, { now = new Date(), anthr
       messages: [{ role: "user", content: JSON.stringify(context) }],
     });
     insightText = response.content[0]?.text?.trim() || null;
-  } catch {
+  } catch (error) {
+    logError({
+      event: "ai.insight.llm_error",
+      userId,
+      errorMessage: error?.message || "unknown",
+      latencyMs: Date.now() - callStart,
+    });
     return null;
   }
 
-  if (!insightText) return null;
+  if (!insightText) {
+    logWarn({ event: "ai.insight.empty_response", userId, latencyMs: Date.now() - callStart });
+    return null;
+  }
+
+  const type = resolveInsightType(forecast.adjustedProjectedBalance, forecast.incomeExpected);
+
+  logInfo({
+    event: "ai.insight.generated",
+    userId,
+    type,
+    charCount: insightText.length,
+    latencyMs: Date.now() - callStart,
+  });
 
   return {
     id: `insight_${userId}_${Date.now()}`,
-    type: resolveInsightType(forecast.adjustedProjectedBalance, forecast.incomeExpected),
+    type,
     title: "Dica do Especialista",
     message: insightText,
     action_label: "Ver detalhes",

--- a/apps/api/src/services/ai.service.js
+++ b/apps/api/src/services/ai.service.js
@@ -1,5 +1,6 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { getLatestForecast } from "./forecast.service.js";
+import { getGoalsSummaryForAI } from "./goals.service.js";
 import { dbQuery } from "../db/index.js";
 import { logInfo, logWarn, logError } from "../observability/logger.js";
 
@@ -63,7 +64,10 @@ export const generateFinancialInsight = async (userId, { now = new Date(), anthr
   const forecast = await getLatestForecast(userId, { now });
   if (!forecast || forecast.daysRemaining <= 0) return null;
 
-  const topCategories = await getTopExpenseCategories(userId, now);
+  const [topCategories, goals] = await Promise.all([
+    getTopExpenseCategories(userId, now),
+    getGoalsSummaryForAI(userId, { now }),
+  ]);
 
   const context = {
     balance: forecast.adjustedProjectedBalance,
@@ -71,6 +75,7 @@ export const generateFinancialInsight = async (userId, { now = new Date(), anthr
     runway: forecast.daysRemaining,
     health_score: forecast.adjustedProjectedBalance > 0 ? "positive" : "negative",
     top_categories: topCategories,
+    goals,
   };
 
   const client = anthropicClient ?? new Anthropic();

--- a/apps/api/src/services/goals.service.js
+++ b/apps/api/src/services/goals.service.js
@@ -1,0 +1,252 @@
+import { dbQuery } from "../db/index.js";
+
+const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+const TITLE_MAX_LENGTH = 200;
+const ICON_MAX_LENGTH = 50;
+const NOTES_MAX_LENGTH = 1000;
+const VALID_ICONS = new Set([
+  "target", "plane", "home", "car", "graduation", "heart",
+  "star", "gift", "briefcase", "umbrella",
+]);
+
+const createError = (status, message) => {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+};
+
+const normalizeUserId = (value) => {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw createError(401, "Usuario nao autenticado.");
+  }
+  return parsed;
+};
+
+const normalizeGoalId = (value) => {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw createError(400, "ID de meta invalido.");
+  }
+  return parsed;
+};
+
+const isValidISODate = (value) => {
+  if (typeof value !== "string" || !ISO_DATE_REGEX.test(value)) return false;
+  const parsed = new Date(`${value}T00:00:00`);
+  return !Number.isNaN(parsed.getTime());
+};
+
+const toMoney = (value) => Number(Number(value || 0).toFixed(2));
+
+/**
+ * Months remaining from `now` until `targetDate` (inclusive of current month).
+ * Returns 0 if the date is in the past.
+ */
+const monthsUntil = (targetDate, now = new Date()) => {
+  const target = new Date(`${targetDate}T00:00:00`);
+  const diff =
+    (target.getFullYear() - now.getFullYear()) * 12 +
+    (target.getMonth() - now.getMonth());
+  return Math.max(0, diff);
+};
+
+/**
+ * How much the user needs to save each month to reach the goal on time.
+ * Returns 0 if the goal is already met or the date has passed.
+ */
+export const calcMonthlyNeeded = (targetAmount, currentAmount, targetDate, now = new Date()) => {
+  const remaining = toMoney(targetAmount) - toMoney(currentAmount);
+  if (remaining <= 0) return 0;
+  const months = monthsUntil(targetDate, now);
+  if (months === 0) return remaining; // overdue — full remaining needed now
+  return Number((remaining / months).toFixed(2));
+};
+
+const rowToGoal = (row, now = new Date()) => {
+  const targetDate =
+    typeof row.target_date === "string"
+      ? row.target_date.slice(0, 10)
+      : new Date(row.target_date).toISOString().slice(0, 10);
+
+  return {
+    id: row.id,
+    userId: row.user_id,
+    title: row.title,
+    targetAmount: Number(row.target_amount),
+    currentAmount: Number(row.current_amount),
+    targetDate,
+    icon: row.icon,
+    notes: row.notes ?? null,
+    monthlyNeeded: calcMonthlyNeeded(row.target_amount, row.current_amount, targetDate, now),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+};
+
+// ─── Queries ──────────────────────────────────────────────────────────────────
+
+export const listGoalsForUser = async (userId, { now = new Date() } = {}) => {
+  const uid = normalizeUserId(userId);
+  const result = await dbQuery(
+    `SELECT * FROM user_goals
+     WHERE user_id = $1 AND deleted_at IS NULL
+     ORDER BY target_date ASC, id ASC`,
+    [uid],
+  );
+  return result.rows.map((row) => rowToGoal(row, now));
+};
+
+export const createGoalForUser = async (userId, data, { now = new Date() } = {}) => {
+  const uid = normalizeUserId(userId);
+  const { title, target_amount, current_amount, target_date, icon, notes } = data ?? {};
+
+  if (!title || typeof title !== "string" || !title.trim()) {
+    throw createError(400, "Titulo da meta e obrigatorio.");
+  }
+  if (title.trim().length > TITLE_MAX_LENGTH) {
+    throw createError(400, `Titulo deve ter no maximo ${TITLE_MAX_LENGTH} caracteres.`);
+  }
+
+  const targetAmt = Number(target_amount);
+  if (!Number.isFinite(targetAmt) || targetAmt <= 0) {
+    throw createError(400, "Valor alvo deve ser maior que zero.");
+  }
+
+  const currentAmt = current_amount !== undefined ? Number(current_amount) : 0;
+  if (!Number.isFinite(currentAmt) || currentAmt < 0) {
+    throw createError(400, "Valor atual nao pode ser negativo.");
+  }
+  if (currentAmt > targetAmt) {
+    throw createError(400, "Valor atual nao pode superar o valor alvo.");
+  }
+
+  if (!isValidISODate(target_date)) {
+    throw createError(400, "Data alvo invalida. Use o formato YYYY-MM-DD.");
+  }
+
+  const resolvedIcon = icon && VALID_ICONS.has(icon) ? icon : "target";
+
+  const resolvedNotes =
+    notes !== undefined && notes !== null
+      ? String(notes).slice(0, NOTES_MAX_LENGTH) || null
+      : null;
+
+  const result = await dbQuery(
+    `INSERT INTO user_goals
+       (user_id, title, target_amount, current_amount, target_date, icon, notes)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
+     RETURNING *`,
+    [uid, title.trim(), toMoney(targetAmt), toMoney(currentAmt), target_date, resolvedIcon, resolvedNotes],
+  );
+
+  return rowToGoal(result.rows[0], now);
+};
+
+export const updateGoalForUser = async (userId, goalId, data, { now = new Date() } = {}) => {
+  const uid = normalizeUserId(userId);
+  const gid = normalizeGoalId(goalId);
+
+  const existing = await dbQuery(
+    `SELECT * FROM user_goals WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL`,
+    [gid, uid],
+  );
+  if (existing.rows.length === 0) {
+    throw createError(404, "Meta nao encontrada.");
+  }
+
+  const prev = existing.rows[0];
+  const { title, target_amount, current_amount, target_date, icon, notes } = data ?? {};
+
+  const nextTitle =
+    title !== undefined
+      ? (typeof title === "string" && title.trim() ? title.trim() : null)
+      : prev.title;
+  if (!nextTitle) throw createError(400, "Titulo da meta nao pode ser vazio.");
+  if (nextTitle.length > TITLE_MAX_LENGTH) {
+    throw createError(400, `Titulo deve ter no maximo ${TITLE_MAX_LENGTH} caracteres.`);
+  }
+
+  const nextTarget =
+    target_amount !== undefined ? Number(target_amount) : Number(prev.target_amount);
+  if (!Number.isFinite(nextTarget) || nextTarget <= 0) {
+    throw createError(400, "Valor alvo deve ser maior que zero.");
+  }
+
+  const nextCurrent =
+    current_amount !== undefined ? Number(current_amount) : Number(prev.current_amount);
+  if (!Number.isFinite(nextCurrent) || nextCurrent < 0) {
+    throw createError(400, "Valor atual nao pode ser negativo.");
+  }
+  if (nextCurrent > nextTarget) {
+    throw createError(400, "Valor atual nao pode superar o valor alvo.");
+  }
+
+  const nextDate = target_date !== undefined ? target_date : prev.target_date;
+  if (!isValidISODate(typeof nextDate === "string" ? nextDate : nextDate.toISOString().slice(0, 10))) {
+    throw createError(400, "Data alvo invalida. Use o formato YYYY-MM-DD.");
+  }
+
+  const nextIcon = icon !== undefined && VALID_ICONS.has(icon) ? icon : prev.icon;
+
+  const nextNotes =
+    notes !== undefined
+      ? (notes !== null ? String(notes).slice(0, NOTES_MAX_LENGTH) || null : null)
+      : prev.notes;
+
+  const result = await dbQuery(
+    `UPDATE user_goals
+     SET title          = $1,
+         target_amount  = $2,
+         current_amount = $3,
+         target_date    = $4,
+         icon           = $5,
+         notes          = $6,
+         updated_at     = NOW()
+     WHERE id = $7 AND user_id = $8 AND deleted_at IS NULL
+     RETURNING *`,
+    [nextTitle, toMoney(nextTarget), toMoney(nextCurrent), nextDate, nextIcon, nextNotes, gid, uid],
+  );
+
+  return rowToGoal(result.rows[0], now);
+};
+
+export const deleteGoalForUser = async (userId, goalId) => {
+  const uid = normalizeUserId(userId);
+  const gid = normalizeGoalId(goalId);
+
+  const result = await dbQuery(
+    `UPDATE user_goals SET deleted_at = NOW(), updated_at = NOW()
+     WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL
+     RETURNING id`,
+    [gid, uid],
+  );
+
+  if (result.rows.length === 0) {
+    throw createError(404, "Meta nao encontrada.");
+  }
+};
+
+/**
+ * Returns a summary of active goals for use in the AI prompt context.
+ * Lightweight — only the fields the LLM needs.
+ */
+export const getGoalsSummaryForAI = async (userId, { now = new Date() } = {}) => {
+  const uid = normalizeUserId(userId);
+  const result = await dbQuery(
+    `SELECT title, target_amount, current_amount, target_date
+     FROM user_goals
+     WHERE user_id = $1 AND deleted_at IS NULL
+     ORDER BY target_date ASC
+     LIMIT 5`,
+    [uid],
+  );
+
+  return result.rows.map((row) => ({
+    title: row.title,
+    monthly_needed: calcMonthlyNeeded(row.target_amount, row.current_amount, row.target_date, now),
+    progress_pct: row.target_amount > 0
+      ? Number(((row.current_amount / row.target_amount) * 100).toFixed(1))
+      : 0,
+  }));
+};

--- a/apps/web/src/components/AIInsightPanel.test.tsx
+++ b/apps/web/src/components/AIInsightPanel.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import AIInsightPanel from "./AIInsightPanel";
+import type { AiInsight } from "../services/ai.service";
+
+const buildInsight = (overrides: Partial<AiInsight> = {}): AiInsight => ({
+  id: "insight_1_123456",
+  type: "success",
+  title: "Dica do Especialista",
+  message: "Seu saldo está ótimo. Reserve R$ 300 para emergências.",
+  action_label: "Ver detalhes",
+  ...overrides,
+});
+
+describe("AIInsightPanel", () => {
+  it("renderiza shimmer de loading quando isLoading e true", () => {
+    render(<AIInsightPanel insight={null} isLoading />);
+    expect(screen.getByRole("status", { name: /carregando/i })).toBeInTheDocument();
+    expect(screen.queryByText("Dica do Especialista")).toBeNull();
+  });
+
+  it("retorna null quando nao esta carregando e insight e null", () => {
+    const { container } = render(<AIInsightPanel insight={null} isLoading={false} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renderiza titulo e mensagem do insight quando insight e valido", () => {
+    render(<AIInsightPanel insight={buildInsight()} isLoading={false} />);
+    expect(screen.getByText(/Dica do Especialista/)).toBeInTheDocument();
+    expect(screen.getByText("Seu saldo está ótimo. Reserve R$ 300 para emergências.")).toBeInTheDocument();
+  });
+
+  it("nao renderiza shimmer quando insight esta presente e isLoading e false", () => {
+    render(<AIInsightPanel insight={buildInsight()} isLoading={false} />);
+    expect(screen.queryByRole("status", { name: /carregando/i })).toBeNull();
+  });
+
+  it("aplica estilo warning para type warning", () => {
+    render(<AIInsightPanel insight={buildInsight({ type: "warning" })} isLoading={false} />);
+    const panel = screen.getByText(/Dica do Especialista/).closest("div");
+    expect(panel?.className).toContain("amber");
+  });
+
+  it("aplica estilo success para type success", () => {
+    render(<AIInsightPanel insight={buildInsight({ type: "success" })} isLoading={false} />);
+    const panel = screen.getByText(/Dica do Especialista/).closest("div");
+    expect(panel?.className).toContain("green");
+  });
+
+  it("aplica estilo info para type info", () => {
+    render(<AIInsightPanel insight={buildInsight({ type: "info" })} isLoading={false} />);
+    const panel = screen.getByText(/Dica do Especialista/).closest("div");
+    expect(panel?.className).toContain("blue");
+  });
+});

--- a/apps/web/src/components/AIInsightPanel.tsx
+++ b/apps/web/src/components/AIInsightPanel.tsx
@@ -1,0 +1,53 @@
+import type { AiInsight } from "../services/ai.service";
+
+interface AIInsightPanelProps {
+  insight: AiInsight | null;
+  isLoading: boolean;
+}
+
+const typeStyles: Record<AiInsight["type"], string> = {
+  warning: "border-amber-400/30 bg-amber-400/10 text-amber-600 dark:text-amber-400",
+  info: "border-blue-400/30 bg-blue-400/10 text-blue-600 dark:text-blue-400",
+  success: "border-green-400/30 bg-green-400/10 text-green-600 dark:text-green-400",
+};
+
+const typeIconLabel: Record<AiInsight["type"], string> = {
+  warning: "⚠",
+  info: "ℹ",
+  success: "✓",
+};
+
+const AIInsightPanel = ({ insight, isLoading }: AIInsightPanelProps): JSX.Element | null => {
+  if (isLoading) {
+    return (
+      <div
+        role="status"
+        aria-label="Carregando dica do especialista"
+        className="rounded border border-cf-border bg-cf-bg-subtle p-4"
+      >
+        <div className="mb-3 h-3 w-28 animate-pulse rounded bg-cf-border" />
+        <div className="space-y-2">
+          <div className="h-2.5 w-full animate-pulse rounded bg-cf-border" />
+          <div className="h-2.5 w-4/5 animate-pulse rounded bg-cf-border" />
+          <div className="h-2.5 w-3/5 animate-pulse rounded bg-cf-border" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!insight) return null;
+
+  const styleClass = typeStyles[insight.type];
+  const icon = typeIconLabel[insight.type];
+
+  return (
+    <div className={`rounded border p-4 ${styleClass}`}>
+      <p className="mb-2 text-xs font-medium uppercase opacity-70">
+        {icon} {insight.title}
+      </p>
+      <p className="text-sm leading-relaxed">{insight.message}</p>
+    </div>
+  );
+};
+
+export default AIInsightPanel;

--- a/apps/web/src/components/CategoryTreemap.test.jsx
+++ b/apps/web/src/components/CategoryTreemap.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";

--- a/apps/web/src/components/GoalFormModal.tsx
+++ b/apps/web/src/components/GoalFormModal.tsx
@@ -1,0 +1,229 @@
+import { useEffect, useRef, useState } from "react";
+import type { Goal, GoalIcon } from "../services/goals.service";
+import { GOAL_ICONS } from "../services/goals.service";
+
+interface GoalFormModalProps {
+  isOpen: boolean;
+  goal?: Goal | null;
+  onSave: (data: {
+    title: string;
+    target_amount: number;
+    current_amount: number;
+    target_date: string;
+    icon: GoalIcon;
+    notes: string | null;
+  }) => Promise<void>;
+  onCancel: () => void;
+}
+
+const ICONS = Object.keys(GOAL_ICONS) as GoalIcon[];
+
+export default function GoalFormModal({ isOpen, goal, onSave, onCancel }: GoalFormModalProps) {
+  const [title, setTitle] = useState("");
+  const [targetAmount, setTargetAmount] = useState("");
+  const [currentAmount, setCurrentAmount] = useState("");
+  const [targetDate, setTargetDate] = useState("");
+  const [icon, setIcon] = useState<GoalIcon>("target");
+  const [notes, setNotes] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const firstInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setTitle(goal?.title ?? "");
+    setTargetAmount(goal ? String(goal.targetAmount) : "");
+    setCurrentAmount(goal ? String(goal.currentAmount) : "");
+    setTargetDate(goal?.targetDate ?? "");
+    setIcon(goal?.icon ?? "target");
+    setNotes(goal?.notes ?? "");
+    setError(null);
+    setSaving(false);
+    setTimeout(() => firstInputRef.current?.focus(), 50);
+  }, [isOpen, goal]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [isOpen, onCancel]);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    const ta = Number(targetAmount);
+    const ca = Number(currentAmount) || 0;
+
+    if (!title.trim()) return setError("Título é obrigatório.");
+    if (!Number.isFinite(ta) || ta <= 0) return setError("Valor alvo deve ser maior que zero.");
+    if (!Number.isFinite(ca) || ca < 0) return setError("Valor atual não pode ser negativo.");
+    if (ca > ta) return setError("Valor atual não pode superar o valor alvo.");
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(targetDate)) return setError("Data alvo inválida.");
+
+    setSaving(true);
+    try {
+      await onSave({
+        title: title.trim(),
+        target_amount: ta,
+        current_amount: ca,
+        target_date: targetDate,
+        icon,
+        notes: notes.trim() || null,
+      });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Erro ao salvar meta.";
+      setError(msg);
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={onCancel}
+    >
+      <div
+        className="w-full max-w-md rounded-lg bg-cf-surface p-5 shadow-xl"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="goal-modal-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id="goal-modal-title" className="mb-4 text-base font-semibold text-cf-text-primary">
+          {goal ? "Editar meta" : "Nova meta de poupança"}
+        </h2>
+
+        <form onSubmit={handleSubmit} className="space-y-3">
+          {/* Title */}
+          <div>
+            <label className="mb-1 block text-xs font-medium text-cf-text-secondary">
+              Título
+            </label>
+            <input
+              ref={firstInputRef}
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Ex: Viagem ao Japão"
+              maxLength={200}
+              className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
+            />
+          </div>
+
+          {/* Amounts */}
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="mb-1 block text-xs font-medium text-cf-text-secondary">
+                Valor alvo (R$)
+              </label>
+              <input
+                type="number"
+                min="0.01"
+                step="0.01"
+                value={targetAmount}
+                onChange={(e) => setTargetAmount(e.target.value)}
+                placeholder="15000"
+                className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-cf-text-secondary">
+                Já guardado (R$)
+              </label>
+              <input
+                type="number"
+                min="0"
+                step="0.01"
+                value={currentAmount}
+                onChange={(e) => setCurrentAmount(e.target.value)}
+                placeholder="0"
+                className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
+              />
+            </div>
+          </div>
+
+          {/* Date */}
+          <div>
+            <label htmlFor="goal-target-date" className="mb-1 block text-xs font-medium text-cf-text-secondary">
+              Data alvo
+            </label>
+            <input
+              id="goal-target-date"
+              type="date"
+              value={targetDate}
+              onChange={(e) => setTargetDate(e.target.value)}
+              className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary focus:outline-none focus:ring-1 focus:ring-brand-1"
+            />
+          </div>
+
+          {/* Icon picker */}
+          <div>
+            <label className="mb-1 block text-xs font-medium text-cf-text-secondary">Ícone</label>
+            <div className="flex flex-wrap gap-2">
+              {ICONS.map((key) => (
+                <button
+                  key={key}
+                  type="button"
+                  title={key}
+                  onClick={() => setIcon(key)}
+                  className={`flex h-9 w-9 items-center justify-center rounded border text-lg transition-colors ${
+                    icon === key
+                      ? "border-brand-1 bg-brand-1/10"
+                      : "border-cf-border bg-cf-bg-subtle hover:border-brand-1/50"
+                  }`}
+                >
+                  {GOAL_ICONS[key]}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Notes */}
+          <div>
+            <label className="mb-1 block text-xs font-medium text-cf-text-secondary">
+              Observações (opcional)
+            </label>
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              maxLength={1000}
+              rows={2}
+              placeholder="Detalhes sobre a meta…"
+              className="w-full resize-none rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
+            />
+          </div>
+
+          {error && (
+            <p className="text-xs text-red-500" role="alert">
+              {error}
+            </p>
+          )}
+
+          <div className="flex justify-end gap-2 pt-1">
+            <button
+              type="button"
+              onClick={onCancel}
+              disabled={saving}
+              className="rounded border border-cf-border px-3 py-1.5 text-sm font-semibold text-cf-text-secondary hover:bg-cf-bg-subtle disabled:opacity-50"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="rounded bg-brand-1 px-3 py-1.5 text-sm font-semibold text-white hover:bg-brand-2 disabled:opacity-50"
+            >
+              {saving ? "Salvando…" : goal ? "Salvar alterações" : "Criar meta"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/GoalsSection.test.tsx
+++ b/apps/web/src/components/GoalsSection.test.tsx
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import GoalsSection from "./GoalsSection";
+import type { Goal } from "../services/goals.service";
+
+vi.mock("../services/goals.service", () => ({
+  GOAL_ICONS: {
+    target: "🎯", plane: "✈️", home: "🏠", car: "🚗", graduation: "🎓",
+    heart: "❤️", star: "⭐", gift: "🎁", briefcase: "💼", umbrella: "☂️",
+  },
+  goalsService: {
+    list:   vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+const { goalsService } = await import("../services/goals.service");
+
+const buildGoal = (overrides: Partial<Goal> = {}): Goal => ({
+  id: 1,
+  userId: 42,
+  title: "Viagem Japão",
+  targetAmount: 15000,
+  currentAmount: 3000,
+  targetDate: "2027-10-01",
+  icon: "plane",
+  notes: null,
+  monthlyNeeded: 500,
+  createdAt: "2026-03-25T00:00:00Z",
+  updatedAt: "2026-03-25T00:00:00Z",
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GoalsSection", () => {
+  // ── Loading ──────────────────────────────────────────────────────────────
+
+  it("exibe shimmer de loading enquanto carrega", () => {
+    vi.mocked(goalsService.list).mockReturnValue(new Promise(() => {}));
+    render(<GoalsSection />);
+    expect(document.querySelector(".animate-pulse")).not.toBeNull();
+  });
+
+  // ── Empty state ───────────────────────────────────────────────────────────
+
+  it("exibe estado vazio quando nao ha metas", async () => {
+    vi.mocked(goalsService.list).mockResolvedValue([]);
+    render(<GoalsSection />);
+    await waitFor(() => expect(screen.getByText("Nenhuma meta ainda")).toBeInTheDocument());
+  });
+
+  // ── List ─────────────────────────────────────────────────────────────────
+
+  it("renderiza cards quando ha metas", async () => {
+    vi.mocked(goalsService.list).mockResolvedValue([buildGoal(), buildGoal({ id: 2, title: "Casa Própria" })]);
+    render(<GoalsSection />);
+    await waitFor(() => expect(screen.getByText("Viagem Japão")).toBeInTheDocument());
+    expect(screen.getByText("Casa Própria")).toBeInTheDocument();
+  });
+
+  it("exibe porcentagem de progresso corretamente", async () => {
+    vi.mocked(goalsService.list).mockResolvedValue([buildGoal({ targetAmount: 10000, currentAmount: 2000 })]);
+    render(<GoalsSection />);
+    await waitFor(() => expect(screen.getByText("20%")).toBeInTheDocument());
+  });
+
+  it("exibe mensagem de meta atingida quando monthlyNeeded e zero", async () => {
+    vi.mocked(goalsService.list).mockResolvedValue([buildGoal({ monthlyNeeded: 0 })]);
+    render(<GoalsSection />);
+    await waitFor(() => expect(screen.getByText(/Meta atingida/)).toBeInTheDocument());
+  });
+
+  // ── Error ─────────────────────────────────────────────────────────────────
+
+  it("exibe mensagem de erro quando list falha", async () => {
+    vi.mocked(goalsService.list).mockRejectedValue(new Error("Falha na rede"));
+    render(<GoalsSection />);
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+  });
+
+  // ── Create ────────────────────────────────────────────────────────────────
+
+  it("abre modal ao clicar em Nova meta", async () => {
+    vi.mocked(goalsService.list).mockResolvedValue([]);
+    render(<GoalsSection />);
+    await waitFor(() => screen.getByText("Nenhuma meta ainda"));
+    const btn = screen.getAllByText(/Nova meta/)[0];
+    fireEvent.click(btn);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Nova meta de poupança")).toBeInTheDocument();
+  });
+
+  it("cria meta e adiciona ao estado sem refetch", async () => {
+    const newGoal = buildGoal({ id: 99, title: "Fundo de Emergência" });
+    vi.mocked(goalsService.list).mockResolvedValue([]);
+    vi.mocked(goalsService.create).mockResolvedValue(newGoal);
+
+    render(<GoalsSection />);
+    await waitFor(() => screen.getByText("Nenhuma meta ainda"));
+
+    fireEvent.click(screen.getByText("Criar meta"));
+    const dialog = await screen.findByRole("dialog");
+
+    const d = within(dialog);
+    fireEvent.change(d.getByPlaceholderText(/Viagem/), { target: { value: "Fundo de Emergência" } });
+    fireEvent.change(d.getByPlaceholderText("15000"), { target: { value: "5000" } });
+    fireEvent.change(d.getByLabelText(/data alvo/i), { target: { value: "2026-12-31" } });
+
+    fireEvent.click(d.getByRole("button", { name: "Criar meta" }));
+
+    await waitFor(() => expect(goalsService.create).toHaveBeenCalledWith(expect.objectContaining({
+      title: "Fundo de Emergência",
+      target_amount: 5000,
+      target_date: "2026-12-31",
+    })));
+    await waitFor(() => expect(screen.getByText("Fundo de Emergência")).toBeInTheDocument());
+  });
+
+  // ── Edit ──────────────────────────────────────────────────────────────────
+
+  it("abre modal de edicao com dados da meta pre-preenchidos", async () => {
+    const goal = buildGoal();
+    vi.mocked(goalsService.list).mockResolvedValue([goal]);
+    render(<GoalsSection />);
+    await waitFor(() => screen.getByText("Viagem Japão"));
+
+    fireEvent.click(screen.getByLabelText("Editar meta Viagem Japão"));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Editar meta")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Viagem Japão")).toBeInTheDocument();
+  });
+
+  it("atualiza meta no estado apos edicao bem-sucedida", async () => {
+    const goal = buildGoal();
+    const updated = { ...goal, title: "Viagem ao Japão (atualizado)", currentAmount: 5000 };
+    vi.mocked(goalsService.list).mockResolvedValue([goal]);
+    vi.mocked(goalsService.update).mockResolvedValue(updated);
+
+    render(<GoalsSection />);
+    await waitFor(() => screen.getByText("Viagem Japão"));
+
+    fireEvent.click(screen.getByLabelText("Editar meta Viagem Japão"));
+    await screen.findByRole("dialog");
+
+    fireEvent.click(screen.getByText("Salvar alterações"));
+    await waitFor(() => expect(goalsService.update).toHaveBeenCalledWith(1, expect.any(Object)));
+    await waitFor(() => expect(screen.getByText("Viagem ao Japão (atualizado)")).toBeInTheDocument());
+  });
+
+  // ── Delete ────────────────────────────────────────────────────────────────
+
+  it("abre confirm dialog ao clicar em excluir", async () => {
+    vi.mocked(goalsService.list).mockResolvedValue([buildGoal()]);
+    render(<GoalsSection />);
+    await waitFor(() => screen.getByText("Viagem Japão"));
+
+    fireEvent.click(screen.getByLabelText("Excluir meta Viagem Japão"));
+    await waitFor(() => expect(screen.getByText("Excluir meta")).toBeInTheDocument());
+  });
+
+  it("remove meta do estado apos confirmacao de exclusao", async () => {
+    vi.mocked(goalsService.list).mockResolvedValue([buildGoal()]);
+    vi.mocked(goalsService.remove).mockResolvedValue(undefined);
+
+    render(<GoalsSection />);
+    await waitFor(() => screen.getByText("Viagem Japão"));
+
+    fireEvent.click(screen.getByLabelText("Excluir meta Viagem Japão"));
+    await screen.findByText("Excluir meta");
+
+    fireEvent.click(screen.getByText("Excluir", { selector: "button" }));
+    await waitFor(() => expect(goalsService.remove).toHaveBeenCalledWith(1));
+    await waitFor(() => expect(screen.queryByText("Viagem Japão")).toBeNull());
+  });
+});

--- a/apps/web/src/components/GoalsSection.test.tsx
+++ b/apps/web/src/components/GoalsSection.test.tsx
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, fireEvent, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import GoalsSection from "./GoalsSection";
 import type { Goal } from "../services/goals.service";
+import type { Forecast } from "../services/forecast.service";
 
 vi.mock("../services/goals.service", () => ({
   GOAL_ICONS: {
@@ -17,7 +17,14 @@ vi.mock("../services/goals.service", () => ({
   },
 }));
 
+vi.mock("../services/forecast.service", () => ({
+  forecastService: {
+    getCurrent: vi.fn(),
+  },
+}));
+
 const { goalsService } = await import("../services/goals.service");
+const { forecastService } = await import("../services/forecast.service");
 
 const buildGoal = (overrides: Partial<Goal> = {}): Goal => ({
   id: 1,
@@ -34,8 +41,25 @@ const buildGoal = (overrides: Partial<Goal> = {}): Goal => ({
   ...overrides,
 });
 
+const buildForecast = (overrides: Partial<Forecast> = {}): Forecast => ({
+  month: "2026-03",
+  projectedBalance: 1000,
+  spendingToDate: 2000,
+  dailyAvgSpending: 80,
+  daysRemaining: 6,
+  flipDetected: false,
+  flipDirection: null,
+  engineVersion: "v2",
+  incomeExpected: 5000,
+  billsPendingTotal: 0,
+  billsPendingCount: 0,
+  adjustedProjectedBalance: 1000,
+  ...overrides,
+});
+
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(forecastService.getCurrent).mockResolvedValue(null);
 });
 
 describe("GoalsSection", () => {
@@ -82,6 +106,31 @@ describe("GoalsSection", () => {
     vi.mocked(goalsService.list).mockRejectedValue(new Error("Falha na rede"));
     render(<GoalsSection />);
     await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+  });
+
+  // ── At-risk indicator ─────────────────────────────────────────────────────
+
+  it("exibe badge de risco quando monthlyNeeded supera saldo projetado", async () => {
+    vi.mocked(goalsService.list).mockResolvedValue([buildGoal({ monthlyNeeded: 800 })]);
+    vi.mocked(forecastService.getCurrent).mockResolvedValue(buildForecast({ adjustedProjectedBalance: 300 }));
+    render(<GoalsSection />);
+    await waitFor(() => expect(screen.getByLabelText(/meta em risco/i)).toBeInTheDocument());
+  });
+
+  it("nao exibe badge de risco quando monthlyNeeded e menor que saldo projetado", async () => {
+    vi.mocked(goalsService.list).mockResolvedValue([buildGoal({ monthlyNeeded: 200 })]);
+    vi.mocked(forecastService.getCurrent).mockResolvedValue(buildForecast({ adjustedProjectedBalance: 1000 }));
+    render(<GoalsSection />);
+    await waitFor(() => screen.getByText("Viagem Japão"));
+    expect(screen.queryByLabelText(/meta em risco/i)).toBeNull();
+  });
+
+  it("nao exibe badge de risco quando forecast nao esta disponivel", async () => {
+    vi.mocked(goalsService.list).mockResolvedValue([buildGoal({ monthlyNeeded: 999 })]);
+    vi.mocked(forecastService.getCurrent).mockResolvedValue(null);
+    render(<GoalsSection />);
+    await waitFor(() => screen.getByText("Viagem Japão"));
+    expect(screen.queryByLabelText(/meta em risco/i)).toBeNull();
   });
 
   // ── Create ────────────────────────────────────────────────────────────────
@@ -177,5 +226,63 @@ describe("GoalsSection", () => {
     fireEvent.click(screen.getByText("Excluir", { selector: "button" }));
     await waitFor(() => expect(goalsService.remove).toHaveBeenCalledWith(1));
     await waitFor(() => expect(screen.queryByText("Viagem Japão")).toBeNull());
+  });
+
+  // ── Quick contribution ────────────────────────────────────────────────────
+
+  it("exibe link de contribuicao rapida em metas nao concluidas", async () => {
+    vi.mocked(goalsService.list).mockResolvedValue([buildGoal({ monthlyNeeded: 500 })]);
+    render(<GoalsSection />);
+    await waitFor(() => screen.getByText("Viagem Japão"));
+    expect(screen.getByText("+ Registrar poupança")).toBeInTheDocument();
+  });
+
+  it("nao exibe link de contribuicao quando meta ja atingida", async () => {
+    vi.mocked(goalsService.list).mockResolvedValue([buildGoal({ monthlyNeeded: 0 })]);
+    render(<GoalsSection />);
+    await waitFor(() => screen.getByText(/Meta atingida/));
+    expect(screen.queryByText("+ Registrar poupança")).toBeNull();
+  });
+
+  it("expande mini-form ao clicar em Registrar poupanca", async () => {
+    vi.mocked(goalsService.list).mockResolvedValue([buildGoal()]);
+    render(<GoalsSection />);
+    await waitFor(() => screen.getByText("Viagem Japão"));
+
+    fireEvent.click(screen.getByText("+ Registrar poupança"));
+    expect(screen.getByLabelText("Valor da contribuição")).toBeInTheDocument();
+    expect(screen.getByText("Guardar")).toBeInTheDocument();
+  });
+
+  it("chama goalsService.update com current_amount somado ao registrar poupanca", async () => {
+    const goal = buildGoal({ currentAmount: 3000 });
+    const updated = { ...goal, currentAmount: 3500, monthlyNeeded: 450 };
+    vi.mocked(goalsService.list).mockResolvedValue([goal]);
+    vi.mocked(goalsService.update).mockResolvedValue(updated);
+
+    render(<GoalsSection />);
+    await waitFor(() => screen.getByText("Viagem Japão"));
+
+    fireEvent.click(screen.getByText("+ Registrar poupança"));
+    fireEvent.change(screen.getByLabelText("Valor da contribuição"), { target: { value: "500" } });
+    fireEvent.click(screen.getByText("Guardar"));
+
+    await waitFor(() =>
+      expect(goalsService.update).toHaveBeenCalledWith(1, { current_amount: 3500 }),
+    );
+  });
+
+  it("exibe erro de validacao quando valor de contribuicao e invalido", async () => {
+    vi.mocked(goalsService.list).mockResolvedValue([buildGoal()]);
+    render(<GoalsSection />);
+    await waitFor(() => screen.getByText("Viagem Japão"));
+
+    fireEvent.click(screen.getByText("+ Registrar poupança"));
+    const contribInput = screen.getByLabelText("Valor da contribuição");
+    fireEvent.change(contribInput, { target: { value: "-10" } });
+    fireEvent.submit(contribInput.closest("form")!);
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+    expect(goalsService.update).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/GoalsSection.tsx
+++ b/apps/web/src/components/GoalsSection.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { formatCurrency } from "../utils/formatCurrency";
 import { getApiErrorMessage } from "../utils/apiError";
 import type { Goal, CreateGoalPayload, GoalIcon } from "../services/goals.service";
 import { GOAL_ICONS, goalsService } from "../services/goals.service";
+import { forecastService } from "../services/forecast.service";
 import GoalFormModal from "./GoalFormModal";
 import ConfirmDialog from "./ConfirmDialog";
 
@@ -10,11 +11,19 @@ import ConfirmDialog from "./ConfirmDialog";
 
 interface GoalCardProps {
   goal: Goal;
+  projectedBalance: number | null;
   onEdit: (goal: Goal) => void;
   onDelete: (goal: Goal) => void;
+  onContribute: (goalId: number, amount: number) => Promise<void>;
 }
 
-function GoalCard({ goal, onEdit, onDelete }: GoalCardProps) {
+function GoalCard({ goal, projectedBalance, onEdit, onDelete, onContribute }: GoalCardProps) {
+  const [showContrib, setShowContrib] = useState(false);
+  const [contribAmt, setContribAmt] = useState("");
+  const [contributing, setContributing] = useState(false);
+  const [contribError, setContribError] = useState<string | null>(null);
+  const contribInputRef = useRef<HTMLInputElement>(null);
+
   const pct = goal.targetAmount > 0
     ? Math.min(100, Math.round((goal.currentAmount / goal.targetAmount) * 100))
     : 0;
@@ -31,6 +40,42 @@ function GoalCard({ goal, onEdit, onDelete }: GoalCardProps) {
     month: "short",
     year: "numeric",
   });
+
+  const isAtRisk =
+    goal.monthlyNeeded > 0 &&
+    projectedBalance !== null &&
+    goal.monthlyNeeded > projectedBalance;
+
+  const handleContribOpen = () => {
+    setContribAmt("");
+    setContribError(null);
+    setShowContrib(true);
+    setTimeout(() => contribInputRef.current?.focus(), 50);
+  };
+
+  const handleContribSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const amt = Number(contribAmt);
+    if (!Number.isFinite(amt) || amt <= 0) {
+      setContribError("Valor inválido.");
+      return;
+    }
+    if (goal.currentAmount + amt > goal.targetAmount) {
+      setContribError("Ultrapassaria o valor alvo.");
+      return;
+    }
+    setContributing(true);
+    setContribError(null);
+    try {
+      await onContribute(goal.id, amt);
+      setShowContrib(false);
+      setContribAmt("");
+    } catch (err) {
+      setContribError(getApiErrorMessage(err, "Erro ao registrar."));
+    } finally {
+      setContributing(false);
+    }
+  };
 
   return (
     <div className="flex flex-col gap-3 rounded border border-cf-border bg-cf-surface p-4">
@@ -87,15 +132,71 @@ function GoalCard({ goal, onEdit, onDelete }: GoalCardProps) {
       {/* Footer stats */}
       <div className="flex items-center justify-between text-xs text-cf-text-secondary">
         {goal.monthlyNeeded > 0 ? (
-          <span>
+          <span className="flex items-center gap-1">
             <span className="font-semibold text-cf-text-primary">{formatCurrency(goal.monthlyNeeded)}</span>
             /mês necessário
+            {isAtRisk && (
+              <span
+                title="Esta meta consome mais do que seu saldo projetado este mês."
+                aria-label="Meta em risco: necessidade mensal supera saldo projetado"
+                className="inline-flex items-center justify-center rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-bold text-amber-500"
+              >
+                ⚠ risco
+              </span>
+            )}
           </span>
         ) : (
           <span className="font-semibold text-green-500">Meta atingida 🎉</span>
         )}
         <span>até {deadline}</span>
       </div>
+
+      {/* Quick contribution */}
+      {goal.monthlyNeeded > 0 && (
+        <div className="border-t border-cf-border pt-2">
+          {!showContrib ? (
+            <button
+              type="button"
+              onClick={handleContribOpen}
+              className="text-xs font-medium text-brand-1 hover:underline"
+            >
+              + Registrar poupança
+            </button>
+          ) : (
+            <form onSubmit={handleContribSubmit} className="flex items-center gap-2">
+              <span className="shrink-0 text-xs text-cf-text-secondary">R$</span>
+              <input
+                ref={contribInputRef}
+                type="number"
+                min="0.01"
+                step="0.01"
+                value={contribAmt}
+                onChange={(e) => { setContribAmt(e.target.value); setContribError(null); }}
+                placeholder="0,00"
+                aria-label="Valor da contribuição"
+                className="w-24 rounded border border-cf-border-input bg-cf-bg-subtle px-2 py-1 text-xs text-cf-text-primary focus:outline-none focus:ring-1 focus:ring-brand-1"
+              />
+              <button
+                type="submit"
+                disabled={contributing}
+                className="rounded bg-brand-1 px-2 py-1 text-xs font-semibold text-white hover:bg-brand-2 disabled:opacity-50"
+              >
+                {contributing ? "…" : "Guardar"}
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowContrib(false)}
+                className="text-xs text-cf-text-secondary hover:text-cf-text-primary"
+              >
+                ✕
+              </button>
+              {contribError && (
+                <span className="text-xs text-red-500" role="alert">{contribError}</span>
+              )}
+            </form>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -106,17 +207,22 @@ type ModalMode = { type: "create" } | { type: "edit"; goal: Goal };
 
 export default function GoalsSection() {
   const [goals, setGoals] = useState<Goal[]>([]);
+  const [projectedBalance, setProjectedBalance] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [modal, setModal] = useState<ModalMode | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Goal | null>(null);
   const [deleting, setDeleting] = useState(false);
 
-  const fetchGoals = async () => {
+  const fetchData = async () => {
     setError(null);
     try {
-      const data = await goalsService.list();
-      setGoals(data);
+      const [goalsData, forecast] = await Promise.all([
+        goalsService.list(),
+        forecastService.getCurrent().catch(() => null),
+      ]);
+      setGoals(goalsData);
+      setProjectedBalance(forecast?.adjustedProjectedBalance ?? null);
     } catch (err) {
       setError(getApiErrorMessage(err, "Erro ao carregar metas."));
     } finally {
@@ -125,7 +231,7 @@ export default function GoalsSection() {
   };
 
   useEffect(() => {
-    void fetchGoals();
+    void fetchData();
   }, []);
 
   const handleSave = async (data: {
@@ -162,6 +268,15 @@ export default function GoalsSection() {
     }
 
     setModal(null);
+  };
+
+  const handleContribute = async (goalId: number, amount: number) => {
+    const goal = goals.find((g) => g.id === goalId);
+    if (!goal) return;
+    const updated = await goalsService.update(goalId, {
+      current_amount: Number((goal.currentAmount + amount).toFixed(2)),
+    });
+    setGoals((prev) => prev.map((g) => (g.id === updated.id ? updated : g)));
   };
 
   const handleDeleteConfirm = async () => {
@@ -202,7 +317,7 @@ export default function GoalsSection() {
         {loading ? (
           <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
             {[1, 2, 3].map((i) => (
-              <div key={i} className="h-32 animate-pulse rounded border border-cf-border bg-cf-bg-subtle" />
+              <div key={i} className="h-40 animate-pulse rounded border border-cf-border bg-cf-bg-subtle" />
             ))}
           </div>
         ) : error ? (
@@ -213,7 +328,7 @@ export default function GoalsSection() {
             <span>{error}</span>
             <button
               type="button"
-              onClick={() => { setLoading(true); void fetchGoals(); }}
+              onClick={() => { setLoading(true); void fetchData(); }}
               className="shrink-0 text-xs font-semibold underline"
             >
               Tentar novamente
@@ -240,8 +355,10 @@ export default function GoalsSection() {
               <GoalCard
                 key={goal.id}
                 goal={goal}
+                projectedBalance={projectedBalance}
                 onEdit={(g) => setModal({ type: "edit", goal: g })}
                 onDelete={setDeleteTarget}
+                onContribute={handleContribute}
               />
             ))}
           </div>

--- a/apps/web/src/components/GoalsSection.tsx
+++ b/apps/web/src/components/GoalsSection.tsx
@@ -1,0 +1,268 @@
+import { useEffect, useState } from "react";
+import { formatCurrency } from "../utils/formatCurrency";
+import { getApiErrorMessage } from "../utils/apiError";
+import type { Goal, CreateGoalPayload, GoalIcon } from "../services/goals.service";
+import { GOAL_ICONS, goalsService } from "../services/goals.service";
+import GoalFormModal from "./GoalFormModal";
+import ConfirmDialog from "./ConfirmDialog";
+
+// ── Goal Card ────────────────────────────────────────────────────────────────
+
+interface GoalCardProps {
+  goal: Goal;
+  onEdit: (goal: Goal) => void;
+  onDelete: (goal: Goal) => void;
+}
+
+function GoalCard({ goal, onEdit, onDelete }: GoalCardProps) {
+  const pct = goal.targetAmount > 0
+    ? Math.min(100, Math.round((goal.currentAmount / goal.targetAmount) * 100))
+    : 0;
+
+  const barColor =
+    pct >= 100 ? "bg-green-500" :
+    pct >= 60  ? "bg-brand-1" :
+    pct >= 30  ? "bg-amber-500" :
+                 "bg-cf-text-secondary";
+
+  const emoji = GOAL_ICONS[goal.icon as GoalIcon] ?? "🎯";
+
+  const deadline = new Date(`${goal.targetDate}T00:00:00`).toLocaleDateString("pt-BR", {
+    month: "short",
+    year: "numeric",
+  });
+
+  return (
+    <div className="flex flex-col gap-3 rounded border border-cf-border bg-cf-surface p-4">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <span className="text-2xl" aria-hidden="true">{emoji}</span>
+          <span className="text-sm font-semibold text-cf-text-primary leading-snug">{goal.title}</span>
+        </div>
+        <div className="flex shrink-0 gap-1">
+          <button
+            type="button"
+            onClick={() => onEdit(goal)}
+            aria-label={`Editar meta ${goal.title}`}
+            className="rounded p-1 text-cf-text-secondary hover:bg-cf-bg-subtle hover:text-cf-text-primary"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+              <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
+            </svg>
+          </button>
+          <button
+            type="button"
+            onClick={() => onDelete(goal)}
+            aria-label={`Excluir meta ${goal.title}`}
+            className="rounded p-1 text-cf-text-secondary hover:bg-cf-bg-subtle hover:text-red-500"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {/* Progress bar */}
+      <div>
+        <div className="mb-1 flex items-center justify-between">
+          <span className="text-xs text-cf-text-secondary">
+            {formatCurrency(goal.currentAmount)} de {formatCurrency(goal.targetAmount)}
+          </span>
+          <span className="text-xs font-semibold text-cf-text-primary">{pct}%</span>
+        </div>
+        <div className="h-1.5 w-full overflow-hidden rounded-full bg-cf-bg-subtle">
+          <div
+            className={`h-full rounded-full transition-all ${barColor}`}
+            style={{ width: `${pct}%` }}
+            role="progressbar"
+            aria-valuenow={pct}
+            aria-valuemin={0}
+            aria-valuemax={100}
+          />
+        </div>
+      </div>
+
+      {/* Footer stats */}
+      <div className="flex items-center justify-between text-xs text-cf-text-secondary">
+        {goal.monthlyNeeded > 0 ? (
+          <span>
+            <span className="font-semibold text-cf-text-primary">{formatCurrency(goal.monthlyNeeded)}</span>
+            /mês necessário
+          </span>
+        ) : (
+          <span className="font-semibold text-green-500">Meta atingida 🎉</span>
+        )}
+        <span>até {deadline}</span>
+      </div>
+    </div>
+  );
+}
+
+// ── Goals Section ────────────────────────────────────────────────────────────
+
+type ModalMode = { type: "create" } | { type: "edit"; goal: Goal };
+
+export default function GoalsSection() {
+  const [goals, setGoals] = useState<Goal[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [modal, setModal] = useState<ModalMode | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Goal | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const fetchGoals = async () => {
+    setError(null);
+    try {
+      const data = await goalsService.list();
+      setGoals(data);
+    } catch (err) {
+      setError(getApiErrorMessage(err, "Erro ao carregar metas."));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void fetchGoals();
+  }, []);
+
+  const handleSave = async (data: {
+    title: string;
+    target_amount: number;
+    current_amount: number;
+    target_date: string;
+    icon: GoalIcon;
+    notes: string | null;
+  }) => {
+    if (!modal) return;
+
+    if (modal.type === "create") {
+      const payload: CreateGoalPayload = {
+        title: data.title,
+        target_amount: data.target_amount,
+        current_amount: data.current_amount,
+        target_date: data.target_date,
+        icon: data.icon,
+        notes: data.notes,
+      };
+      const created = await goalsService.create(payload);
+      setGoals((prev) => [...prev, created]);
+    } else {
+      const updated = await goalsService.update(modal.goal.id, {
+        title: data.title,
+        target_amount: data.target_amount,
+        current_amount: data.current_amount,
+        target_date: data.target_date,
+        icon: data.icon,
+        notes: data.notes,
+      });
+      setGoals((prev) => prev.map((g) => (g.id === updated.id ? updated : g)));
+    }
+
+    setModal(null);
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    try {
+      await goalsService.remove(deleteTarget.id);
+      setGoals((prev) => prev.filter((g) => g.id !== deleteTarget.id));
+      setDeleteTarget(null);
+    } catch (err) {
+      setError(getApiErrorMessage(err, "Erro ao excluir meta."));
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <section>
+      <div className="rounded border border-cf-border bg-cf-surface p-4">
+        {/* Header */}
+        <div className="mb-4 flex items-center justify-between gap-2">
+          <div>
+            <h3 className="text-sm font-semibold text-cf-text-primary">Metas de Poupança</h3>
+            <p className="text-xs text-cf-text-secondary">
+              Acompanhe o progresso dos seus objetivos financeiros
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setModal({ type: "create" })}
+            className="shrink-0 rounded bg-brand-1 px-3 py-1.5 text-xs font-semibold text-white hover:bg-brand-2"
+          >
+            + Nova meta
+          </button>
+        </div>
+
+        {/* Content */}
+        {loading ? (
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="h-32 animate-pulse rounded border border-cf-border bg-cf-bg-subtle" />
+            ))}
+          </div>
+        ) : error ? (
+          <div
+            className="flex items-center justify-between gap-3 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+            role="alert"
+          >
+            <span>{error}</span>
+            <button
+              type="button"
+              onClick={() => { setLoading(true); void fetchGoals(); }}
+              className="shrink-0 text-xs font-semibold underline"
+            >
+              Tentar novamente
+            </button>
+          </div>
+        ) : goals.length === 0 ? (
+          <div className="flex flex-col items-center gap-2 py-8 text-center">
+            <span className="text-3xl">🎯</span>
+            <p className="text-sm font-medium text-cf-text-primary">Nenhuma meta ainda</p>
+            <p className="text-xs text-cf-text-secondary">
+              Crie sua primeira meta e acompanhe o progresso mês a mês.
+            </p>
+            <button
+              type="button"
+              onClick={() => setModal({ type: "create" })}
+              className="mt-1 rounded bg-brand-1 px-4 py-1.5 text-sm font-semibold text-white hover:bg-brand-2"
+            >
+              Criar meta
+            </button>
+          </div>
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {goals.map((goal) => (
+              <GoalCard
+                key={goal.id}
+                goal={goal}
+                onEdit={(g) => setModal({ type: "edit", goal: g })}
+                onDelete={setDeleteTarget}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <GoalFormModal
+        isOpen={modal !== null}
+        goal={modal?.type === "edit" ? modal.goal : null}
+        onSave={handleSave}
+        onCancel={() => setModal(null)}
+      />
+
+      <ConfirmDialog
+        isOpen={deleteTarget !== null}
+        title="Excluir meta"
+        description={`Tem certeza que deseja excluir "${deleteTarget?.title}"? Esta ação não pode ser desfeita.`}
+        confirmLabel={deleting ? "Excluindo…" : "Excluir"}
+        onConfirm={() => void handleDeleteConfirm()}
+        onCancel={() => setDeleteTarget(null)}
+      />
+    </section>
+  );
+}

--- a/apps/web/src/components/HealthOverview.tsx
+++ b/apps/web/src/components/HealthOverview.tsx
@@ -17,6 +17,7 @@ interface TrajectoryPoint {
   balance: number;
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const generateTrajectory = (forecast: Forecast): TrajectoryPoint[] => {
   const { adjustedProjectedBalance, dailyAvgSpending, daysRemaining } = forecast;
   if (daysRemaining <= 0) return [];

--- a/apps/web/src/components/HealthOverview.tsx
+++ b/apps/web/src/components/HealthOverview.tsx
@@ -8,6 +8,8 @@ import {
   XAxis,
 } from "recharts";
 import { forecastService, type Forecast } from "../services/forecast.service";
+import { aiService, type AiInsight } from "../services/ai.service";
+import AIInsightPanel from "./AIInsightPanel";
 import { formatCurrency } from "../utils/formatCurrency";
 
 interface TrajectoryPoint {
@@ -94,9 +96,20 @@ const TrajectoryTooltip = ({
 
 const HealthOverview = (): JSX.Element | null => {
   const [forecast, setForecast] = useState<Forecast | null>(null);
+  const [insight, setInsight] = useState<AiInsight | null>(null);
+  const [isLoadingInsight, setIsLoadingInsight] = useState(true);
 
   useEffect(() => {
     void forecastService.getCurrent().then(setForecast).catch(() => undefined);
+  }, []);
+
+  useEffect(() => {
+    setIsLoadingInsight(true);
+    void aiService
+      .getInsight()
+      .then(setInsight)
+      .catch(() => setInsight(null))
+      .finally(() => setIsLoadingInsight(false));
   }, []);
 
   if (forecast === null || forecast.daysRemaining <= 0) return null;
@@ -110,10 +123,12 @@ const HealthOverview = (): JSX.Element | null => {
   const color = gaugeColor(adjustedProjectedBalance, gaugePct);
   const isAtRisk = adjustedProjectedBalance <= 0;
 
+  const showInsightPanel = isLoadingInsight || insight !== null;
+
   return (
     <div className="rounded border border-cf-border bg-cf-surface p-4">
       <h3 className="mb-4 text-sm font-semibold text-cf-text-primary">Saúde Financeira do Mês</h3>
-      <div className="grid gap-4 sm:grid-cols-2">
+      <div className={`grid gap-4 ${showInsightPanel ? "sm:grid-cols-3" : "sm:grid-cols-2"}`}>
         {/* D5 — Gauge */}
         <div className="flex flex-col items-center justify-center gap-2 rounded border border-cf-border bg-cf-bg-subtle p-4">
           <p className="text-xs font-medium uppercase text-cf-text-secondary">Dinheiro Livre</p>
@@ -125,6 +140,11 @@ const HealthOverview = (): JSX.Element | null => {
             {isAtRisk ? "Projeção negativa — revise seus gastos" : "projetado ao fim do mês"}
           </p>
         </div>
+
+        {/* AI Insight */}
+        {showInsightPanel && (
+          <AIInsightPanel insight={insight} isLoading={isLoadingInsight} />
+        )}
 
         {/* D4-lite — Trajectory */}
         <div className="rounded border border-cf-border bg-cf-bg-subtle p-4">

--- a/apps/web/src/components/WelcomeCard.tsx
+++ b/apps/web/src/components/WelcomeCard.tsx
@@ -12,9 +12,9 @@ const WelcomeCard = ({ onAddTransaction, onOpenProfileSettings }: WelcomeCardPro
     // "cf_activation_welcome_viewed_v1": sessionStorage key that prevents re-firing on reload.
     // Bump the version suffix (v2, v3…) whenever the WelcomeCard logic changes in a way
     // that requires re-showing the card to users who have already seen it.
-    if (!tracked.current && !sessionStorage.getItem("cf_activation_welcome_viewed_v1")) {
+    if (!tracked.current && !sessionStorage.getItem("cf_activation_welcome_viewed_v2")) {
       tracked.current = true;
-      sessionStorage.setItem("cf_activation_welcome_viewed_v1", "1");
+      sessionStorage.setItem("cf_activation_welcome_viewed_v2", "1");
       trackActivationEvent("welcome_card_viewed");
     }
   }, []);
@@ -24,10 +24,10 @@ const WelcomeCard = ({ onAddTransaction, onOpenProfileSettings }: WelcomeCardPro
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
           <h2 className="text-base font-semibold text-cf-text-primary">
-            Comece a organizar sua vida financeira
+            Comece a pilotar sua vida financeira
           </h2>
           <p className="mt-1 text-sm text-cf-text-secondary">
-            Registre sua primeira transação para visualizar seu saldo, gráficos e projeção de saldo ao fim do mês.
+            Registre sua primeira transação e deixe o Especialista IA guiar você do extrato de hoje até as metas de amanhã.
           </p>
 
           <ol className="mt-4 space-y-2">
@@ -45,8 +45,8 @@ const WelcomeCard = ({ onAddTransaction, onOpenProfileSettings }: WelcomeCardPro
                 2
               </span>
               <span>
-                <strong className="font-semibold text-cf-text-primary">Veja seu saldo em tempo real</strong>
-                {" — "}entradas menos saídas calculadas automaticamente
+                <strong className="font-semibold text-cf-text-primary">Configure seu perfil</strong>
+                {" — "}salário e dia de pagamento para ativar a projeção de saldo do mês
               </span>
             </li>
             <li className="flex items-start gap-2.5 text-sm text-cf-text-secondary">
@@ -54,8 +54,17 @@ const WelcomeCard = ({ onAddTransaction, onOpenProfileSettings }: WelcomeCardPro
                 3
               </span>
               <span>
-                <strong className="font-semibold text-cf-text-primary">Configure seu perfil</strong>
-                {" — "}salário e dia de pagamento para ativar a projeção de saldo
+                <strong className="font-semibold text-cf-text-primary">Defina suas metas de poupança</strong>
+                {" — "}viagem, casa, reserva de emergência — acompanhe o progresso mês a mês
+              </span>
+            </li>
+            <li className="flex items-start gap-2.5 text-sm text-cf-text-secondary">
+              <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-brand-1/20 text-xs font-bold text-brand-1">
+                4
+              </span>
+              <span>
+                <strong className="font-semibold text-cf-text-primary">Ouça o Especialista IA</strong>
+                {" — "}análise automática do seu cenário com dicas personalizadas e alertas de risco
               </span>
             </li>
           </ol>

--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -22,6 +22,10 @@ vi.mock("../components/HealthOverview", () => ({
   default: () => null,
 }));
 
+vi.mock("../components/GoalsSection", () => ({
+  default: () => null,
+}));
+
 vi.mock("../components/CategoryTreemap", () => ({
   default: ({ data }) =>
     Array.isArray(data) && data.length > 0 ? (

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -56,6 +56,7 @@ const TransactionChart = lazy(() => import("../components/TransactionChart"));
 const TrendChart = lazy(() => import("../components/TrendChart"));
 const CategoryTreemap = lazy(() => import("../components/CategoryTreemap"));
 const HealthOverview = lazy(() => import("../components/HealthOverview"));
+const GoalsSection = lazy(() => import("../components/GoalsSection"));
 
 type SummaryMetricKey = "income" | "expense" | "balance";
 type MonthOverMonthDirection = "up" | "down" | "flat";
@@ -2350,6 +2351,10 @@ const App = ({
         <BillsSummaryWidget onOpenBills={handleOpenBills} />
 
         <SalaryWidget />
+
+        <Suspense fallback={null}>
+          <GoalsSection />
+        </Suspense>
 
 
       <section>

--- a/apps/web/src/services/ai.service.ts
+++ b/apps/web/src/services/ai.service.ts
@@ -1,0 +1,16 @@
+import { api } from "./api";
+
+export interface AiInsight {
+  id: string;
+  type: "warning" | "success" | "info";
+  title: string;
+  message: string;
+  action_label: string;
+}
+
+export const aiService = {
+  getInsight: async (): Promise<AiInsight | null> => {
+    const { data } = await api.get<AiInsight | null>("/ai/insight");
+    return data;
+  },
+};

--- a/apps/web/src/services/goals.service.ts
+++ b/apps/web/src/services/goals.service.ts
@@ -1,0 +1,72 @@
+import { api } from "./api";
+
+export interface Goal {
+  id: number;
+  userId: number;
+  title: string;
+  targetAmount: number;
+  currentAmount: number;
+  targetDate: string;
+  icon: GoalIcon;
+  notes: string | null;
+  monthlyNeeded: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type GoalIcon =
+  | "target"
+  | "plane"
+  | "home"
+  | "car"
+  | "graduation"
+  | "heart"
+  | "star"
+  | "gift"
+  | "briefcase"
+  | "umbrella";
+
+export const GOAL_ICONS: Record<GoalIcon, string> = {
+  target:     "🎯",
+  plane:      "✈️",
+  home:       "🏠",
+  car:        "🚗",
+  graduation: "🎓",
+  heart:      "❤️",
+  star:       "⭐",
+  gift:       "🎁",
+  briefcase:  "💼",
+  umbrella:   "☂️",
+};
+
+export interface CreateGoalPayload {
+  title: string;
+  target_amount: number;
+  current_amount?: number;
+  target_date: string;
+  icon?: GoalIcon;
+  notes?: string | null;
+}
+
+export type UpdateGoalPayload = Partial<CreateGoalPayload>;
+
+export const goalsService = {
+  list: async (): Promise<Goal[]> => {
+    const { data } = await api.get<Goal[]>("/goals");
+    return data;
+  },
+
+  create: async (payload: CreateGoalPayload): Promise<Goal> => {
+    const { data } = await api.post<Goal>("/goals", payload);
+    return data;
+  },
+
+  update: async (id: number, payload: UpdateGoalPayload): Promise<Goal> => {
+    const { data } = await api.patch<Goal>(`/goals/${id}`, payload);
+    return data;
+  },
+
+  remove: async (id: number): Promise<void> => {
+    await api.delete(`/goals/${id}`);
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       "name": "@control-finance/api",
       "version": "1.29.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.80.0",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
@@ -112,6 +113,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.80.0.tgz",
+      "integrity": "sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -6175,6 +6196,19 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -9290,6 +9324,12 @@
       "bin": {
         "tree-kill": "cli.js"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",


### PR DESCRIPTION
## Summary

- **Migration 030**: tabela `user_goals` com soft-delete e índice composto `(user_id, deleted_at)`
- **API `/goals`**: CRUD completo (GET / POST / PATCH / DELETE) com auth, entitlement gate e rate-limit
- **`goals.service.js`**: `calcMonthlyNeeded` — quanto poupar por mês para bater o prazo; `getGoalsSummaryForAI` — contexto de metas injetado no prompt do Claude Haiku
- **Frontend `GoalsSection`**: grid de cards com barra de progresso, shimmer, empty state e retry
- **`GoalCard`**: badge âmbar `⚠ risco` quando `monthlyNeeded > adjustedProjectedBalance`; mini-form inline `+ Registrar poupança` (PATCH sem abrir modal)
- **`GoalFormModal`**: create/edit com icon picker emoji e validação client-side
- **AI `SYSTEM_PROMPT`**: prioriza conflito metas vs. saldo antes de qualquer outro insight
- **`WelcomeCard` v2**: 4 passos narrando a jornada completa — transação → perfil → metas → IA

## Test plan

- [ ] `POST /goals` cria meta e retorna `monthlyNeeded` calculado
- [ ] `GET /goals` retorna apenas metas do usuário autenticado (isolamento)
- [ ] Badge `⚠ risco` aparece quando `monthlyNeeded > adjustedProjectedBalance`
- [ ] `+ Registrar poupança` faz PATCH somando ao `current_amount` atual
- [ ] Usuário sem trial/plano recebe 402 ao tentar criar meta
- [ ] WelcomeCard v2 exibe 4 passos para novos usuários (sessionStorage `v2`)
- [ ] Migration 030 aplica automaticamente no boot via `runMigrations()`
- [ ] Suites: 552/552 api · 239/239 web