### PR TITLE
feat(ux): require confirmation before bulk-deleting transactions

### DIFF
--- a/apps/web/src/components/TransactionList.jsx
+++ b/apps/web/src/components/TransactionList.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import PropTypes from "prop-types";
 import { CATEGORY_ENTRY } from "./DatabaseUtils";
 import { useMaskedCurrency } from "../context/DiscreetModeContext";
+import ConfirmDialog from "./ConfirmDialog";
 
 const formatDate = (value) => {
   const date = new Date(`${value}T00:00:00`);
@@ -15,6 +16,7 @@ const formatDate = (value) => {
 const TransactionList = ({ transactions, onDelete, onEdit, onBulkDelete }) => {
   const money = useMaskedCurrency();
   const [selectedIds, setSelectedIds] = useState(new Set());
+  const [showBulkConfirm, setShowBulkConfirm] = useState(false);
 
   const toggleSelect = (id) => {
     setSelectedIds((prev) => {
@@ -36,10 +38,11 @@ const TransactionList = ({ transactions, onDelete, onEdit, onBulkDelete }) => {
     }
   };
 
-  const handleBulkDelete = () => {
+  const handleBulkDeleteConfirm = () => {
     if (selectedIds.size === 0 || !onBulkDelete) return;
     const ids = [...selectedIds];
     setSelectedIds(new Set());
+    setShowBulkConfirm(false);
     onBulkDelete(ids);
   };
 
@@ -55,7 +58,7 @@ const TransactionList = ({ transactions, onDelete, onEdit, onBulkDelete }) => {
           </span>
           <button
             type="button"
-            onClick={handleBulkDelete}
+            onClick={() => setShowBulkConfirm(true)}
             className="rounded border border-red-300 bg-red-100 px-3 py-1 text-xs font-semibold text-red-700 hover:bg-red-200 dark:border-red-700 dark:bg-red-900/40 dark:text-red-300"
           >
             Excluir selecionadas ({selectedIds.size})
@@ -140,6 +143,15 @@ const TransactionList = ({ transactions, onDelete, onEdit, onBulkDelete }) => {
           </div>
         </div>
       ))}
+
+      <ConfirmDialog
+        isOpen={showBulkConfirm}
+        title={`Excluir ${selectedIds.size} ${selectedIds.size === 1 ? "transação" : "transações"}?`}
+        description="Esta ação não pode ser desfeita."
+        confirmLabel="Excluir"
+        onConfirm={handleBulkDeleteConfirm}
+        onCancel={() => setShowBulkConfirm(false)}
+      />
     </div>
   );
 };

--- a/apps/web/src/components/TransactionList.test.jsx
+++ b/apps/web/src/components/TransactionList.test.jsx
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import TransactionList from "./TransactionList";
-import { DiscreetModeContext } from "../context/DiscreetModeContext";
 
 vi.mock("../context/DiscreetModeContext", async (importOriginal) => {
   const actual = await importOriginal();

--- a/apps/web/src/components/TransactionList.test.jsx
+++ b/apps/web/src/components/TransactionList.test.jsx
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import TransactionList from "./TransactionList";
+import { DiscreetModeContext } from "../context/DiscreetModeContext";
+
+vi.mock("../context/DiscreetModeContext", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useMaskedCurrency: () => (v) => `R$ ${v}`,
+  };
+});
+
+const buildTransaction = (overrides = {}) => ({
+  id: 1,
+  value: 100,
+  type: "Saída",
+  date: "2026-03-25",
+  categoryName: "Moradia",
+  description: "Aluguel",
+  notes: null,
+  ...overrides,
+});
+
+const defaultProps = {
+  transactions: [buildTransaction(), buildTransaction({ id: 2, description: "Luz" })],
+  onDelete: vi.fn(),
+  onEdit: vi.fn(),
+  onBulkDelete: vi.fn(),
+};
+
+describe("TransactionList — bulk delete confirmation", () => {
+  it("não chama onBulkDelete ao clicar no botão, abre confirmação", async () => {
+    render(<TransactionList {...defaultProps} />);
+
+    await userEvent.click(screen.getByRole("checkbox", { name: /selecionar todas/i }));
+    await userEvent.click(screen.getByRole("button", { name: /excluir selecionadas/i }));
+
+    expect(defaultProps.onBulkDelete).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("cancela sem deletar", async () => {
+    render(<TransactionList {...defaultProps} />);
+
+    await userEvent.click(screen.getByRole("checkbox", { name: /selecionar todas/i }));
+    await userEvent.click(screen.getByRole("button", { name: /excluir selecionadas/i }));
+    await userEvent.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(defaultProps.onBulkDelete).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("confirma e chama onBulkDelete com os ids selecionados", async () => {
+    const onBulkDelete = vi.fn();
+    render(<TransactionList {...defaultProps} onBulkDelete={onBulkDelete} />);
+
+    await userEvent.click(screen.getByRole("checkbox", { name: /selecionar todas/i }));
+    await userEvent.click(screen.getByRole("button", { name: /excluir selecionadas/i }));
+    await userEvent.click(screen.getByRole("button", { name: /^excluir$/i }));
+
+    expect(onBulkDelete).toHaveBeenCalledWith(expect.arrayContaining([1, 2]));
+    expect(onBulkDelete).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Intercepts the bulk-delete action with a `ConfirmDialog` before calling `onBulkDelete`.

- Button "Excluir selecionadas (N)" now opens a confirmation dialog instead of deleting immediately
- Dialog title is dynamic: "Excluir N transação?" / "Excluir N transações?"
- Description: "Esta ação não pode ser desfeita."
- Cancel preserves the current selection unchanged
- Confirm clears selection then calls `onBulkDelete` with the ids

No backend changes. No new dependencies — reuses the existing `ConfirmDialog` component.

## Coverage

| Suite | Passed | New tests |
|-------|--------|-----------|
| Web   | 269 / 269 | 3 (new `TransactionList.test.jsx`) |

New tests:
1. Button click opens dialog without calling `onBulkDelete`
2. Cancel closes dialog, `onBulkDelete` not called
3. Confirm calls `onBulkDelete` with correct ids