### PR TITLE
feat: Sprint B — Preferências do Copiloto (ai_tone + ai_insight_frequency)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,12 @@ O Control Finance evoluiu de um gerenciador de gastos para uma experiência de *
 * Health Overview com leitura mais executiva do momento financeiro
 * alertas proativos quando a trajetória exige ajuste
 
-### 3. Especialista IA
+### 3. Especialista IA com preferências do usuário
 
-* endpoint dedicado para geração de insight financeiro
-* análise baseada em forecast e categorias de gasto
+* endpoint dedicado para geração de insight financeiro contextual
+* análise baseada em forecast, categorias de gasto e metas em andamento
+* **tom configurável**: Pragmático · Motivador · Sarcástico — o usuário define como o Especialista se comunica
+* **frequência configurável**: Sempre · Só quando há risco — suprime insights positivos e economiza chamadas ao LLM
 * falha silenciosa do LLM sem quebrar o dashboard
 * proteção por rate limiter para controle de abuso e custo
 
@@ -51,7 +53,13 @@ O Control Finance evoluiu de um gerenciador de gastos para uma experiência de *
 * integração das metas ao contexto da IA
 * ação rápida para reduzir fricção no uso
 
-### 5. Onboarding orientado a valor
+### 5. Painel de controle do usuário
+
+* Perfil reestruturado em três seções: Dados da conta · Preferências · Assinatura
+* Modo Discreto: oculta valores monetários com máscara textual `R$ ••••` (sem blur — layout estável)
+* Preferências do Copiloto: tom e frequência do Especialista IA configuráveis e persistidos no backend
+
+### 6. Onboarding orientado a valor
 
 * WelcomeCard v2 com a jornada:
 

--- a/apps/api/src/ai.test.js
+++ b/apps/api/src/ai.test.js
@@ -153,6 +153,68 @@ describe("GET /ai/insight", () => {
     expect(res.body).toBeNull();
   });
 
+  it("retorna null sem chamar LLM quando risk_only e forecast positivo", async () => {
+    const token = await registerAndLogin("ai-risk-only-skip@test.dev");
+    const userId = await getUserId("ai-risk-only-skip@test.dev");
+    await insertForecast(userId, { projected_balance: 800 });
+    await dbQuery(
+      `INSERT INTO user_profiles (user_id, ai_insight_frequency) VALUES ($1, 'risk_only')`,
+      [userId],
+    );
+
+    const res = await request(app)
+      .get("/ai/insight")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toBeNull();
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("chama LLM quando risk_only mas forecast negativo", async () => {
+    const token = await registerAndLogin("ai-risk-only-warn@test.dev");
+    const userId = await getUserId("ai-risk-only-warn@test.dev");
+    await insertForecast(userId, { projected_balance: -200 });
+    await dbQuery(
+      `INSERT INTO user_profiles (user_id, ai_insight_frequency) VALUES ($1, 'risk_only')`,
+      [userId],
+    );
+
+    mockCreate.mockResolvedValueOnce(
+      buildMockAnthropicResponse("Saldo negativo. Corte gastos imediatamente."),
+    );
+
+    const res = await request(app)
+      .get("/ai/insight")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.type).toBe("warning");
+    expect(mockCreate).toHaveBeenCalledOnce();
+  });
+
+  it("usa system prompt do tom motivador quando ai_tone e motivator", async () => {
+    const token = await registerAndLogin("ai-motivator@test.dev");
+    const userId = await getUserId("ai-motivator@test.dev");
+    await insertForecast(userId);
+    await dbQuery(
+      `INSERT INTO user_profiles (user_id, ai_tone) VALUES ($1, 'motivator')`,
+      [userId],
+    );
+
+    mockCreate.mockResolvedValueOnce(
+      buildMockAnthropicResponse("Você está indo bem! Continue assim."),
+    );
+
+    await request(app)
+      .get("/ai/insight")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(mockCreate).toHaveBeenCalledOnce();
+    const callArg = mockCreate.mock.calls[0][0];
+    expect(callArg.system).toContain("encorajador");
+  });
+
   it("passa top_categories ao LLM quando existem transacoes de saida", async () => {
     const token = await registerAndLogin("ai-categories@test.dev");
     const userId = await getUserId("ai-categories@test.dev");

--- a/apps/api/src/db/migrations/031_add_ai_preferences_to_user_profiles.sql
+++ b/apps/api/src/db/migrations/031_add_ai_preferences_to_user_profiles.sql
@@ -1,0 +1,8 @@
+-- Sprint B: Copilot preferences — ai_tone and ai_insight_frequency
+-- Two separate ALTER TABLE statements for pg-mem compatibility (no multi-column ADD COLUMN).
+
+ALTER TABLE user_profiles
+  ADD COLUMN IF NOT EXISTS ai_tone TEXT NOT NULL DEFAULT 'pragmatic';
+
+ALTER TABLE user_profiles
+  ADD COLUMN IF NOT EXISTS ai_insight_frequency TEXT NOT NULL DEFAULT 'always';

--- a/apps/api/src/me.test.js
+++ b/apps/api/src/me.test.js
@@ -337,6 +337,49 @@ describe("PATCH /me/profile", () => {
     expect(trialEndsAt.getTime()).toBeGreaterThanOrEqual(signupPlus14.getTime() - 1000);
   });
 
+  it("persiste ai_tone e ai_insight_frequency e retorna no round-trip GET /me", async () => {
+    const token = await registerAndLogin("patch-ai-prefs@test.dev");
+
+    const patchRes = await request(app)
+      .patch("/me/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ ai_tone: "motivator", ai_insight_frequency: "risk_only" });
+
+    expect(patchRes.status).toBe(200);
+    expect(patchRes.body.aiTone).toBe("motivator");
+    expect(patchRes.body.aiInsightFrequency).toBe("risk_only");
+
+    const getRes = await request(app)
+      .get("/me")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(getRes.status).toBe(200);
+    expect(getRes.body.profile.aiTone).toBe("motivator");
+    expect(getRes.body.profile.aiInsightFrequency).toBe("risk_only");
+  });
+
+  it("retorna 400 para ai_tone invalido", async () => {
+    const token = await registerAndLogin("patch-ai-tone-bad@test.dev");
+
+    const response = await request(app)
+      .patch("/me/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ ai_tone: "guru" });
+
+    expectErrorResponseWithRequestId(response, 400, "ai_tone deve ser um de: pragmatic, motivator, sarcastic.");
+  });
+
+  it("retorna 400 para ai_insight_frequency invalido", async () => {
+    const token = await registerAndLogin("patch-ai-freq-bad@test.dev");
+
+    const response = await request(app)
+      .patch("/me/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ ai_insight_frequency: "never" });
+
+    expectErrorResponseWithRequestId(response, 400, "ai_insight_frequency deve ser um de: always, risk_only.");
+  });
+
   it("nao altera trial_ends_at quando payday nao e enviado", async () => {
     const token = await registerAndLogin("patch-no-payday@test.dev");
     const userResult = await dbQuery(

--- a/apps/api/src/services/ai.service.js
+++ b/apps/api/src/services/ai.service.js
@@ -4,8 +4,14 @@ import { getGoalsSummaryForAI } from "./goals.service.js";
 import { dbQuery } from "../db/index.js";
 import { logInfo, logWarn, logError } from "../observability/logger.js";
 
-const SYSTEM_PROMPT =
-  "Você é o Especialista Financeiro do app Control Finance. Analise os dados JSON e retorne um único insight acionável de no máximo 180 caracteres. Prioridade: se alguma meta tiver monthly_needed maior que o balance, alerte que o plano está inviável e sugira qual gasto cortar. Se os dados forem negativos sem metas, aponte a categoria culpada. Se forem positivos, parabenize e reforce a meta mais próxima do prazo. Retorne APENAS o texto do insight, sem formatação, sem aspas, sem JSON.";
+const SYSTEM_PROMPTS = {
+  pragmatic:
+    "Você é o Especialista Financeiro do app Control Finance. Analise os dados JSON e retorne um único insight acionável de no máximo 180 caracteres. Prioridade: se alguma meta tiver monthly_needed maior que o balance, alerte que o plano está inviável e sugira qual gasto cortar. Se os dados forem negativos sem metas, aponte a categoria culpada. Se forem positivos, parabenize e reforce a meta mais próxima do prazo. Retorne APENAS o texto do insight, sem formatação, sem aspas, sem JSON.",
+  motivator:
+    "Você é o Especialista Financeiro do app Control Finance, com estilo encorajador. Analise os dados JSON e retorne um único insight de no máximo 180 caracteres que celebre progresso e enquadre desafios como oportunidades. Se alguma meta estiver em risco, incentive a mudança com entusiasmo. Se os dados forem negativos, aponte o caminho com energia positiva. Se forem positivos, comemore e reforce a conquista. Retorne APENAS o texto do insight, sem formatação, sem aspas, sem JSON.",
+  sarcastic:
+    "Você é o Especialista Financeiro do app Control Finance, com estilo levemente sarcástico. Analise os dados JSON e retorne um único insight de no máximo 180 caracteres. Se alguma meta estiver em risco, comente com ironia sobre o gasto culpado. Se os dados forem negativos, seja direto com humor ácido. Se forem positivos, parabenize — mas com leve surpresa. Retorne APENAS o texto do insight, sem formatação, sem aspas, sem JSON.",
+};
 
 const monthStartStr = (now) => {
   const y = now.getUTCFullYear();
@@ -44,6 +50,18 @@ const getTopExpenseCategories = async (userId, now = new Date()) => {
   }));
 };
 
+const getAiPreferences = async (userId) => {
+  const result = await dbQuery(
+    `SELECT ai_tone, ai_insight_frequency FROM user_profiles WHERE user_id = $1 LIMIT 1`,
+    [userId],
+  );
+  const row = result.rows[0];
+  return {
+    aiTone: row?.ai_tone ?? "pragmatic",
+    aiInsightFrequency: row?.ai_insight_frequency ?? "always",
+  };
+};
+
 const resolveInsightType = (adjustedBalance, incomeExpected) => {
   if (adjustedBalance <= 0) return "warning";
   const pct = incomeExpected != null && incomeExpected > 0
@@ -64,10 +82,15 @@ export const generateFinancialInsight = async (userId, { now = new Date(), anthr
   const forecast = await getLatestForecast(userId, { now });
   if (!forecast || forecast.daysRemaining <= 0) return null;
 
-  const [topCategories, goals] = await Promise.all([
+  const [topCategories, goals, { aiTone, aiInsightFrequency }] = await Promise.all([
     getTopExpenseCategories(userId, now),
     getGoalsSummaryForAI(userId, { now }),
+    getAiPreferences(userId),
   ]);
+
+  // Early exit: skip LLM call when user only wants risk alerts and forecast is healthy
+  const previewType = resolveInsightType(forecast.adjustedProjectedBalance, forecast.incomeExpected);
+  if (aiInsightFrequency === "risk_only" && previewType === "success") return null;
 
   const context = {
     balance: forecast.adjustedProjectedBalance,
@@ -79,6 +102,7 @@ export const generateFinancialInsight = async (userId, { now = new Date(), anthr
   };
 
   const client = anthropicClient ?? new Anthropic();
+  const systemPrompt = SYSTEM_PROMPTS[aiTone] ?? SYSTEM_PROMPTS.pragmatic;
 
   let insightText;
   const callStart = Date.now();
@@ -86,7 +110,7 @@ export const generateFinancialInsight = async (userId, { now = new Date(), anthr
     const response = await client.messages.create({
       model: "claude-haiku-4-5-20251001",
       max_tokens: 256,
-      system: SYSTEM_PROMPT,
+      system: systemPrompt,
       messages: [{ role: "user", content: JSON.stringify(context) }],
     });
     insightText = response.content[0]?.text?.trim() || null;

--- a/apps/api/src/services/profile.service.js
+++ b/apps/api/src/services/profile.service.js
@@ -61,6 +61,28 @@ const normalizeAvatarUrl = (value) => {
   return trimmed;
 };
 
+const AI_TONE_VALID = ["pragmatic", "motivator", "sarcastic"];
+const AI_INSIGHT_FREQUENCY_VALID = ["always", "risk_only"];
+
+const normalizeAiTone = (value) => {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || !AI_TONE_VALID.includes(value)) {
+    throw createError(400, `ai_tone deve ser um de: ${AI_TONE_VALID.join(", ")}.`);
+  }
+  return value;
+};
+
+const normalizeAiInsightFrequency = (value) => {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || !AI_INSIGHT_FREQUENCY_VALID.includes(value)) {
+    throw createError(
+      400,
+      `ai_insight_frequency deve ser um de: ${AI_INSIGHT_FREQUENCY_VALID.join(", ")}.`,
+    );
+  }
+  return value;
+};
+
 const rowToProfile = (row) => ({
   displayName: row.display_name ?? null,
   salaryMonthly:
@@ -69,6 +91,10 @@ const rowToProfile = (row) => ({
       : null,
   payday: row.payday !== null && row.payday !== undefined ? Number(row.payday) : null,
   avatarUrl: row.avatar_url ?? null,
+  aiTone: AI_TONE_VALID.includes(row.ai_tone) ? row.ai_tone : "pragmatic",
+  aiInsightFrequency: AI_INSIGHT_FREQUENCY_VALID.includes(row.ai_insight_frequency)
+    ? row.ai_insight_frequency
+    : "always",
 });
 
 // Returns ISO string for trial end date and whether trial has expired
@@ -105,7 +131,7 @@ export const getMyProfile = async (userId) => {
 
   const [profileResult, identitiesResult] = await Promise.all([
     dbQuery(
-      `SELECT display_name, salary_monthly, payday, avatar_url
+      `SELECT display_name, salary_monthly, payday, avatar_url, ai_tone, ai_insight_frequency
        FROM user_profiles WHERE user_id = $1 LIMIT 1`,
       [normalizedUserId],
     ),
@@ -144,6 +170,12 @@ export const updateMyProfile = async (userId, payload = {}) => {
 
   const avatarUrl = normalizeAvatarUrl(payload.avatar_url);
   if (avatarUrl !== undefined) updates.avatar_url = avatarUrl;
+
+  const aiTone = normalizeAiTone(payload.ai_tone);
+  if (aiTone !== undefined) updates.ai_tone = aiTone;
+
+  const aiInsightFrequency = normalizeAiInsightFrequency(payload.ai_insight_frequency);
+  if (aiInsightFrequency !== undefined) updates.ai_insight_frequency = aiInsightFrequency;
 
   if (Object.keys(updates).length === 0) {
     throw createError(400, "Nenhum campo valido enviado para atualizacao.");
@@ -188,7 +220,7 @@ export const updateMyProfile = async (userId, payload = {}) => {
   }
 
   const result = await dbQuery(
-    `SELECT display_name, salary_monthly, payday, avatar_url
+    `SELECT display_name, salary_monthly, payday, avatar_url, ai_tone, ai_insight_frequency
      FROM user_profiles WHERE user_id = $1 LIMIT 1`,
     [normalizedUserId],
   );

--- a/apps/web/src/pages/ProfileSettings.test.tsx
+++ b/apps/web/src/pages/ProfileSettings.test.tsx
@@ -137,6 +137,86 @@ describe("ProfileSettings — Preferências (Modo Discreto)", () => {
   });
 });
 
+describe("ProfileSettings — Preferências (Copiloto)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    vi.mocked(profileService.getMe).mockResolvedValue(buildMe());
+    vi.mocked(profileService.updateProfile).mockResolvedValue({
+      displayName: "Jr Valerio",
+      salaryMonthly: 5000,
+      payday: 5,
+      avatarUrl: null,
+      aiTone: "pragmatic",
+      aiInsightFrequency: "always",
+    });
+  });
+
+  it("renders ai_tone radio group with pragmatic selected by default", async () => {
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByRole("radio", { name: /Pragmático/i })).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("radio", { name: /Pragmático/i })).toBeChecked();
+    expect(screen.getByRole("radio", { name: /Motivador/i })).not.toBeChecked();
+    expect(screen.getByRole("radio", { name: /Sarcástico/i })).not.toBeChecked();
+  });
+
+  it("saves ai_tone immediately when radio is selected", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByRole("radio", { name: /Motivador/i })).toBeInTheDocument(),
+    );
+    await user.click(screen.getByRole("radio", { name: /Motivador/i }));
+    expect(profileService.updateProfile).toHaveBeenCalledWith({ ai_tone: "motivator" });
+    expect(screen.getByRole("radio", { name: /Motivador/i })).toBeChecked();
+  });
+
+  it("renders ai_insight_frequency radio group with always selected by default", async () => {
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByRole("radio", { name: /Sempre/i })).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("radio", { name: /Sempre/i })).toBeChecked();
+    expect(screen.getByRole("radio", { name: /Só quando há risco/i })).not.toBeChecked();
+  });
+
+  it("saves ai_insight_frequency immediately when radio is selected", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByRole("radio", { name: /Só quando há risco/i })).toBeInTheDocument(),
+    );
+    await user.click(screen.getByRole("radio", { name: /Só quando há risco/i }));
+    expect(profileService.updateProfile).toHaveBeenCalledWith({
+      ai_insight_frequency: "risk_only",
+    });
+    expect(screen.getByRole("radio", { name: /Só quando há risco/i })).toBeChecked();
+  });
+
+  it("loads saved preferences from profile on mount", async () => {
+    vi.mocked(profileService.getMe).mockResolvedValue(
+      buildMe({
+        profile: {
+          displayName: "Jr Valerio",
+          salaryMonthly: 5000,
+          payday: 5,
+          avatarUrl: null,
+          aiTone: "sarcastic",
+          aiInsightFrequency: "risk_only",
+        },
+      }),
+    );
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByRole("radio", { name: /Sarcástico/i })).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("radio", { name: /Sarcástico/i })).toBeChecked();
+    expect(screen.getByRole("radio", { name: /Só quando há risco/i })).toBeChecked();
+  });
+});
+
 describe("ProfileSettings — Assinatura", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/web/src/pages/ProfileSettings.tsx
+++ b/apps/web/src/pages/ProfileSettings.tsx
@@ -90,6 +90,10 @@ const ProfileSettings = ({
   const [trialEndsAt, setTrialEndsAt] = useState<string | null>(null);
   const [trialExpired, setTrialExpired] = useState(false);
 
+  // Copilot preferences (saved inline on change)
+  const [aiTone, setAiTone] = useState("pragmatic");
+  const [aiInsightFrequency, setAiInsightFrequency] = useState("always");
+
   const [isLoading, setIsLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
@@ -119,6 +123,8 @@ const ProfileSettings = ({
         p?.payday !== null && p?.payday !== undefined ? String(p.payday) : "",
       );
       setAvatarUrl(p?.avatarUrl ?? "");
+      setAiTone(p?.aiTone ?? "pragmatic");
+      setAiInsightFrequency(p?.aiInsightFrequency ?? "always");
     } catch (error) {
       setLoadError(getApiErrorMessage(error, "Não foi possível carregar o perfil."));
     } finally {
@@ -132,6 +138,19 @@ const ProfileSettings = ({
       if (successTimerRef.current) clearTimeout(successTimerRef.current);
     };
   }, [loadProfile]);
+
+  const handleAiPrefChange = useCallback(
+    async (field: "ai_tone" | "ai_insight_frequency", value: string) => {
+      if (field === "ai_tone") setAiTone(value);
+      else setAiInsightFrequency(value);
+      try {
+        await profileService.updateProfile({ [field]: value });
+      } catch {
+        // silent fail — preference restored on next page load
+      }
+    },
+    [],
+  );
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -388,31 +407,109 @@ const ProfileSettings = ({
                 description="Configurações de exibição e privacidade."
               />
 
-              <div className="flex items-start justify-between gap-4">
-                <div>
-                  <p className="text-sm font-semibold text-cf-text-primary">Modo Discreto</p>
-                  <p className="mt-0.5 text-xs text-cf-text-secondary">
-                    Oculta valores monetários nas telas. Útil para usar o app em público.
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  role="switch"
-                  aria-checked={isDiscreetMode}
-                  onClick={toggleDiscreetMode}
-                  className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-brand-1 focus:ring-offset-2 ${
-                    isDiscreetMode ? "bg-brand-1" : "bg-cf-border"
-                  }`}
-                >
-                  <span
-                    className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
-                      isDiscreetMode ? "translate-x-6" : "translate-x-1"
+              <div className="space-y-5">
+                {/* Modo Discreto */}
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <p className="text-sm font-semibold text-cf-text-primary">Modo Discreto</p>
+                    <p className="mt-0.5 text-xs text-cf-text-secondary">
+                      Oculta valores monetários nas telas. Útil para usar o app em público.
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={isDiscreetMode}
+                    onClick={toggleDiscreetMode}
+                    className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-brand-1 focus:ring-offset-2 ${
+                      isDiscreetMode ? "bg-brand-1" : "bg-cf-border"
                     }`}
-                  />
-                  <span className="sr-only">
-                    {isDiscreetMode ? "Desativar modo discreto" : "Ativar modo discreto"}
-                  </span>
-                </button>
+                  >
+                    <span
+                      className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                        isDiscreetMode ? "translate-x-6" : "translate-x-1"
+                      }`}
+                    />
+                    <span className="sr-only">
+                      {isDiscreetMode ? "Desativar modo discreto" : "Ativar modo discreto"}
+                    </span>
+                  </button>
+                </div>
+
+                <hr className="border-cf-border" />
+
+                {/* Tom do Especialista IA */}
+                <div>
+                  <p className="text-sm font-semibold text-cf-text-primary">Tom do Especialista IA</p>
+                  <p className="mt-0.5 text-xs text-cf-text-secondary">
+                    Como o Especialista se comunica com você.
+                  </p>
+                  <div className="mt-3 flex flex-wrap gap-2" role="radiogroup" aria-label="Tom do Especialista IA">
+                    {(
+                      [
+                        { value: "pragmatic", label: "Pragmático", desc: "Direto e objetivo" },
+                        { value: "motivator", label: "Motivador", desc: "Encorajador e positivo" },
+                        { value: "sarcastic", label: "Sarcástico", desc: "Com humor ácido" },
+                      ] as const
+                    ).map(({ value, label, desc }) => (
+                      <label
+                        key={value}
+                        className={`flex cursor-pointer items-center gap-2 rounded border px-3 py-2 text-sm transition-colors ${
+                          aiTone === value
+                            ? "border-brand-1 bg-brand-1/10 text-cf-text-primary"
+                            : "border-cf-border bg-cf-bg-subtle text-cf-text-secondary hover:border-brand-1/50"
+                        }`}
+                      >
+                        <input
+                          type="radio"
+                          name="ai_tone"
+                          value={value}
+                          checked={aiTone === value}
+                          onChange={() => void handleAiPrefChange("ai_tone", value)}
+                          className="sr-only"
+                        />
+                        <span className="font-semibold">{label}</span>
+                        <span className="text-xs opacity-70">— {desc}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Frequência do insight */}
+                <div>
+                  <p className="text-sm font-semibold text-cf-text-primary">Frequência do insight</p>
+                  <p className="mt-0.5 text-xs text-cf-text-secondary">
+                    Quando o Especialista aparece no dashboard.
+                  </p>
+                  <div className="mt-3 flex flex-wrap gap-2" role="radiogroup" aria-label="Frequência do insight">
+                    {(
+                      [
+                        { value: "always", label: "Sempre", desc: "Mostra o insight em todo acesso" },
+                        { value: "risk_only", label: "Só quando há risco", desc: "Suprime mensagens positivas" },
+                      ] as const
+                    ).map(({ value, label, desc }) => (
+                      <label
+                        key={value}
+                        className={`flex cursor-pointer items-center gap-2 rounded border px-3 py-2 text-sm transition-colors ${
+                          aiInsightFrequency === value
+                            ? "border-brand-1 bg-brand-1/10 text-cf-text-primary"
+                            : "border-cf-border bg-cf-bg-subtle text-cf-text-secondary hover:border-brand-1/50"
+                        }`}
+                      >
+                        <input
+                          type="radio"
+                          name="ai_insight_frequency"
+                          value={value}
+                          checked={aiInsightFrequency === value}
+                          onChange={() => void handleAiPrefChange("ai_insight_frequency", value)}
+                          className="sr-only"
+                        />
+                        <span className="font-semibold">{label}</span>
+                        <span className="text-xs opacity-70">— {desc}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
               </div>
             </section>
 

--- a/apps/web/src/services/profile.service.ts
+++ b/apps/web/src/services/profile.service.ts
@@ -5,6 +5,8 @@ export interface UserProfile {
   salaryMonthly: number | null;
   payday: number | null;
   avatarUrl: string | null;
+  aiTone?: string;
+  aiInsightFrequency?: string;
 }
 
 export interface MeResponse {
@@ -23,6 +25,8 @@ export interface ProfileUpdatePayload {
   salary_monthly?: number | null;
   payday?: number | null;
   avatar_url?: string | null;
+  ai_tone?: string;
+  ai_insight_frequency?: string;
 }
 
 export const profileService = {

--- a/docs/roadmap-execution.md
+++ b/docs/roadmap-execution.md
@@ -132,41 +132,33 @@ Toda entrega nova deve responder a pelo menos um destes critérios:
 
 ---
 
-## 5. Sprint B — Preferências do Copiloto (próximo)
+## 5. ✅ Sprint B — Preferências do Copiloto (mergeado em main — PR #269)
 
-### Objetivo
+### O que foi entregue
 
-Permitir que o usuário ajuste o comportamento do copiloto.
+**Migration 031** — `ai_tone` e `ai_insight_frequency` em `user_profiles`.
 
-### Pré-requisito
+| Campo | Tipo | Default | Valores válidos |
+|---|---|---|---|
+| `ai_tone` | TEXT NOT NULL | `'pragmatic'` | `pragmatic` · `motivator` · `sarcastic` |
+| `ai_insight_frequency` | TEXT NOT NULL | `'always'` | `always` · `risk_only` |
 
-Sprint A mergeado e em produção.
+**Backend:**
+- `normalizeAiTone` e `normalizeAiInsightFrequency` — validação de enum com 400 explícito
+- `rowToProfile` inclui os dois campos com fallback defensivo (valor inválido no banco → default)
+- `GET /me` retorna `aiTone` e `aiInsightFrequency` dentro de `profile`
+- `PATCH /me/profile` persiste os dois campos na allowlist (bug silencioso prevenido)
+- `ai.service`: `SYSTEM_PROMPTS` por tom + early exit quando `risk_only + success` (0 tokens gastos)
 
-### Escopo previsto
+**Frontend (`ProfileSettings.tsx`):**
+- Seção **Preferências** ganha dois radio groups: Tom do Especialista IA + Frequência do insight
+- Preferências salvas inline no onChange via `PATCH /me/profile` (sem botão extra)
+- Carregadas do backend no mount; fallback local para `pragmatic` / `always`
 
-#### Backend (1 migration)
-
-Adicionar à tabela `user_profiles`:
-
-```sql
-ai_tone TEXT DEFAULT 'pragmatic'  -- 'pragmatic' | 'motivator' | 'sarcastic'
-ai_insight_frequency TEXT DEFAULT 'always'  -- 'always' | 'risk_only'
-```
-
-`updateMyProfile` já tem o padrão de normalização — apenas adicionar as duas novas chaves.
-
-#### Frontend
-
-- Radio group "Tom do Especialista" na seção **Preferências** do perfil
-- `ai_insight_frequency = 'risk_only'`: `AIInsightPanel` suprime o painel quando `type === "success"`
-- `ai_tone` passado via request param ou carregado no contexto do fetch de `GET /ai/insight`
-
-### O que NÃO entra no Sprint B
-
-- Contador de uso de IA visível (precisaria de tabela dedicada + cron de janela)
-- Histórico de sessões (device tracking — outra liga)
-- Upload de foto (sem storage configurado)
-- `plan` completo no `GET /me` (precisaria join na tabela `subscriptions`)
+**Regras respeitadas:**
+- Persistência via backend — sobrevive troca de dispositivo (não é `localStorage`)
+- Valor inválido no banco nunca quebra a UI
+- `risk_only` suprime o painel **e** o call à Anthropic (sem custo de token em forecast positivo)
 
 ---
 
@@ -258,3 +250,286 @@ Se essa frente for aberta no futuro, deve nascer como **subdomínio próprio**, 
 
 > **O Control Finance já pensa como copiloto.**
 > **Os próximos passos devem fazê-lo agir como copiloto — sem sacrificar foco, clareza e qualidade estrutural.**
+
+---
+
+## 11. Visão de produto — O Copiloto da Vida Real
+
+O Control Finance tem potencial de ser o app financeiro mais útil para a maioria dos brasileiros:
+trabalhadores com renda mensal entre R$ 2.000 e R$ 8.000, que vivem o fluxo de caixa mês a mês,
+não têm assessor financeiro, e precisam de clareza — não de palestra.
+
+### O usuário real
+
+- Recebe salário todo dia 5 ou todo dia 15
+- Tem conta bancária, talvez cartão de crédito, talvez rotativo
+- Paga boletos no prazo (quando lembra)
+- Não tem "investimentos" — tem uma TED para poupança quando sobra
+- Sente o dinheiro acabar antes do fim do mês e não sabe exatamente por quê
+- Não quer um app que o julgue; quer um app que o ajude
+
+### O que diferencia este produto
+
+- **Proativo, não reativo**: avisa antes do problema, não depois
+- **Sem julgamento**: linguagem de parceiro, não de banco
+- **Contextual**: entende o calendário brasileiro (payday, 13°, FGTS, INSS, IPVA, IPTU)
+- **Útil sem esforço**: o valor cresce com uso mínimo — não exige planilhas
+
+---
+
+## 12. Regra de Ouro de UX — Modo Sem Humilhação
+
+> **Nunca fazer o usuário se sentir burro, pobre ou irresponsável.**
+
+O app lida com dinheiro — o assunto mais carregado emocionalmente na vida da maioria das pessoas.
+Copywriting errado quebra a relação com o produto.
+
+### O que NÃO escrever
+
+| ❌ Tom errado | ✅ Tom correto |
+|---|---|
+| "Você gastou demais este mês" | "O mês tá mais apertado que o planejado" |
+| "Sua saúde financeira está crítica" | "Atenção: o saldo pode zerar antes do dia 30" |
+| "Você ainda não atingiu sua meta" | "Faltam R$ 120 para a meta. Você consegue" |
+| "Sem assinatura, você perde acesso" | "Quer continuar com o copiloto completo?" |
+| "Plano gratuito limitado" | "Você está no trial — aproveite" |
+
+### Princípios
+
+1. **Parceiro, não juiz** — o app está do lado do usuário, não avaliando ele
+2. **Concreto, não vago** — "R$ 312 a menos que semana passada" > "gastos aumentaram"
+3. **Ação, não culpa** — toda mensagem negativa termina com o que o usuário pode fazer
+4. **Humor contextual** — tom leve quando situação permite; sério quando o risco é real
+5. **Celebrar o pequeno** — guardar R$ 50 é uma vitória real para muita gente
+
+---
+
+## 13. Backlog estratégico — Faixa 1: Sobrevivência e Controle de Dano
+
+Features que evitam que o usuário "se afogue" no mês. Alto impacto emocional, baixo esforço técnico.
+
+### 13.1 Modo Sobrevivência
+
+Ativado automaticamente quando `projeção do mês < 10% do salário` (ou quando o usuário ativa manualmente).
+
+No modo sobrevivência:
+- Dashboard simplifica: mostra só saldo atual, dias até o pagamento, e quanto pode gastar por dia
+- Fórmula exibida: `(saldo atual) ÷ (dias restantes) = R$ X/dia`
+- Especialista IA muda tom: foco em cortes imediatos, não em metas de longo prazo
+- Notificação diária opcional: "Hoje: R$ 43 disponíveis"
+
+Requer: nenhuma migration nova — usa forecast existente + novo threshold no frontend.
+
+### 13.2 Detector de Semanas Perigosas
+
+Analisa o histórico de transações e detecta padrões de semanas pesadas (ex: semana do boleto do aluguel, semana do cartão).
+
+Exibe no dashboard: "Semana de 20 a 26 costuma ser pesada para você — R$ 800 em média."
+
+Requer: query de agregação sobre `transactions` por semana do mês; sem nova tabela.
+
+### 13.3 Reserva Anti-Aperto
+
+Meta especial: "fundo de emergência mínimo" — valor equivalente a N dias de gasto médio.
+
+Diferente das metas normais (Saving Goals):
+- Meta é dinâmica (recalcula conforme gasto médio muda)
+- Não tem prazo — é um nível mínimo permanente
+- Badge "Reserva protegida" / "Reserva em risco" no dashboard
+
+Requer: novo tipo de meta ou campo especial em `user_goals`.
+
+### 13.4 Calendário de Pressão Financeira
+
+Vista mensal que pinta os dias com base na pressão esperada:
+- Vermelho: dia de vencimento de boleto / fatura de cartão
+- Amarelo: semana historicamente pesada
+- Verde: dias tranquilos
+
+Permite o usuário ver, de relance, onde o mês vai apertar.
+
+Requer: cruzamento de `bills` (vencimentos) + histórico de `transactions` por dia da semana do mês.
+
+### 13.5 Alertas de Conta Esquecida
+
+Detecta contas cadastradas em `bills` com vencimento nos próximos 3 dias sem pagamento registrado.
+
+Notificação: "Conta de luz vence em 2 dias — R$ 89. Já pagou?"
+Ação rápida: marcar como paga direto da notificação.
+
+Requer: lógica de comparação entre `bills.due_date` e ausência de transação correspondente.
+
+### 13.6 Gastos Domésticos Essenciais (Botijão, Remédios, Escola)
+
+Categoria especial "Essenciais recorrentes" para gastos que não são mensais mas são certos:
+- Botijão de gás (a cada 30–45 dias, ~R$ 120)
+- Remédios de uso contínuo (mensal, valor fixo)
+- Material escolar (anual, mas previsível)
+- IPVA / IPTU (anual, parcelável)
+
+O app detecta esses gastos no histórico e os projeta automaticamente no forecast.
+
+Requer: tag/flag especial em categorias ou novo campo `recurrence_type` em `transactions`.
+
+### 13.7 Planejamento Familiar e Escolar
+
+Módulo de eventos financeiros de ciclo anual:
+- Janeiro/Fevereiro: material escolar + matrícula
+- Março: IPVA
+- Junho/Julho: férias escolares
+- Novembro/Dezembro: 13° salário + presentes de Natal
+
+O usuário marca os eventos relevantes para ele e o copiloto os inclui no forecast anual.
+
+Requer: tabela `financial_calendar_events` com tipo, mês, valor estimado.
+
+---
+
+## 14. Backlog estratégico — Faixa 2: Otimização de Fluxo de Caixa
+
+Features que melhoram como o dinheiro flui — sem exigir disciplina extra do usuário.
+
+### 14.1 Missão Escapar de Dívida Cara
+
+Para usuários com cartão rotativo ou empréstimo pessoal:
+
+1. Usuário cadastra a dívida (valor, juros mensais, parcelas)
+2. App calcula o custo real da dívida (quanto vai pagar no total)
+3. Compara com cenário de quitar antecipado
+4. Propõe um plano: "Se guardar R$ 150/mês, quita em 4 meses e economiza R$ 380"
+
+Formato de missão (gamificação leve): progresso visual, celebração ao atingir marcos.
+
+Requer: nova tabela `debts` com campos de amortização; cálculo de juros compostos.
+
+### 14.2 Radar de Assinaturas
+
+Detecta automaticamente gastos recorrentes no histórico de transações e os agrupa:
+- Netflix, Spotify, Amazon Prime
+- Academia, plano de saúde
+- Software, serviços digitais
+
+Exibe painel: "Você tem R$ 320/mês em assinaturas. Qual você realmente usa?"
+Botão: "Marcar como cancelada" (não bloqueia a transação; só marca no radar).
+
+Requer: algoritmo de detecção de recorrência sobre `transactions` (mesmo descritor + intervalo regular).
+
+### 14.3 Análise de Gastos por Semana
+
+Granularidade menor no dashboard: ver quanto foi gasto em cada semana do mês.
+
+Útil para entender onde o dinheiro vai — muitos usuários percebem padrões semanais que não viam no mensal.
+
+Requer: query de agregação por semana do mês sobre `transactions`; sem nova infra.
+
+### 14.4 Simulador de Impacto — "Posso comprar isso?"
+
+Usuário informa um valor e recebe:
+- Impacto no saldo projetado do mês
+- Impacto nas metas em andamento
+- Recomendação do Especialista IA ("Pode, mas vai ficar apertado na semana de 20 a 26")
+
+Alta percepção de valor. Reutiliza forecast existente + `GET /ai/insight` com prompt especializado.
+
+Requer: endpoint de simulação ou lógica client-side com re-cálculo do forecast.
+
+### 14.5 Comparativo Mês a Mês
+
+Gráfico de barras simples: gastos por categoria nos últimos 3 meses.
+Destaque automático: "Alimentação subiu 23% em relação ao mês passado."
+
+Requer: query agregada sobre `transactions` por categoria + mês; sem nova tabela.
+
+### 14.6 Análise do 13° Salário
+
+Quando usuário cadastra recebimento do 13° (ou o app detecta pela data + valor):
+- Simula impacto nas metas se X% for destinado a elas
+- Sugere quitação da dívida cara com o 13°
+- Alerta sobre gastos de dezembro que costumam consumir o 13° antes do Natal
+
+Requer: detecção de sazonalidade + prompt especializado para IA.
+
+---
+
+## 15. Backlog estratégico — Faixa 3: Inteligência Avançada
+
+Features que transformam dados em decisões. Requerem mais dados acumulados para funcionar bem.
+
+### 15.1 Especialista IA com Memória de Contexto
+
+O Especialista hoje responde com contexto do mês atual.
+Com memória:
+- Compara com comportamento histórico do próprio usuário
+- Identifica padrões de vários meses ("Você sempre estoura em março — é IPVA?")
+- Ajusta tom conforme progresso do usuário ao longo do tempo
+
+Requer: histórico de insights salvo por usuário; contexto ampliado no prompt.
+
+### 15.2 Tom Personalizado do Especialista IA
+
+Configuração na seção Preferências (Sprint B):
+- **Pragmático** (padrão): direto, objetivo, sem enrolação
+- **Motivador**: celebra progresso, enquadra problemas como desafios superáveis
+- **Sarcástico**: humor ácido para quem prefere esse estilo ("Parabéns, mais um mês sem economizar nada")
+
+Implementação: campo `ai_tone` em `user_profiles` + variação de system prompt.
+
+### 15.3 Frequência do Especialista IA
+
+Configuração na seção Preferências (Sprint B):
+- **Sempre** (padrão): insight toda vez que o usuário abre o dashboard
+- **Só quando há risco**: suprime insights de tipo `success`; exibe só `warning` e `info`
+
+Implementação: campo `ai_insight_frequency` em `user_profiles` + filtro no `AIInsightPanel`.
+
+### 15.4 Score de Saúde Financeira Pessoal
+
+Número de 0 a 100 calculado a partir de:
+- Razão despesas/renda
+- Regularidade de poupança
+- Cobertura da reserva de emergência
+- Controle de dívidas
+
+Não é comparativo com outras pessoas — é histórico pessoal.
+Exibido no HealthOverview como número + tendência (↑ melhorando / ↓ piorando).
+
+### 15.5 Previsão de Fim de Dinheiro
+
+Não apenas "saldo projetado no fim do mês" — mas "em qual dia o saldo vai zerar (se o padrão continuar)".
+
+Exibido como: "No ritmo atual, o saldo zera por volta do dia 22."
+Com destaque quando a data é menos de 5 dias à frente.
+
+Requer: refinamento do forecast engine com projeção diária.
+
+### 15.6 Modo Conversa com o Especialista (Chat Financeiro)
+
+Interface de chat livre com o Especialista IA.
+Usuário pode perguntar: "Quanto gastei com alimentação nos últimos 3 meses?" ou "O que aconteceu de errado em fevereiro?"
+
+O Especialista responde com dados reais do usuário — não respostas genéricas.
+
+Requer: contexto enriquecido (transações + metas + forecast) + interface de chat; uso significativo de tokens.
+
+---
+
+## 16. Decisões de não fazer (e por quê)
+
+| Feature | Por que não agora |
+|---|---|
+| App mobile (iOS/Android) | Web responsiva cobre 80% do uso; mobile nativo antes de tração é risco de escopo |
+| Open Finance / Pix automático | Requer certificação regulatória (BACEN) — fora do alcance de produto solo |
+| Planilha de orçamento anual | Usuário-alvo não tem hábito de planejar 12 meses; fecha o app sem usar |
+| Chatbot de atendimento | Confunde com Especialista IA; duas personas de IA = confusão |
+| Integração com bancos por scraping | Frágil, contra ToS dos bancos, risco legal |
+| Gamificação pesada (pontos, badges, ranking) | Distrai da função; usuários financeiramente estressados não querem jogar |
+
+---
+
+## 17. Notas de produto para não esquecer
+
+- **Payday é sagrado**: tudo no produto orbita em torno do dia de pagamento do usuário. Forecast, metas, alertas — tudo usa `payday` como âncora.
+- **O mês do usuário não é o mês do calendário**: se o usuário recebe dia 15, o "mês financeiro" dele é de 15 a 14.
+- **Renda irregular é a realidade de muitos**: autônomos, freelancers, comissionados. O forecast precisa lidar com isso sem quebrar.
+- **Cartão de crédito = buraco negro para muitos usuários**: a fatura fecha em uma data, vence em outra, e o gasto já foi feito semanas antes. Tratamento correto do cartão é feature de alta percepção de valor.
+- **Silêncio é melhor que dado errado**: se o app não tem dados suficientes para um insight, não inventa um. Melhor não mostrar nada do que mostrar algo impreciso.


### PR DESCRIPTION
## Resumo

Implementa a Sprint B — Preferências do Copiloto.

### O que entrou

**Migration 031** em `user_profiles`:
- `ai_tone TEXT NOT NULL DEFAULT 'pragmatic'` — `pragmatic | motivator | sarcastic`
- `ai_insight_frequency TEXT NOT NULL DEFAULT 'always'` — `always | risk_only`

**Backend:**
- `GET /me` retorna as preferências dentro de `profile`
- `PATCH /me/profile` persiste e valida enums (400 explícito para valor inválido)
- Fallback defensivo: valor inválido no banco → `pragmatic` / `always` sem crash
- `ai.service`: `SYSTEM_PROMPTS` por tom; `risk_only` faz early exit antes do call à Anthropic quando o forecast é positivo — sem custo de token

**Frontend:**
- Radio groups em `ProfileSettings` (Seção Preferências): Tom do Especialista IA + Frequência do insight
- Save inline no `onChange` via `PATCH /me/profile` — sem botão extra
- Preferências carregadas do backend no mount; fallback local para defaults

**Docs:**
- `docs/roadmap-execution.md`: Sprint B marcada como ✅
- README: Especialista IA e Painel de controle atualizados

### Fora de escopo

- Contador de uso de IA
- Billing/entitlements avançados
- Chat do Especialista
- Parser de documentos

## Validação

- API: 558 testes verdes
- Web: 266 testes verdes
- Lint dos arquivos alterados: ok