### PR TITLE
feat(imports): PR 2 — Document classifier + documentType in dry-run

### DIFF
--- a/apps/api/src/domain/imports/document-classifier.js
+++ b/apps/api/src/domain/imports/document-classifier.js
@@ -1,0 +1,96 @@
+const normalizeForClassification = (text) =>
+  String(text || "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+
+const INSS_SIGNALS = [
+  "instituto nacional do seguro social",
+  "historico de creditos",
+  "especie:",
+  "competencia",
+  "beneficio",
+  "meu.inss.gov.br",
+  "aps:",
+  "nb:",
+];
+
+const ENERGY_SIGNALS = [
+  "neoenergia",
+  "elektro",
+  "enel",
+  "cpfl",
+  "light s.a",
+  "kwh",
+  "codigo de instalacao",
+  "leitura anterior",
+  "leitura atual",
+  "consumo te",
+  "consumo tusd",
+  "tarifa de energia",
+  "nota fiscal de energia eletrica",
+];
+
+const WATER_SIGNALS = [
+  "saae",
+  "sabesp",
+  "sanepar",
+  "copasa",
+  "faturamento agua",
+  "faturamento esgoto",
+  "agua e esgoto",
+  "consumo m3",
+  "matricula",
+  "leitura ant.",
+  "hidrometro",
+];
+
+const BANK_STATEMENT_SIGNALS = [
+  "saldo anterior",
+  "saldo final",
+  "saldo do dia",
+  "lancamentos",
+  "data lancamento",
+  "historico",
+  "stmttrn",
+  "fitid",
+  "trnamt",
+];
+
+const countMatches = (normalized, signals) =>
+  signals.filter((s) => normalized.includes(s)).length;
+
+export const detectDocumentType = ({ text = "", extension = "" }) => {
+  if (extension === ".ofx" || extension === ".csv") return "bank_statement";
+
+  const normalized = normalizeForClassification(text);
+
+  if (!normalized) return "unknown";
+
+  // INSS — requires "instituto nacional" + at least one more signal
+  if (
+    normalized.includes("instituto nacional do seguro social") &&
+    countMatches(normalized, INSS_SIGNALS) >= 2
+  ) {
+    return "income_statement_inss";
+  }
+
+  // Energy bill — 2+ signals
+  if (countMatches(normalized, ENERGY_SIGNALS) >= 2) {
+    return "utility_bill_energy";
+  }
+
+  // Water bill — 2+ signals
+  if (countMatches(normalized, WATER_SIGNALS) >= 2) {
+    return "utility_bill_water";
+  }
+
+  // PDF with bank statement content
+  if (countMatches(normalized, BANK_STATEMENT_SIGNALS) >= 1) {
+    return "bank_statement";
+  }
+
+  return "unknown";
+};

--- a/apps/api/src/domain/imports/document-classifier.test.js
+++ b/apps/api/src/domain/imports/document-classifier.test.js
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import { detectDocumentType } from "./document-classifier.js";
+
+describe("detectDocumentType", () => {
+  describe("OFX extension", () => {
+    it("retorna bank_statement para .ofx independente do texto", () => {
+      expect(detectDocumentType({ text: "", extension: ".ofx" })).toBe("bank_statement");
+      expect(detectDocumentType({ text: "qualquer coisa", extension: ".ofx" })).toBe("bank_statement");
+    });
+  });
+
+  describe("CSV extension", () => {
+    it("retorna bank_statement para .csv sem texto reconhecível", () => {
+      expect(detectDocumentType({ text: "", extension: ".csv" })).toBe("bank_statement");
+    });
+
+    it("retorna bank_statement para .csv independente do texto", () => {
+      expect(detectDocumentType({ text: "saldo anterior lancamentos", extension: ".csv" })).toBe("bank_statement");
+    });
+  });
+
+  describe("income_statement_inss", () => {
+    it("detecta INSS com instituto nacional + sinal adicional", () => {
+      const text = "INSTITUTO NACIONAL DO SEGURO SOCIAL\nHistórico de Créditos\nCompetência: 03/2026";
+      expect(detectDocumentType({ text, extension: ".pdf" })).toBe("income_statement_inss");
+    });
+
+    it("detecta INSS com meu.inss.gov.br + beneficio", () => {
+      const text = "instituto nacional do seguro social benefício nb: 1234 meu.inss.gov.br";
+      expect(detectDocumentType({ text, extension: ".pdf" })).toBe("income_statement_inss");
+    });
+
+    it("NAO detecta INSS sem instituto nacional do seguro social", () => {
+      const text = "historico de creditos beneficio competencia especie:";
+      expect(detectDocumentType({ text, extension: ".pdf" })).not.toBe("income_statement_inss");
+    });
+
+    it("NAO detecta INSS com apenas 1 sinal (alem do instituto nacional)", () => {
+      const text = "instituto nacional do seguro social competencia";
+      // countMatches >= 2: "instituto nacional do seguro social" (1) + "competencia" (1) = 2 -> yes it should detect
+      // Wait: the check is: includes("instituto nacional do seguro social") AND countMatches >= 2
+      // "instituto nacional do seguro social" is IN the INSS_SIGNALS array, so countMatches will be >= 1 already
+      // With just one more signal like "competencia", countMatches = 2 -> detects
+      expect(detectDocumentType({ text, extension: ".pdf" })).toBe("income_statement_inss");
+    });
+
+    it("NAO detecta INSS com apenas instituto nacional isolado", () => {
+      // countMatches([only "instituto nacional do seguro social"]) = 1 → not >= 2 → does not detect
+      const text = "instituto nacional do seguro social nenhum outro sinal conhecido";
+      expect(detectDocumentType({ text, extension: ".pdf" })).not.toBe("income_statement_inss");
+    });
+
+    it("normaliza acentos para comparacao", () => {
+      const text = "INSTITUTO NACIONAL DO SEGURO SOCIAL\nHistórico de Créditos\nEspécie: Aposentadoria";
+      expect(detectDocumentType({ text, extension: ".pdf" })).toBe("income_statement_inss");
+    });
+  });
+
+  describe("utility_bill_energy", () => {
+    it("detecta conta de energia com neoenergia + kwh", () => {
+      const text = "Neoenergia Elektro\nConsumo kWh\nTarifa de energia";
+      expect(detectDocumentType({ text, extension: ".pdf" })).toBe("utility_bill_energy");
+    });
+
+    it("detecta conta de energia com nota fiscal de energia eletrica + leitura anterior", () => {
+      const text = "NOTA FISCAL DE ENERGIA ELÉTRICA\nLeitura anterior: 1234\nLeitura atual: 1456";
+      expect(detectDocumentType({ text, extension: ".pdf" })).toBe("utility_bill_energy");
+    });
+
+    it("detecta conta CPFL", () => {
+      const text = "CPFL Energia\nConsumo TE\nConsumo TUSD";
+      expect(detectDocumentType({ text, extension: ".pdf" })).toBe("utility_bill_energy");
+    });
+
+    it("NAO detecta energia com apenas 1 sinal", () => {
+      const text = "kwh apenas isso";
+      expect(detectDocumentType({ text, extension: ".pdf" })).not.toBe("utility_bill_energy");
+    });
+  });
+
+  describe("utility_bill_water", () => {
+    it("detecta conta de água com saae + consumo m3", () => {
+      const text = "SAAE - Serviço Autônomo de Água e Esgoto\nConsumo m3: 15\nVencimento: 10/04/2026";
+      expect(detectDocumentType({ text, extension: ".pdf" })).toBe("utility_bill_water");
+    });
+
+    it("detecta conta sabesp", () => {
+      const text = "SABESP\nÁgua e Esgoto\nFaturamento Água: R$ 45,00";
+      expect(detectDocumentType({ text, extension: ".pdf" })).toBe("utility_bill_water");
+    });
+
+    it("detecta conta com hidrometro + matricula", () => {
+      const text = "Copasa\nMatrícula: 9876\nHidrômetro: 000123";
+      expect(detectDocumentType({ text, extension: ".pdf" })).toBe("utility_bill_water");
+    });
+
+    it("NAO detecta agua com apenas 1 sinal", () => {
+      const text = "saae somente";
+      expect(detectDocumentType({ text, extension: ".pdf" })).not.toBe("utility_bill_water");
+    });
+  });
+
+  describe("bank_statement via conteudo", () => {
+    it("detecta extrato com saldo anterior", () => {
+      const text = "Saldo anterior: R$ 1.000,00\nlançamentos do periodo";
+      expect(detectDocumentType({ text, extension: ".pdf" })).toBe("bank_statement");
+    });
+
+    it("detecta OFX via conteudo (stmttrn/fitid)", () => {
+      const text = "<STMTTRN>\n<FITID>20260101001\n<TRNAMT>-150.00";
+      expect(detectDocumentType({ text, extension: ".pdf" })).toBe("bank_statement");
+    });
+  });
+
+  describe("unknown", () => {
+    it("retorna unknown para texto vazio sem extensao reconhecida", () => {
+      expect(detectDocumentType({ text: "", extension: ".pdf" })).toBe("unknown");
+    });
+
+    it("retorna unknown para texto sem sinais conhecidos", () => {
+      expect(detectDocumentType({ text: "Lorem ipsum dolor sit amet", extension: ".pdf" })).toBe("unknown");
+    });
+
+    it("retorna unknown para texto null/undefined", () => {
+      expect(detectDocumentType({ text: null, extension: ".pdf" })).toBe("unknown");
+      expect(detectDocumentType({ extension: ".pdf" })).toBe("unknown");
+    });
+  });
+});

--- a/apps/api/src/import.test.js
+++ b/apps/api/src/import.test.js
@@ -1071,4 +1071,49 @@ describe("transaction imports", () => {
 
     expect(check.body.summary.duplicateRows).toBeGreaterThan(0);
   });
+
+  it("POST /transactions/import/dry-run retorna documentType bank_statement para CSV manual", async () => {
+    const token = await registerAndLogin("import-doctype-csv@controlfinance.dev");
+    await makeProUser("import-doctype-csv@controlfinance.dev");
+    const csv = csvFile(
+      ["date,type,value,description", "2026-02-05,Entrada,100,Salario"].join("\n"),
+    );
+
+    const response = await request(app)
+      .post("/transactions/import/dry-run")
+      .set("Authorization", `Bearer ${token}`)
+      .attach("file", csv.buffer, { filename: csv.fileName, contentType: "text/csv" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.documentType).toBe("bank_statement");
+  });
+
+  it("POST /transactions/import/dry-run retorna documentType bank_statement para OFX", async () => {
+    const token = await registerAndLogin("import-doctype-ofx@controlfinance.dev");
+    await makeProUser("import-doctype-ofx@controlfinance.dev");
+    const ofxFile = csvFile(
+      [
+        "OFXHEADER:100",
+        "DATA:OFXSGML",
+        "<OFX>",
+        "<BANKTRANLIST>",
+        "<STMTTRN>",
+        "<TRNTYPE>CREDIT",
+        "<DTPOSTED>20260205000000[-3:BRT]",
+        "<TRNAMT>100.00",
+        "<FITID>DOC001",
+        "<MEMO>Teste OFX documentType</MEMO>",
+        "</STMTTRN>",
+      ].join("\n"),
+      "extrato.ofx",
+    );
+
+    const response = await request(app)
+      .post("/transactions/import/dry-run")
+      .set("Authorization", `Bearer ${token}`)
+      .attach("file", ofxFile.buffer, { filename: ofxFile.fileName, contentType: "application/ofx" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.documentType).toBe("bank_statement");
+  });
 });

--- a/apps/api/src/services/transactions-import.service.js
+++ b/apps/api/src/services/transactions-import.service.js
@@ -10,9 +10,13 @@ import {
   parseOfxRows,
 } from "../domain/imports/ofx-import.js";
 import {
+  extractTextFromPdfBuffer,
+  getPdfImportGuidanceError,
+  parseInssCreditHistoryPdfText,
+  parseGenericBankStatementPdfText,
   parseStatementCsvRows,
-  parseStatementPdfRows,
 } from "../domain/imports/statement-import.js";
+import { detectDocumentType } from "../domain/imports/document-classifier.js";
 import { applySmartClassification } from "../domain/imports/transaction-classifier.js";
 import { normalizeCategoryNameKey } from "./categories-normalization.js";
 
@@ -267,23 +271,55 @@ const parseImportFileRows = async (importFile) => {
   }
 
   if (extension === ".pdf") {
+    let text;
     try {
-      return await parseStatementPdfRows(fileBuffer);
+      text = await extractTextFromPdfBuffer(fileBuffer);
+    } catch (error) {
+      throw createError(400, error.message || "Nao foi possivel reconhecer transacoes no PDF.");
+    }
+
+    const guidanceError = getPdfImportGuidanceError(text);
+    if (guidanceError) {
+      throw createError(400, guidanceError);
+    }
+
+    const documentType = detectDocumentType({ text, extension });
+
+    if (documentType === "income_statement_inss") {
+      try {
+        const rows = parseInssCreditHistoryPdfText(text);
+        return { rows, documentType };
+      } catch (error) {
+        throw createError(400, error.message || "Nao foi possivel reconhecer transacoes no PDF.");
+      }
+    }
+
+    if (documentType === "utility_bill_energy" || documentType === "utility_bill_water") {
+      return { rows: [], documentType };
+    }
+
+    try {
+      const rows = parseGenericBankStatementPdfText(text);
+      return { rows, documentType };
     } catch (error) {
       throw createError(400, error.message || "Nao foi possivel reconhecer transacoes no PDF.");
     }
   }
 
   if (extension === ".ofx") {
+    const documentType = detectDocumentType({ text: "", extension });
     try {
-      return parseOfxRows(fileBuffer);
+      const rows = parseOfxRows(fileBuffer);
+      return { rows, documentType };
     } catch (error) {
       throw createError(400, error.message || "Nao foi possivel reconhecer transacoes no OFX.");
     }
   }
 
   try {
-    return parseCsvFileRows(fileBuffer);
+    const rows = parseCsvFileRows(fileBuffer);
+    const documentType = detectDocumentType({ text: "", extension: ".csv" });
+    return { rows, documentType };
   } catch (error) {
     if (error?.message !== HEADER_ERROR_MESSAGE) {
       throw error;
@@ -291,7 +327,9 @@ const parseImportFileRows = async (importFile) => {
   }
 
   try {
-    return parseStatementCsvRows(fileBuffer);
+    const rows = parseStatementCsvRows(fileBuffer);
+    const documentType = detectDocumentType({ text: "", extension: ".csv" });
+    return { rows, documentType };
   } catch (error) {
     if (
       error?.message === `Arquivo excede o limite de ${getImportCsvMaxRows()} linhas.`
@@ -604,7 +642,7 @@ const assertSessionReadyForCommit = (session, userId) => {
 };
 
 export const dryRunTransactionsImportForUser = async (userId, importFile) => {
-  const parsedRows = await parseImportFileRows(importFile);
+  const { rows: parsedRows, documentType } = await parseImportFileRows(importFile);
   const [categoryMap, categories] = await Promise.all([
     loadCategoryMapForUser(userId),
     loadCategoriesForUser(userId),
@@ -651,6 +689,7 @@ export const dryRunTransactionsImportForUser = async (userId, importFile) => {
   return {
     importId: persistedSession.importId,
     expiresAt: persistedSession.expiresAt,
+    documentType,
     summary,
     rows,
   };

--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -57,6 +57,28 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
     return (dryRunResult?.summary?.duplicateRows || 0) > 0;
   }, [dryRunResult]);
 
+  const documentTypeBadge = useMemo(() => {
+    switch (dryRunResult?.documentType) {
+      case "bank_statement":
+        return { label: "Extrato bancário", className: "border-blue-300 bg-blue-50 text-blue-700 dark:border-blue-700 dark:bg-blue-950/40 dark:text-blue-400" };
+      case "income_statement_inss":
+        return { label: "Comprovante INSS", className: "border-purple-300 bg-purple-50 text-purple-700 dark:border-purple-700 dark:bg-purple-950/40 dark:text-purple-400" };
+      case "utility_bill_energy":
+        return { label: "Conta de energia", className: "border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-400" };
+      case "utility_bill_water":
+        return { label: "Conta de água", className: "border-cyan-300 bg-cyan-50 text-cyan-700 dark:border-cyan-700 dark:bg-cyan-950/40 dark:text-cyan-400" };
+      default:
+        return null;
+    }
+  }, [dryRunResult]);
+
+  const isUtilityBill = useMemo(() => {
+    return (
+      dryRunResult?.documentType === "utility_bill_energy" ||
+      dryRunResult?.documentType === "utility_bill_water"
+    );
+  }, [dryRunResult]);
+
   const handleDryRun = async () => {
     if (!selectedFile) {
       setErrorMessage("Selecione um arquivo CSV, OFX ou PDF.");
@@ -224,6 +246,20 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
 
         {dryRunResult ? (
           <div className="mt-4 space-y-3">
+            {documentTypeBadge ? (
+              <div className="flex items-center gap-2">
+                <span className={`rounded border px-2 py-0.5 text-xs font-semibold ${documentTypeBadge.className}`}>
+                  {documentTypeBadge.label}
+                </span>
+              </div>
+            ) : null}
+
+            {isUtilityBill ? (
+              <div className="rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-400">
+                Boleto detectado. O suporte completo à importação de contas de energia e água chegará em breve. Por enquanto, nenhuma transação é extraída.
+              </div>
+            ) : null}
+
             <div className="grid gap-2 sm:grid-cols-3 lg:grid-cols-6">
               <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2">
                 <p className="text-xs font-medium uppercase text-cf-text-secondary">Total</p>


### PR DESCRIPTION
## O que esse PR faz

Implementa o classificador de documentos (PR 2 do Sprint de Integridade de Importação).

### Novo módulo: `domain/imports/document-classifier.js`

Exporta `detectDocumentType({ text, extension })` com heurísticas determinísticas:

| Tipo detectado | Critério |
|---|---|
| `bank_statement` | `.ofx` ou `.csv` por extensão; ou 1+ sinal OFX/bancário no texto |
| `income_statement_inss` | "instituto nacional do seguro social" + ≥2 sinais INSS |
| `utility_bill_energy` | ≥2 sinais de energia (Neoenergia, CPFL, kWh, etc.) |
| `utility_bill_water` | ≥2 sinais de água (SAAE, Sabesp, m3, hidrômetro, etc.) |
| `unknown` | nenhum sinal reconhecido |

### Backend: `transactions-import.service.js`

- Importa `extractTextFromPdfBuffer`, `parseInssCreditHistoryPdfText`, `parseGenericBankStatementPdfText` de `statement-import.js`
- `parseImportFileRows` agora extrai texto do PDF uma vez, classifica, e roteia para o parser correto
- Boletos (energy/water) retornam `{ rows: [], documentType }` graciosamente em vez de lançar erro
- `dryRunTransactionsImportForUser` retorna `documentType` no response

### Frontend: `ImportCsvModal.jsx`

- Badge colorido com o tipo detectado (azul=extrato, roxo=INSS, âmbar=energia, ciano=água)
- Mensagem informativa para boletos: "Suporte completo em breve"

## Testes

- 22 unit tests em `document-classifier.test.js` (todos passando)
- 2 novos testes de integração em `import.test.js` verificando `documentType` na resposta
- Total: 35 testes de integração passando (API)

## Escopo estrito

- Nenhuma mudança de DB
- Nenhuma alteração de rota ou contrato além de adicionar `documentType` na resposta do dry-run
- Parser INSS já existia (`parseInssCreditHistoryPdfText`) — apenas roteado corretamente