### PR TITLE
feat(import): extract structured suggestion from INSS, energy and water PDFs

### DIFF
--- a/apps/api/src/domain/imports/statement-import-suggestion.test.js
+++ b/apps/api/src/domain/imports/statement-import-suggestion.test.js
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractInssSuggestion,
+  extractEnergyBillSuggestion,
+  extractWaterBillSuggestion,
+} from "./statement-import.js";
+
+// ---------------------------------------------------------------------------
+// extractInssSuggestion
+// ---------------------------------------------------------------------------
+
+const INSS_SAMPLE = `
+INSS - Instituto Nacional do Seguro Social
+Histórico de Créditos
+
+NB: 177.682.989-9
+Espécie: 21 - PENSÃO POR MORTE PREVIDENCIÁRIA
+
+03/2026  R$ 2.803,52
+07/04/2026
+101 VALOR TOTAL DE MR DO PERIODO R$ 4.958,67
+216 EMPRESTIMO CONSIGNADO R$ 1.200,00
+`.trim();
+
+const INSS_WITHOUT_GROSS = `
+INSS - Instituto Nacional do Seguro Social
+NB 42.123.456-0
+Espécie: 32 - APOSENTADORIA POR TEMPO DE CONTRIBUICAO
+
+02/2026  R$ 1.500,00
+05/03/2026
+`.trim();
+
+describe("extractInssSuggestion", () => {
+  it("retorna null quando o texto nao tem entrada de credito", () => {
+    expect(extractInssSuggestion("texto qualquer sem creditos")).toBeNull();
+  });
+
+  it("extrai netAmount e referenceMonth da entrada mais recente", () => {
+    const result = extractInssSuggestion(INSS_SAMPLE);
+    expect(result).not.toBeNull();
+    expect(result.type).toBe("profile");
+    expect(result.referenceMonth).toBe("03/2026");
+    expect(result.netAmount).toBeCloseTo(2803.52);
+  });
+
+  it("extrai grossAmount da rubrica 101", () => {
+    const result = extractInssSuggestion(INSS_SAMPLE);
+    expect(result.grossAmount).toBeCloseTo(4958.67);
+  });
+
+  it("extrai paymentDate como ISO quando disponivel", () => {
+    const result = extractInssSuggestion(INSS_SAMPLE);
+    expect(result.paymentDate).toBe("2026-04-07");
+  });
+
+  it("extrai benefitId e benefitKind", () => {
+    const result = extractInssSuggestion(INSS_SAMPLE);
+    expect(result.benefitId).toMatch(/177/);
+    expect(result.benefitKind).toMatch(/pensao por morte/i);
+  });
+
+  it("retorna grossAmount null quando rubrica 101 ausente", () => {
+    const result = extractInssSuggestion(INSS_WITHOUT_GROSS);
+    expect(result).not.toBeNull();
+    expect(result.grossAmount).toBeNull();
+    expect(result.netAmount).toBeCloseTo(1500.0);
+  });
+
+  it("tolera NB sem pontuacao", () => {
+    const result = extractInssSuggestion(INSS_WITHOUT_GROSS);
+    expect(result.benefitId).toMatch(/42/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractEnergyBillSuggestion
+// ---------------------------------------------------------------------------
+
+const ENERGY_SAMPLE = `
+Neoenergia Elektro Distribuição S.A.
+NOTA FISCAL / CONTA DE ENERGIA ELÉTRICA
+
+Código de Instalação: 41864557
+Referência: Dezembro/2025
+Vencimento: 21/01/2026
+TOTAL A PAGAR R$ 412,00
+`.trim();
+
+const ENERGY_NO_FIELDS = `
+Documento qualquer sem campos de boleto de energia.
+`.trim();
+
+describe("extractEnergyBillSuggestion", () => {
+  it("retorna null quando nenhum campo relevante esta presente", () => {
+    expect(extractEnergyBillSuggestion(ENERGY_NO_FIELDS)).toBeNull();
+  });
+
+  it("retorna type=bill e billType=energy", () => {
+    const result = extractEnergyBillSuggestion(ENERGY_SAMPLE);
+    expect(result).not.toBeNull();
+    expect(result.type).toBe("bill");
+    expect(result.billType).toBe("energy");
+  });
+
+  it("extrai issuer da lista de distribuidoras conhecidas", () => {
+    const result = extractEnergyBillSuggestion(ENERGY_SAMPLE);
+    expect(result.issuer).toMatch(/neoenergia/);
+  });
+
+  it("resolve referenceMonth para MM/AAAA a partir de nome de mes", () => {
+    const result = extractEnergyBillSuggestion(ENERGY_SAMPLE);
+    expect(result.referenceMonth).toBe("12/2025");
+  });
+
+  it("extrai dueDate como ISO", () => {
+    const result = extractEnergyBillSuggestion(ENERGY_SAMPLE);
+    expect(result.dueDate).toBe("2026-01-21");
+  });
+
+  it("extrai amountDue", () => {
+    const result = extractEnergyBillSuggestion(ENERGY_SAMPLE);
+    expect(result.amountDue).toBeCloseTo(412.0);
+  });
+
+  it("extrai customerCode", () => {
+    const result = extractEnergyBillSuggestion(ENERGY_SAMPLE);
+    expect(result.customerCode).toBe("41864557");
+  });
+
+  it("aceita referenceMonth numerico MM/AAAA", () => {
+    const text = "CPFL Energia\nReferência: 03/2026\nVencimento: 10/04/2026\nTOTAL A PAGAR R$ 300,00";
+    const result = extractEnergyBillSuggestion(text);
+    expect(result.referenceMonth).toBe("03/2026");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractWaterBillSuggestion
+// ---------------------------------------------------------------------------
+
+const WATER_SAMPLE = `
+SAAE - Serviço Autônomo de Água e Esgoto de Atibaia
+Matrícula: 62092-0
+Referência: 02/2026
+Vencimento: 28/03/2026
+TOTAL A PAGAR R$ 403,88
+`.trim();
+
+const WATER_NO_FIELDS = `
+Documento qualquer sem campos de boleto de agua.
+`.trim();
+
+describe("extractWaterBillSuggestion", () => {
+  it("retorna null quando nenhum campo relevante esta presente", () => {
+    expect(extractWaterBillSuggestion(WATER_NO_FIELDS)).toBeNull();
+  });
+
+  it("retorna type=bill e billType=water", () => {
+    const result = extractWaterBillSuggestion(WATER_SAMPLE);
+    expect(result).not.toBeNull();
+    expect(result.type).toBe("bill");
+    expect(result.billType).toBe("water");
+  });
+
+  it("extrai issuer da lista de prestadoras conhecidas", () => {
+    const result = extractWaterBillSuggestion(WATER_SAMPLE);
+    expect(result.issuer).toMatch(/saae/);
+  });
+
+  it("resolve referenceMonth MM/AAAA numerico", () => {
+    const result = extractWaterBillSuggestion(WATER_SAMPLE);
+    expect(result.referenceMonth).toBe("02/2026");
+  });
+
+  it("extrai dueDate como ISO", () => {
+    const result = extractWaterBillSuggestion(WATER_SAMPLE);
+    expect(result.dueDate).toBe("2026-03-28");
+  });
+
+  it("extrai amountDue", () => {
+    const result = extractWaterBillSuggestion(WATER_SAMPLE);
+    expect(result.amountDue).toBeCloseTo(403.88);
+  });
+
+  it("extrai customerCode da matricula", () => {
+    const result = extractWaterBillSuggestion(WATER_SAMPLE);
+    expect(result.customerCode).toMatch(/62092/);
+  });
+});

--- a/apps/api/src/domain/imports/statement-import.js
+++ b/apps/api/src/domain/imports/statement-import.js
@@ -477,6 +477,166 @@ export const parseInssCreditHistoryPdfText = (text) => {
   return finalizeStatementRows(rows);
 };
 
+const MONTH_NAMES_MAP = {
+  janeiro: "01", fevereiro: "02", marco: "03", abril: "04", maio: "05", junho: "06",
+  julho: "07", agosto: "08", setembro: "09", outubro: "10", novembro: "11", dezembro: "12",
+  jan: "01", fev: "02", mar: "03", abr: "04", mai: "05", jun: "06",
+  jul: "07", ago: "08", set: "09", out: "10", nov: "11", dez: "12",
+};
+
+const resolveReferenceMonth = (raw) => {
+  if (!raw) return null;
+  const numericMatch = raw.match(/(\d{2})\/?(\d{4})/);
+  if (numericMatch) return `${numericMatch[1]}/${numericMatch[2]}`;
+  const normalized = collapseWhitespace(raw)
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+  const namedMatch = normalized.match(/([a-z]+)[\s/]+(\d{4})/);
+  if (namedMatch) {
+    const mm = MONTH_NAMES_MAP[namedMatch[1]];
+    if (mm) return `${mm}/${namedMatch[2]}`;
+  }
+  return null;
+};
+
+const normalizeForExtraction = (text) =>
+  String(text || "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+
+export const extractInssSuggestion = (text) => {
+  const normalized = normalizeForExtraction(text);
+
+  // Benefit ID (NB)
+  const nbMatch = normalized.match(/\bnb[:\s#°]*([\d.\-/]+)/i);
+  const benefitId = nbMatch ? nbMatch[1].trim() : null;
+
+  // Benefit kind (Espécie)
+  const especieMatch = normalized.match(/especie[:\s]+(\d+)\s*[-–]\s*([^\n\r]{3,60})/i);
+  const benefitKind = especieMatch ? collapseWhitespace(especieMatch[2]) : null;
+
+  // Most recent credit entry (first match — PDF lists newest first)
+  const entryMatch = normalized.match(/^(\d{2}\/\d{4})\s+r\$\s*([\d.,]+)/m);
+  if (!entryMatch) return null;
+
+  const referenceMonth = entryMatch[1];
+  const netAmount = parseSignedAmount(entryMatch[2]);
+  if (netAmount === null) return null;
+
+  // Find the block for this entry to get payment date and gross amount
+  const entryStart = normalized.indexOf(entryMatch[0]);
+  const nextEntryMatch = normalized.slice(entryStart + 1).match(/\d{2}\/\d{4}\s+r\$\s*[\d.,]+/);
+  const blockEnd = nextEntryMatch
+    ? entryStart + 1 + normalized.slice(entryStart + 1).indexOf(nextEntryMatch[0])
+    : entryStart + 2000;
+  const block = normalized.slice(entryStart, blockEnd);
+
+  const fullDates = block.match(/\d{2}\/\d{2}\/\d{4}/g) || [];
+  const paymentDateRaw = fullDates[fullDates.length - 1] || null;
+  const paymentDate = paymentDateRaw ? toIsoDateString(paymentDateRaw) : null;
+
+  const grossMatch = block.match(/101\s+valor total de mr do periodo\s+r\$\s*([\d.,]+)/i);
+  const grossAmount = grossMatch ? parseSignedAmount(grossMatch[1]) : null;
+
+  return {
+    type: "profile",
+    benefitId,
+    benefitKind,
+    referenceMonth,
+    paymentDate,
+    netAmount: Math.abs(netAmount),
+    grossAmount: grossAmount !== null ? Math.abs(grossAmount) : null,
+  };
+};
+
+const ENERGY_ISSUERS = [
+  "neoenergia", "neoenergia elektro", "cpfl energia", "enel", "cemig", "light", "eletropaulo",
+  "energisa", "elektro", "coelba", "celpe", "cosern", "ceal", "ceron", "boa energia",
+];
+const WATER_ISSUERS = [
+  "saae", "sabesp", "sanepar", "copasa", "cagece", "caern", "casan", "embasa",
+  "compesa", "agespisa", "caema", "cosanpa",
+];
+
+const detectIssuerFromText = (normalizedText, candidates) => {
+  for (const candidate of candidates) {
+    if (normalizedText.includes(candidate)) return candidate;
+  }
+  return null;
+};
+
+const extractBillFields = (normalizedText) => {
+  // Reference month
+  const refMatch = normalizedText.match(
+    /(?:referencia|referencia do mes|competencia|periodo de referencia|mes de referencia)[:\s]+([a-z]+[\s/]+\d{4}|\d{1,2}[/]\d{4})/i,
+  );
+  const referenceMonth = resolveReferenceMonth(refMatch ? refMatch[1] : null);
+
+  // Due date
+  const dueMatch = normalizedText.match(/vencimento[:\s]+(\d{2}\/\d{2}\/\d{4})/i);
+  const dueDate = dueMatch ? toIsoDateString(dueMatch[1]) : null;
+
+  // Amount due
+  const amountMatch = normalizedText.match(
+    /(?:total a pagar|valor a pagar|total do documento|valor total)[:\s]*r?\$?\s*([\d.,]+)/i,
+  );
+  const amountDue = amountMatch ? parseSignedAmount(amountMatch[1]) : null;
+
+  return { referenceMonth, dueDate, amountDue: amountDue !== null ? Math.abs(amountDue) : null };
+};
+
+export const extractEnergyBillSuggestion = (text) => {
+  const normalized = normalizeForExtraction(text);
+
+  const issuerKey = detectIssuerFromText(normalized, ENERGY_ISSUERS);
+  const { referenceMonth, dueDate, amountDue } = extractBillFields(normalized);
+
+  // Customer code: "Código de Instalação", "N° Instalação", "Código do cliente"
+  const codeMatch = normalized.match(
+    /(?:codigo de instalacao|n[°o] instalacao|instalacao|codigo do cliente|numero do cliente|numero da instalacao)[:\s#°]*([\d.\-/]+)/i,
+  );
+  const customerCode = codeMatch ? codeMatch[1].trim() : null;
+
+  if (!referenceMonth && !dueDate && amountDue === null) return null;
+
+  return {
+    type: "bill",
+    billType: "energy",
+    issuer: issuerKey,
+    referenceMonth,
+    dueDate,
+    amountDue,
+    customerCode,
+  };
+};
+
+export const extractWaterBillSuggestion = (text) => {
+  const normalized = normalizeForExtraction(text);
+
+  const issuerKey = detectIssuerFromText(normalized, WATER_ISSUERS);
+  const { referenceMonth, dueDate, amountDue } = extractBillFields(normalized);
+
+  // Customer code: "Matrícula", "Código do cliente", "N° contrato"
+  const codeMatch = normalized.match(
+    /(?:matricula|matricula do imovel|codigo do cliente|n[°o] contrato|numero do cliente)[:\s#°]*([\d.\-/]+)/i,
+  );
+  const customerCode = codeMatch ? codeMatch[1].trim() : null;
+
+  if (!referenceMonth && !dueDate && amountDue === null) return null;
+
+  return {
+    type: "bill",
+    billType: "water",
+    issuer: issuerKey,
+    referenceMonth,
+    dueDate,
+    amountDue,
+    customerCode,
+  };
+};
+
 export const extractTextFromPdfBuffer = async (buffer) => extractTextFromPdfWithOcr(buffer);
 
 export const parseStatementPdfRows = async (buffer) => {

--- a/apps/api/src/services/transactions-import.service.js
+++ b/apps/api/src/services/transactions-import.service.js
@@ -15,6 +15,9 @@ import {
   parseInssCreditHistoryPdfText,
   parseGenericBankStatementPdfText,
   parseStatementCsvRows,
+  extractInssSuggestion,
+  extractEnergyBillSuggestion,
+  extractWaterBillSuggestion,
 } from "../domain/imports/statement-import.js";
 import { detectDocumentType } from "../domain/imports/document-classifier.js";
 import { applySmartClassification } from "../domain/imports/transaction-classifier.js";
@@ -288,19 +291,26 @@ const parseImportFileRows = async (importFile) => {
     if (documentType === "income_statement_inss") {
       try {
         const rows = parseInssCreditHistoryPdfText(text);
-        return { rows, documentType };
+        const suggestion = extractInssSuggestion(text);
+        return { rows, documentType, suggestion };
       } catch (error) {
         throw createError(400, error.message || "Nao foi possivel reconhecer transacoes no PDF.");
       }
     }
 
-    if (documentType === "utility_bill_energy" || documentType === "utility_bill_water") {
-      return { rows: [], documentType };
+    if (documentType === "utility_bill_energy") {
+      const suggestion = extractEnergyBillSuggestion(text);
+      return { rows: [], documentType, suggestion };
+    }
+
+    if (documentType === "utility_bill_water") {
+      const suggestion = extractWaterBillSuggestion(text);
+      return { rows: [], documentType, suggestion };
     }
 
     try {
       const rows = parseGenericBankStatementPdfText(text);
-      return { rows, documentType };
+      return { rows, documentType, suggestion: null };
     } catch (error) {
       throw createError(400, error.message || "Nao foi possivel reconhecer transacoes no PDF.");
     }
@@ -310,7 +320,7 @@ const parseImportFileRows = async (importFile) => {
     const documentType = detectDocumentType({ text: "", extension });
     try {
       const rows = parseOfxRows(fileBuffer);
-      return { rows, documentType };
+      return { rows, documentType, suggestion: null };
     } catch (error) {
       throw createError(400, error.message || "Nao foi possivel reconhecer transacoes no OFX.");
     }
@@ -319,7 +329,7 @@ const parseImportFileRows = async (importFile) => {
   try {
     const rows = parseCsvFileRows(fileBuffer);
     const documentType = detectDocumentType({ text: "", extension: ".csv" });
-    return { rows, documentType };
+    return { rows, documentType, suggestion: null };
   } catch (error) {
     if (error?.message !== HEADER_ERROR_MESSAGE) {
       throw error;
@@ -329,7 +339,7 @@ const parseImportFileRows = async (importFile) => {
   try {
     const rows = parseStatementCsvRows(fileBuffer);
     const documentType = detectDocumentType({ text: "", extension: ".csv" });
-    return { rows, documentType };
+    return { rows, documentType, suggestion: null };
   } catch (error) {
     if (
       error?.message === `Arquivo excede o limite de ${getImportCsvMaxRows()} linhas.`
@@ -642,7 +652,7 @@ const assertSessionReadyForCommit = (session, userId) => {
 };
 
 export const dryRunTransactionsImportForUser = async (userId, importFile) => {
-  const { rows: parsedRows, documentType } = await parseImportFileRows(importFile);
+  const { rows: parsedRows, documentType, suggestion } = await parseImportFileRows(importFile);
   const [categoryMap, categories] = await Promise.all([
     loadCategoryMapForUser(userId),
     loadCategoriesForUser(userId),
@@ -690,6 +700,7 @@ export const dryRunTransactionsImportForUser = async (userId, importFile) => {
     importId: persistedSession.importId,
     expiresAt: persistedSession.expiresAt,
     documentType,
+    suggestion: suggestion || null,
     summary,
     rows,
   };

--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -79,6 +79,33 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
     );
   }, [dryRunResult]);
 
+  const suggestionCard = useMemo(() => {
+    const suggestion = dryRunResult?.suggestion;
+    if (!suggestion) return null;
+
+    if (suggestion.type === "profile") {
+      const lines = [];
+      if (suggestion.referenceMonth) lines.push(`Competência: ${suggestion.referenceMonth}`);
+      if (suggestion.paymentDate) lines.push(`Pagamento: ${suggestion.paymentDate}`);
+      if (suggestion.netAmount != null) lines.push(`Líquido: R$ ${suggestion.netAmount.toFixed(2).replace(".", ",")}`);
+      if (suggestion.grossAmount != null) lines.push(`Bruto (MR): R$ ${suggestion.grossAmount.toFixed(2).replace(".", ",")}`);
+      if (suggestion.benefitKind) lines.push(`Espécie: ${suggestion.benefitKind}`);
+      return { kind: "profile", lines };
+    }
+
+    if (suggestion.type === "bill") {
+      const lines = [];
+      if (suggestion.issuer) lines.push(`Emissor: ${suggestion.issuer}`);
+      if (suggestion.referenceMonth) lines.push(`Referência: ${suggestion.referenceMonth}`);
+      if (suggestion.dueDate) lines.push(`Vencimento: ${suggestion.dueDate}`);
+      if (suggestion.amountDue != null) lines.push(`Total a pagar: R$ ${suggestion.amountDue.toFixed(2).replace(".", ",")}`);
+      if (suggestion.customerCode) lines.push(`Código: ${suggestion.customerCode}`);
+      return { kind: "bill", lines };
+    }
+
+    return null;
+  }, [dryRunResult]);
+
   const handleDryRun = async () => {
     if (!selectedFile) {
       setErrorMessage("Selecione um arquivo CSV, OFX ou PDF.");
@@ -257,6 +284,19 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
             {isUtilityBill ? (
               <div className="rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-400">
                 Boleto detectado. O suporte completo à importação de contas de energia e água chegará em breve. Por enquanto, nenhuma transação é extraída.
+              </div>
+            ) : null}
+
+            {suggestionCard ? (
+              <div className="rounded border border-blue-200 bg-blue-50 px-3 py-2 dark:border-blue-800 dark:bg-blue-950/40">
+                <p className="mb-1 text-xs font-semibold uppercase text-blue-700 dark:text-blue-400">
+                  {suggestionCard.kind === "profile" ? "Dados extraídos do comprovante" : "Dados do boleto"}
+                </p>
+                <ul className="space-y-0.5">
+                  {suggestionCard.lines.map((line) => (
+                    <li key={line} className="text-xs text-blue-700 dark:text-blue-300">{line}</li>
+                  ))}
+                </ul>
               </div>
             ) : null}
 


### PR DESCRIPTION
## O que faz

PR 3 do Sprint de Integridade de Importação.

Adiciona extração estruturada de dados úteis nos PDFs já classificados pelo PR 2, sem persistência e sem ação automática — apenas expõe os dados para o frontend mostrar e para o PR 4 agir.

## Mudanças

### Backend — `statement-import.js`
- `extractInssSuggestion(text)` → `{ type: "profile", benefitId, benefitKind, referenceMonth, paymentDate, netAmount, grossAmount }`
  - Pega a entrada mais recente do histórico de créditos (primeira linha `MM/YYYY  R$ X`)
  - Extrai NB, espécie, rubrica 101 (MR bruto) e data de pagamento do mesmo bloco
- `extractEnergyBillSuggestion(text)` → `{ type: "bill", billType: "energy", issuer, referenceMonth, dueDate, amountDue, customerCode }`
  - Reconhece distribuidoras: Neoenergia, Elektro, CPFL, Enel, Cemig, Light, Energisa, Coelba...
- `extractWaterBillSuggestion(text)` → `{ type: "bill", billType: "water", issuer, referenceMonth, dueDate, amountDue, customerCode }`
  - Reconhece prestadoras: SAAE, Sabesp, Sanepar, Copasa, Cagece, Caern...
- Mês de referência resolve tanto `MM/AAAA` numérico quanto nome por extenso (`Dezembro/2025`)

### Backend — `transactions-import.service.js`
- `parseImportFileRows` retorna `{ rows, documentType, suggestion }` em todos os branches
- `dryRunTransactionsImportForUser` expõe `suggestion` no response do dry-run

### Frontend — `ImportCsvModal.jsx`
- Memo `suggestionCard` formata as linhas do objeto `suggestion`
- Card azul exibe dados extraídos abaixo do badge de tipo e acima da tabela de linhas
- Sem botões de ação — fluxo de confirmação/atualização de perfil chega no PR 4

## Testes

- 22 novos testes unitários: `statement-import-suggestion.test.js`
  - `extractInssSuggestion`: null sem creditos, netAmount/grossAmount/paymentDate/benefitId, grossAmount null sem rubrica 101
  - `extractEnergyBillSuggestion`: null sem campos, type/billType, issuer, referenceMonth (nome e numérico), dueDate, amountDue, customerCode
  - `extractWaterBillSuggestion`: idem para água
- Suíte completa API: **606/606 passando**
- Web: falhas pré-existentes em main (`ReferenceError: React is not defined` em ImportCsvModal.test.jsx); mudança do modal validada por inspeção — baixo acoplamento, apenas um memo e JSX condicional adicionados

## Contrato JSON (dry-run response)

```json
{
  "importId": "...",
  "documentType": "income_statement_inss",
  "suggestion": {
    "type": "profile",
    "benefitId": "177.682.989-9",
    "benefitKind": "PENSÃO POR MORTE PREVIDENCIÁRIA",
    "referenceMonth": "03/2026",
    "paymentDate": "2026-04-07",
    "netAmount": 2803.52,
    "grossAmount": 4958.67
  },
  "summary": { ... },
  "rows": [ ... ]
}
```

```json
{
  "documentType": "utility_bill_energy",
  "suggestion": {
    "type": "bill",
    "billType": "energy",
    "issuer": "neoenergia elektro",
    "referenceMonth": "12/2025",
    "dueDate": "2026-01-21",
    "amountDue": 412.00,
    "customerCode": "41864557"
  },
  "rows": []
}
```