### PR TITLE
feat(categories): system categories, type field and import category override

### DIFF
--- a/apps/api/src/categories.test.js
+++ b/apps/api/src/categories.test.js
@@ -80,16 +80,14 @@ describe("categories", () => {
 
     expect(listResponse.status).toBe(200);
     expect(Array.isArray(listResponse.body)).toBe(true);
-    expect(listResponse.body).toHaveLength(2);
-    expect(listResponse.body.map((category) => category.name)).toEqual([
-      "Alimentacao",
-      "Transporte",
-    ]);
-    expect(listResponse.body.map((category) => category.normalizedName)).toEqual([
-      "alimentacao",
-      "transporte",
-    ]);
-    expect(listResponse.body.every((category) => category.deletedAt === null)).toBe(true);
+    // System categories are also returned; filter to check only user-created ones
+    const userCategories = listResponse.body.filter((c) => !c.system);
+    expect(userCategories).toHaveLength(2);
+    expect(userCategories.map((c) => c.name)).toEqual(["Alimentacao", "Transporte"]);
+    expect(userCategories.map((c) => c.normalizedName)).toEqual(["alimentacao", "transporte"]);
+    expect(userCategories.every((c) => c.deletedAt === null)).toBe(true);
+    // System categories are present and have system=true
+    expect(listResponse.body.some((c) => c.system === true)).toBe(true);
   });
 
   it("POST /categories bloqueia nome vazio", async () => {
@@ -174,12 +172,14 @@ describe("categories", () => {
       .set("Authorization", `Bearer ${tokenUserB}`);
 
     expect(listUserAResponse.status).toBe(200);
-    expect(listUserAResponse.body).toHaveLength(1);
-    expect(listUserAResponse.body[0].name).toBe("Lazer");
+    const userAOwn = listUserAResponse.body.filter((c) => !c.system);
+    expect(userAOwn).toHaveLength(1);
+    expect(userAOwn[0].name).toBe("Lazer");
 
     expect(listUserBResponse.status).toBe(200);
-    expect(listUserBResponse.body).toHaveLength(1);
-    expect(listUserBResponse.body[0].name).toBe("Transporte");
+    const userBOwn = listUserBResponse.body.filter((c) => !c.system);
+    expect(userBOwn).toHaveLength(1);
+    expect(userBOwn[0].name).toBe("Transporte");
   });
 
   it("PATCH /categories/:id renomeia categoria ativa", async () => {
@@ -244,7 +244,8 @@ describe("categories", () => {
     expect(deleteResponse.status).toBe(200);
     expect(deleteResponse.body.deletedAt).toBeTruthy();
     expect(listActiveResponse.status).toBe(200);
-    expect(listActiveResponse.body).toEqual([]);
+    // After soft-delete, user's own categories are empty (system categories still present)
+    expect(listActiveResponse.body.filter((c) => !c.system)).toEqual([]);
 
     expect(recreateResponse.status).toBe(201);
     expect(recreateResponse.body.name).toBe("Mercado");
@@ -252,11 +253,12 @@ describe("categories", () => {
     expect(recreateResponse.body.id).not.toBe(createResponse.body.id);
 
     expect(listWithDeletedResponse.status).toBe(200);
-    expect(listWithDeletedResponse.body).toHaveLength(2);
-    expect(listWithDeletedResponse.body[0].id).toBe(recreateResponse.body.id);
-    expect(listWithDeletedResponse.body[0].deletedAt).toBeNull();
-    expect(listWithDeletedResponse.body[1].id).toBe(createResponse.body.id);
-    expect(listWithDeletedResponse.body[1].deletedAt).toBeTruthy();
+    const userRows = listWithDeletedResponse.body.filter((c) => !c.system);
+    expect(userRows).toHaveLength(2);
+    expect(userRows[0].id).toBe(recreateResponse.body.id);
+    expect(userRows[0].deletedAt).toBeNull();
+    expect(userRows[1].id).toBe(createResponse.body.id);
+    expect(userRows[1].deletedAt).toBeTruthy();
   });
 
   it("POST /categories/:id/restore restaura categoria sem conflito", async () => {

--- a/apps/api/src/db/migrations/033_upgrade_categories_system.sql
+++ b/apps/api/src/db/migrations/033_upgrade_categories_system.sql
@@ -1,0 +1,41 @@
+-- Make user_id nullable so system (shared) categories have NULL user_id
+ALTER TABLE categories ALTER COLUMN user_id DROP NOT NULL;
+
+-- Add type column: 'income' | 'expense' (NULL = uncategorized / user decides)
+ALTER TABLE categories
+ADD COLUMN IF NOT EXISTS type TEXT;
+
+-- Add system flag: TRUE for seed categories shipped with the platform
+ALTER TABLE categories
+ADD COLUMN IF NOT EXISTS system BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Add partial unique index for system categories (user_id IS NULL)
+-- The existing idx_categories_user_normalized_active_unique handles user rows fine
+-- because NULL != NULL in Postgres indexes (so system rows don't conflict with it).
+-- We need a separate index to prevent duplicate system category names.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_categories_system_normalized_unique
+  ON categories (normalized_name)
+  WHERE user_id IS NULL AND deleted_at IS NULL;
+
+-- System categories — income
+INSERT INTO categories (user_id, name, normalized_name, type, system) VALUES
+  (NULL, 'Salário CLT',       'salario clt',       'income',  TRUE),
+  (NULL, 'Benefício INSS',    'beneficio inss',     'income',  TRUE),
+  (NULL, 'Freelancer',        'freelancer',         'income',  TRUE),
+  (NULL, '13º Salário',       '13o salario',        'income',  TRUE),
+  (NULL, 'Reembolso',         'reembolso',          'income',  TRUE);
+
+-- System categories — expense
+INSERT INTO categories (user_id, name, normalized_name, type, system) VALUES
+  (NULL, 'Moradia',           'moradia',            'expense', TRUE),
+  (NULL, 'Energia',           'energia',            'expense', TRUE),
+  (NULL, 'Água',              'agua',               'expense', TRUE),
+  (NULL, 'Gás',               'gas',                'expense', TRUE),
+  (NULL, 'Internet',          'internet',           'expense', TRUE),
+  (NULL, 'Mercado',           'mercado',            'expense', TRUE),
+  (NULL, 'Farmácia',          'farmacia',           'expense', TRUE),
+  (NULL, 'Transporte',        'transporte',         'expense', TRUE),
+  (NULL, 'Saúde',             'saude',              'expense', TRUE),
+  (NULL, 'Educação',          'educacao',           'expense', TRUE),
+  (NULL, 'Empréstimos',       'emprestimos',        'expense', TRUE),
+  (NULL, 'Lazer',             'lazer',              'expense', TRUE);

--- a/apps/api/src/routes/transactions.routes.js
+++ b/apps/api/src/routes/transactions.routes.js
@@ -358,9 +358,13 @@ router.post("/import/commit", importRateLimiter, requireFeature("csv_import"), a
   trackCommitAttemptMetrics();
 
   try {
+    const categoryOverrides = Array.isArray(req.body?.categoryOverrides)
+      ? req.body.categoryOverrides
+      : [];
     const commitResult = await commitTransactionsImportForUser(
       req.user.id,
       req.body?.importId,
+      categoryOverrides,
     );
     const observability = commitResult.observability || {};
     const rowsTotal = Number(observability.totalRows) || Number(commitResult.imported) || 0;

--- a/apps/api/src/services/categories.service.js
+++ b/apps/api/src/services/categories.service.js
@@ -66,12 +66,16 @@ const toISOStringOrNull = (value) => {
 
 const mapCategory = (row) => ({
   id: Number(row.id),
-  userId: Number(row.user_id),
+  userId: row.user_id != null ? Number(row.user_id) : null,
   name: row.name,
   normalizedName: row.normalized_name,
+  type: row.type ?? null,
+  system: Boolean(row.system),
   deletedAt: toISOStringOrNull(row.deleted_at),
   createdAt: toISOStringOrNull(row.created_at),
 });
+
+const isSystemCategory = (row) => Boolean(row.system);
 
 const normalizeIncludeDeleted = (value) => String(value || "").toLowerCase() === "true";
 
@@ -81,19 +85,26 @@ const throwIfUniqueConstraintError = (error) => {
   }
 };
 
+const normalizeType = (value) => {
+  if (typeof value === "undefined") return undefined;
+  if (value === "income" || value === "expense") return value;
+  return null;
+};
+
 export const createCategoryForUser = async (userId, payload = {}) => {
   const normalizedUserId = normalizeUserId(userId);
   const name = normalizeCategoryName(payload.name);
   const normalizedName = normalizeCategoryNameKey(name);
+  const type = normalizeType(payload.type);
 
   try {
     const result = await dbQuery(
       `
-        INSERT INTO categories (user_id, name, normalized_name)
-        VALUES ($1, $2, $3)
-        RETURNING id, user_id, name, normalized_name, deleted_at, created_at
+        INSERT INTO categories (user_id, name, normalized_name, type)
+        VALUES ($1, $2, $3, $4)
+        RETURNING id, user_id, name, normalized_name, type, system, deleted_at, created_at
       `,
-      [normalizedUserId, name, normalizedName],
+      [normalizedUserId, name, normalizedName, type ?? null],
     );
 
     return mapCategory(result.rows[0]);
@@ -109,12 +120,14 @@ export const listCategoriesByUser = async (userId, options = {}) => {
 
   const result = await dbQuery(
     `
-      SELECT id, user_id, name, normalized_name, deleted_at, created_at
+      SELECT id, user_id, name, normalized_name, type, system, deleted_at, created_at
       FROM categories
-      WHERE user_id = $1
+      WHERE (user_id = $1 OR user_id IS NULL)
       ${includeDeleted ? "" : "AND deleted_at IS NULL"}
       ORDER BY
         (deleted_at IS NOT NULL) ASC,
+        system DESC,
+        type ASC NULLS LAST,
         normalized_name ASC,
         id ASC
     `,
@@ -137,8 +150,9 @@ export const updateCategoryForUser = async (userId, categoryId, payload = {}) =>
         SET name = $3, normalized_name = $4
         WHERE id = $1
           AND user_id = $2
+          AND system IS NOT TRUE
           AND deleted_at IS NULL
-        RETURNING id, user_id, name, normalized_name, deleted_at, created_at
+        RETURNING id, user_id, name, normalized_name, type, system, deleted_at, created_at
       `,
       [normalizedCategoryId, normalizedUserId, name, normalizedName],
     );
@@ -164,8 +178,9 @@ export const deleteCategoryForUser = async (userId, categoryId) => {
       SET deleted_at = NOW()
       WHERE id = $1
         AND user_id = $2
+        AND system IS NOT TRUE
         AND deleted_at IS NULL
-      RETURNING id, user_id, name, normalized_name, deleted_at, created_at
+      RETURNING id, user_id, name, normalized_name, type, system, deleted_at, created_at
     `,
     [normalizedCategoryId, normalizedUserId],
   );
@@ -188,8 +203,9 @@ export const restoreCategoryForUser = async (userId, categoryId) => {
         SET deleted_at = NULL
         WHERE id = $1
           AND user_id = $2
+          AND system IS NOT TRUE
           AND deleted_at IS NOT NULL
-        RETURNING id, user_id, name, normalized_name, deleted_at, created_at
+        RETURNING id, user_id, name, normalized_name, type, system, deleted_at, created_at
       `,
       [normalizedCategoryId, normalizedUserId],
     );

--- a/apps/api/src/services/transactions-import.service.js
+++ b/apps/api/src/services/transactions-import.service.js
@@ -689,7 +689,7 @@ export const dryRunTransactionsImportForUser = async (userId, importFile) => {
 
   const normalizedRows = rows
     .filter((row) => row.status === "valid" && row.normalized)
-    .map((row) => ({ ...row.normalized, fingerprint: row.fingerprint }));
+    .map((row) => ({ ...row.normalized, fingerprint: row.fingerprint, line: row.line }));
 
   const persistedSession = await persistImportSession(userId, {
     normalizedRows,
@@ -777,7 +777,23 @@ export const getTransactionsImportMetricsByUser = async (userId) => {
   };
 };
 
-export const commitTransactionsImportForUser = async (userId, importId) => {
+const buildCategoryOverrideMap = (overrides) => {
+  if (!Array.isArray(overrides) || overrides.length === 0) return new Map();
+  return new Map(
+    overrides
+      .filter(
+        (o) =>
+          o != null &&
+          typeof o.line === "number" &&
+          Number.isInteger(o.line) &&
+          o.line > 0 &&
+          (o.categoryId === null || (Number.isInteger(o.categoryId) && o.categoryId > 0)),
+      )
+      .map((o) => [o.line, o.categoryId ?? null]),
+  );
+};
+
+export const commitTransactionsImportForUser = async (userId, importId, categoryOverrides = []) => {
   const normalizedImportId = normalizeImportId(importId);
   const importSession = await loadImportSessionById(normalizedImportId);
 
@@ -787,9 +803,15 @@ export const commitTransactionsImportForUser = async (userId, importId) => {
     typeof importSession.payload_json === "string"
       ? JSON.parse(importSession.payload_json)
       : importSession.payload_json || {};
-  const normalizedRows = Array.isArray(payload.normalizedRows)
-    ? payload.normalizedRows
-    : [];
+  const sessionRows = Array.isArray(payload.normalizedRows) ? payload.normalizedRows : [];
+  const overrideMap = buildCategoryOverrideMap(categoryOverrides);
+  const normalizedRows = overrideMap.size === 0
+    ? sessionRows
+    : sessionRows.map((row) =>
+        overrideMap.has(row.line)
+          ? { ...row, categoryId: overrideMap.get(row.line) }
+          : row,
+      );
   const payloadSummary = payload.summary || {};
   const observabilitySummary = {
     totalRows: normalizeSummaryInteger(payloadSummary.totalRows, normalizedRows.length),

--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { transactionsService } from "../services/transactions.service";
 import { profileService } from "../services/profile.service";
+import { categoriesService } from "../services/categories.service";
 import { formatCurrency } from "../utils/formatCurrency";
 import { getApiErrorMessage } from "../utils/apiError";
 
@@ -16,6 +17,13 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
   const [showProfileConfirm, setShowProfileConfirm] = useState(false);
   const [isApplyingProfile, setIsApplyingProfile] = useState(false);
   const [profileApplied, setProfileApplied] = useState(false);
+  const [categories, setCategories] = useState([]);
+  // categoryOverrides: Record<line, categoryId | null>
+  const [categoryOverrides, setCategoryOverrides] = useState({});
+  // inlineCreate: { line, type } | null — which row's inline form is open
+  const [inlineCreate, setInlineCreate] = useState(null);
+  const [inlineCreateName, setInlineCreateName] = useState("");
+  const [isCreatingCategory, setIsCreatingCategory] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
@@ -31,6 +39,9 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
     setShowProfileConfirm(false);
     setIsApplyingProfile(false);
     setProfileApplied(false);
+    setCategoryOverrides({});
+    setInlineCreate(null);
+    setInlineCreateName("");
   }, [isOpen]);
 
   useEffect(() => {
@@ -55,6 +66,11 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
       window.removeEventListener("keydown", handleEscapeKey);
     };
   }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    categoriesService.listCategories().then(setCategories).catch(() => {});
+  }, [isOpen]);
 
   const hasValidRows = useMemo(() => {
     return (dryRunResult?.summary?.validRows || 0) > 0;
@@ -140,6 +156,27 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
     }
   };
 
+  const handleInlineCreateCategory = useCallback(
+    async (line, rowType) => {
+      const trimmedName = inlineCreateName.trim();
+      if (!trimmedName) return;
+      setIsCreatingCategory(true);
+      try {
+        const inferredType = rowType === "Entrada" ? "income" : rowType === "Saida" ? "expense" : undefined;
+        const created = await categoriesService.createCategory(trimmedName, inferredType);
+        setCategories((prev) => [...prev, created]);
+        setCategoryOverrides((prev) => ({ ...prev, [line]: created.id }));
+        setInlineCreate(null);
+        setInlineCreateName("");
+      } catch {
+        // silently fail — user can try again
+      } finally {
+        setIsCreatingCategory(false);
+      }
+    },
+    [inlineCreateName],
+  );
+
   const handleDryRun = async () => {
     if (!selectedFile) {
       setErrorMessage("Selecione um arquivo CSV, OFX ou PDF.");
@@ -178,7 +215,11 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
     setSuccessMessage("");
 
     try {
-      const commitResult = await transactionsService.commitImportCsv(dryRunResult.importId);
+      const overridesArray = Object.entries(categoryOverrides).map(([line, categoryId]) => ({
+        line: Number(line),
+        categoryId: categoryId ?? null,
+      }));
+      const commitResult = await transactionsService.commitImportCsv(dryRunResult.importId, overridesArray);
 
       if (onImported) {
         await onImported(commitResult);
@@ -258,6 +299,9 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
               setSuccessMessage("");
               setProfileApplied(false);
               setShowProfileConfirm(false);
+              setCategoryOverrides({});
+              setInlineCreate(null);
+              setInlineCreateName("");
             }}
             className="block w-full text-sm text-cf-text-primary file:mr-3 file:rounded file:border file:border-cf-border file:bg-cf-bg-subtle file:px-3 file:py-1 file:text-sm file:font-semibold file:text-cf-text-primary hover:file:bg-cf-border"
           />
@@ -472,16 +516,76 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
                           {row.raw.value || "-"}
                         </td>
                         <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">{row.raw.date || "-"}</td>
-                        <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
-                          {row.raw.category ? (
-                            row.raw.category
-                          ) : row.status === "valid" ? (
-                            <span className="inline-flex items-center gap-1.5">
-                              <span className="rounded border border-amber-300 bg-amber-50 px-1.5 py-0.5 text-xs font-medium text-amber-700">
-                                Revisar
-                              </span>
-                              <span className="text-cf-text-secondary">Sem categoria</span>
-                            </span>
+                        <td className="border-b border-cf-border px-2 py-2">
+                          {row.status === "valid" ? (
+                            <div className="space-y-1">
+                              <div className="flex items-center gap-1">
+                                <select
+                                  aria-label={`Categoria da linha ${row.line}`}
+                                  value={
+                                    categoryOverrides[row.line] !== undefined
+                                      ? categoryOverrides[row.line] ?? ""
+                                      : row.normalized?.categoryId ?? ""
+                                  }
+                                  onChange={(e) => {
+                                    const val = e.target.value === "" ? null : Number(e.target.value);
+                                    setCategoryOverrides((prev) => ({ ...prev, [row.line]: val }));
+                                  }}
+                                  className="rounded border border-cf-border bg-cf-surface px-1 py-0.5 text-xs text-cf-text-primary"
+                                >
+                                  <option value="">— Sem categoria —</option>
+                                  {categories.map((cat) => (
+                                    <option key={cat.id} value={cat.id}>{cat.name}</option>
+                                  ))}
+                                </select>
+                                {inlineCreate?.line !== row.line && (
+                                  <button
+                                    type="button"
+                                    title="Nova categoria"
+                                    onClick={() => { setInlineCreate({ line: row.line, type: row.raw.type }); setInlineCreateName(""); }}
+                                    className="rounded border border-cf-border px-1 py-0.5 text-xs text-cf-text-secondary hover:bg-cf-bg-subtle"
+                                  >
+                                    +
+                                  </button>
+                                )}
+                              </div>
+                              {inlineCreate?.line === row.line && (
+                                <div className="flex items-center gap-1">
+                                  <input
+                                    type="text"
+                                    value={inlineCreateName}
+                                    onChange={(e) => setInlineCreateName(e.target.value)}
+                                    onKeyDown={(e) => { if (e.key === "Enter") handleInlineCreateCategory(row.line, row.raw.type); if (e.key === "Escape") setInlineCreate(null); }}
+                                    placeholder="Nova categoria"
+                                    className="rounded border border-cf-border bg-cf-surface px-1 py-0.5 text-xs text-cf-text-primary"
+                                    // eslint-disable-next-line jsx-a11y/no-autofocus
+                                    autoFocus
+                                  />
+                                  <button
+                                    type="button"
+                                    disabled={isCreatingCategory}
+                                    onClick={() => handleInlineCreateCategory(row.line, row.raw.type)}
+                                    className="rounded border border-brand-1 bg-brand-1 px-1.5 py-0.5 text-xs text-white disabled:opacity-60"
+                                  >
+                                    OK
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={() => setInlineCreate(null)}
+                                    className="rounded border border-cf-border px-1.5 py-0.5 text-xs text-cf-text-secondary"
+                                  >
+                                    ✕
+                                  </button>
+                                </div>
+                              )}
+                              {!categoryOverrides[row.line] && !row.normalized?.categoryId && inlineCreate?.line !== row.line && (
+                                <span className="inline-flex items-center gap-1.5">
+                                  <span className="rounded border border-amber-300 bg-amber-50 px-1.5 py-0.5 text-xs font-medium text-amber-700">
+                                    Revisar
+                                  </span>
+                                </span>
+                              )}
+                            </div>
                           ) : (
                             "—"
                           )}

--- a/apps/web/src/services/categories.service.ts
+++ b/apps/web/src/services/categories.service.ts
@@ -2,9 +2,11 @@ import { api } from "./api";
 
 export interface CategoryItem {
   id: number;
-  userId: number;
+  userId: number | null;
   name: string;
   normalizedName: string;
+  type: "income" | "expense" | null;
+  system: boolean;
   deletedAt: string | null;
   createdAt: string | null;
 }
@@ -43,21 +45,27 @@ const normalizeCategoryItem = (payload: CategoryApiPayload): CategoryItem => {
         ? payload.normalized_name.trim()
         : "";
 
+  const rawType = payload?.type;
+  const type: "income" | "expense" | null =
+    rawType === "income" || rawType === "expense" ? rawType : null;
+
   return {
     id: Number.isInteger(normalizedId) && normalizedId > 0 ? normalizedId : 0,
     userId:
       Number.isInteger(normalizedUserId) && normalizedUserId > 0
         ? normalizedUserId
-        : 0,
+        : null,
     name: normalizedName,
     normalizedName: normalizedKey,
+    type,
+    system: Boolean(payload?.system),
     deletedAt: normalizeIsoStringOrNull(payload?.deletedAt ?? payload?.deleted_at),
     createdAt: normalizeIsoStringOrNull(payload?.createdAt ?? payload?.created_at),
   };
 };
 
 const isValidCategoryItem = (item: CategoryItem): boolean =>
-  item.id > 0 && item.userId > 0 && Boolean(item.name);
+  item.id > 0 && Boolean(item.name);
 
 export const categoriesService = {
   listCategories: async (includeDeleted = false): Promise<CategoryItem[]> => {
@@ -73,8 +81,8 @@ export const categoriesService = {
       .filter(isValidCategoryItem);
   },
 
-  createCategory: async (name: string): Promise<CategoryItem> => {
-    const { data } = await api.post("/categories", { name });
+  createCategory: async (name: string, type?: "income" | "expense"): Promise<CategoryItem> => {
+    const { data } = await api.post("/categories", { name, type });
     return normalizeCategoryItem(data as CategoryApiPayload);
   },
 

--- a/apps/web/src/services/transactions.service.ts
+++ b/apps/web/src/services/transactions.service.ts
@@ -721,8 +721,11 @@ export const transactionsService = {
       rows,
     };
   },
-  commitImportCsv: async (importId: string): Promise<ImportCommitResult> => {
-    const { data } = await api.post("/transactions/import/commit", { importId });
+  commitImportCsv: async (
+    importId: string,
+    categoryOverrides: { line: number; categoryId: number | null }[] = [],
+  ): Promise<ImportCommitResult> => {
+    const { data } = await api.post("/transactions/import/commit", { importId, categoryOverrides });
     const responseBody = data as ImportCommitApiResponse;
 
     return {


### PR DESCRIPTION
## Summary
- Adds system categories seeded at migration time
- Adds category `type` field (income/expense) for better classification
- Allows import flow to override/suggest category during CSV import

## Test plan
- [ ] System categories present after migration
- [ ] Category type filters correctly in transaction views
- [ ] Import modal correctly maps categories from dry-run response