### PR TITLE
feat(import): batch category assignment in dry-run preview

### DIFF
--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -31,6 +31,9 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
   // bill bridge
   const [isBillModalOpen, setIsBillModalOpen] = useState(false);
   const [billCreated, setBillCreated] = useState(false);
+  // batch category
+  const [selectedPreviewLines, setSelectedPreviewLines] = useState(new Set());
+  const [batchCategoryId, setBatchCategoryId] = useState("");
 
   useEffect(() => {
     if (isOpen) {
@@ -53,6 +56,8 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
     setIsUndoing(false);
     setIsBillModalOpen(false);
     setBillCreated(false);
+    setSelectedPreviewLines(new Set());
+    setBatchCategoryId("");
   }, [isOpen]);
 
   useEffect(() => {
@@ -180,6 +185,39 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
       setIsApplyingProfile(false);
       setShowProfileConfirm(false);
     }
+  };
+
+  const validPreviewLines = useMemo(
+    () => (dryRunResult?.rows ?? []).filter((r) => r.status === "valid").map((r) => r.line),
+    [dryRunResult],
+  );
+
+  const togglePreviewLine = (line) => {
+    setSelectedPreviewLines((prev) => {
+      const next = new Set(prev);
+      if (next.has(line)) next.delete(line); else next.add(line);
+      return next;
+    });
+  };
+
+  const toggleSelectAllPreview = () => {
+    if (selectedPreviewLines.size === validPreviewLines.length) {
+      setSelectedPreviewLines(new Set());
+    } else {
+      setSelectedPreviewLines(new Set(validPreviewLines));
+    }
+  };
+
+  const handleApplyBatchCategory = () => {
+    if (selectedPreviewLines.size === 0) return;
+    const val = batchCategoryId === "" ? null : Number(batchCategoryId);
+    setCategoryOverrides((prev) => {
+      const next = { ...prev };
+      selectedPreviewLines.forEach((line) => { next[line] = val; });
+      return next;
+    });
+    setSelectedPreviewLines(new Set());
+    setBatchCategoryId("");
   };
 
   const handleInlineCreateCategory = useCallback(
@@ -553,10 +591,52 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
                 Sem linhas para pré-visualizar.
               </div>
             ) : (
+              <>
+                {selectedPreviewLines.size > 0 && (
+                  <div className="mb-1 flex flex-wrap items-center gap-2 rounded border border-brand-1/40 bg-brand-1/5 px-3 py-2">
+                    <span className="text-xs font-medium text-cf-text-primary">
+                      {selectedPreviewLines.size} {selectedPreviewLines.size === 1 ? "linha selecionada" : "linhas selecionadas"}
+                    </span>
+                    <select
+                      aria-label="Categoria para aplicar em lote"
+                      value={batchCategoryId}
+                      onChange={(e) => setBatchCategoryId(e.target.value)}
+                      className="rounded border border-cf-border bg-cf-surface px-1 py-0.5 text-xs text-cf-text-primary"
+                    >
+                      <option value="">— Sem categoria —</option>
+                      {categories.map((cat) => (
+                        <option key={cat.id} value={cat.id}>{cat.name}</option>
+                      ))}
+                    </select>
+                    <button
+                      type="button"
+                      onClick={handleApplyBatchCategory}
+                      className="rounded border border-brand-1 bg-brand-1 px-2 py-0.5 text-xs font-semibold text-white hover:opacity-90"
+                    >
+                      Aplicar categoria
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setSelectedPreviewLines(new Set())}
+                      className="rounded border border-cf-border px-2 py-0.5 text-xs text-cf-text-secondary hover:bg-cf-bg-subtle"
+                    >
+                      Cancelar
+                    </button>
+                  </div>
+                )}
               <div className="max-h-80 overflow-auto rounded border border-cf-border">
                 <table className="min-w-full border-collapse text-left text-xs">
                   <thead className="bg-cf-bg-subtle">
                     <tr>
+                      <th className="border-b border-cf-border px-2 py-2">
+                        <input
+                          type="checkbox"
+                          aria-label="Selecionar todas as linhas válidas"
+                          checked={validPreviewLines.length > 0 && selectedPreviewLines.size === validPreviewLines.length}
+                          onChange={toggleSelectAllPreview}
+                          className="h-3.5 w-3.5 cursor-pointer accent-brand-1"
+                        />
+                      </th>
                       <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Linha</th>
                       <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Status</th>
                       <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Descricao</th>
@@ -569,6 +649,17 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
                   <tbody>
                     {dryRunResult.rows.map((row) => (
                       <tr key={`import-row-${row.line}`} className="align-top">
+                        <td className="border-b border-cf-border px-2 py-2">
+                          {row.status === "valid" ? (
+                            <input
+                              type="checkbox"
+                              aria-label={`Selecionar linha ${row.line}`}
+                              checked={selectedPreviewLines.has(row.line)}
+                              onChange={() => togglePreviewLine(row.line)}
+                              className="h-3.5 w-3.5 cursor-pointer accent-brand-1"
+                            />
+                          ) : null}
+                        </td>
                         <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">{row.line}</td>
                         <td className="border-b border-cf-border px-2 py-2">
                           <span
@@ -680,6 +771,7 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
                   </tbody>
                 </table>
               </div>
+              </>
             )}
           </div>
         ) : null}

--- a/apps/web/src/components/ImportCsvModal.test.jsx
+++ b/apps/web/src/components/ImportCsvModal.test.jsx
@@ -213,4 +213,72 @@ describe("ImportCsvModal", () => {
       ).toBeInTheDocument();
     });
   });
+
+  describe("batch category", () => {
+    const buildMultiRowResponse = () =>
+      buildDryRunResponse({
+        summary: { totalRows: 2, validRows: 2, invalidRows: 0, income: 200, expense: 0 },
+        rows: [
+          {
+            line: 2,
+            status: "valid",
+            raw: { date: "2026-02-21", type: "Entrada", value: "100", description: "PIX A", notes: "", category: "" },
+            normalized: { date: "2026-02-21", type: "Entrada", value: 100, description: "PIX A", notes: "", categoryId: null },
+            errors: [],
+          },
+          {
+            line: 3,
+            status: "valid",
+            raw: { date: "2026-02-22", type: "Entrada", value: "100", description: "PIX B", notes: "", category: "" },
+            normalized: { date: "2026-02-22", type: "Entrada", value: 100, description: "PIX B", notes: "", categoryId: null },
+            errors: [],
+          },
+        ],
+      });
+
+    it("selecionar todas exibe toolbar de categoria em lote", async () => {
+      const file = new File(["date,type,value"], "import.csv", { type: "text/csv" });
+      transactionsService.dryRunImportCsv.mockResolvedValueOnce(buildMultiRowResponse());
+      categoriesService.listCategories.mockResolvedValue([{ id: 5, name: "Salário" }]);
+
+      render(<ImportCsvModal isOpen onClose={vi.fn()} />);
+      await userEvent.upload(screen.getByLabelText("Arquivo do extrato"), file);
+      await userEvent.click(screen.getByRole("button", { name: "Pré-visualizar" }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("checkbox", { name: /selecionar todas as linhas válidas/i })).toBeInTheDocument();
+      });
+
+      await userEvent.click(screen.getByRole("checkbox", { name: /selecionar todas as linhas válidas/i }));
+
+      expect(screen.getByText(/2 linhas selecionadas/i)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /aplicar categoria/i })).toBeInTheDocument();
+    });
+
+    it("aplicar categoria em lote preenche overrides nas linhas selecionadas", async () => {
+      const file = new File(["date,type,value"], "import.csv", { type: "text/csv" });
+      transactionsService.dryRunImportCsv.mockResolvedValueOnce(buildMultiRowResponse());
+      categoriesService.listCategories.mockResolvedValue([{ id: 5, name: "Salário" }]);
+
+      render(<ImportCsvModal isOpen onClose={vi.fn()} />);
+      await userEvent.upload(screen.getByLabelText("Arquivo do extrato"), file);
+      await userEvent.click(screen.getByRole("button", { name: "Pré-visualizar" }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("checkbox", { name: /selecionar todas as linhas válidas/i })).toBeInTheDocument();
+      });
+
+      await userEvent.click(screen.getByRole("checkbox", { name: /selecionar todas as linhas válidas/i }));
+      await userEvent.selectOptions(screen.getByRole("combobox", { name: /categoria para aplicar em lote/i }), "5");
+      await userEvent.click(screen.getByRole("button", { name: /aplicar categoria/i }));
+
+      // toolbar disappears after apply (selection cleared)
+      expect(screen.queryByText(/linhas selecionadas/i)).not.toBeInTheDocument();
+
+      // both row selects now show Salário
+      const rowSelects = screen.getAllByRole("combobox", { name: /categoria da linha/i });
+      expect(rowSelects).toHaveLength(2);
+      rowSelects.forEach((sel) => expect(sel).toHaveValue("5"));
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds multi-row category assignment to the import dry-run preview table.

- **Per-row checkboxes** on valid rows (invalid/duplicate rows get no checkbox)
- **Master checkbox** in table header — selects/deselects all valid rows at once
- **Batch toolbar** appears above the table when any rows are selected:
  - Shows count: "N linhas selecionadas"
  - Category dropdown (same list as per-row selects)
  - "Aplicar categoria" button — writes chosen `categoryId` into `categoryOverrides` for every selected line
  - "Cancelar" — clears selection without applying
- Applying clears the selection and resets the batch dropdown
- Existing per-row override behaviour is fully preserved

No backend changes. No new dependencies. Pure UI state.

## Coverage

| Suite | Passed | New tests |
|-------|--------|-----------|
| Web   | 268 / 268 | 2 (new `describe("batch category")` in `ImportCsvModal.test.jsx`) |

New tests:
1. Selecting all valid rows shows the batch toolbar with correct count
2. Applying a batch category fills the per-row selects for all selected lines and clears the toolbar