### PR TITLE
feat(import): undo import session + bulk delete transactions (PR 5.5)

### DIFF
--- a/apps/api/src/db/migrations/034_add_import_metadata_to_transactions.sql
+++ b/apps/api/src/db/migrations/034_add_import_metadata_to_transactions.sql
@@ -1,0 +1,10 @@
+-- Track which import session each transaction came from, enabling bulk undo
+ALTER TABLE transactions ADD COLUMN IF NOT EXISTS import_session_id TEXT;
+ALTER TABLE transactions ADD COLUMN IF NOT EXISTS imported_at TIMESTAMPTZ;
+ALTER TABLE transactions ADD COLUMN IF NOT EXISTS import_file_name TEXT;
+ALTER TABLE transactions ADD COLUMN IF NOT EXISTS import_document_type TEXT;
+
+-- Index to quickly find all transactions from one import session
+CREATE INDEX IF NOT EXISTS idx_transactions_user_import_session
+  ON transactions (user_id, import_session_id)
+  WHERE import_session_id IS NOT NULL AND deleted_at IS NULL;

--- a/apps/api/src/import.test.js
+++ b/apps/api/src/import.test.js
@@ -850,7 +850,7 @@ describe("transaction imports", () => {
       });
 
     expect(commitResponse.status).toBe(200);
-    expect(commitResponse.body).toEqual({
+    expect(commitResponse.body).toMatchObject({
       imported: 2,
       summary: {
         income: 1000,
@@ -858,6 +858,7 @@ describe("transaction imports", () => {
         balance: 779.5,
       },
     });
+    expect(typeof commitResponse.body.importSessionId).toBe("string");
 
     const listResponse = await request(app)
       .get("/transactions")
@@ -1115,5 +1116,191 @@ describe("transaction imports", () => {
 
     expect(response.status).toBe(200);
     expect(response.body.documentType).toBe("bank_statement");
+  });
+
+  it("POST /transactions/import/commit retorna importSessionId", async () => {
+    const token = await registerAndLogin("import-session-id@controlfinance.dev");
+    await makeProUser("import-session-id@controlfinance.dev");
+
+    const csv = csvFile("date,type,value,description\n2026-03-01,Entrada,500,Teste sessao");
+
+    const dryRunResponse = await request(app)
+      .post("/transactions/import/dry-run")
+      .set("Authorization", `Bearer ${token}`)
+      .attach("file", csv.buffer, { filename: csv.fileName, contentType: "text/csv" });
+
+    expect(dryRunResponse.status).toBe(200);
+
+    const commitResponse = await request(app)
+      .post("/transactions/import/commit")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ importId: dryRunResponse.body.importId });
+
+    expect(commitResponse.status).toBe(200);
+    expect(typeof commitResponse.body.importSessionId).toBe("string");
+    expect(commitResponse.body.importSessionId).toBe(dryRunResponse.body.importId);
+    expect(commitResponse.body.imported).toBe(1);
+  });
+
+  it("DELETE /transactions/imports/:sessionId desfaz importacao por sessao", async () => {
+    const token = await registerAndLogin("import-undo@controlfinance.dev");
+    await makeProUser("import-undo@controlfinance.dev");
+
+    const csv = csvFile(
+      "date,type,value,description\n2026-03-01,Entrada,100,Transacao A\n2026-03-02,Saida,50,Transacao B",
+    );
+
+    const dryRunResponse = await request(app)
+      .post("/transactions/import/dry-run")
+      .set("Authorization", `Bearer ${token}`)
+      .attach("file", csv.buffer, { filename: csv.fileName, contentType: "text/csv" });
+
+    expect(dryRunResponse.status).toBe(200);
+
+    const commitResponse = await request(app)
+      .post("/transactions/import/commit")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ importId: dryRunResponse.body.importId });
+
+    expect(commitResponse.status).toBe(200);
+    expect(commitResponse.body.imported).toBe(2);
+
+    const sessionId = commitResponse.body.importSessionId;
+
+    const undoResponse = await request(app)
+      .delete(`/transactions/imports/${sessionId}`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(undoResponse.status).toBe(200);
+    expect(undoResponse.body.importSessionId).toBe(sessionId);
+    expect(undoResponse.body.deletedCount).toBe(2);
+    expect(undoResponse.body.success).toBe(true);
+
+    // Transacoes devem estar soft-deleted (GET retorna zero)
+    const listResponse = await request(app)
+      .get("/transactions")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.data).toHaveLength(0);
+  });
+
+  it("DELETE /transactions/imports/:sessionId retorna 404 para sessao de outro usuario", async () => {
+    const tokenA = await registerAndLogin("import-undo-owner-a@controlfinance.dev");
+    const tokenB = await registerAndLogin("import-undo-owner-b@controlfinance.dev");
+    await makeProUser("import-undo-owner-a@controlfinance.dev");
+
+    const csv = csvFile("date,type,value,description\n2026-03-01,Entrada,100,Teste");
+
+    const dryRunResponse = await request(app)
+      .post("/transactions/import/dry-run")
+      .set("Authorization", `Bearer ${tokenA}`)
+      .attach("file", csv.buffer, { filename: csv.fileName, contentType: "text/csv" });
+
+    const commitResponse = await request(app)
+      .post("/transactions/import/commit")
+      .set("Authorization", `Bearer ${tokenA}`)
+      .send({ importId: dryRunResponse.body.importId });
+
+    const sessionId = commitResponse.body.importSessionId;
+
+    const undoResponse = await request(app)
+      .delete(`/transactions/imports/${sessionId}`)
+      .set("Authorization", `Bearer ${tokenB}`);
+
+    expectErrorResponseWithRequestId(undoResponse, 404, "Sessao de importacao nao encontrada.");
+  });
+
+  it("DELETE /transactions/imports/:sessionId bloqueia sem token", async () => {
+    const response = await request(app).delete(
+      "/transactions/imports/00000000-0000-4000-8000-000000000000",
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("POST /transactions/bulk-delete exclui transacoes selecionadas", async () => {
+    const token = await registerAndLogin("bulk-delete@controlfinance.dev");
+
+    const t1 = await request(app)
+      .post("/transactions")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ type: "Entrada", value: 100, date: "2026-03-01", description: "T1" });
+    const t2 = await request(app)
+      .post("/transactions")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ type: "Entrada", value: 200, date: "2026-03-02", description: "T2" });
+    const t3 = await request(app)
+      .post("/transactions")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ type: "Saida", value: 50, date: "2026-03-03", description: "T3" });
+
+    expect(t1.status).toBe(201);
+    expect(t2.status).toBe(201);
+    expect(t3.status).toBe(201);
+
+    const bulkResponse = await request(app)
+      .post("/transactions/bulk-delete")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionIds: [t1.body.id, t2.body.id] });
+
+    expect(bulkResponse.status).toBe(200);
+    expect(bulkResponse.body.deletedCount).toBe(2);
+    expect(bulkResponse.body.success).toBe(true);
+
+    const listResponse = await request(app)
+      .get("/transactions")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.data).toHaveLength(1);
+    expect(listResponse.body.data[0].id).toBe(t3.body.id);
+  });
+
+  it("POST /transactions/bulk-delete nao exclui transacoes de outro usuario", async () => {
+    const tokenA = await registerAndLogin("bulk-delete-owner-a@controlfinance.dev");
+    const tokenB = await registerAndLogin("bulk-delete-owner-b@controlfinance.dev");
+
+    const tx = await request(app)
+      .post("/transactions")
+      .set("Authorization", `Bearer ${tokenA}`)
+      .send({ type: "Entrada", value: 100, date: "2026-03-01", description: "De A" });
+
+    expect(tx.status).toBe(201);
+
+    const bulkResponse = await request(app)
+      .post("/transactions/bulk-delete")
+      .set("Authorization", `Bearer ${tokenB}`)
+      .send({ transactionIds: [tx.body.id] });
+
+    expect(bulkResponse.status).toBe(200);
+    expect(bulkResponse.body.deletedCount).toBe(0);
+
+    const listResponse = await request(app)
+      .get("/transactions")
+      .set("Authorization", `Bearer ${tokenA}`);
+
+    expect(listResponse.body.data).toHaveLength(1);
+  });
+
+  it("POST /transactions/bulk-delete retorna deletedCount 0 para lista vazia", async () => {
+    const token = await registerAndLogin("bulk-delete-empty@controlfinance.dev");
+
+    const response = await request(app)
+      .post("/transactions/bulk-delete")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionIds: [] });
+
+    expect(response.status).toBe(200);
+    expect(response.body.deletedCount).toBe(0);
+    expect(response.body.success).toBe(true);
+  });
+
+  it("POST /transactions/bulk-delete bloqueia sem token", async () => {
+    const response = await request(app)
+      .post("/transactions/bulk-delete")
+      .send({ transactionIds: [1] });
+
+    expect(response.status).toBe(401);
   });
 });

--- a/apps/api/src/routes/transactions.routes.js
+++ b/apps/api/src/routes/transactions.routes.js
@@ -25,7 +25,9 @@ import {
   updateTransactionForUser,
 } from "../services/transactions.service.js";
 import {
+  bulkDeleteTransactionsForUser,
   commitTransactionsImportForUser,
+  deleteImportSessionForUser,
   dryRunTransactionsImportForUser,
   getTransactionsImportMetricsByUser,
   listTransactionsImportSessionsByUser,
@@ -249,6 +251,25 @@ router.post("/", transactionsWriteRateLimiter, async (req, res, next) => {
   }
 });
 
+router.delete("/imports/:sessionId", transactionsWriteRateLimiter, async (req, res, next) => {
+  try {
+    const result = await deleteImportSessionForUser(req.user.id, req.params.sessionId);
+    res.status(200).json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post("/bulk-delete", transactionsWriteRateLimiter, async (req, res, next) => {
+  try {
+    const ids = Array.isArray(req.body?.transactionIds) ? req.body.transactionIds : [];
+    const result = await bulkDeleteTransactionsForUser(req.user.id, ids);
+    res.status(200).json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
 router.patch("/:id", transactionsWriteRateLimiter, async (req, res, next) => {
   try {
     const updatedTransaction = await updateTransactionForUser(
@@ -386,6 +407,7 @@ router.post("/import/commit", importRateLimiter, requireFeature("csv_import"), a
 
     res.status(200).json({
       imported: commitResult.imported,
+      importSessionId: commitResult.importSessionId,
       summary: commitResult.summary,
     });
   } catch (error) {

--- a/apps/api/src/services/transactions-import.service.js
+++ b/apps/api/src/services/transactions-import.service.js
@@ -694,6 +694,8 @@ export const dryRunTransactionsImportForUser = async (userId, importFile) => {
   const persistedSession = await persistImportSession(userId, {
     normalizedRows,
     summary,
+    fileName: importFile?.originalname || null,
+    documentType,
   });
 
   return {
@@ -813,6 +815,8 @@ export const commitTransactionsImportForUser = async (userId, importId, category
           : row,
       );
   const payloadSummary = payload.summary || {};
+  const importFileName = payload.fileName || null;
+  const importDocumentType = payload.documentType || null;
   const observabilitySummary = {
     totalRows: normalizeSummaryInteger(payloadSummary.totalRows, normalizedRows.length),
     validRows: normalizeSummaryInteger(payloadSummary.validRows, normalizedRows.length),
@@ -851,8 +855,8 @@ export const commitTransactionsImportForUser = async (userId, importId, category
 
     const insertValuesPlaceholders = normalizedRows
       .map((_, rowIndex) => {
-        const startParameter = rowIndex * 7 + 2;
-        return `($1, $${startParameter}, $${startParameter + 1}, $${startParameter + 2}::date, $${startParameter + 3}, $${startParameter + 4}, $${startParameter + 5}, $${startParameter + 6})`;
+        const p = rowIndex * 10 + 2;
+        return `($1, $${p}, $${p + 1}, $${p + 2}::date, $${p + 3}, $${p + 4}, $${p + 5}, $${p + 6}, $${p + 7}, NOW(), $${p + 8}, $${p + 9})`;
       })
       .join(", ");
 
@@ -867,12 +871,15 @@ export const commitTransactionsImportForUser = async (userId, importId, category
         row.notes || "",
         row.categoryId,
         row.fingerprint || null,
+        normalizedImportId,
+        importFileName,
+        importDocumentType,
       );
     });
 
     const insertResult = await transactionClient.query(
       `
-        INSERT INTO transactions (user_id, type, value, date, description, notes, category_id, import_fingerprint)
+        INSERT INTO transactions (user_id, type, value, date, description, notes, category_id, import_fingerprint, import_session_id, imported_at, import_file_name, import_document_type)
         VALUES ${insertValuesPlaceholders}
         RETURNING type, value
       `,
@@ -904,6 +911,7 @@ export const commitTransactionsImportForUser = async (userId, importId, category
 
   return {
     imported: commitOutcome.imported,
+    importSessionId: normalizedImportId,
     summary: {
       income: commitOutcome.income,
       expense: commitOutcome.expense,
@@ -916,4 +924,48 @@ export const commitTransactionsImportForUser = async (userId, importId, category
       invalidRows: observabilitySummary.invalidRows,
     },
   };
+};
+
+export const deleteImportSessionForUser = async (userId, sessionId) => {
+  const normalizedSessionId = normalizeImportId(sessionId);
+
+  const result = await withDbTransaction(async (transactionClient) => {
+    const sessionResult = await transactionClient.query(
+      `SELECT id, user_id FROM transaction_import_sessions WHERE id = $1 LIMIT 1`,
+      [normalizedSessionId],
+    );
+    const session = sessionResult.rows[0] || null;
+    assertSessionOwnership(session, userId);
+
+    const deleteResult = await transactionClient.query(
+      `UPDATE transactions SET deleted_at = NOW()
+       WHERE user_id = $1 AND import_session_id = $2 AND deleted_at IS NULL`,
+      [userId, normalizedSessionId],
+    );
+
+    return { deletedCount: Number(deleteResult.rowCount || 0) };
+  });
+
+  return { importSessionId: normalizedSessionId, deletedCount: result.deletedCount, success: true };
+};
+
+export const bulkDeleteTransactionsForUser = async (userId, transactionIds) => {
+  if (!Array.isArray(transactionIds) || transactionIds.length === 0) {
+    return { deletedCount: 0, success: true };
+  }
+
+  const validIds = transactionIds.filter((id) => Number.isInteger(id) && id > 0);
+
+  if (validIds.length === 0) {
+    return { deletedCount: 0, success: true };
+  }
+
+  const placeholders = validIds.map((_, index) => `$${index + 2}`).join(", ");
+  const result = await dbQuery(
+    `UPDATE transactions SET deleted_at = NOW()
+     WHERE user_id = $1 AND id IN (${placeholders}) AND deleted_at IS NULL`,
+    [userId, ...validIds],
+  );
+
+  return { deletedCount: Number(result.rowCount || 0), success: true };
 };

--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -24,6 +24,9 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
   const [inlineCreate, setInlineCreate] = useState(null);
   const [inlineCreateName, setInlineCreateName] = useState("");
   const [isCreatingCategory, setIsCreatingCategory] = useState(false);
+  // post-commit state
+  const [lastCommitResult, setLastCommitResult] = useState(null);
+  const [isUndoing, setIsUndoing] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
@@ -42,6 +45,8 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
     setCategoryOverrides({});
     setInlineCreate(null);
     setInlineCreateName("");
+    setLastCommitResult(null);
+    setIsUndoing(false);
   }, [isOpen]);
 
   useEffect(() => {
@@ -220,13 +225,7 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
         categoryId: categoryId ?? null,
       }));
       const commitResult = await transactionsService.commitImportCsv(dryRunResult.importId, overridesArray);
-
-      if (onImported) {
-        await onImported(commitResult);
-        return;
-      }
-
-      setSuccessMessage(`Importação concluída com sucesso (${commitResult.imported} linhas).`);
+      setLastCommitResult(commitResult);
     } catch (error) {
       const apiMessage = getApiErrorMessage(error, "Não foi possível confirmar a importação.");
       setErrorMessage(
@@ -236,6 +235,25 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
       );
     } finally {
       setIsCommitting(false);
+    }
+  };
+
+  const handleCloseAfterCommit = async () => {
+    if (onImported) await onImported(lastCommitResult);
+    else onClose();
+  };
+
+  const handleUndo = async () => {
+    if (!lastCommitResult?.importSessionId) return;
+    setIsUndoing(true);
+    setErrorMessage("");
+    try {
+      await transactionsService.deleteImportSession(lastCommitResult.importSessionId);
+      if (onImported) await onImported(null);
+      else onClose();
+    } catch (error) {
+      setErrorMessage(getApiErrorMessage(error, "Não foi possível desfazer a importação."));
+      setIsUndoing(false);
     }
   };
 
@@ -313,31 +331,59 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
           </p>
         </div>
 
-        <div className="mt-3 flex flex-wrap items-center gap-2">
-          <button
-            type="button"
-            onClick={handleDryRun}
-            disabled={isDryRunning || isCommitting}
-            className="rounded border border-brand-1 bg-brand-1 px-3 py-1.5 text-sm font-semibold text-white hover:bg-brand-2 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {isDryRunning ? "Processando..." : "Pré-visualizar"}
-          </button>
-          <button
-            type="button"
-            onClick={handleCommit}
-            disabled={!hasValidRows || isDryRunning || isCommitting}
-            className="rounded border border-cf-border bg-cf-surface px-3 py-1.5 text-sm font-semibold text-cf-text-primary hover:bg-cf-bg-subtle disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {isCommitting ? "Importando..." : "Importar"}
-          </button>
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-1.5 text-sm font-semibold text-cf-text-secondary"
-          >
-            Fechar
-          </button>
-        </div>
+        {lastCommitResult ? (
+          <div className="mt-3 rounded border border-green-200 bg-green-50 px-3 py-3 dark:border-green-800 dark:bg-green-950/40">
+            <p className="mb-2 text-sm font-semibold text-green-700 dark:text-green-400">
+              {lastCommitResult.imported === 1
+                ? "1 lançamento importado."
+                : `${lastCommitResult.imported} lançamentos importados.`}
+            </p>
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                onClick={handleCloseAfterCommit}
+                disabled={isUndoing}
+                className="rounded border border-green-400 bg-green-100 px-3 py-1.5 text-sm font-semibold text-green-700 hover:bg-green-200 disabled:cursor-not-allowed disabled:opacity-60 dark:border-green-700 dark:bg-green-900/40 dark:text-green-300"
+              >
+                Fechar
+              </button>
+              <button
+                type="button"
+                onClick={handleUndo}
+                disabled={isUndoing}
+                className="rounded border border-red-300 bg-red-50 px-3 py-1.5 text-sm font-semibold text-red-600 hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-red-700 dark:bg-red-950/40 dark:text-red-400"
+              >
+                {isUndoing ? "Desfazendo..." : "Desfazer importação"}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={handleDryRun}
+              disabled={isDryRunning || isCommitting}
+              className="rounded border border-brand-1 bg-brand-1 px-3 py-1.5 text-sm font-semibold text-white hover:bg-brand-2 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isDryRunning ? "Processando..." : "Pré-visualizar"}
+            </button>
+            <button
+              type="button"
+              onClick={handleCommit}
+              disabled={!hasValidRows || isDryRunning || isCommitting}
+              className="rounded border border-cf-border bg-cf-surface px-3 py-1.5 text-sm font-semibold text-cf-text-primary hover:bg-cf-bg-subtle disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isCommitting ? "Importando..." : "Importar"}
+            </button>
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-1.5 text-sm font-semibold text-cf-text-secondary"
+            >
+              Fechar
+            </button>
+          </div>
+        )}
 
         {errorMessage ? (
           <div className="mt-3 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">

--- a/apps/web/src/components/ImportCsvModal.test.jsx
+++ b/apps/web/src/components/ImportCsvModal.test.jsx
@@ -3,11 +3,20 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ImportCsvModal from "./ImportCsvModal";
 import { transactionsService } from "../services/transactions.service";
+import { categoriesService } from "../services/categories.service";
 
 vi.mock("../services/transactions.service", () => ({
   transactionsService: {
     dryRunImportCsv: vi.fn(),
     commitImportCsv: vi.fn(),
+    deleteImportSession: vi.fn(),
+  },
+}));
+
+vi.mock("../services/categories.service", () => ({
+  categoriesService: {
+    listCategories: vi.fn(),
+    createCategory: vi.fn(),
   },
 }));
 
@@ -50,6 +59,7 @@ const buildDryRunResponse = (overrides = {}) => ({
 describe("ImportCsvModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    categoriesService.listCategories.mockResolvedValue([]);
   });
 
   it("does not render when isOpen is false", () => {
@@ -86,13 +96,14 @@ describe("ImportCsvModal", () => {
     expect(invalidRowsCard).toHaveTextContent("1");
   });
 
-  it("commits import and calls onImported callback", async () => {
+  it("commits import and calls onImported callback when Fechar is clicked", async () => {
     const onImported = vi.fn();
     const file = new File(["date,type,value"], "import.csv", { type: "text/csv" });
 
     transactionsService.dryRunImportCsv.mockResolvedValueOnce(buildDryRunResponse());
     transactionsService.commitImportCsv.mockResolvedValueOnce({
       imported: 1,
+      importSessionId: "import-session-1",
       summary: { income: 100, expense: 20, balance: 80 },
     });
 
@@ -107,8 +118,17 @@ describe("ImportCsvModal", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "Importar" }));
 
+    // After commit, modal shows success state with count
     await waitFor(() => {
-      expect(transactionsService.commitImportCsv).toHaveBeenCalledWith("import-session-1");
+      expect(screen.getByText("1 lançamento importado.")).toBeInTheDocument();
+    });
+
+    // onImported not yet called — deferred until user clicks Fechar
+    expect(onImported).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole("button", { name: "Fechar" }));
+
+    await waitFor(() => {
       expect(onImported).toHaveBeenCalled();
     });
   });
@@ -154,6 +174,7 @@ describe("ImportCsvModal", () => {
 
   it("nao exibe badge Revisar quando linha valida ja tem categoria", async () => {
     const file = new File(["date,type,value"], "import.csv", { type: "text/csv" });
+    categoriesService.listCategories.mockResolvedValueOnce([{ id: 1, name: "Trabalho", normalizedName: "trabalho" }]);
     transactionsService.dryRunImportCsv.mockResolvedValueOnce(buildDryRunResponse());
 
     render(<ImportCsvModal isOpen onClose={vi.fn()} />);

--- a/apps/web/src/components/TransactionList.jsx
+++ b/apps/web/src/components/TransactionList.jsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import PropTypes from "prop-types";
 import { CATEGORY_ENTRY } from "./DatabaseUtils";
 import { useMaskedCurrency } from "../context/DiscreetModeContext";
@@ -11,16 +12,90 @@ const formatDate = (value) => {
   return date.toLocaleDateString("pt-BR");
 };
 
-const TransactionList = ({ transactions, onDelete, onEdit }) => {
+const TransactionList = ({ transactions, onDelete, onEdit, onBulkDelete }) => {
   const money = useMaskedCurrency();
+  const [selectedIds, setSelectedIds] = useState(new Set());
+
+  const toggleSelect = (id) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const toggleSelectAll = () => {
+    if (selectedIds.size === transactions.length) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(transactions.map((t) => t.id)));
+    }
+  };
+
+  const handleBulkDelete = () => {
+    if (selectedIds.size === 0 || !onBulkDelete) return;
+    const ids = [...selectedIds];
+    setSelectedIds(new Set());
+    onBulkDelete(ids);
+  };
+
+  const allSelected = transactions.length > 0 && selectedIds.size === transactions.length;
+  const someSelected = selectedIds.size > 0;
+
   return (
     <div className="mx-auto max-w-700 px-2 sm:px-0">
+      {someSelected && onBulkDelete ? (
+        <div className="mb-2 flex items-center justify-between rounded border border-red-200 bg-red-50 px-3 py-2 dark:border-red-800 dark:bg-red-950/40">
+          <span className="text-sm font-medium text-red-700 dark:text-red-400">
+            {selectedIds.size} {selectedIds.size === 1 ? "selecionada" : "selecionadas"}
+          </span>
+          <button
+            type="button"
+            onClick={handleBulkDelete}
+            className="rounded border border-red-300 bg-red-100 px-3 py-1 text-xs font-semibold text-red-700 hover:bg-red-200 dark:border-red-700 dark:bg-red-900/40 dark:text-red-300"
+          >
+            Excluir selecionadas ({selectedIds.size})
+          </button>
+        </div>
+      ) : null}
+
+      {onBulkDelete && transactions.length > 0 ? (
+        <div className="mb-1 flex items-center gap-2 px-1">
+          <input
+            type="checkbox"
+            id="select-all-transactions"
+            checked={allSelected}
+            onChange={toggleSelectAll}
+            className="h-3.5 w-3.5 cursor-pointer accent-brand-1"
+          />
+          <label htmlFor="select-all-transactions" className="cursor-pointer text-xs text-cf-text-secondary">
+            Selecionar todas
+          </label>
+        </div>
+      ) : null}
+
       {transactions.map((transaction) => (
         <div
           key={transaction.id}
           className="my-2 flex w-full min-w-0 flex-col items-start gap-2 rounded border border-brand-1 bg-cf-surface p-3.5 sm:flex-row sm:items-center sm:justify-between"
         >
           <div className="flex min-w-0 flex-1 flex-col">
+            {onBulkDelete ? (
+              <div className="mb-1 flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  id={`select-transaction-${transaction.id}`}
+                  checked={selectedIds.has(transaction.id)}
+                  onChange={() => toggleSelect(transaction.id)}
+                  className="h-3.5 w-3.5 cursor-pointer accent-brand-1"
+                  aria-label={`Selecionar transação ${transaction.id}`}
+                />
+              </div>
+            ) : null}
             <span className="break-words text-sm font-medium text-cf-text-primary">
               {transaction.description || "Sem descrição"}
             </span>
@@ -83,6 +158,7 @@ TransactionList.propTypes = {
   ).isRequired,
   onDelete: PropTypes.func.isRequired,
   onEdit: PropTypes.func.isRequired,
+  onBulkDelete: PropTypes.func,
 };
 
 export default TransactionList;

--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -104,6 +104,8 @@ vi.mock("../services/transactions.service", () => ({
     getImportHistory: vi.fn(),
     dryRunImportCsv: vi.fn(),
     commitImportCsv: vi.fn(),
+    deleteImportSession: vi.fn(),
+    bulkDeleteTransactions: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
     remove: vi.fn(),
@@ -291,6 +293,8 @@ describe("App", () => {
     });
     transactionsService.update.mockResolvedValue({});
     transactionsService.restore.mockResolvedValue({});
+    transactionsService.bulkDeleteTransactions.mockResolvedValue({ deletedCount: 0, success: true });
+    transactionsService.deleteImportSession.mockResolvedValue({ importSessionId: "", deletedCount: 0, success: true });
     analyticsService.getMonthlyTrend.mockResolvedValue(buildTrendResponse());
     forecastService.getCurrent.mockResolvedValue(null);
     forecastService.recompute.mockResolvedValue({
@@ -2113,7 +2117,14 @@ describe("App", () => {
     await waitFor(() => {
       expect(transactionsService.commitImportCsv).toHaveBeenCalledWith(
         "11111111-1111-4111-8111-111111111111",
+        [],
       );
+    });
+
+    // Modal shows committed state — click Fechar to trigger onImported
+    await user.click(screen.getByRole("button", { name: "Fechar" }));
+
+    await waitFor(() => {
       expect(transactionsService.listPage).toHaveBeenCalledTimes(2);
       expect(transactionsService.getMonthlySummary).toHaveBeenCalledTimes(2);
       expect(transactionsService.getMonthlySummaryCompare).toHaveBeenCalledTimes(2);

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -1386,6 +1386,18 @@ const App = ({
     }
   };
 
+  const handleBulkDeleteTransactions = async (ids: number[]) => {
+    setRequestError("");
+    try {
+      await transactionsService.bulkDeleteTransactions(ids);
+      await loadTransactions();
+      await loadMonthlySummary();
+      await loadMonthlyBudgets();
+    } catch (error) {
+      setRequestError(getApiErrorMessage(error, "Não foi possível excluir as transações."));
+    }
+  };
+
   const handleExportCsv = async () => {
     setRequestError("");
     setExportingCsv(true);
@@ -2649,6 +2661,7 @@ const App = ({
             transactions={transactionsWithCategoryName}
             onDelete={requestDeleteTransaction}
             onEdit={openEditModal}
+            onBulkDelete={handleBulkDeleteTransactions}
           />
         )}
 

--- a/apps/web/src/services/transactions.service.ts
+++ b/apps/web/src/services/transactions.service.ts
@@ -174,6 +174,7 @@ export interface ImportDryRunResult {
 
 export interface ImportCommitResult {
   imported: number;
+  importSessionId: string;
   summary: {
     income: number;
     expense: number;
@@ -329,6 +330,7 @@ interface ImportDryRunApiResponse {
 
 interface ImportCommitApiResponse {
   imported?: unknown;
+  importSessionId?: unknown;
   summary?: {
     income?: unknown;
     expense?: unknown;
@@ -730,12 +732,21 @@ export const transactionsService = {
 
     return {
       imported: Number(responseBody.imported) || 0,
+      importSessionId: String(responseBody.importSessionId || ""),
       summary: {
         income: Number(responseBody.summary?.income) || 0,
         expense: Number(responseBody.summary?.expense) || 0,
         balance: Number(responseBody.summary?.balance) || 0,
       },
     };
+  },
+  deleteImportSession: async (sessionId: string): Promise<{ importSessionId: string; deletedCount: number; success: boolean }> => {
+    const { data } = await api.delete(`/transactions/imports/${sessionId}`);
+    return data as { importSessionId: string; deletedCount: number; success: boolean };
+  },
+  bulkDeleteTransactions: async (transactionIds: number[]): Promise<{ deletedCount: number; success: boolean }> => {
+    const { data } = await api.post("/transactions/bulk-delete", { transactionIds });
+    return data as { deletedCount: number; success: boolean };
   },
   getImportHistory: async (options: ImportHistoryOptions = {}): Promise<ImportHistoryResponse> => {
     const fallbackLimit =


### PR DESCRIPTION
## Summary
- Migration 034: adds `import_session_id`, `imported_at`, `import_file_name`, `import_document_type` to transactions
- `DELETE /transactions/imports/:sessionId` — soft-deletes all transactions from an import session
- `POST /transactions/bulk-delete` — soft-deletes a list of transaction IDs (ownership-gated)
- ImportCsvModal: deferred `onImported` — success state shows [Fechar] / [Desfazer importação] buttons
- TransactionList: per-row checkboxes + floating bulk-delete toolbar

## Test plan
- [ ] API: DELETE /imports/:sessionId reverts all transactions from session
- [ ] API: POST /bulk-delete removes selected transactions, guards ownership
- [ ] Modal: "Desfazer importação" rolls back via session ID
- [ ] TransactionList: select rows, bulk-delete removes them from view