### PR TITLE
feat(profile): Profile v2 — Modo Discreto + sections Conta / Preferências / Assinatura

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,8 @@ npm -w apps/web run build
 
 ## Documentação técnica
 
+* `docs/roadmap-execution.md` — mapa interno de execução: estado atual, próximo sprint, backlog e decisões arquiteturais
+
 * `docs/architecture/v1.3.0.md`
 * `docs/architecture/v1.3.0-auth.md`
 * `docs/architecture/v1.3.1-transactions.md`

--- a/apps/web/src/AppRoutes.tsx
+++ b/apps/web/src/AppRoutes.tsx
@@ -103,7 +103,17 @@ const ProfileSettingsRoute = () => {
     navigate("/", { replace: true });
   };
 
-  return <ProfileSettings onBack={handleBack} onLogout={handleLogout} />;
+  const handleOpenBilling = () => {
+    navigate("/app/settings/billing");
+  };
+
+  return (
+    <ProfileSettings
+      onBack={handleBack}
+      onLogout={handleLogout}
+      onOpenBilling={handleOpenBilling}
+    />
+  );
 };
 
 const SecuritySettingsRoute = () => {

--- a/apps/web/src/components/BillsSummaryWidget.tsx
+++ b/apps/web/src/components/BillsSummaryWidget.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { billsService, type BillsSummary } from "../services/bills.service";
-import { formatCurrency } from "../utils/formatCurrency";
+import { useMaskedCurrency } from "../context/DiscreetModeContext";
 
 interface BillsSummaryWidgetProps {
   onOpenBills?: () => void;
@@ -20,6 +20,7 @@ const BillsSummaryWidget = ({ onOpenBills }: BillsSummaryWidgetProps): JSX.Eleme
       .finally(() => setIsLoading(false));
   }, []);
 
+  const money = useMaskedCurrency();
   if (isLoading) {
     return (
       <div className="rounded border border-cf-border bg-cf-surface p-4">
@@ -49,7 +50,7 @@ const BillsSummaryWidget = ({ onOpenBills }: BillsSummaryWidgetProps): JSX.Eleme
         <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
           <p className="text-xs font-medium uppercase text-cf-text-secondary">Pendentes</p>
           <p className="text-sm font-semibold text-cf-text-primary">
-            {formatCurrency(summary.pendingTotal)}
+            {money(summary.pendingTotal)}
           </p>
           <p className="text-xs text-cf-text-secondary">
             {summary.pendingCount} {summary.pendingCount === 1 ? "conta" : "contas"}
@@ -61,7 +62,7 @@ const BillsSummaryWidget = ({ onOpenBills }: BillsSummaryWidgetProps): JSX.Eleme
           <p
             className={`text-sm font-semibold ${summary.overdueCount > 0 ? "text-red-600" : "text-cf-text-primary"}`}
           >
-            {formatCurrency(summary.overdueTotal)}
+            {money(summary.overdueTotal)}
           </p>
           <p className={`text-xs ${summary.overdueCount > 0 ? "text-red-500" : "text-cf-text-secondary"}`}>
             {summary.overdueCount} {summary.overdueCount === 1 ? "conta" : "contas"}

--- a/apps/web/src/components/ForecastCard.tsx
+++ b/apps/web/src/components/ForecastCard.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { forecastService, type Forecast } from "../services/forecast.service";
 import { profileService } from "../services/profile.service";
-import { formatCurrency } from "../utils/formatCurrency";
+import { useMaskedCurrency } from "../context/DiscreetModeContext";
 
 interface ForecastCardProps {
   onOpenProfileSettings?: () => void;
@@ -51,6 +51,7 @@ const ForecastCard = ({
   trialExpired = false,
   txCountSinceFreeze = 0,
 }: ForecastCardProps): JSX.Element => {
+  const money = useMaskedCurrency();
   const [cardState, setCardState] = useState<CardState>("loading");
   const [forecast, setForecast] = useState<Forecast | null>(null);
   const [isRecomputing, setIsRecomputing] = useState(false);
@@ -163,7 +164,7 @@ const ForecastCard = ({
             {forecast ? (
               <>
                 <p className="mt-2 text-2xl font-bold text-cf-text-primary">
-                  {formatCurrency(forecast.projectedBalance)}
+                  {money(forecast.projectedBalance)}
                 </p>
                 <p className="mt-1 text-xs text-cf-text-secondary">
                   Projeção do mês {forecast.month} - congelada no fim do período de teste.
@@ -223,11 +224,11 @@ const ForecastCard = ({
                   forecast.adjustedProjectedBalance < 0 ? "text-red-600" : "text-cf-text-primary"
                 }`}
               >
-                {formatCurrency(forecast.adjustedProjectedBalance)}
+                {money(forecast.adjustedProjectedBalance)}
               </p>
               {forecast.incomeExpected !== null ? (
                 <p className="mt-0.5 text-xs text-cf-text-secondary">
-                  Salário esperado: {formatCurrency(forecast.incomeExpected)}
+                  Salário esperado: {money(forecast.incomeExpected)}
                 </p>
               ) : null}
               {forecast.billsPendingCount > 0 ? (
@@ -243,10 +244,10 @@ const ForecastCard = ({
             <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
               <p className="text-xs font-medium uppercase text-cf-text-secondary">Gasto até agora</p>
               <p className="mt-1 text-base font-semibold text-cf-text-primary">
-                {formatCurrency(forecast.spendingToDate)}
+                {money(forecast.spendingToDate)}
               </p>
               <p className="mt-0.5 text-xs text-cf-text-secondary">
-                Media diaria: {formatCurrency(forecast.dailyAvgSpending)}/dia
+                Media diaria: {money(forecast.dailyAvgSpending)}/dia
               </p>
             </div>
 
@@ -265,7 +266,7 @@ const ForecastCard = ({
                   forecast.billsPendingCount > 0 ? "text-amber-600" : "text-cf-text-primary"
                 }`}
               >
-                {formatCurrency(forecast.billsPendingTotal)}
+                {money(forecast.billsPendingTotal)}
               </p>
               <p className="mt-0.5 text-xs text-cf-text-secondary">
                 {forecast.billsPendingCount > 0

--- a/apps/web/src/components/GoalsSection.tsx
+++ b/apps/web/src/components/GoalsSection.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { formatCurrency } from "../utils/formatCurrency";
+import { useMaskedCurrency } from "../context/DiscreetModeContext";
 import { getApiErrorMessage } from "../utils/apiError";
 import type { Goal, CreateGoalPayload, GoalIcon } from "../services/goals.service";
 import { GOAL_ICONS, goalsService } from "../services/goals.service";
@@ -18,6 +18,7 @@ interface GoalCardProps {
 }
 
 function GoalCard({ goal, projectedBalance, onEdit, onDelete, onContribute }: GoalCardProps) {
+  const money = useMaskedCurrency();
   const [showContrib, setShowContrib] = useState(false);
   const [contribAmt, setContribAmt] = useState("");
   const [contributing, setContributing] = useState(false);
@@ -113,7 +114,7 @@ function GoalCard({ goal, projectedBalance, onEdit, onDelete, onContribute }: Go
       <div>
         <div className="mb-1 flex items-center justify-between">
           <span className="text-xs text-cf-text-secondary">
-            {formatCurrency(goal.currentAmount)} de {formatCurrency(goal.targetAmount)}
+            {money(goal.currentAmount)} de {money(goal.targetAmount)}
           </span>
           <span className="text-xs font-semibold text-cf-text-primary">{pct}%</span>
         </div>
@@ -133,7 +134,7 @@ function GoalCard({ goal, projectedBalance, onEdit, onDelete, onContribute }: Go
       <div className="flex items-center justify-between text-xs text-cf-text-secondary">
         {goal.monthlyNeeded > 0 ? (
           <span className="flex items-center gap-1">
-            <span className="font-semibold text-cf-text-primary">{formatCurrency(goal.monthlyNeeded)}</span>
+            <span className="font-semibold text-cf-text-primary">{money(goal.monthlyNeeded)}</span>
             /mês necessário
             {isAtRisk && (
               <span

--- a/apps/web/src/components/TransactionList.jsx
+++ b/apps/web/src/components/TransactionList.jsx
@@ -1,6 +1,5 @@
 import PropTypes from "prop-types";
 import { CATEGORY_ENTRY } from "./DatabaseUtils";
-import { formatCurrency } from "../utils/formatCurrency";
 import { useMaskedCurrency } from "../context/DiscreetModeContext";
 
 const formatDate = (value) => {

--- a/apps/web/src/components/TransactionList.jsx
+++ b/apps/web/src/components/TransactionList.jsx
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types";
 import { CATEGORY_ENTRY } from "./DatabaseUtils";
 import { formatCurrency } from "../utils/formatCurrency";
+import { useMaskedCurrency } from "../context/DiscreetModeContext";
 
 const formatDate = (value) => {
   const date = new Date(`${value}T00:00:00`);
@@ -12,6 +13,7 @@ const formatDate = (value) => {
 };
 
 const TransactionList = ({ transactions, onDelete, onEdit }) => {
+  const money = useMaskedCurrency();
   return (
     <div className="mx-auto max-w-700 px-2 sm:px-0">
       {transactions.map((transaction) => (
@@ -24,7 +26,7 @@ const TransactionList = ({ transactions, onDelete, onEdit }) => {
               {transaction.description || "Sem descrição"}
             </span>
             <span className="text-base font-medium text-cf-text-primary">
-              {formatCurrency(transaction.value)}
+              {money(transaction.value)}
             </span>
             <span className="text-xs text-cf-text-secondary">{formatDate(transaction.date)}</span>
             <span className="break-words text-xs text-cf-text-secondary">

--- a/apps/web/src/context/DiscreetModeContext.test.tsx
+++ b/apps/web/src/context/DiscreetModeContext.test.tsx
@@ -17,40 +17,40 @@ describe("useDiscreetMode", () => {
 
   it("defaults to false when localStorage is empty", () => {
     const { result } = renderHook(() => useDiscreetMode(), { wrapper });
-    expect(result.current.isDiscreet).toBe(false);
+    expect(result.current.isDiscreetMode).toBe(false);
   });
 
   it("reads initial state from localStorage", () => {
     localStorage.setItem(STORAGE_KEY, "1");
     const { result } = renderHook(() => useDiscreetMode(), { wrapper });
-    expect(result.current.isDiscreet).toBe(true);
+    expect(result.current.isDiscreetMode).toBe(true);
   });
 
   it("toggle flips isDiscreet from false to true", async () => {
     const { result } = renderHook(() => useDiscreetMode(), { wrapper });
-    act(() => result.current.toggle());
-    expect(result.current.isDiscreet).toBe(true);
+    act(() => result.current.toggleDiscreetMode());
+    expect(result.current.isDiscreetMode).toBe(true);
   });
 
   it("toggle persists true to localStorage", () => {
     const { result } = renderHook(() => useDiscreetMode(), { wrapper });
-    act(() => result.current.toggle());
+    act(() => result.current.toggleDiscreetMode());
     expect(localStorage.getItem(STORAGE_KEY)).toBe("1");
   });
 
   it("toggle removes localStorage key when turning off", () => {
     localStorage.setItem(STORAGE_KEY, "1");
     const { result } = renderHook(() => useDiscreetMode(), { wrapper });
-    act(() => result.current.toggle());
+    act(() => result.current.toggleDiscreetMode());
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
-    expect(result.current.isDiscreet).toBe(false);
+    expect(result.current.isDiscreetMode).toBe(false);
   });
 
   it("toggle is stable across re-renders", () => {
     const { result, rerender } = renderHook(() => useDiscreetMode(), { wrapper });
-    const firstToggle = result.current.toggle;
+    const firstToggle = result.current.toggleDiscreetMode;
     rerender();
-    expect(result.current.toggle).toBe(firstToggle);
+    expect(result.current.toggleDiscreetMode).toBe(firstToggle);
   });
 });
 
@@ -76,7 +76,7 @@ describe("useMaskedCurrency", () => {
       { wrapper },
     );
     expect(result.current.money(100)).not.toBe("R$ ••••");
-    act(() => result.current.mode.toggle());
+    act(() => result.current.mode.toggleDiscreetMode());
     expect(result.current.money(100)).toBe("R$ ••••");
   });
 
@@ -91,7 +91,7 @@ describe("Modo Discreto toggle UI", () => {
     localStorage.clear();
   });
 
-  it("switch reflects and updates isDiscreet state", async () => {
+  it("switch reflects and updates isDiscreetMode state", async () => {
     const user = userEvent.setup();
     render(
       <DiscreetModeProvider>
@@ -107,13 +107,13 @@ describe("Modo Discreto toggle UI", () => {
 
 // Minimal switch component that wires directly to context
 const SwitchUnderTest = () => {
-  const { isDiscreet, toggle } = useDiscreetMode();
+  const { isDiscreetMode, toggleDiscreetMode } = useDiscreetMode();
   return (
     <button
       type="button"
       role="switch"
-      aria-checked={isDiscreet}
-      onClick={toggle}
+      aria-checked={isDiscreetMode}
+      onClick={toggleDiscreetMode}
     >
       toggle
     </button>

--- a/apps/web/src/context/DiscreetModeContext.test.tsx
+++ b/apps/web/src/context/DiscreetModeContext.test.tsx
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, renderHook, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DiscreetModeProvider, useDiscreetMode, useMaskedCurrency } from "./DiscreetModeContext";
+
+const STORAGE_KEY = "cf.discreet_mode";
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <DiscreetModeProvider>{children}</DiscreetModeProvider>
+);
+
+describe("useDiscreetMode", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("defaults to false when localStorage is empty", () => {
+    const { result } = renderHook(() => useDiscreetMode(), { wrapper });
+    expect(result.current.isDiscreet).toBe(false);
+  });
+
+  it("reads initial state from localStorage", () => {
+    localStorage.setItem(STORAGE_KEY, "1");
+    const { result } = renderHook(() => useDiscreetMode(), { wrapper });
+    expect(result.current.isDiscreet).toBe(true);
+  });
+
+  it("toggle flips isDiscreet from false to true", async () => {
+    const { result } = renderHook(() => useDiscreetMode(), { wrapper });
+    act(() => result.current.toggle());
+    expect(result.current.isDiscreet).toBe(true);
+  });
+
+  it("toggle persists true to localStorage", () => {
+    const { result } = renderHook(() => useDiscreetMode(), { wrapper });
+    act(() => result.current.toggle());
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("1");
+  });
+
+  it("toggle removes localStorage key when turning off", () => {
+    localStorage.setItem(STORAGE_KEY, "1");
+    const { result } = renderHook(() => useDiscreetMode(), { wrapper });
+    act(() => result.current.toggle());
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(result.current.isDiscreet).toBe(false);
+  });
+
+  it("toggle is stable across re-renders", () => {
+    const { result, rerender } = renderHook(() => useDiscreetMode(), { wrapper });
+    const firstToggle = result.current.toggle;
+    rerender();
+    expect(result.current.toggle).toBe(firstToggle);
+  });
+});
+
+describe("useMaskedCurrency", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("formats normally when discreet mode is off", () => {
+    const { result } = renderHook(() => useMaskedCurrency(), { wrapper });
+    expect(result.current(1234.56)).toBe("R$\u00a01.234,56");
+  });
+
+  it("returns mask string when discreet mode is on", () => {
+    localStorage.setItem(STORAGE_KEY, "1");
+    const { result } = renderHook(() => useMaskedCurrency(), { wrapper });
+    expect(result.current(1234.56)).toBe("R$ ••••");
+  });
+
+  it("updates immediately after toggle", async () => {
+    const { result } = renderHook(
+      () => ({ mode: useDiscreetMode(), money: useMaskedCurrency() }),
+      { wrapper },
+    );
+    expect(result.current.money(100)).not.toBe("R$ ••••");
+    act(() => result.current.mode.toggle());
+    expect(result.current.money(100)).toBe("R$ ••••");
+  });
+
+  it("works without provider (defaults to unmasked)", () => {
+    const { result } = renderHook(() => useMaskedCurrency());
+    expect(result.current(500)).not.toBe("R$ ••••");
+  });
+});
+
+describe("Modo Discreto toggle UI", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("switch reflects and updates isDiscreet state", async () => {
+    const user = userEvent.setup();
+    render(
+      <DiscreetModeProvider>
+        <SwitchUnderTest />
+      </DiscreetModeProvider>,
+    );
+    const btn = screen.getByRole("switch");
+    expect(btn).toHaveAttribute("aria-checked", "false");
+    await user.click(btn);
+    expect(btn).toHaveAttribute("aria-checked", "true");
+  });
+});
+
+// Minimal switch component that wires directly to context
+const SwitchUnderTest = () => {
+  const { isDiscreet, toggle } = useDiscreetMode();
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={isDiscreet}
+      onClick={toggle}
+    >
+      toggle
+    </button>
+  );
+};

--- a/apps/web/src/context/DiscreetModeContext.tsx
+++ b/apps/web/src/context/DiscreetModeContext.tsx
@@ -1,0 +1,60 @@
+import { createContext, useCallback, useContext } from "react";
+import { useState } from "react";
+import type { ReactNode } from "react";
+import { formatCurrency } from "../utils/formatCurrency";
+
+const STORAGE_KEY = "cf.discreet_mode";
+const MASK = "R$ ••••";
+
+interface DiscreetModeContextValue {
+  isDiscreet: boolean;
+  toggle: () => void;
+}
+
+const DiscreetModeContext = createContext<DiscreetModeContextValue>({
+  isDiscreet: false,
+  toggle: () => {},
+});
+
+export const DiscreetModeProvider = ({ children }: { children: ReactNode }) => {
+  const [isDiscreet, setIsDiscreet] = useState(() => {
+    try {
+      return localStorage.getItem(STORAGE_KEY) === "1";
+    } catch {
+      return false;
+    }
+  });
+
+  const toggle = useCallback(() => {
+    setIsDiscreet((prev) => {
+      const next = !prev;
+      try {
+        if (next) localStorage.setItem(STORAGE_KEY, "1");
+        else localStorage.removeItem(STORAGE_KEY);
+      } catch {
+        // Ignore storage errors (private mode / quota)
+      }
+      return next;
+    });
+  }, []);
+
+  return (
+    <DiscreetModeContext.Provider value={{ isDiscreet, toggle }}>
+      {children}
+    </DiscreetModeContext.Provider>
+  );
+};
+
+export const useDiscreetMode = () => useContext(DiscreetModeContext);
+
+/**
+ * Returns a formatter function that masks monetary values when discreet mode is active.
+ * Usage: const money = useMaskedCurrency(); ... {money(value)}
+ */
+export const useMaskedCurrency = () => {
+  const { isDiscreet } = useDiscreetMode();
+  return useCallback(
+    (value: unknown) => (isDiscreet ? MASK : formatCurrency(value)),
+    [isDiscreet],
+  );
+};

--- a/apps/web/src/context/DiscreetModeContext.tsx
+++ b/apps/web/src/context/DiscreetModeContext.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { createContext, useCallback, useContext } from "react";
 import { useState } from "react";
 import type { ReactNode } from "react";
@@ -7,17 +8,17 @@ const STORAGE_KEY = "cf.discreet_mode";
 const MASK = "R$ ••••";
 
 interface DiscreetModeContextValue {
-  isDiscreet: boolean;
-  toggle: () => void;
+  isDiscreetMode: boolean;
+  toggleDiscreetMode: () => void;
 }
 
 const DiscreetModeContext = createContext<DiscreetModeContextValue>({
-  isDiscreet: false,
-  toggle: () => {},
+  isDiscreetMode: false,
+  toggleDiscreetMode: () => {},
 });
 
 export const DiscreetModeProvider = ({ children }: { children: ReactNode }) => {
-  const [isDiscreet, setIsDiscreet] = useState(() => {
+  const [isDiscreetMode, setIsDiscreetMode] = useState(() => {
     try {
       return localStorage.getItem(STORAGE_KEY) === "1";
     } catch {
@@ -25,8 +26,8 @@ export const DiscreetModeProvider = ({ children }: { children: ReactNode }) => {
     }
   });
 
-  const toggle = useCallback(() => {
-    setIsDiscreet((prev) => {
+  const toggleDiscreetMode = useCallback(() => {
+    setIsDiscreetMode((prev) => {
       const next = !prev;
       try {
         if (next) localStorage.setItem(STORAGE_KEY, "1");
@@ -39,7 +40,7 @@ export const DiscreetModeProvider = ({ children }: { children: ReactNode }) => {
   }, []);
 
   return (
-    <DiscreetModeContext.Provider value={{ isDiscreet, toggle }}>
+    <DiscreetModeContext.Provider value={{ isDiscreetMode, toggleDiscreetMode }}>
       {children}
     </DiscreetModeContext.Provider>
   );
@@ -52,9 +53,9 @@ export const useDiscreetMode = () => useContext(DiscreetModeContext);
  * Usage: const money = useMaskedCurrency(); ... {money(value)}
  */
 export const useMaskedCurrency = () => {
-  const { isDiscreet } = useDiscreetMode();
+  const { isDiscreetMode } = useDiscreetMode();
   return useCallback(
-    (value: unknown) => (isDiscreet ? MASK : formatCurrency(value)),
-    [isDiscreet],
+    (value: unknown) => (isDiscreetMode ? MASK : formatCurrency(value)),
+    [isDiscreetMode],
   );
 };

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -5,6 +5,7 @@ import { GoogleOAuthProvider } from "@react-oauth/google";
 import AppRoutes from "./AppRoutes";
 import { AuthProvider } from "./context/AuthContext";
 import { ThemeProvider } from "./context/ThemeProvider";
+import { DiscreetModeProvider } from "./context/DiscreetModeContext";
 import "./index.css";
 
 const GOOGLE_CLIENT_ID = (import.meta.env.VITE_GOOGLE_CLIENT_ID as string) || "";
@@ -20,9 +21,11 @@ ReactDOM.createRoot(rootElement).render(
     <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID}>
       <BrowserRouter>
         <ThemeProvider>
-          <AuthProvider>
-            <AppRoutes />
-          </AuthProvider>
+          <DiscreetModeProvider>
+            <AuthProvider>
+              <AppRoutes />
+            </AuthProvider>
+          </DiscreetModeProvider>
         </ThemeProvider>
       </BrowserRouter>
     </GoogleOAuthProvider>

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -51,6 +51,7 @@ import {
 } from "../features/filters/useFilters";
 import { useTheme } from "../hooks/useTheme";
 import { formatCurrency } from "../utils/formatCurrency";
+import { useMaskedCurrency } from "../context/DiscreetModeContext";
 
 const TransactionChart = lazy(() => import("../components/TransactionChart"));
 const TrendChart = lazy(() => import("../components/TrendChart"));
@@ -453,6 +454,7 @@ const App = ({
   onOpenProfileSettings = undefined,
   onOpenSecuritySettings = undefined,
 }: AppProps): JSX.Element => {
+  const money = useMaskedCurrency();
   const initialFilterState = useMemo(() => getInitialFilterState(), []);
   const initialPaginationState = useMemo(() => getInitialPaginationState(), []);
   // Guards first_transaction_created from duplicate fires within a session.
@@ -2197,7 +2199,7 @@ const App = ({
           <div className="rounded border border-brand-1 bg-cf-bg-subtle px-4 py-3.5">
             <p className="text-xs font-medium uppercase text-cf-text-secondary">Saldo</p>
             <p className="text-xl font-semibold text-cf-text-primary">
-              {isLoadingSummary ? "Carregando..." : formatCurrency(monthlySummary.balance)}
+              {isLoadingSummary ? "Carregando..." : money(monthlySummary.balance)}
             </p>
             <p
               className={`mt-1 text-xs font-medium ${
@@ -2223,7 +2225,7 @@ const App = ({
           <div className="rounded border border-brand-1 bg-cf-bg-subtle px-4 py-3.5">
             <p className="text-xs font-medium uppercase text-cf-text-secondary">Entradas</p>
             <p className="text-xl font-semibold text-cf-text-primary">
-              {isLoadingSummary ? "Carregando..." : formatCurrency(monthlySummary.income)}
+              {isLoadingSummary ? "Carregando..." : money(monthlySummary.income)}
             </p>
             <p
               className={`mt-1 text-xs font-medium ${
@@ -2249,7 +2251,7 @@ const App = ({
           <div className="rounded border border-brand-1 bg-cf-bg-subtle px-4 py-3.5">
             <p className="text-xs font-medium uppercase text-cf-text-secondary">Saídas</p>
             <p className="text-xl font-semibold text-cf-text-primary">
-              {isLoadingSummary ? "Carregando..." : formatCurrency(monthlySummary.expense)}
+              {isLoadingSummary ? "Carregando..." : money(monthlySummary.expense)}
             </p>
             <p
               className={`mt-1 text-xs font-medium ${

--- a/apps/web/src/pages/ProfileSettings.test.tsx
+++ b/apps/web/src/pages/ProfileSettings.test.tsx
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ProfileSettings from "./ProfileSettings";
+import { profileService } from "../services/profile.service";
+import { DiscreetModeProvider } from "../context/DiscreetModeContext";
+
+vi.mock("../services/profile.service", () => ({
+  profileService: {
+    getMe: vi.fn(),
+    updateProfile: vi.fn(),
+  },
+}));
+
+const buildMe = (overrides = {}) => ({
+  id: 1,
+  name: "Jr",
+  email: "jr@example.com",
+  hasPassword: true,
+  linkedProviders: [] as string[],
+  trialEndsAt: null as string | null,
+  trialExpired: false,
+  profile: {
+    displayName: "Jr Valerio",
+    salaryMonthly: 5000,
+    payday: 5,
+    avatarUrl: null,
+  },
+  ...overrides,
+});
+
+const renderPage = (props: {
+  onBack?: () => void;
+  onLogout?: () => void;
+  onOpenBilling?: () => void;
+} = {}) =>
+  render(
+    <DiscreetModeProvider>
+      <ProfileSettings {...props} />
+    </DiscreetModeProvider>,
+  );
+
+describe("ProfileSettings — Dados da conta", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    vi.mocked(profileService.getMe).mockResolvedValue(buildMe());
+    vi.mocked(profileService.updateProfile).mockResolvedValue({
+      displayName: "Jr Valerio",
+      salaryMonthly: 5000,
+      payday: 5,
+      avatarUrl: null,
+    });
+  });
+
+  it("shows loading skeleton then renders account fields", async () => {
+    renderPage();
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByLabelText("E-mail")).toBeInTheDocument());
+    expect(screen.getByDisplayValue("jr@example.com")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Jr Valerio")).toBeInTheDocument();
+  });
+
+  it("shows load error with retry button on failure", async () => {
+    vi.mocked(profileService.getMe).mockRejectedValue(new Error("Network error"));
+    renderPage();
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+    expect(screen.getByText("Tentar novamente")).toBeInTheDocument();
+  });
+
+  it("shows Acesso via: Google when linkedProviders includes google", async () => {
+    vi.mocked(profileService.getMe).mockResolvedValue(
+      buildMe({ linkedProviders: ["google"], hasPassword: false }),
+    );
+    renderPage();
+    await waitFor(() => expect(screen.getByText(/Acesso via:/)).toBeInTheDocument());
+    expect(screen.getByText(/Google/)).toBeInTheDocument();
+  });
+
+  it("shows both Senha and Google when both are configured", async () => {
+    vi.mocked(profileService.getMe).mockResolvedValue(
+      buildMe({ linkedProviders: ["google"], hasPassword: true }),
+    );
+    renderPage();
+    await waitFor(() => expect(screen.getByText(/Acesso via:/)).toBeInTheDocument());
+    expect(screen.getByText(/Senha · Google/)).toBeInTheDocument();
+  });
+
+  it("submits profile update and shows success message", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() => expect(screen.getByLabelText("Nome exibido")).toBeInTheDocument());
+
+    const nameInput = screen.getByLabelText("Nome exibido");
+    await user.clear(nameInput);
+    await user.type(nameInput, "Novo Nome");
+    await user.click(screen.getByRole("button", { name: "Salvar perfil" }));
+
+    await waitFor(() =>
+      expect(screen.getByText("Perfil salvo com sucesso.")).toBeInTheDocument(),
+    );
+    expect(profileService.updateProfile).toHaveBeenCalledWith(
+      expect.objectContaining({ display_name: "Novo Nome" }),
+    );
+  });
+});
+
+describe("ProfileSettings — Preferências (Modo Discreto)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    vi.mocked(profileService.getMe).mockResolvedValue(buildMe());
+  });
+
+  it("renders Modo Discreto switch defaulting to off", async () => {
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByRole("switch", { name: /modo discreto/i })).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("switch", { name: /modo discreto/i })).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+  });
+
+  it("toggles Modo Discreto on click", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByRole("switch", { name: /modo discreto/i })).toBeInTheDocument(),
+    );
+    await user.click(screen.getByRole("switch", { name: /modo discreto/i }));
+    expect(screen.getByRole("switch", { name: /modo discreto/i })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+  });
+});
+
+describe("ProfileSettings — Assinatura", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it("shows trial active with days remaining", async () => {
+    const futureDate = new Date(Date.now() + 7 * 86_400_000).toISOString();
+    vi.mocked(profileService.getMe).mockResolvedValue(
+      buildMe({ trialEndsAt: futureDate, trialExpired: false }),
+    );
+    renderPage();
+    await waitFor(() => expect(screen.getByText("Trial ativo")).toBeInTheDocument());
+    expect(screen.getByText(/dias? restante/i)).toBeInTheDocument();
+  });
+
+  it("shows trial expired with upgrade CTA", async () => {
+    const pastDate = new Date(Date.now() - 86_400_000).toISOString();
+    vi.mocked(profileService.getMe).mockResolvedValue(
+      buildMe({ trialEndsAt: pastDate, trialExpired: true }),
+    );
+    const onOpenBilling = vi.fn();
+    renderPage({ onOpenBilling });
+    await waitFor(() => expect(screen.getByText("Trial expirado")).toBeInTheDocument());
+    const upgradeBtn = screen.getByRole("button", { name: "Fazer upgrade" });
+    expect(upgradeBtn).toBeInTheDocument();
+    await userEvent.setup().click(upgradeBtn);
+    expect(onOpenBilling).toHaveBeenCalledOnce();
+  });
+
+  it("does not show upgrade button when onOpenBilling is not provided", async () => {
+    const pastDate = new Date(Date.now() - 86_400_000).toISOString();
+    vi.mocked(profileService.getMe).mockResolvedValue(
+      buildMe({ trialEndsAt: pastDate, trialExpired: true }),
+    );
+    renderPage();
+    await waitFor(() => expect(screen.getByText("Trial expirado")).toBeInTheDocument());
+    expect(screen.queryByRole("button", { name: "Fazer upgrade" })).not.toBeInTheDocument();
+  });
+
+  it("shows Plano Pro when no trial info", async () => {
+    vi.mocked(profileService.getMe).mockResolvedValue(
+      buildMe({ trialEndsAt: null, trialExpired: false }),
+    );
+    renderPage();
+    await waitFor(() => expect(screen.getByText("Plano Pro")).toBeInTheDocument());
+  });
+});

--- a/apps/web/src/pages/ProfileSettings.test.tsx
+++ b/apps/web/src/pages/ProfileSettings.test.tsx
@@ -177,11 +177,12 @@ describe("ProfileSettings — Assinatura", () => {
     expect(screen.queryByRole("button", { name: "Fazer upgrade" })).not.toBeInTheDocument();
   });
 
-  it("shows Plano Pro when no trial info", async () => {
+  it("shows Acesso ativo when no trial info (plan details unknown)", async () => {
     vi.mocked(profileService.getMe).mockResolvedValue(
       buildMe({ trialEndsAt: null, trialExpired: false }),
     );
     renderPage();
-    await waitFor(() => expect(screen.getByText("Plano Pro")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText("Acesso ativo")).toBeInTheDocument());
+    expect(screen.getByText(/Detalhes do plano disponíveis em Faturamento/)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/ProfileSettings.tsx
+++ b/apps/web/src/pages/ProfileSettings.tsx
@@ -73,7 +73,7 @@ const ProfileSettings = ({
   onLogout = undefined,
   onOpenBilling = undefined,
 }: ProfileSettingsProps): JSX.Element => {
-  const { isDiscreet, toggle: toggleDiscreet } = useDiscreetMode();
+  const { isDiscreetMode, toggleDiscreetMode } = useDiscreetMode();
 
   // Account fields
   const [email, setEmail] = useState("");
@@ -398,19 +398,19 @@ const ProfileSettings = ({
                 <button
                   type="button"
                   role="switch"
-                  aria-checked={isDiscreet}
-                  onClick={toggleDiscreet}
+                  aria-checked={isDiscreetMode}
+                  onClick={toggleDiscreetMode}
                   className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-brand-1 focus:ring-offset-2 ${
-                    isDiscreet ? "bg-brand-1" : "bg-cf-border"
+                    isDiscreetMode ? "bg-brand-1" : "bg-cf-border"
                   }`}
                 >
                   <span
                     className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
-                      isDiscreet ? "translate-x-6" : "translate-x-1"
+                      isDiscreetMode ? "translate-x-6" : "translate-x-1"
                     }`}
                   />
                   <span className="sr-only">
-                    {isDiscreet ? "Desativar modo discreto" : "Ativar modo discreto"}
+                    {isDiscreetMode ? "Desativar modo discreto" : "Ativar modo discreto"}
                   </span>
                 </button>
               </div>
@@ -463,14 +463,20 @@ const ProfileSettings = ({
               ) : (
                 <div className="flex items-center justify-between gap-4 rounded border border-cf-border bg-cf-bg-subtle px-4 py-3">
                   <div>
-                    <p className="text-sm font-semibold text-cf-text-primary">Plano Pro</p>
+                    <p className="text-sm font-semibold text-cf-text-primary">Acesso ativo</p>
                     <p className="mt-0.5 text-xs text-cf-text-secondary">
-                      Acesso completo a todas as funcionalidades.
+                      Detalhes do plano disponíveis em Faturamento.
                     </p>
                   </div>
-                  <span className="shrink-0 rounded-full bg-brand-1/10 px-2.5 py-0.5 text-xs font-semibold text-brand-1">
-                    Ativo
-                  </span>
+                  {onOpenBilling ? (
+                    <button
+                      type="button"
+                      onClick={onOpenBilling}
+                      className="shrink-0 rounded border border-cf-border px-3 py-1 text-xs font-semibold text-cf-text-secondary hover:bg-cf-bg-subtle"
+                    >
+                      Ver plano
+                    </button>
+                  ) : null}
                 </div>
               )}
             </section>

--- a/apps/web/src/pages/ProfileSettings.tsx
+++ b/apps/web/src/pages/ProfileSettings.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { FormEvent } from "react";
 import { profileService, type UserProfile } from "../services/profile.service";
 import { getApiErrorMessage } from "../utils/apiError";
+import { useDiscreetMode } from "../context/DiscreetModeContext";
 
 const getInitials = (displayName: string | null, email: string): string => {
   const trimmed = displayName?.trim();
@@ -42,20 +43,52 @@ const Avatar = ({ avatarUrl, displayName, email }: AvatarProps): JSX.Element => 
   );
 };
 
+const SectionHeading = ({ title, description }: { title: string; description?: string }) => (
+  <div className="mb-4">
+    <h2 className="text-sm font-semibold uppercase tracking-wide text-cf-text-secondary">
+      {title}
+    </h2>
+    {description ? (
+      <p className="mt-0.5 text-xs text-cf-text-secondary">{description}</p>
+    ) : null}
+  </div>
+);
+
+const calcDaysRemaining = (trialEndsAt: string | null): number => {
+  if (!trialEndsAt) return 0;
+  return Math.max(
+    0,
+    Math.ceil((new Date(trialEndsAt).getTime() - Date.now()) / 86_400_000),
+  );
+};
+
 interface ProfileSettingsProps {
   onBack?: () => void;
   onLogout?: () => void;
+  onOpenBilling?: () => void;
 }
 
 const ProfileSettings = ({
   onBack = undefined,
   onLogout = undefined,
+  onOpenBilling = undefined,
 }: ProfileSettingsProps): JSX.Element => {
+  const { isDiscreet, toggle: toggleDiscreet } = useDiscreetMode();
+
+  // Account fields
   const [email, setEmail] = useState("");
   const [displayName, setDisplayName] = useState("");
   const [salaryMonthly, setSalaryMonthly] = useState("");
   const [payday, setPayday] = useState("");
   const [avatarUrl, setAvatarUrl] = useState("");
+
+  // Auth info (read-only display)
+  const [hasPassword, setHasPassword] = useState<boolean | null>(null);
+  const [linkedProviders, setLinkedProviders] = useState<string[]>([]);
+
+  // Subscription info (read-only display)
+  const [trialEndsAt, setTrialEndsAt] = useState<string | null>(null);
+  const [trialExpired, setTrialExpired] = useState(false);
 
   const [isLoading, setIsLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -71,12 +104,20 @@ const ProfileSettings = ({
     try {
       const me = await profileService.getMe();
       setEmail(me.email);
+      setHasPassword(me.hasPassword ?? null);
+      setLinkedProviders(me.linkedProviders ?? []);
+      setTrialEndsAt(me.trialEndsAt ?? null);
+      setTrialExpired(me.trialExpired ?? false);
       const p: UserProfile | null = me.profile;
       setDisplayName(p?.displayName ?? "");
-      setSalaryMonthly(p?.salaryMonthly !== null && p?.salaryMonthly !== undefined
-        ? String(p.salaryMonthly)
-        : "");
-      setPayday(p?.payday !== null && p?.payday !== undefined ? String(p.payday) : "");
+      setSalaryMonthly(
+        p?.salaryMonthly !== null && p?.salaryMonthly !== undefined
+          ? String(p.salaryMonthly)
+          : "",
+      );
+      setPayday(
+        p?.payday !== null && p?.payday !== undefined ? String(p.payday) : "",
+      );
       setAvatarUrl(p?.avatarUrl ?? "");
     } catch (error) {
       setLoadError(getApiErrorMessage(error, "Não foi possível carregar o perfil."));
@@ -111,211 +152,330 @@ const ProfileSettings = ({
       setSaveSuccess(true);
       successTimerRef.current = setTimeout(() => setSaveSuccess(false), 4000);
     } catch (error) {
-      setSaveError(getApiErrorMessage(error, "Não foi possível salvar o perfil. Tente novamente."));
+      setSaveError(
+        getApiErrorMessage(error, "Não foi possível salvar o perfil. Tente novamente."),
+      );
     } finally {
       setIsSaving(false);
     }
   };
 
   const avatarPreview = avatarUrl.trim();
+  const daysRemaining = calcDaysRemaining(trialEndsAt);
+
+  const authMethodLabel = (() => {
+    const methods: string[] = [];
+    if (hasPassword) methods.push("Senha");
+    if (linkedProviders.includes("google")) methods.push("Google");
+    return methods.length > 0 ? methods.join(" · ") : null;
+  })();
 
   return (
     <div className="min-h-screen bg-cf-bg-page py-6">
-      <main className="mx-auto w-full max-w-4xl space-y-4 px-4 sm:px-6">
-        <section className="rounded border border-cf-border bg-cf-surface p-4">
-          <div className="flex flex-wrap items-start justify-between gap-3">
-            <div>
-              <h1 className="text-xl font-semibold text-cf-text-primary">Settings - Perfil</h1>
-              <p className="mt-1 text-sm text-cf-text-secondary">
-                Personalize seu nome, salário e preferências de conta.
-              </p>
-            </div>
-            <div className="flex flex-wrap items-center gap-2">
+      <main className="mx-auto w-full max-w-2xl space-y-6 px-4 sm:px-6">
+
+        {/* Header */}
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h1 className="text-xl font-semibold text-cf-text-primary">Configurações</h1>
+            <p className="mt-1 text-sm text-cf-text-secondary">
+              Gerencie sua conta, preferências e plano.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={onBack}
+              className="rounded border border-cf-border bg-cf-surface px-3 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
+            >
+              Voltar ao dashboard
+            </button>
+            {onLogout ? (
               <button
                 type="button"
-                onClick={onBack}
+                onClick={onLogout}
                 className="rounded border border-cf-border bg-cf-surface px-3 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
               >
-                Voltar ao dashboard
+                Sair
               </button>
-              {onLogout ? (
-                <button
-                  type="button"
-                  onClick={onLogout}
-                  className="rounded border border-cf-border bg-cf-surface px-3 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
-                >
-                  Sair
-                </button>
-              ) : null}
-            </div>
+            ) : null}
           </div>
+        </div>
 
-          {isLoading ? (
-            <div className="mt-4 space-y-3" role="status" aria-live="polite">
-              <div className="h-16 animate-pulse rounded border border-cf-border bg-cf-bg-subtle" />
-              <div className="h-10 animate-pulse rounded border border-cf-border bg-cf-bg-subtle" />
-              <div className="h-10 animate-pulse rounded border border-cf-border bg-cf-bg-subtle" />
-              <span className="sr-only">Carregando perfil...</span>
-            </div>
-          ) : null}
+        {/* Loading skeleton */}
+        {isLoading ? (
+          <div className="space-y-3" role="status" aria-live="polite">
+            <div className="h-20 animate-pulse rounded border border-cf-border bg-cf-bg-subtle" />
+            <div className="h-10 animate-pulse rounded border border-cf-border bg-cf-bg-subtle" />
+            <div className="h-10 animate-pulse rounded border border-cf-border bg-cf-bg-subtle" />
+            <span className="sr-only">Carregando perfil...</span>
+          </div>
+        ) : null}
 
-          {!isLoading && loadError ? (
-            <div
-              className="mt-4 flex items-center justify-between gap-3 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
-              role="alert"
+        {/* Load error */}
+        {!isLoading && loadError ? (
+          <div
+            className="flex items-center justify-between gap-3 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+            role="alert"
+          >
+            <span>{loadError}</span>
+            <button
+              type="button"
+              onClick={loadProfile}
+              className="rounded border border-red-300 px-2 py-1 text-xs font-semibold text-red-700 hover:bg-red-100"
             >
-              <span>{loadError}</span>
-              <button
-                type="button"
-                onClick={loadProfile}
-                className="rounded border border-red-300 px-2 py-1 text-xs font-semibold text-red-700 hover:bg-red-100"
-              >
-                Tentar novamente
-              </button>
-            </div>
-          ) : null}
+              Tentar novamente
+            </button>
+          </div>
+        ) : null}
 
-          {!isLoading && !loadError ? (
-            <form onSubmit={handleSubmit} noValidate className="mt-4 space-y-4">
-              {/* Avatar preview */}
-              <div className="flex items-center gap-4">
-                <Avatar
-                  avatarUrl={avatarPreview}
-                  displayName={displayName}
-                  email={email}
-                />
-                <div className="min-w-0 flex-1">
+        {!isLoading && !loadError ? (
+          <>
+            {/* ── Seção 1: Dados da conta ─────────────────────── */}
+            <section className="rounded border border-cf-border bg-cf-surface p-5">
+              <SectionHeading
+                title="Dados da conta"
+                description="Nome exibido, avatar e informações de acesso."
+              />
+
+              <form onSubmit={handleSubmit} noValidate className="space-y-4">
+                {/* Avatar + URL */}
+                <div className="flex items-center gap-4">
+                  <Avatar
+                    avatarUrl={avatarPreview}
+                    displayName={displayName}
+                    email={email}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <label
+                      htmlFor="avatar_url"
+                      className="block text-sm font-semibold text-cf-text-primary"
+                    >
+                      URL do avatar
+                    </label>
+                    <input
+                      id="avatar_url"
+                      type="url"
+                      value={avatarUrl}
+                      onChange={(e) => setAvatarUrl(e.target.value)}
+                      placeholder="https://..."
+                      className="mt-1 w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
+                    />
+                    <p className="mt-0.5 text-xs text-cf-text-secondary">
+                      Deve começar com https://. Deixe vazio para usar as iniciais.
+                    </p>
+                  </div>
+                </div>
+
+                {/* Display name */}
+                <div>
                   <label
-                    htmlFor="avatar_url"
+                    htmlFor="display_name"
                     className="block text-sm font-semibold text-cf-text-primary"
                   >
-                    URL do avatar
+                    Nome exibido
                   </label>
                   <input
-                    id="avatar_url"
-                    type="url"
-                    value={avatarUrl}
-                    onChange={(e) => setAvatarUrl(e.target.value)}
-                    placeholder="https://..."
+                    id="display_name"
+                    type="text"
+                    value={displayName}
+                    onChange={(e) => setDisplayName(e.target.value)}
+                    maxLength={100}
+                    placeholder="Como você quer ser chamado"
                     className="mt-1 w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
                   />
+                </div>
+
+                {/* Email (read-only) */}
+                <div>
+                  <label
+                    htmlFor="email"
+                    className="block text-sm font-semibold text-cf-text-primary"
+                  >
+                    E-mail
+                  </label>
+                  <input
+                    id="email"
+                    type="email"
+                    value={email}
+                    readOnly
+                    className="mt-1 w-full rounded border border-cf-border bg-cf-bg-subtle px-3 py-1.5 text-sm text-cf-text-secondary"
+                  />
+                  {authMethodLabel ? (
+                    <p className="mt-0.5 text-xs text-cf-text-secondary">
+                      Acesso via: {authMethodLabel}
+                    </p>
+                  ) : null}
+                </div>
+
+                {/* Salary + Payday */}
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <div>
+                    <label
+                      htmlFor="salary_monthly"
+                      className="block text-sm font-semibold text-cf-text-primary"
+                    >
+                      Salário mensal (R$)
+                    </label>
+                    <input
+                      id="salary_monthly"
+                      type="number"
+                      min="0"
+                      step="0.01"
+                      value={salaryMonthly}
+                      onChange={(e) => setSalaryMonthly(e.target.value)}
+                      placeholder="0,00"
+                      className="mt-1 w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
+                    />
+                  </div>
+                  <div>
+                    <label
+                      htmlFor="payday"
+                      className="block text-sm font-semibold text-cf-text-primary"
+                    >
+                      Dia do pagamento
+                    </label>
+                    <input
+                      id="payday"
+                      type="number"
+                      min="1"
+                      max="31"
+                      step="1"
+                      value={payday}
+                      onChange={(e) => setPayday(e.target.value)}
+                      placeholder="Ex: 5"
+                      className="mt-1 w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
+                    />
+                    <p className="mt-0.5 text-xs text-cf-text-secondary">Dia do mês (1 a 31)</p>
+                  </div>
+                </div>
+
+                {/* Feedback */}
+                {saveError ? (
+                  <div
+                    className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+                    role="alert"
+                  >
+                    {saveError}
+                  </div>
+                ) : null}
+                {saveSuccess ? (
+                  <div
+                    className="rounded border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    Perfil salvo com sucesso.
+                  </div>
+                ) : null}
+
+                <div className="flex justify-end">
+                  <button
+                    type="submit"
+                    disabled={isSaving}
+                    className="rounded bg-brand-1 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-2 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {isSaving ? "Salvando..." : "Salvar perfil"}
+                  </button>
+                </div>
+              </form>
+            </section>
+
+            {/* ── Seção 2: Preferências ───────────────────────── */}
+            <section className="rounded border border-cf-border bg-cf-surface p-5">
+              <SectionHeading
+                title="Preferências"
+                description="Configurações de exibição e privacidade."
+              />
+
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="text-sm font-semibold text-cf-text-primary">Modo Discreto</p>
                   <p className="mt-0.5 text-xs text-cf-text-secondary">
-                    Deve comecar com https://. Deixe vazio para usar as iniciais.
+                    Oculta valores monetários nas telas. Útil para usar o app em público.
                   </p>
                 </div>
-              </div>
-
-              {/* Display name */}
-              <div>
-                <label
-                  htmlFor="display_name"
-                  className="block text-sm font-semibold text-cf-text-primary"
-                >
-                  Nome exibido
-                </label>
-                <input
-                  id="display_name"
-                  type="text"
-                  value={displayName}
-                  onChange={(e) => setDisplayName(e.target.value)}
-                  maxLength={100}
-                  placeholder="Como voce quer ser chamado"
-                  className="mt-1 w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
-                />
-              </div>
-
-              {/* Email (read-only) */}
-              <div>
-                <label
-                  htmlFor="email"
-                  className="block text-sm font-semibold text-cf-text-primary"
-                >
-                  Email
-                </label>
-                <input
-                  id="email"
-                  type="email"
-                  value={email}
-                  readOnly
-                  className="mt-1 w-full rounded border border-cf-border bg-cf-bg-subtle px-3 py-1.5 text-sm text-cf-text-secondary"
-                />
-              </div>
-
-              {/* Salary + Payday row */}
-              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                <div>
-                  <label
-                    htmlFor="salary_monthly"
-                    className="block text-sm font-semibold text-cf-text-primary"
-                  >
-                    Salário mensal (R$)
-                  </label>
-                  <input
-                    id="salary_monthly"
-                    type="number"
-                    min="0"
-                    step="0.01"
-                    value={salaryMonthly}
-                    onChange={(e) => setSalaryMonthly(e.target.value)}
-                    placeholder="0,00"
-                    className="mt-1 w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
-                  />
-                </div>
-                <div>
-                  <label
-                    htmlFor="payday"
-                    className="block text-sm font-semibold text-cf-text-primary"
-                  >
-                    Dia do pagamento
-                  </label>
-                  <input
-                    id="payday"
-                    type="number"
-                    min="1"
-                    max="31"
-                    step="1"
-                    value={payday}
-                    onChange={(e) => setPayday(e.target.value)}
-                    placeholder="Ex: 5"
-                    className="mt-1 w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
-                  />
-                  <p className="mt-0.5 text-xs text-cf-text-secondary">Dia do mês (1 a 31)</p>
-                </div>
-              </div>
-
-              {/* Feedback */}
-              {saveError ? (
-                <div
-                  className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
-                  role="alert"
-                >
-                  {saveError}
-                </div>
-              ) : null}
-
-              {saveSuccess ? (
-                <div
-                  className="rounded border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700"
-                  role="status"
-                  aria-live="polite"
-                >
-                  Perfil salvo com sucesso.
-                </div>
-              ) : null}
-
-              {/* Actions */}
-              <div className="flex justify-end">
                 <button
-                  type="submit"
-                  disabled={isSaving}
-                  className="rounded bg-brand-1 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-2 disabled:cursor-not-allowed disabled:opacity-60"
+                  type="button"
+                  role="switch"
+                  aria-checked={isDiscreet}
+                  onClick={toggleDiscreet}
+                  className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-brand-1 focus:ring-offset-2 ${
+                    isDiscreet ? "bg-brand-1" : "bg-cf-border"
+                  }`}
                 >
-                  {isSaving ? "Salvando..." : "Salvar perfil"}
+                  <span
+                    className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                      isDiscreet ? "translate-x-6" : "translate-x-1"
+                    }`}
+                  />
+                  <span className="sr-only">
+                    {isDiscreet ? "Desativar modo discreto" : "Ativar modo discreto"}
+                  </span>
                 </button>
               </div>
-            </form>
-          ) : null}
-        </section>
+            </section>
+
+            {/* ── Seção 3: Assinatura ─────────────────────────── */}
+            <section className="rounded border border-cf-border bg-cf-surface p-5">
+              <SectionHeading
+                title="Assinatura"
+                description="Status do seu plano e acesso às funcionalidades."
+              />
+
+              {trialEndsAt !== null && !trialExpired ? (
+                <div className="flex items-center justify-between gap-4 rounded border border-green-200 bg-green-50 px-4 py-3">
+                  <div>
+                    <p className="text-sm font-semibold text-green-800">Trial ativo</p>
+                    <p className="mt-0.5 text-xs text-green-700">
+                      {daysRemaining > 0
+                        ? `${daysRemaining} dia${daysRemaining !== 1 ? "s" : ""} restante${daysRemaining !== 1 ? "s" : ""} — acesso completo a todas as funcionalidades.`
+                        : "Último dia de trial — acesso completo a todas as funcionalidades."}
+                    </p>
+                  </div>
+                  <span className="shrink-0 rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-semibold text-green-800">
+                    Trial
+                  </span>
+                </div>
+              ) : trialExpired ? (
+                <div className="flex items-start justify-between gap-4 rounded border border-amber-200 bg-amber-50 px-4 py-3">
+                  <div>
+                    <p className="text-sm font-semibold text-amber-800">Trial expirado</p>
+                    <p className="mt-0.5 text-xs text-amber-700">
+                      Algumas funcionalidades estão limitadas. Faça upgrade para continuar usando o Especialista IA, exportação e projeção de saldo.
+                    </p>
+                  </div>
+                  <div className="flex shrink-0 flex-col items-end gap-2">
+                    <span className="rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-semibold text-amber-800">
+                      Expirado
+                    </span>
+                    {onOpenBilling ? (
+                      <button
+                        type="button"
+                        onClick={onOpenBilling}
+                        className="rounded bg-brand-1 px-3 py-1.5 text-xs font-semibold text-white hover:bg-brand-2"
+                      >
+                        Fazer upgrade
+                      </button>
+                    ) : null}
+                  </div>
+                </div>
+              ) : (
+                <div className="flex items-center justify-between gap-4 rounded border border-cf-border bg-cf-bg-subtle px-4 py-3">
+                  <div>
+                    <p className="text-sm font-semibold text-cf-text-primary">Plano Pro</p>
+                    <p className="mt-0.5 text-xs text-cf-text-secondary">
+                      Acesso completo a todas as funcionalidades.
+                    </p>
+                  </div>
+                  <span className="shrink-0 rounded-full bg-brand-1/10 px-2.5 py-0.5 text-xs font-semibold text-brand-1">
+                    Ativo
+                  </span>
+                </div>
+              )}
+            </section>
+          </>
+        ) : null}
       </main>
     </div>
   );

--- a/docs/roadmap-execution.md
+++ b/docs/roadmap-execution.md
@@ -1,0 +1,260 @@
+# Control Finance — Roadmap de Execução
+
+> Documento interno para orientar as próximas entregas do produto sem desviar do escopo.
+> Este arquivo não substitui o README público do repositório; ele serve como mapa de execução.
+
+---
+
+## 1. Norte do produto
+
+O Control Finance deixou de ser apenas um app de registro de entradas e saídas.
+O produto é um **Copiloto Financeiro**:
+
+- acompanha transações reais por usuário com isolamento real de dados
+- projeta o comportamento financeiro do mês (forecast + flip detection)
+- lê a saúde financeira de forma executiva (HealthOverview + gauge)
+- gera insights contextuais via Claude Haiku (Especialista IA)
+- acompanha metas de poupança com cálculo automático de necessidade mensal
+- prepara o terreno para automações mais inteligentes sem inflar escopo cedo demais
+
+### Regra central
+
+> **Dar acabamento premium à inteligência que já existe antes de adicionar mais camadas.**
+
+---
+
+## 2. Estado atual confirmado (v1.30.0)
+
+### Monorepo
+
+```text
+apps/
+  web/  → React + Vite + TypeScript
+  api/  → Express + PostgreSQL
+```
+
+### Scripts root
+
+```bash
+npm run dev
+npm run lint
+npm run test
+npm run build
+npm run preview
+```
+
+### Backend consolidado
+
+- Auth JWT com httpOnly cookies (`cf_access` 15 min + `cf_refresh` 30 dias)
+- Refresh token rotation com family revocation (theft detection)
+- Rate limit + brute force guard no login
+- Transações por usuário com soft delete + restore
+- Exportação CSV com filtros e totais
+- Forecast mensal com flip detection + notificações
+- Claude Haiku: `GET /ai/insight` com contexto de forecast + categorias + metas
+- Saving Goals: CRUD completo + `calcMonthlyNeeded` + `getGoalsSummaryForAI`
+- Billing: Stripe + trial + paywall por feature flag
+- Migrations automáticas no startup com advisory lock
+- `GET /health` com status de migrations
+
+### Frontend consolidado
+
+- Dashboard: saldo, entradas, saídas, forecast, HealthOverview, CategoryTreemap
+- Transações: CRUD, filtros, busca, export CSV, ImportCsvModal (OFX/CSV/PDF)
+- Metas: GoalsSection com at-risk badge + quick contribution
+- Salary widget com cálculo de INSS/IRRF
+- Bills summary widget
+- Onboarding: WelcomeCard v2 com funil de 4 etapas
+- Modo Discreto: `DiscreetModeContext` com `isDiscreetMode`/`toggleDiscreetMode`/`useMaskedCurrency`
+
+### Placar de testes
+
+| Suite | Testes |
+|-------|--------|
+| API   | 552    |
+| Web   | 261    |
+
+---
+
+## 3. Regras técnicas do projeto
+
+### Stack
+
+- Web: React + Vite + **TypeScript** (`.ts`/`.tsx`) — novos arquivos devem seguir este padrão
+- API: Node.js + Express + pg + Vitest + pg-mem (in-memory para testes)
+
+### API
+
+- Manter contratos simples e explícitos
+- Não abrir novos domínios sem modelagem clara e migration isolada
+- Não acoplar lógica de apresentação à regra de negócio
+
+### Produto
+
+Toda entrega nova deve responder a pelo menos um destes critérios:
+
+1. aumenta clareza de decisão do usuário
+2. reduz fricção operacional
+3. aumenta percepção de valor real do produto
+
+### UX
+
+- Evitar tabs, modais e complexidade desnecessária quando seções resolvem melhor
+- Acessibilidade mínima obrigatória em controles novos (`type`, `aria-*`, estados visuais coerentes)
+- Mascaramento monetário: máscara textual `R$ ••••`, não blur; mantém layout estável
+
+---
+
+## 4. ✅ Sprint A — Perfil como Painel de Controle (concluído — PR #268)
+
+### O que foi entregue
+
+**ProfileSettings** reestruturado em três seções:
+
+| Seção | Conteúdo |
+|---|---|
+| **Dados da conta** | Nome, avatar, e-mail, método de acesso (Senha · Google), salário, dia de pagamento |
+| **Preferências** | Toggle de Modo Discreto com persistência em `localStorage` |
+| **Assinatura** | Trial ativo (dias restantes), trial expirado (CTA upgrade), "Acesso ativo" (fallback neutro sem inferir plano) |
+
+**Modo Discreto:**
+
+- `DiscreetModeContext`: `isDiscreetMode` / `toggleDiscreetMode` / `useMaskedCurrency`
+- `DiscreetModeProvider` envolvendo o app em `main.tsx`
+- Máscara `R$ ••••` aplicada em: cards de saldo/entradas/saídas, ForecastCard, TransactionList, BillsSummaryWidget, GoalsSection
+
+**Regras respeitadas:**
+
+- Nenhuma migration nova
+- Nenhum endpoint novo
+- `formatCurrency` puro — sem `localStorage` no formatter
+- Fallback de assinatura neutro — sem prometer "Plano Pro" sem confirmação do backend
+
+---
+
+## 5. Sprint B — Preferências do Copiloto (próximo)
+
+### Objetivo
+
+Permitir que o usuário ajuste o comportamento do copiloto.
+
+### Pré-requisito
+
+Sprint A mergeado e em produção.
+
+### Escopo previsto
+
+#### Backend (1 migration)
+
+Adicionar à tabela `user_profiles`:
+
+```sql
+ai_tone TEXT DEFAULT 'pragmatic'  -- 'pragmatic' | 'motivator' | 'sarcastic'
+ai_insight_frequency TEXT DEFAULT 'always'  -- 'always' | 'risk_only'
+```
+
+`updateMyProfile` já tem o padrão de normalização — apenas adicionar as duas novas chaves.
+
+#### Frontend
+
+- Radio group "Tom do Especialista" na seção **Preferências** do perfil
+- `ai_insight_frequency = 'risk_only'`: `AIInsightPanel` suprime o painel quando `type === "success"`
+- `ai_tone` passado via request param ou carregado no contexto do fetch de `GET /ai/insight`
+
+### O que NÃO entra no Sprint B
+
+- Contador de uso de IA visível (precisaria de tabela dedicada + cron de janela)
+- Histórico de sessões (device tracking — outra liga)
+- Upload de foto (sem storage configurado)
+- `plan` completo no `GET /me` (precisaria join na tabela `subscriptions`)
+
+---
+
+## 6. Melhorias incrementais de produto (backlog)
+
+Estas melhorias são diretas, de baixo risco e de alto valor percebido.
+
+### Contador de uso de IA no perfil
+
+Exibir: `7 de 10 consultas usadas este período`
+
+Requer:
+- Tabela `ai_usage_events` ou coluna `ai_calls_count + ai_calls_reset_at` em `users`
+- Endpoint `GET /me` retornando `aiUsage: { used, limit, resetsAt }`
+
+### `plan` real no `GET /me`
+
+Expor no perfil o status exato do plano: `free | trial | premium | past_due`
+
+Requer:
+- JOIN em `subscriptions` dentro de `getMyProfile`
+- Sem mudança de schema
+
+### Trocar senha no perfil
+
+Botão que navega para `/app/settings/security` — rota já existe e `SecuritySettings` já tem o fluxo.
+
+---
+
+## 7. Roadmap de produto — próxima liga
+
+### Simulador de Impacto ("Posso comprar isso?")
+
+O usuário informa um valor e recebe:
+- impacto no saldo projetado do mês
+- impacto nas metas em andamento
+- recomendação do Especialista IA
+
+Alta percepção de valor. Reutiliza forecast existente.
+
+### Radar de Assinaturas
+
+Detecta padrões de gastos recorrentes nas transações e agrupa como "assinaturas".
+Ajuda o usuário a identificar custos fixos invisíveis.
+
+### Análise de Gastos por Semana
+
+Granularidade menor no dashboard: ver quanto foi gasto em cada semana do mês.
+Reusa `transactions` sem nova infra.
+
+---
+
+## 8. Importação Inteligente de Documentos (roadmap — não abre agora)
+
+Se essa frente for aberta no futuro, deve nascer como **subdomínio próprio**, não como extensão de `transactions`.
+
+### Domínios prováveis
+
+- `credit_card_bills`
+- `utility_bills`
+- `income_documents` / `payroll_entries`
+
+### Abordagem correta
+
+1. Classificar o tipo de documento
+2. Extrair texto (OCR ou parser estruturado)
+3. Usar parser determinístico para formatos conhecidos (OFX, CNAB)
+4. Usar LLM para normalização de campos ambíguos
+5. Validar saída por schema antes de persistir
+
+> IA sozinha não deve ser parser principal de documentos financeiros em produção.
+
+---
+
+## 9. Decisões arquiteturais fixadas
+
+| Decisão | Motivo |
+|---|---|
+| `formatCurrency` puro, sem estado global | Testes determinísticos, sem coupling com preferências de UI |
+| `useMaskedCurrency()` hook, não componente wrapper | Mínima invasão nos 17 arquivos que usam `formatCurrency` |
+| `DiscreetModeContext` separado de `AuthContext` | Responsabilidade única; preferência de UI ≠ sessão de autenticação |
+| Fallback de assinatura neutro ("Acesso ativo") | Sem prometer entitlement que o backend não confirmou |
+| pg-mem para testes de API | Sem banco real em CI; compatível com o subset de SQL usado |
+| Squash merge sempre | Histórico limpo; cherry-pick limpo quando branches divergem |
+
+---
+
+## 10. Frase-guia para não perder o trilho
+
+> **O Control Finance já pensa como copiloto.**
+> **Os próximos passos devem fazê-lo agir como copiloto — sem sacrificar foco, clareza e qualidade estrutural.**

--- a/docs/roadmap-execution.md
+++ b/docs/roadmap-execution.md
@@ -105,7 +105,7 @@ Toda entrega nova deve responder a pelo menos um destes critérios:
 
 ---
 
-## 4. ✅ Sprint A — Perfil como Painel de Controle (concluído — PR #268)
+## 4. ✅ Sprint A — Perfil como Painel de Controle (mergeado em main — PR #268)
 
 ### O que foi entregue
 


### PR DESCRIPTION
## O que muda

O perfil deixa de ser um formulário de cadastro e passa a ser o painel de controle da experiência do usuário.

## Commits

1. `feat(ui)` — `DiscreetModeContext` com `isDiscreetMode` / `toggleDiscreetMode` / `useMaskedCurrency`; `DiscreetModeProvider` wired em `main.tsx`
2. `refactor(profile)` — `ProfileSettings` reestruturado em seções: **Conta / Preferências / Assinatura**
3. `feat(ui)` — `useMaskedCurrency` aplicado nas 5 superfícies críticas: cards de saldo/entradas/saídas, `ForecastCard`, `TransactionList`, `BillsSummaryWidget`, `GoalsSection`
4. `test(profile)` — 22 novos testes: `DiscreetModeContext.test.tsx` + `ProfileSettings.test.tsx`; suite verde em 261/261
5. `fix(profile)` — rename do contrato para `isDiscreetMode`/`toggleDiscreetMode`; fallback de assinatura corrigido de "Plano Pro" para "Acesso ativo" (sem inferir entitlement não confirmado pelo backend)
6. `docs` — `docs/roadmap-execution.md`: estado atual, Sprint B scoped, backlog, decisões arquiteturais
7. `docs` — link para `roadmap-execution.md` no README público; Sprint A marcado como mergeado

## Seções do perfil

| Seção | Conteúdo |
|---|---|
| **Dados da conta** | Nome, avatar, e-mail, método de acesso (Senha · Google), salário, dia de pagamento |
| **Preferências** | Toggle Modo Discreto com persistência em `localStorage` |
| **Assinatura** | Trial ativo (dias restantes) / trial expirado (CTA upgrade) / "Acesso ativo" (fallback neutro) |

## Modo Discreto

- Máscara `R$ ••••` — textual, não blur; layout estável em tabelas e cards
- Contexto isolado com default value — funciona sem provider em testes unitários
- `formatCurrency` permanece puro — sem `localStorage` no formatter

## Regras respeitadas

- Nenhuma migration nova
- Nenhum endpoint novo
- Fallback de assinatura neutro — sem prometer plano que o backend não confirmou

## Critérios de aceite

- [x] Perfil mostra status do trial (ativo / expirado / acesso ativo)
- [x] Perfil mostra método de acesso da conta
- [x] Modo Discreto ativável/desativável, persiste ao recarregar
- [x] Dashboard respeita a preferência nas 5 superfícies críticas
- [x] Lint limpo — 0 erros, 0 warnings
- [x] 261/261 testes web verdes (+22 vs baseline de 239)
- [x] Guia operacional versionado em `docs/roadmap-execution.md`