### PR TITLE
feat(categories): system categories, type field and import category override

### DIFF
--- a/apps/api/src/categories.test.js
+++ b/apps/api/src/categories.test.js
@@ -80,16 +80,14 @@ describe("categories", () => {
 
     expect(listResponse.status).toBe(200);
     expect(Array.isArray(listResponse.body)).toBe(true);
-    expect(listResponse.body).toHaveLength(2);
-    expect(listResponse.body.map((category) => category.name)).toEqual([
-      "Alimentacao",
-      "Transporte",
-    ]);
-    expect(listResponse.body.map((category) => category.normalizedName)).toEqual([
-      "alimentacao",
-      "transporte",
-    ]);
-    expect(listResponse.body.every((category) => category.deletedAt === null)).toBe(true);
+    // System categories are also returned; filter to check only user-created ones
+    const userCategories = listResponse.body.filter((c) => !c.system);
+    expect(userCategories).toHaveLength(2);
+    expect(userCategories.map((c) => c.name)).toEqual(["Alimentacao", "Transporte"]);
+    expect(userCategories.map((c) => c.normalizedName)).toEqual(["alimentacao", "transporte"]);
+    expect(userCategories.every((c) => c.deletedAt === null)).toBe(true);
+    // System categories are present and have system=true
+    expect(listResponse.body.some((c) => c.system === true)).toBe(true);
   });
 
   it("POST /categories bloqueia nome vazio", async () => {
@@ -174,12 +172,14 @@ describe("categories", () => {
       .set("Authorization", `Bearer ${tokenUserB}`);
 
     expect(listUserAResponse.status).toBe(200);
-    expect(listUserAResponse.body).toHaveLength(1);
-    expect(listUserAResponse.body[0].name).toBe("Lazer");
+    const userAOwn = listUserAResponse.body.filter((c) => !c.system);
+    expect(userAOwn).toHaveLength(1);
+    expect(userAOwn[0].name).toBe("Lazer");
 
     expect(listUserBResponse.status).toBe(200);
-    expect(listUserBResponse.body).toHaveLength(1);
-    expect(listUserBResponse.body[0].name).toBe("Transporte");
+    const userBOwn = listUserBResponse.body.filter((c) => !c.system);
+    expect(userBOwn).toHaveLength(1);
+    expect(userBOwn[0].name).toBe("Transporte");
   });
 
   it("PATCH /categories/:id renomeia categoria ativa", async () => {
@@ -244,7 +244,8 @@ describe("categories", () => {
     expect(deleteResponse.status).toBe(200);
     expect(deleteResponse.body.deletedAt).toBeTruthy();
     expect(listActiveResponse.status).toBe(200);
-    expect(listActiveResponse.body).toEqual([]);
+    // After soft-delete, user's own categories are empty (system categories still present)
+    expect(listActiveResponse.body.filter((c) => !c.system)).toEqual([]);
 
     expect(recreateResponse.status).toBe(201);
     expect(recreateResponse.body.name).toBe("Mercado");
@@ -252,11 +253,12 @@ describe("categories", () => {
     expect(recreateResponse.body.id).not.toBe(createResponse.body.id);
 
     expect(listWithDeletedResponse.status).toBe(200);
-    expect(listWithDeletedResponse.body).toHaveLength(2);
-    expect(listWithDeletedResponse.body[0].id).toBe(recreateResponse.body.id);
-    expect(listWithDeletedResponse.body[0].deletedAt).toBeNull();
-    expect(listWithDeletedResponse.body[1].id).toBe(createResponse.body.id);
-    expect(listWithDeletedResponse.body[1].deletedAt).toBeTruthy();
+    const userRows = listWithDeletedResponse.body.filter((c) => !c.system);
+    expect(userRows).toHaveLength(2);
+    expect(userRows[0].id).toBe(recreateResponse.body.id);
+    expect(userRows[0].deletedAt).toBeNull();
+    expect(userRows[1].id).toBe(createResponse.body.id);
+    expect(userRows[1].deletedAt).toBeTruthy();
   });
 
   it("POST /categories/:id/restore restaura categoria sem conflito", async () => {

--- a/apps/api/src/db/migrations/033_upgrade_categories_system.sql
+++ b/apps/api/src/db/migrations/033_upgrade_categories_system.sql
@@ -1,0 +1,41 @@
+-- Make user_id nullable so system (shared) categories have NULL user_id
+ALTER TABLE categories ALTER COLUMN user_id DROP NOT NULL;
+
+-- Add type column: 'income' | 'expense' (NULL = uncategorized / user decides)
+ALTER TABLE categories
+ADD COLUMN IF NOT EXISTS type TEXT;
+
+-- Add system flag: TRUE for seed categories shipped with the platform
+ALTER TABLE categories
+ADD COLUMN IF NOT EXISTS system BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Add partial unique index for system categories (user_id IS NULL)
+-- The existing idx_categories_user_normalized_active_unique handles user rows fine
+-- because NULL != NULL in Postgres indexes (so system rows don't conflict with it).
+-- We need a separate index to prevent duplicate system category names.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_categories_system_normalized_unique
+  ON categories (normalized_name)
+  WHERE user_id IS NULL AND deleted_at IS NULL;
+
+-- System categories — income
+INSERT INTO categories (user_id, name, normalized_name, type, system) VALUES
+  (NULL, 'Salário CLT',       'salario clt',       'income',  TRUE),
+  (NULL, 'Benefício INSS',    'beneficio inss',     'income',  TRUE),
+  (NULL, 'Freelancer',        'freelancer',         'income',  TRUE),
+  (NULL, '13º Salário',       '13o salario',        'income',  TRUE),
+  (NULL, 'Reembolso',         'reembolso',          'income',  TRUE);
+
+-- System categories — expense
+INSERT INTO categories (user_id, name, normalized_name, type, system) VALUES
+  (NULL, 'Moradia',           'moradia',            'expense', TRUE),
+  (NULL, 'Energia',           'energia',            'expense', TRUE),
+  (NULL, 'Água',              'agua',               'expense', TRUE),
+  (NULL, 'Gás',               'gas',                'expense', TRUE),
+  (NULL, 'Internet',          'internet',           'expense', TRUE),
+  (NULL, 'Mercado',           'mercado',            'expense', TRUE),
+  (NULL, 'Farmácia',          'farmacia',           'expense', TRUE),
+  (NULL, 'Transporte',        'transporte',         'expense', TRUE),
+  (NULL, 'Saúde',             'saude',              'expense', TRUE),
+  (NULL, 'Educação',          'educacao',           'expense', TRUE),
+  (NULL, 'Empréstimos',       'emprestimos',        'expense', TRUE),
+  (NULL, 'Lazer',             'lazer',              'expense', TRUE);

--- a/apps/api/src/domain/imports/statement-import-suggestion.test.js
+++ b/apps/api/src/domain/imports/statement-import-suggestion.test.js
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractInssSuggestion,
+  extractEnergyBillSuggestion,
+  extractWaterBillSuggestion,
+} from "./statement-import.js";
+
+// ---------------------------------------------------------------------------
+// extractInssSuggestion
+// ---------------------------------------------------------------------------
+
+const INSS_SAMPLE = `
+INSS - Instituto Nacional do Seguro Social
+Histórico de Créditos
+
+NB: 177.682.989-9
+Espécie: 21 - PENSÃO POR MORTE PREVIDENCIÁRIA
+
+03/2026  R$ 2.803,52
+07/04/2026
+101 VALOR TOTAL DE MR DO PERIODO R$ 4.958,67
+216 EMPRESTIMO CONSIGNADO R$ 1.200,00
+`.trim();
+
+const INSS_WITHOUT_GROSS = `
+INSS - Instituto Nacional do Seguro Social
+NB 42.123.456-0
+Espécie: 32 - APOSENTADORIA POR TEMPO DE CONTRIBUICAO
+
+02/2026  R$ 1.500,00
+05/03/2026
+`.trim();
+
+describe("extractInssSuggestion", () => {
+  it("retorna null quando o texto nao tem entrada de credito", () => {
+    expect(extractInssSuggestion("texto qualquer sem creditos")).toBeNull();
+  });
+
+  it("extrai netAmount e referenceMonth da entrada mais recente", () => {
+    const result = extractInssSuggestion(INSS_SAMPLE);
+    expect(result).not.toBeNull();
+    expect(result.type).toBe("profile");
+    expect(result.referenceMonth).toBe("03/2026");
+    expect(result.netAmount).toBeCloseTo(2803.52);
+  });
+
+  it("extrai grossAmount da rubrica 101", () => {
+    const result = extractInssSuggestion(INSS_SAMPLE);
+    expect(result.grossAmount).toBeCloseTo(4958.67);
+  });
+
+  it("extrai paymentDate como ISO quando disponivel", () => {
+    const result = extractInssSuggestion(INSS_SAMPLE);
+    expect(result.paymentDate).toBe("2026-04-07");
+  });
+
+  it("extrai benefitId e benefitKind", () => {
+    const result = extractInssSuggestion(INSS_SAMPLE);
+    expect(result.benefitId).toMatch(/177/);
+    expect(result.benefitKind).toMatch(/pensao por morte/i);
+  });
+
+  it("retorna grossAmount null quando rubrica 101 ausente", () => {
+    const result = extractInssSuggestion(INSS_WITHOUT_GROSS);
+    expect(result).not.toBeNull();
+    expect(result.grossAmount).toBeNull();
+    expect(result.netAmount).toBeCloseTo(1500.0);
+  });
+
+  it("tolera NB sem pontuacao", () => {
+    const result = extractInssSuggestion(INSS_WITHOUT_GROSS);
+    expect(result.benefitId).toMatch(/42/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractEnergyBillSuggestion
+// ---------------------------------------------------------------------------
+
+const ENERGY_SAMPLE = `
+Neoenergia Elektro Distribuição S.A.
+NOTA FISCAL / CONTA DE ENERGIA ELÉTRICA
+
+Código de Instalação: 41864557
+Referência: Dezembro/2025
+Vencimento: 21/01/2026
+TOTAL A PAGAR R$ 412,00
+`.trim();
+
+const ENERGY_NO_FIELDS = `
+Documento qualquer sem campos de boleto de energia.
+`.trim();
+
+describe("extractEnergyBillSuggestion", () => {
+  it("retorna null quando nenhum campo relevante esta presente", () => {
+    expect(extractEnergyBillSuggestion(ENERGY_NO_FIELDS)).toBeNull();
+  });
+
+  it("retorna type=bill e billType=energy", () => {
+    const result = extractEnergyBillSuggestion(ENERGY_SAMPLE);
+    expect(result).not.toBeNull();
+    expect(result.type).toBe("bill");
+    expect(result.billType).toBe("energy");
+  });
+
+  it("extrai issuer da lista de distribuidoras conhecidas", () => {
+    const result = extractEnergyBillSuggestion(ENERGY_SAMPLE);
+    expect(result.issuer).toMatch(/neoenergia/);
+  });
+
+  it("resolve referenceMonth para MM/AAAA a partir de nome de mes", () => {
+    const result = extractEnergyBillSuggestion(ENERGY_SAMPLE);
+    expect(result.referenceMonth).toBe("12/2025");
+  });
+
+  it("extrai dueDate como ISO", () => {
+    const result = extractEnergyBillSuggestion(ENERGY_SAMPLE);
+    expect(result.dueDate).toBe("2026-01-21");
+  });
+
+  it("extrai amountDue", () => {
+    const result = extractEnergyBillSuggestion(ENERGY_SAMPLE);
+    expect(result.amountDue).toBeCloseTo(412.0);
+  });
+
+  it("extrai customerCode", () => {
+    const result = extractEnergyBillSuggestion(ENERGY_SAMPLE);
+    expect(result.customerCode).toBe("41864557");
+  });
+
+  it("aceita referenceMonth numerico MM/AAAA", () => {
+    const text = "CPFL Energia\nReferência: 03/2026\nVencimento: 10/04/2026\nTOTAL A PAGAR R$ 300,00";
+    const result = extractEnergyBillSuggestion(text);
+    expect(result.referenceMonth).toBe("03/2026");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractWaterBillSuggestion
+// ---------------------------------------------------------------------------
+
+const WATER_SAMPLE = `
+SAAE - Serviço Autônomo de Água e Esgoto de Atibaia
+Matrícula: 62092-0
+Referência: 02/2026
+Vencimento: 28/03/2026
+TOTAL A PAGAR R$ 403,88
+`.trim();
+
+const WATER_NO_FIELDS = `
+Documento qualquer sem campos de boleto de agua.
+`.trim();
+
+describe("extractWaterBillSuggestion", () => {
+  it("retorna null quando nenhum campo relevante esta presente", () => {
+    expect(extractWaterBillSuggestion(WATER_NO_FIELDS)).toBeNull();
+  });
+
+  it("retorna type=bill e billType=water", () => {
+    const result = extractWaterBillSuggestion(WATER_SAMPLE);
+    expect(result).not.toBeNull();
+    expect(result.type).toBe("bill");
+    expect(result.billType).toBe("water");
+  });
+
+  it("extrai issuer da lista de prestadoras conhecidas", () => {
+    const result = extractWaterBillSuggestion(WATER_SAMPLE);
+    expect(result.issuer).toMatch(/saae/);
+  });
+
+  it("resolve referenceMonth MM/AAAA numerico", () => {
+    const result = extractWaterBillSuggestion(WATER_SAMPLE);
+    expect(result.referenceMonth).toBe("02/2026");
+  });
+
+  it("extrai dueDate como ISO", () => {
+    const result = extractWaterBillSuggestion(WATER_SAMPLE);
+    expect(result.dueDate).toBe("2026-03-28");
+  });
+
+  it("extrai amountDue", () => {
+    const result = extractWaterBillSuggestion(WATER_SAMPLE);
+    expect(result.amountDue).toBeCloseTo(403.88);
+  });
+
+  it("extrai customerCode da matricula", () => {
+    const result = extractWaterBillSuggestion(WATER_SAMPLE);
+    expect(result.customerCode).toMatch(/62092/);
+  });
+});

--- a/apps/api/src/domain/imports/statement-import.js
+++ b/apps/api/src/domain/imports/statement-import.js
@@ -477,6 +477,166 @@ export const parseInssCreditHistoryPdfText = (text) => {
   return finalizeStatementRows(rows);
 };
 
+const MONTH_NAMES_MAP = {
+  janeiro: "01", fevereiro: "02", marco: "03", abril: "04", maio: "05", junho: "06",
+  julho: "07", agosto: "08", setembro: "09", outubro: "10", novembro: "11", dezembro: "12",
+  jan: "01", fev: "02", mar: "03", abr: "04", mai: "05", jun: "06",
+  jul: "07", ago: "08", set: "09", out: "10", nov: "11", dez: "12",
+};
+
+const resolveReferenceMonth = (raw) => {
+  if (!raw) return null;
+  const numericMatch = raw.match(/(\d{2})\/?(\d{4})/);
+  if (numericMatch) return `${numericMatch[1]}/${numericMatch[2]}`;
+  const normalized = collapseWhitespace(raw)
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+  const namedMatch = normalized.match(/([a-z]+)[\s/]+(\d{4})/);
+  if (namedMatch) {
+    const mm = MONTH_NAMES_MAP[namedMatch[1]];
+    if (mm) return `${mm}/${namedMatch[2]}`;
+  }
+  return null;
+};
+
+const normalizeForExtraction = (text) =>
+  String(text || "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+
+export const extractInssSuggestion = (text) => {
+  const normalized = normalizeForExtraction(text);
+
+  // Benefit ID (NB)
+  const nbMatch = normalized.match(/\bnb[:\s#°]*([\d.\-/]+)/i);
+  const benefitId = nbMatch ? nbMatch[1].trim() : null;
+
+  // Benefit kind (Espécie)
+  const especieMatch = normalized.match(/especie[:\s]+(\d+)\s*[-–]\s*([^\n\r]{3,60})/i);
+  const benefitKind = especieMatch ? collapseWhitespace(especieMatch[2]) : null;
+
+  // Most recent credit entry (first match — PDF lists newest first)
+  const entryMatch = normalized.match(/^(\d{2}\/\d{4})\s+r\$\s*([\d.,]+)/m);
+  if (!entryMatch) return null;
+
+  const referenceMonth = entryMatch[1];
+  const netAmount = parseSignedAmount(entryMatch[2]);
+  if (netAmount === null) return null;
+
+  // Find the block for this entry to get payment date and gross amount
+  const entryStart = normalized.indexOf(entryMatch[0]);
+  const nextEntryMatch = normalized.slice(entryStart + 1).match(/\d{2}\/\d{4}\s+r\$\s*[\d.,]+/);
+  const blockEnd = nextEntryMatch
+    ? entryStart + 1 + normalized.slice(entryStart + 1).indexOf(nextEntryMatch[0])
+    : entryStart + 2000;
+  const block = normalized.slice(entryStart, blockEnd);
+
+  const fullDates = block.match(/\d{2}\/\d{2}\/\d{4}/g) || [];
+  const paymentDateRaw = fullDates[fullDates.length - 1] || null;
+  const paymentDate = paymentDateRaw ? toIsoDateString(paymentDateRaw) : null;
+
+  const grossMatch = block.match(/101\s+valor total de mr do periodo\s+r\$\s*([\d.,]+)/i);
+  const grossAmount = grossMatch ? parseSignedAmount(grossMatch[1]) : null;
+
+  return {
+    type: "profile",
+    benefitId,
+    benefitKind,
+    referenceMonth,
+    paymentDate,
+    netAmount: Math.abs(netAmount),
+    grossAmount: grossAmount !== null ? Math.abs(grossAmount) : null,
+  };
+};
+
+const ENERGY_ISSUERS = [
+  "neoenergia", "neoenergia elektro", "cpfl energia", "enel", "cemig", "light", "eletropaulo",
+  "energisa", "elektro", "coelba", "celpe", "cosern", "ceal", "ceron", "boa energia",
+];
+const WATER_ISSUERS = [
+  "saae", "sabesp", "sanepar", "copasa", "cagece", "caern", "casan", "embasa",
+  "compesa", "agespisa", "caema", "cosanpa",
+];
+
+const detectIssuerFromText = (normalizedText, candidates) => {
+  for (const candidate of candidates) {
+    if (normalizedText.includes(candidate)) return candidate;
+  }
+  return null;
+};
+
+const extractBillFields = (normalizedText) => {
+  // Reference month
+  const refMatch = normalizedText.match(
+    /(?:referencia|referencia do mes|competencia|periodo de referencia|mes de referencia)[:\s]+([a-z]+[\s/]+\d{4}|\d{1,2}[/]\d{4})/i,
+  );
+  const referenceMonth = resolveReferenceMonth(refMatch ? refMatch[1] : null);
+
+  // Due date
+  const dueMatch = normalizedText.match(/vencimento[:\s]+(\d{2}\/\d{2}\/\d{4})/i);
+  const dueDate = dueMatch ? toIsoDateString(dueMatch[1]) : null;
+
+  // Amount due
+  const amountMatch = normalizedText.match(
+    /(?:total a pagar|valor a pagar|total do documento|valor total)[:\s]*r?\$?\s*([\d.,]+)/i,
+  );
+  const amountDue = amountMatch ? parseSignedAmount(amountMatch[1]) : null;
+
+  return { referenceMonth, dueDate, amountDue: amountDue !== null ? Math.abs(amountDue) : null };
+};
+
+export const extractEnergyBillSuggestion = (text) => {
+  const normalized = normalizeForExtraction(text);
+
+  const issuerKey = detectIssuerFromText(normalized, ENERGY_ISSUERS);
+  const { referenceMonth, dueDate, amountDue } = extractBillFields(normalized);
+
+  // Customer code: "Código de Instalação", "N° Instalação", "Código do cliente"
+  const codeMatch = normalized.match(
+    /(?:codigo de instalacao|n[°o] instalacao|instalacao|codigo do cliente|numero do cliente|numero da instalacao)[:\s#°]*([\d.\-/]+)/i,
+  );
+  const customerCode = codeMatch ? codeMatch[1].trim() : null;
+
+  if (!referenceMonth && !dueDate && amountDue === null) return null;
+
+  return {
+    type: "bill",
+    billType: "energy",
+    issuer: issuerKey,
+    referenceMonth,
+    dueDate,
+    amountDue,
+    customerCode,
+  };
+};
+
+export const extractWaterBillSuggestion = (text) => {
+  const normalized = normalizeForExtraction(text);
+
+  const issuerKey = detectIssuerFromText(normalized, WATER_ISSUERS);
+  const { referenceMonth, dueDate, amountDue } = extractBillFields(normalized);
+
+  // Customer code: "Matrícula", "Código do cliente", "N° contrato"
+  const codeMatch = normalized.match(
+    /(?:matricula|matricula do imovel|codigo do cliente|n[°o] contrato|numero do cliente)[:\s#°]*([\d.\-/]+)/i,
+  );
+  const customerCode = codeMatch ? codeMatch[1].trim() : null;
+
+  if (!referenceMonth && !dueDate && amountDue === null) return null;
+
+  return {
+    type: "bill",
+    billType: "water",
+    issuer: issuerKey,
+    referenceMonth,
+    dueDate,
+    amountDue,
+    customerCode,
+  };
+};
+
 export const extractTextFromPdfBuffer = async (buffer) => extractTextFromPdfWithOcr(buffer);
 
 export const parseStatementPdfRows = async (buffer) => {

--- a/apps/api/src/routes/transactions.routes.js
+++ b/apps/api/src/routes/transactions.routes.js
@@ -358,9 +358,13 @@ router.post("/import/commit", importRateLimiter, requireFeature("csv_import"), a
   trackCommitAttemptMetrics();
 
   try {
+    const categoryOverrides = Array.isArray(req.body?.categoryOverrides)
+      ? req.body.categoryOverrides
+      : [];
     const commitResult = await commitTransactionsImportForUser(
       req.user.id,
       req.body?.importId,
+      categoryOverrides,
     );
     const observability = commitResult.observability || {};
     const rowsTotal = Number(observability.totalRows) || Number(commitResult.imported) || 0;

--- a/apps/api/src/services/categories.service.js
+++ b/apps/api/src/services/categories.service.js
@@ -66,12 +66,16 @@ const toISOStringOrNull = (value) => {
 
 const mapCategory = (row) => ({
   id: Number(row.id),
-  userId: Number(row.user_id),
+  userId: row.user_id != null ? Number(row.user_id) : null,
   name: row.name,
   normalizedName: row.normalized_name,
+  type: row.type ?? null,
+  system: Boolean(row.system),
   deletedAt: toISOStringOrNull(row.deleted_at),
   createdAt: toISOStringOrNull(row.created_at),
 });
+
+const isSystemCategory = (row) => Boolean(row.system);
 
 const normalizeIncludeDeleted = (value) => String(value || "").toLowerCase() === "true";
 
@@ -81,19 +85,26 @@ const throwIfUniqueConstraintError = (error) => {
   }
 };
 
+const normalizeType = (value) => {
+  if (typeof value === "undefined") return undefined;
+  if (value === "income" || value === "expense") return value;
+  return null;
+};
+
 export const createCategoryForUser = async (userId, payload = {}) => {
   const normalizedUserId = normalizeUserId(userId);
   const name = normalizeCategoryName(payload.name);
   const normalizedName = normalizeCategoryNameKey(name);
+  const type = normalizeType(payload.type);
 
   try {
     const result = await dbQuery(
       `
-        INSERT INTO categories (user_id, name, normalized_name)
-        VALUES ($1, $2, $3)
-        RETURNING id, user_id, name, normalized_name, deleted_at, created_at
+        INSERT INTO categories (user_id, name, normalized_name, type)
+        VALUES ($1, $2, $3, $4)
+        RETURNING id, user_id, name, normalized_name, type, system, deleted_at, created_at
       `,
-      [normalizedUserId, name, normalizedName],
+      [normalizedUserId, name, normalizedName, type ?? null],
     );
 
     return mapCategory(result.rows[0]);
@@ -109,12 +120,14 @@ export const listCategoriesByUser = async (userId, options = {}) => {
 
   const result = await dbQuery(
     `
-      SELECT id, user_id, name, normalized_name, deleted_at, created_at
+      SELECT id, user_id, name, normalized_name, type, system, deleted_at, created_at
       FROM categories
-      WHERE user_id = $1
+      WHERE (user_id = $1 OR user_id IS NULL)
       ${includeDeleted ? "" : "AND deleted_at IS NULL"}
       ORDER BY
         (deleted_at IS NOT NULL) ASC,
+        system DESC,
+        type ASC NULLS LAST,
         normalized_name ASC,
         id ASC
     `,
@@ -137,8 +150,9 @@ export const updateCategoryForUser = async (userId, categoryId, payload = {}) =>
         SET name = $3, normalized_name = $4
         WHERE id = $1
           AND user_id = $2
+          AND system IS NOT TRUE
           AND deleted_at IS NULL
-        RETURNING id, user_id, name, normalized_name, deleted_at, created_at
+        RETURNING id, user_id, name, normalized_name, type, system, deleted_at, created_at
       `,
       [normalizedCategoryId, normalizedUserId, name, normalizedName],
     );
@@ -164,8 +178,9 @@ export const deleteCategoryForUser = async (userId, categoryId) => {
       SET deleted_at = NOW()
       WHERE id = $1
         AND user_id = $2
+        AND system IS NOT TRUE
         AND deleted_at IS NULL
-      RETURNING id, user_id, name, normalized_name, deleted_at, created_at
+      RETURNING id, user_id, name, normalized_name, type, system, deleted_at, created_at
     `,
     [normalizedCategoryId, normalizedUserId],
   );
@@ -188,8 +203,9 @@ export const restoreCategoryForUser = async (userId, categoryId) => {
         SET deleted_at = NULL
         WHERE id = $1
           AND user_id = $2
+          AND system IS NOT TRUE
           AND deleted_at IS NOT NULL
-        RETURNING id, user_id, name, normalized_name, deleted_at, created_at
+        RETURNING id, user_id, name, normalized_name, type, system, deleted_at, created_at
       `,
       [normalizedCategoryId, normalizedUserId],
     );

--- a/apps/api/src/services/transactions-import.service.js
+++ b/apps/api/src/services/transactions-import.service.js
@@ -15,6 +15,9 @@ import {
   parseInssCreditHistoryPdfText,
   parseGenericBankStatementPdfText,
   parseStatementCsvRows,
+  extractInssSuggestion,
+  extractEnergyBillSuggestion,
+  extractWaterBillSuggestion,
 } from "../domain/imports/statement-import.js";
 import { detectDocumentType } from "../domain/imports/document-classifier.js";
 import { applySmartClassification } from "../domain/imports/transaction-classifier.js";
@@ -288,19 +291,26 @@ const parseImportFileRows = async (importFile) => {
     if (documentType === "income_statement_inss") {
       try {
         const rows = parseInssCreditHistoryPdfText(text);
-        return { rows, documentType };
+        const suggestion = extractInssSuggestion(text);
+        return { rows, documentType, suggestion };
       } catch (error) {
         throw createError(400, error.message || "Nao foi possivel reconhecer transacoes no PDF.");
       }
     }
 
-    if (documentType === "utility_bill_energy" || documentType === "utility_bill_water") {
-      return { rows: [], documentType };
+    if (documentType === "utility_bill_energy") {
+      const suggestion = extractEnergyBillSuggestion(text);
+      return { rows: [], documentType, suggestion };
+    }
+
+    if (documentType === "utility_bill_water") {
+      const suggestion = extractWaterBillSuggestion(text);
+      return { rows: [], documentType, suggestion };
     }
 
     try {
       const rows = parseGenericBankStatementPdfText(text);
-      return { rows, documentType };
+      return { rows, documentType, suggestion: null };
     } catch (error) {
       throw createError(400, error.message || "Nao foi possivel reconhecer transacoes no PDF.");
     }
@@ -310,7 +320,7 @@ const parseImportFileRows = async (importFile) => {
     const documentType = detectDocumentType({ text: "", extension });
     try {
       const rows = parseOfxRows(fileBuffer);
-      return { rows, documentType };
+      return { rows, documentType, suggestion: null };
     } catch (error) {
       throw createError(400, error.message || "Nao foi possivel reconhecer transacoes no OFX.");
     }
@@ -319,7 +329,7 @@ const parseImportFileRows = async (importFile) => {
   try {
     const rows = parseCsvFileRows(fileBuffer);
     const documentType = detectDocumentType({ text: "", extension: ".csv" });
-    return { rows, documentType };
+    return { rows, documentType, suggestion: null };
   } catch (error) {
     if (error?.message !== HEADER_ERROR_MESSAGE) {
       throw error;
@@ -329,7 +339,7 @@ const parseImportFileRows = async (importFile) => {
   try {
     const rows = parseStatementCsvRows(fileBuffer);
     const documentType = detectDocumentType({ text: "", extension: ".csv" });
-    return { rows, documentType };
+    return { rows, documentType, suggestion: null };
   } catch (error) {
     if (
       error?.message === `Arquivo excede o limite de ${getImportCsvMaxRows()} linhas.`
@@ -642,7 +652,7 @@ const assertSessionReadyForCommit = (session, userId) => {
 };
 
 export const dryRunTransactionsImportForUser = async (userId, importFile) => {
-  const { rows: parsedRows, documentType } = await parseImportFileRows(importFile);
+  const { rows: parsedRows, documentType, suggestion } = await parseImportFileRows(importFile);
   const [categoryMap, categories] = await Promise.all([
     loadCategoryMapForUser(userId),
     loadCategoriesForUser(userId),
@@ -690,6 +700,7 @@ export const dryRunTransactionsImportForUser = async (userId, importFile) => {
     importId: persistedSession.importId,
     expiresAt: persistedSession.expiresAt,
     documentType,
+    suggestion: suggestion || null,
     summary,
     rows,
   };

--- a/apps/api/src/services/transactions-import.service.js
+++ b/apps/api/src/services/transactions-import.service.js
@@ -689,7 +689,7 @@ export const dryRunTransactionsImportForUser = async (userId, importFile) => {
 
   const normalizedRows = rows
     .filter((row) => row.status === "valid" && row.normalized)
-    .map((row) => ({ ...row.normalized, fingerprint: row.fingerprint }));
+    .map((row) => ({ ...row.normalized, fingerprint: row.fingerprint, line: row.line }));
 
   const persistedSession = await persistImportSession(userId, {
     normalizedRows,
@@ -777,7 +777,23 @@ export const getTransactionsImportMetricsByUser = async (userId) => {
   };
 };
 
-export const commitTransactionsImportForUser = async (userId, importId) => {
+const buildCategoryOverrideMap = (overrides) => {
+  if (!Array.isArray(overrides) || overrides.length === 0) return new Map();
+  return new Map(
+    overrides
+      .filter(
+        (o) =>
+          o != null &&
+          typeof o.line === "number" &&
+          Number.isInteger(o.line) &&
+          o.line > 0 &&
+          (o.categoryId === null || (Number.isInteger(o.categoryId) && o.categoryId > 0)),
+      )
+      .map((o) => [o.line, o.categoryId ?? null]),
+  );
+};
+
+export const commitTransactionsImportForUser = async (userId, importId, categoryOverrides = []) => {
   const normalizedImportId = normalizeImportId(importId);
   const importSession = await loadImportSessionById(normalizedImportId);
 
@@ -787,9 +803,15 @@ export const commitTransactionsImportForUser = async (userId, importId) => {
     typeof importSession.payload_json === "string"
       ? JSON.parse(importSession.payload_json)
       : importSession.payload_json || {};
-  const normalizedRows = Array.isArray(payload.normalizedRows)
-    ? payload.normalizedRows
-    : [];
+  const sessionRows = Array.isArray(payload.normalizedRows) ? payload.normalizedRows : [];
+  const overrideMap = buildCategoryOverrideMap(categoryOverrides);
+  const normalizedRows = overrideMap.size === 0
+    ? sessionRows
+    : sessionRows.map((row) =>
+        overrideMap.has(row.line)
+          ? { ...row, categoryId: overrideMap.get(row.line) }
+          : row,
+      );
   const payloadSummary = payload.summary || {};
   const observabilitySummary = {
     totalRows: normalizeSummaryInteger(payloadSummary.totalRows, normalizedRows.length),

--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { transactionsService } from "../services/transactions.service";
 import { profileService } from "../services/profile.service";
+import { categoriesService } from "../services/categories.service";
 import { formatCurrency } from "../utils/formatCurrency";
 import { getApiErrorMessage } from "../utils/apiError";
 
@@ -16,6 +17,13 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
   const [showProfileConfirm, setShowProfileConfirm] = useState(false);
   const [isApplyingProfile, setIsApplyingProfile] = useState(false);
   const [profileApplied, setProfileApplied] = useState(false);
+  const [categories, setCategories] = useState([]);
+  // categoryOverrides: Record<line, categoryId | null>
+  const [categoryOverrides, setCategoryOverrides] = useState({});
+  // inlineCreate: { line, type } | null — which row's inline form is open
+  const [inlineCreate, setInlineCreate] = useState(null);
+  const [inlineCreateName, setInlineCreateName] = useState("");
+  const [isCreatingCategory, setIsCreatingCategory] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
@@ -31,6 +39,9 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
     setShowProfileConfirm(false);
     setIsApplyingProfile(false);
     setProfileApplied(false);
+    setCategoryOverrides({});
+    setInlineCreate(null);
+    setInlineCreateName("");
   }, [isOpen]);
 
   useEffect(() => {
@@ -55,6 +66,11 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
       window.removeEventListener("keydown", handleEscapeKey);
     };
   }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    categoriesService.listCategories().then(setCategories).catch(() => {});
+  }, [isOpen]);
 
   const hasValidRows = useMemo(() => {
     return (dryRunResult?.summary?.validRows || 0) > 0;
@@ -140,6 +156,27 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
     }
   };
 
+  const handleInlineCreateCategory = useCallback(
+    async (line, rowType) => {
+      const trimmedName = inlineCreateName.trim();
+      if (!trimmedName) return;
+      setIsCreatingCategory(true);
+      try {
+        const inferredType = rowType === "Entrada" ? "income" : rowType === "Saida" ? "expense" : undefined;
+        const created = await categoriesService.createCategory(trimmedName, inferredType);
+        setCategories((prev) => [...prev, created]);
+        setCategoryOverrides((prev) => ({ ...prev, [line]: created.id }));
+        setInlineCreate(null);
+        setInlineCreateName("");
+      } catch {
+        // silently fail — user can try again
+      } finally {
+        setIsCreatingCategory(false);
+      }
+    },
+    [inlineCreateName],
+  );
+
   const handleDryRun = async () => {
     if (!selectedFile) {
       setErrorMessage("Selecione um arquivo CSV, OFX ou PDF.");
@@ -178,7 +215,11 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
     setSuccessMessage("");
 
     try {
-      const commitResult = await transactionsService.commitImportCsv(dryRunResult.importId);
+      const overridesArray = Object.entries(categoryOverrides).map(([line, categoryId]) => ({
+        line: Number(line),
+        categoryId: categoryId ?? null,
+      }));
+      const commitResult = await transactionsService.commitImportCsv(dryRunResult.importId, overridesArray);
 
       if (onImported) {
         await onImported(commitResult);
@@ -258,6 +299,9 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
               setSuccessMessage("");
               setProfileApplied(false);
               setShowProfileConfirm(false);
+              setCategoryOverrides({});
+              setInlineCreate(null);
+              setInlineCreateName("");
             }}
             className="block w-full text-sm text-cf-text-primary file:mr-3 file:rounded file:border file:border-cf-border file:bg-cf-bg-subtle file:px-3 file:py-1 file:text-sm file:font-semibold file:text-cf-text-primary hover:file:bg-cf-border"
           />
@@ -472,16 +516,76 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
                           {row.raw.value || "-"}
                         </td>
                         <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">{row.raw.date || "-"}</td>
-                        <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
-                          {row.raw.category ? (
-                            row.raw.category
-                          ) : row.status === "valid" ? (
-                            <span className="inline-flex items-center gap-1.5">
-                              <span className="rounded border border-amber-300 bg-amber-50 px-1.5 py-0.5 text-xs font-medium text-amber-700">
-                                Revisar
-                              </span>
-                              <span className="text-cf-text-secondary">Sem categoria</span>
-                            </span>
+                        <td className="border-b border-cf-border px-2 py-2">
+                          {row.status === "valid" ? (
+                            <div className="space-y-1">
+                              <div className="flex items-center gap-1">
+                                <select
+                                  aria-label={`Categoria da linha ${row.line}`}
+                                  value={
+                                    categoryOverrides[row.line] !== undefined
+                                      ? categoryOverrides[row.line] ?? ""
+                                      : row.normalized?.categoryId ?? ""
+                                  }
+                                  onChange={(e) => {
+                                    const val = e.target.value === "" ? null : Number(e.target.value);
+                                    setCategoryOverrides((prev) => ({ ...prev, [row.line]: val }));
+                                  }}
+                                  className="rounded border border-cf-border bg-cf-surface px-1 py-0.5 text-xs text-cf-text-primary"
+                                >
+                                  <option value="">— Sem categoria —</option>
+                                  {categories.map((cat) => (
+                                    <option key={cat.id} value={cat.id}>{cat.name}</option>
+                                  ))}
+                                </select>
+                                {inlineCreate?.line !== row.line && (
+                                  <button
+                                    type="button"
+                                    title="Nova categoria"
+                                    onClick={() => { setInlineCreate({ line: row.line, type: row.raw.type }); setInlineCreateName(""); }}
+                                    className="rounded border border-cf-border px-1 py-0.5 text-xs text-cf-text-secondary hover:bg-cf-bg-subtle"
+                                  >
+                                    +
+                                  </button>
+                                )}
+                              </div>
+                              {inlineCreate?.line === row.line && (
+                                <div className="flex items-center gap-1">
+                                  <input
+                                    type="text"
+                                    value={inlineCreateName}
+                                    onChange={(e) => setInlineCreateName(e.target.value)}
+                                    onKeyDown={(e) => { if (e.key === "Enter") handleInlineCreateCategory(row.line, row.raw.type); if (e.key === "Escape") setInlineCreate(null); }}
+                                    placeholder="Nova categoria"
+                                    className="rounded border border-cf-border bg-cf-surface px-1 py-0.5 text-xs text-cf-text-primary"
+                                    // eslint-disable-next-line jsx-a11y/no-autofocus
+                                    autoFocus
+                                  />
+                                  <button
+                                    type="button"
+                                    disabled={isCreatingCategory}
+                                    onClick={() => handleInlineCreateCategory(row.line, row.raw.type)}
+                                    className="rounded border border-brand-1 bg-brand-1 px-1.5 py-0.5 text-xs text-white disabled:opacity-60"
+                                  >
+                                    OK
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={() => setInlineCreate(null)}
+                                    className="rounded border border-cf-border px-1.5 py-0.5 text-xs text-cf-text-secondary"
+                                  >
+                                    ✕
+                                  </button>
+                                </div>
+                              )}
+                              {!categoryOverrides[row.line] && !row.normalized?.categoryId && inlineCreate?.line !== row.line && (
+                                <span className="inline-flex items-center gap-1.5">
+                                  <span className="rounded border border-amber-300 bg-amber-50 px-1.5 py-0.5 text-xs font-medium text-amber-700">
+                                    Revisar
+                                  </span>
+                                </span>
+                              )}
+                            </div>
                           ) : (
                             "—"
                           )}

--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { transactionsService } from "../services/transactions.service";
+import { profileService } from "../services/profile.service";
 import { formatCurrency } from "../utils/formatCurrency";
 import { getApiErrorMessage } from "../utils/apiError";
 
@@ -12,6 +13,9 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
   const [dryRunResult, setDryRunResult] = useState(null);
   const [errorMessage, setErrorMessage] = useState("");
   const [successMessage, setSuccessMessage] = useState("");
+  const [showProfileConfirm, setShowProfileConfirm] = useState(false);
+  const [isApplyingProfile, setIsApplyingProfile] = useState(false);
+  const [profileApplied, setProfileApplied] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
@@ -24,6 +28,9 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
     setDryRunResult(null);
     setErrorMessage("");
     setSuccessMessage("");
+    setShowProfileConfirm(false);
+    setIsApplyingProfile(false);
+    setProfileApplied(false);
   }, [isOpen]);
 
   useEffect(() => {
@@ -105,6 +112,33 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
 
     return null;
   }, [dryRunResult]);
+
+  const profilePatch = useMemo(() => {
+    const suggestion = dryRunResult?.suggestion;
+    if (suggestion?.type !== "profile") return null;
+    const patch = {};
+    if (suggestion.netAmount != null) patch.salary_monthly = suggestion.netAmount;
+    if (suggestion.paymentDate) {
+      const day = new Date(`${suggestion.paymentDate}T12:00:00Z`).getUTCDate();
+      if (day >= 1 && day <= 31) patch.payday = day;
+    }
+    return Object.keys(patch).length > 0 ? patch : null;
+  }, [dryRunResult]);
+
+  const handleApplyProfile = async () => {
+    if (!profilePatch) return;
+    setIsApplyingProfile(true);
+    setErrorMessage("");
+    try {
+      await profileService.updateProfile(profilePatch);
+      setProfileApplied(true);
+    } catch (error) {
+      setErrorMessage(getApiErrorMessage(error, "Não foi possível atualizar o perfil."));
+    } finally {
+      setIsApplyingProfile(false);
+      setShowProfileConfirm(false);
+    }
+  };
 
   const handleDryRun = async () => {
     if (!selectedFile) {
@@ -222,6 +256,8 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
               setDryRunResult(null);
               setErrorMessage("");
               setSuccessMessage("");
+              setProfileApplied(false);
+              setShowProfileConfirm(false);
             }}
             className="block w-full text-sm text-cf-text-primary file:mr-3 file:rounded file:border file:border-cf-border file:bg-cf-bg-subtle file:px-3 file:py-1 file:text-sm file:font-semibold file:text-cf-text-primary hover:file:bg-cf-border"
           />
@@ -292,11 +328,63 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
                 <p className="mb-1 text-xs font-semibold uppercase text-blue-700 dark:text-blue-400">
                   {suggestionCard.kind === "profile" ? "Dados extraídos do comprovante" : "Dados do boleto"}
                 </p>
-                <ul className="space-y-0.5">
+                <ul className="mb-2 space-y-0.5">
                   {suggestionCard.lines.map((line) => (
                     <li key={line} className="text-xs text-blue-700 dark:text-blue-300">{line}</li>
                   ))}
                 </ul>
+                {suggestionCard.kind === "profile" && profilePatch && !profileApplied ? (
+                  showProfileConfirm ? (
+                    <div className="mt-2 rounded border border-blue-300 bg-blue-100 px-3 py-2 dark:border-blue-700 dark:bg-blue-900/40">
+                      <p className="mb-2 text-xs font-semibold text-blue-800 dark:text-blue-200">
+                        Confirmar atualização do perfil?
+                      </p>
+                      <ul className="mb-3 space-y-0.5">
+                        {profilePatch.salary_monthly != null && (
+                          <li className="text-xs text-blue-700 dark:text-blue-300">
+                            Renda líquida mensal → R$ {profilePatch.salary_monthly.toFixed(2).replace(".", ",")}
+                          </li>
+                        )}
+                        {profilePatch.payday != null && (
+                          <li className="text-xs text-blue-700 dark:text-blue-300">
+                            Dia de pagamento → dia {profilePatch.payday}
+                          </li>
+                        )}
+                      </ul>
+                      <div className="flex gap-2">
+                        <button
+                          type="button"
+                          onClick={handleApplyProfile}
+                          disabled={isApplyingProfile}
+                          className="rounded bg-blue-600 px-3 py-1 text-xs font-semibold text-white hover:bg-blue-700 disabled:opacity-60"
+                        >
+                          {isApplyingProfile ? "Salvando..." : "Confirmar"}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setShowProfileConfirm(false)}
+                          disabled={isApplyingProfile}
+                          className="rounded border border-blue-300 px-3 py-1 text-xs font-semibold text-blue-700 hover:bg-blue-100 dark:border-blue-700 dark:text-blue-300 disabled:opacity-60"
+                        >
+                          Cancelar
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => setShowProfileConfirm(true)}
+                      className="mt-1 rounded border border-blue-400 bg-blue-100 px-3 py-1 text-xs font-semibold text-blue-700 hover:bg-blue-200 dark:border-blue-600 dark:bg-blue-900/40 dark:text-blue-300 dark:hover:bg-blue-800/40"
+                    >
+                      Atualizar perfil com esses dados
+                    </button>
+                  )
+                ) : null}
+                {suggestionCard.kind === "profile" && profileApplied ? (
+                  <p className="mt-1 text-xs font-semibold text-green-600 dark:text-green-400">
+                    Perfil atualizado com sucesso.
+                  </p>
+                ) : null}
               </div>
             ) : null}
 

--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -79,6 +79,33 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
     );
   }, [dryRunResult]);
 
+  const suggestionCard = useMemo(() => {
+    const suggestion = dryRunResult?.suggestion;
+    if (!suggestion) return null;
+
+    if (suggestion.type === "profile") {
+      const lines = [];
+      if (suggestion.referenceMonth) lines.push(`Competência: ${suggestion.referenceMonth}`);
+      if (suggestion.paymentDate) lines.push(`Pagamento: ${suggestion.paymentDate}`);
+      if (suggestion.netAmount != null) lines.push(`Líquido: R$ ${suggestion.netAmount.toFixed(2).replace(".", ",")}`);
+      if (suggestion.grossAmount != null) lines.push(`Bruto (MR): R$ ${suggestion.grossAmount.toFixed(2).replace(".", ",")}`);
+      if (suggestion.benefitKind) lines.push(`Espécie: ${suggestion.benefitKind}`);
+      return { kind: "profile", lines };
+    }
+
+    if (suggestion.type === "bill") {
+      const lines = [];
+      if (suggestion.issuer) lines.push(`Emissor: ${suggestion.issuer}`);
+      if (suggestion.referenceMonth) lines.push(`Referência: ${suggestion.referenceMonth}`);
+      if (suggestion.dueDate) lines.push(`Vencimento: ${suggestion.dueDate}`);
+      if (suggestion.amountDue != null) lines.push(`Total a pagar: R$ ${suggestion.amountDue.toFixed(2).replace(".", ",")}`);
+      if (suggestion.customerCode) lines.push(`Código: ${suggestion.customerCode}`);
+      return { kind: "bill", lines };
+    }
+
+    return null;
+  }, [dryRunResult]);
+
   const handleDryRun = async () => {
     if (!selectedFile) {
       setErrorMessage("Selecione um arquivo CSV, OFX ou PDF.");
@@ -257,6 +284,19 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
             {isUtilityBill ? (
               <div className="rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-400">
                 Boleto detectado. O suporte completo à importação de contas de energia e água chegará em breve. Por enquanto, nenhuma transação é extraída.
+              </div>
+            ) : null}
+
+            {suggestionCard ? (
+              <div className="rounded border border-blue-200 bg-blue-50 px-3 py-2 dark:border-blue-800 dark:bg-blue-950/40">
+                <p className="mb-1 text-xs font-semibold uppercase text-blue-700 dark:text-blue-400">
+                  {suggestionCard.kind === "profile" ? "Dados extraídos do comprovante" : "Dados do boleto"}
+                </p>
+                <ul className="space-y-0.5">
+                  {suggestionCard.lines.map((line) => (
+                    <li key={line} className="text-xs text-blue-700 dark:text-blue-300">{line}</li>
+                  ))}
+                </ul>
               </div>
             ) : null}
 

--- a/apps/web/src/services/categories.service.ts
+++ b/apps/web/src/services/categories.service.ts
@@ -2,9 +2,11 @@ import { api } from "./api";
 
 export interface CategoryItem {
   id: number;
-  userId: number;
+  userId: number | null;
   name: string;
   normalizedName: string;
+  type: "income" | "expense" | null;
+  system: boolean;
   deletedAt: string | null;
   createdAt: string | null;
 }
@@ -43,21 +45,27 @@ const normalizeCategoryItem = (payload: CategoryApiPayload): CategoryItem => {
         ? payload.normalized_name.trim()
         : "";
 
+  const rawType = payload?.type;
+  const type: "income" | "expense" | null =
+    rawType === "income" || rawType === "expense" ? rawType : null;
+
   return {
     id: Number.isInteger(normalizedId) && normalizedId > 0 ? normalizedId : 0,
     userId:
       Number.isInteger(normalizedUserId) && normalizedUserId > 0
         ? normalizedUserId
-        : 0,
+        : null,
     name: normalizedName,
     normalizedName: normalizedKey,
+    type,
+    system: Boolean(payload?.system),
     deletedAt: normalizeIsoStringOrNull(payload?.deletedAt ?? payload?.deleted_at),
     createdAt: normalizeIsoStringOrNull(payload?.createdAt ?? payload?.created_at),
   };
 };
 
 const isValidCategoryItem = (item: CategoryItem): boolean =>
-  item.id > 0 && item.userId > 0 && Boolean(item.name);
+  item.id > 0 && Boolean(item.name);
 
 export const categoriesService = {
   listCategories: async (includeDeleted = false): Promise<CategoryItem[]> => {
@@ -73,8 +81,8 @@ export const categoriesService = {
       .filter(isValidCategoryItem);
   },
 
-  createCategory: async (name: string): Promise<CategoryItem> => {
-    const { data } = await api.post("/categories", { name });
+  createCategory: async (name: string, type?: "income" | "expense"): Promise<CategoryItem> => {
+    const { data } = await api.post("/categories", { name, type });
     return normalizeCategoryItem(data as CategoryApiPayload);
   },
 

--- a/apps/web/src/services/transactions.service.ts
+++ b/apps/web/src/services/transactions.service.ts
@@ -721,8 +721,11 @@ export const transactionsService = {
       rows,
     };
   },
-  commitImportCsv: async (importId: string): Promise<ImportCommitResult> => {
-    const { data } = await api.post("/transactions/import/commit", { importId });
+  commitImportCsv: async (
+    importId: string,
+    categoryOverrides: { line: number; categoryId: number | null }[] = [],
+  ): Promise<ImportCommitResult> => {
+    const { data } = await api.post("/transactions/import/commit", { importId, categoryOverrides });
     const responseBody = data as ImportCommitApiResponse;
 
     return {


### PR DESCRIPTION
## O que faz

PR 5 do Sprint de Integridade de Importação. Depende de #274 (PR 3) e #275 (PR 4).

Resolve o gargalo visual mais crítico do preview de importação: o mar de "Sem categoria". Agora o usuário vê um `<select>` em cada linha válida, pode escolher uma das 17 categorias padrão do sistema, criar uma categoria nova inline sem sair da tela, e essas escolhas são enviadas ao backend no commit.

## Mudanças

### Migration 033
- `user_id` agora nullable → permite categorias com `user_id IS NULL` (sistema)
- Novas colunas: `type TEXT` (`income`|`expense`) e `system BOOLEAN DEFAULT FALSE`
- Índice parcial `idx_categories_system_normalized_unique` para unicidade por nome entre categorias de sistema
- Seeds: **5 de receita** (Salário CLT, Benefício INSS, Freelancer, 13º Salário, Reembolso) + **12 de despesa** (Moradia, Energia, Água, Gás, Internet, Mercado, Farmácia, Transporte, Saúde, Educação, Empréstimos, Lazer)

### `categories.service.js`
- `listCategoriesByUser` retorna `(user_id = $1 OR user_id IS NULL)` — inclui sistema
- `mapCategory` expõe `type` e `system`; `userId: null` para categorias de sistema
- `createCategoryForUser` aceita `type` opcional
- `update`/`delete`/`restore` adicionam `AND system IS NOT TRUE` — sistema não é mutável pelo usuário

### `transactions-import.service.js`
- `normalizedRows` persistidos com campo `line` (para matching de overrides)
- `commitTransactionsImportForUser(userId, importId, categoryOverrides = [])` aplica overrides `[{line, categoryId}]` antes do INSERT

### `transactions.routes.js`
- Passa `categoryOverrides` do body para o serviço

### `categories.service.ts` (web)
- `CategoryItem` ganha `type` e `system`, `userId` vira `number | null`
- `isValidCategoryItem` não exige `userId > 0` (categorias de sistema têm `userId: null`)
- `createCategory` aceita `type` opcional

### `transactions.service.ts` (web)
- `commitImportCsv(importId, categoryOverrides?)` — segundo parâmetro opcional

### `ImportCsvModal.jsx`
- Carrega categorias no `isOpen` (`categoriesService.listCategories()`)
- Coluna Categoria no preview: `<select>` com todas as opções (sistema + próprias do usuário)
- Botão `+` por linha → mini-form inline → `POST /categories` → auto-seleciona a nova categoria → fecha form
- Estado `categoryOverrides: Record<line, categoryId>` → enviado no commit

## Testes

**API: 606/606 passando**
- 3 testes de categorias atualizados: assertions agora filtram `!c.system` para verificar categorias do usuário (o total da lista cresceu com as 17 categorias de sistema)

**Web:** falhas pré-existentes em main não relacionadas. Modal validado por inspeção.

## UX antes/depois

**Antes:** coluna Categoria mostrava "Sem categoria" / badge "Revisar" em quase todas as linhas, sem forma de corrigir antes do import.

**Depois:** coluna Categoria mostra `<select>` com 17 opções padrão. Usuário escolhe categoria, confirma com "Importar" — transação entra categorizada. Pode também criar categoria nova inline ("+ → 'Farmácia pessoal' → OK") sem sair do modal.