### PR TITLE
fix(ui): remove unused theme variable (lint blocker)

### DIFF
--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -545,7 +545,7 @@ const App = ({
 
   const onPaginationReset = useCallback(() => setCurrentOffset(DEFAULT_OFFSET), []);
 
-  const { theme, themePreference, setThemePreference } = useTheme();
+  const { themePreference, setThemePreference } = useTheme();
   const cycleTheme = useCallback(() => {
     setThemePreference(
       themePreference === "system" ? "light" : themePreference === "light" ? "dark" : "system",


### PR DESCRIPTION
Removes the unused `theme` destructuring from `useTheme()` in `App.tsx` — leftover from the 3-mode theme refactor in #270. Fixes CI lint failure (`no-unused-vars`).