### PR TITLE
feat(import): INSS → income history bridge

### DIFF
--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -6,6 +6,7 @@ import { categoriesService } from "../services/categories.service";
 import { formatCurrency } from "../utils/formatCurrency";
 import { getApiErrorMessage } from "../utils/apiError";
 import BillModal from "./BillModal";
+import IncomeStatementQuickModal from "./IncomeStatementQuickModal";
 
 const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
   const fileInputRef = useRef(null);
@@ -31,6 +32,9 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
   // bill bridge
   const [isBillModalOpen, setIsBillModalOpen] = useState(false);
   const [billCreated, setBillCreated] = useState(false);
+  // income statement bridge
+  const [isIncomeModalOpen, setIsIncomeModalOpen] = useState(false);
+  const [incomeStatementCreated, setIncomeStatementCreated] = useState(false);
   // batch category
   const [selectedPreviewLines, setSelectedPreviewLines] = useState(new Set());
   const [batchCategoryId, setBatchCategoryId] = useState("");
@@ -56,6 +60,8 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
     setIsUndoing(false);
     setIsBillModalOpen(false);
     setBillCreated(false);
+    setIsIncomeModalOpen(false);
+    setIncomeStatementCreated(false);
     setSelectedPreviewLines(new Set());
     setBatchCategoryId("");
   }, [isOpen]);
@@ -169,6 +175,16 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
       referenceMonth: suggestion.referenceMonth ?? undefined,
       billType: suggestion.billType ?? undefined,
       sourceImportSessionId: dryRunResult?.importId ?? undefined,
+    };
+  }, [dryRunResult]);
+
+  const incomePrefill = useMemo(() => {
+    const suggestion = dryRunResult?.suggestion;
+    if (suggestion?.type !== "profile") return null;
+    return {
+      referenceMonth: suggestion.referenceMonth ?? undefined,
+      netAmount: suggestion.netAmount ?? undefined,
+      paymentDate: suggestion.paymentDate ?? undefined,
     };
   }, [dryRunResult]);
 
@@ -534,6 +550,20 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
                     Perfil atualizado com sucesso.
                   </p>
                 ) : null}
+                {suggestionCard.kind === "profile" && !incomeStatementCreated ? (
+                  <button
+                    type="button"
+                    onClick={() => setIsIncomeModalOpen(true)}
+                    className="mt-1 rounded border border-blue-400 bg-blue-100 px-3 py-1 text-xs font-semibold text-blue-700 hover:bg-blue-200 dark:border-blue-600 dark:bg-blue-900/40 dark:text-blue-300 dark:hover:bg-blue-800/40"
+                  >
+                    Registrar no histórico de renda
+                  </button>
+                ) : null}
+                {suggestionCard.kind === "profile" && incomeStatementCreated ? (
+                  <p className="mt-1 text-xs font-semibold text-green-600 dark:text-green-400">
+                    Lançamento registrado no histórico de renda.
+                  </p>
+                ) : null}
                 {suggestionCard.kind === "bill" && !billCreated ? (
                   <button
                     type="button"
@@ -786,6 +816,16 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
         }}
         prefill={billPrefill}
         categories={categories}
+      />
+
+      <IncomeStatementQuickModal
+        isOpen={isIncomeModalOpen}
+        onClose={() => setIsIncomeModalOpen(false)}
+        prefill={incomePrefill}
+        onCreated={() => {
+          setIsIncomeModalOpen(false);
+          setIncomeStatementCreated(true);
+        }}
       />
     </div>
   );

--- a/apps/web/src/components/ImportCsvModal.test.jsx
+++ b/apps/web/src/components/ImportCsvModal.test.jsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import ImportCsvModal from "./ImportCsvModal";
 import { transactionsService } from "../services/transactions.service";
 import { categoriesService } from "../services/categories.service";
+import { incomeSourcesService } from "../services/incomeSources.service";
 
 vi.mock("../services/transactions.service", () => ({
   transactionsService: {
@@ -17,6 +18,13 @@ vi.mock("../services/categories.service", () => ({
   categoriesService: {
     listCategories: vi.fn(),
     createCategory: vi.fn(),
+  },
+}));
+
+vi.mock("../services/incomeSources.service", () => ({
+  incomeSourcesService: {
+    list: vi.fn(),
+    createStatement: vi.fn(),
   },
 }));
 
@@ -60,6 +68,7 @@ describe("ImportCsvModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     categoriesService.listCategories.mockResolvedValue([]);
+    incomeSourcesService.list.mockResolvedValue([]);
   });
 
   it("does not render when isOpen is false", () => {
@@ -211,6 +220,66 @@ describe("ImportCsvModal", () => {
       expect(
         screen.getByText("Sessão de importação expirada. Rode a pré-visualização novamente."),
       ).toBeInTheDocument();
+    });
+  });
+
+  describe("income statement bridge", () => {
+    const buildInssResponse = () =>
+      buildDryRunResponse({
+        documentType: "income_statement_inss",
+        summary: { totalRows: 0, validRows: 0, invalidRows: 0, income: 0, expense: 0 },
+        rows: [],
+        suggestion: {
+          type: "profile",
+          referenceMonth: "2026-02",
+          netAmount: 1412.0,
+          paymentDate: "2026-02-25",
+          grossAmount: 1800.0,
+          benefitKind: "Aposentadoria",
+        },
+      });
+
+    it("exibe botao Registrar no historico de renda para suggestion type=profile", async () => {
+      const file = new File(["dummy"], "inss.pdf", { type: "application/pdf" });
+      transactionsService.dryRunImportCsv.mockResolvedValueOnce(buildInssResponse());
+
+      render(<ImportCsvModal isOpen onClose={vi.fn()} />);
+      await userEvent.upload(screen.getByLabelText("Arquivo do extrato"), file);
+      await userEvent.click(screen.getByRole("button", { name: "Pré-visualizar" }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "Registrar no histórico de renda" }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("abre IncomeStatementQuickModal ao clicar no botao", async () => {
+      const file = new File(["dummy"], "inss.pdf", { type: "application/pdf" });
+      transactionsService.dryRunImportCsv.mockResolvedValueOnce(buildInssResponse());
+      incomeSourcesService.list.mockResolvedValue([
+        { id: 1, name: "INSS Benefício", deductions: [], userId: 1, categoryId: null, defaultDay: null, notes: null, createdAt: "", updatedAt: "" },
+      ]);
+
+      render(<ImportCsvModal isOpen onClose={vi.fn()} />);
+      await userEvent.upload(screen.getByLabelText("Arquivo do extrato"), file);
+      await userEvent.click(screen.getByRole("button", { name: "Pré-visualizar" }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "Registrar no histórico de renda" }),
+        ).toBeInTheDocument();
+      });
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Registrar no histórico de renda" }),
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("dialog", { name: /Registrar no histórico de renda/i }),
+        ).toBeInTheDocument();
+      });
     });
   });
 

--- a/apps/web/src/components/IncomeStatementQuickModal.test.tsx
+++ b/apps/web/src/components/IncomeStatementQuickModal.test.tsx
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import IncomeStatementQuickModal from "./IncomeStatementQuickModal";
+import { incomeSourcesService } from "../services/incomeSources.service";
+
+vi.mock("../services/incomeSources.service", () => ({
+  incomeSourcesService: {
+    list: vi.fn(),
+    createStatement: vi.fn(),
+  },
+}));
+
+const buildSource = (overrides = {}) => ({
+  id: 1,
+  userId: 1,
+  name: "INSS Benefício",
+  categoryId: null,
+  defaultDay: null,
+  notes: null,
+  deductions: [],
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+  ...overrides,
+});
+
+describe("IncomeStatementQuickModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not render when isOpen is false", () => {
+    render(
+      <IncomeStatementQuickModal isOpen={false} onClose={vi.fn()} />,
+    );
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("shows guidance when no income sources exist", async () => {
+    vi.mocked(incomeSourcesService.list).mockResolvedValue([]);
+
+    render(<IncomeStatementQuickModal isOpen onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Nenhuma fonte de renda cadastrada/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("pre-fills fields from prefill prop", async () => {
+    vi.mocked(incomeSourcesService.list).mockResolvedValue([buildSource()]);
+
+    render(
+      <IncomeStatementQuickModal
+        isOpen
+        onClose={vi.fn()}
+        prefill={{ referenceMonth: "2026-02", netAmount: 1412.0, paymentDate: "2026-02-25" }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Competência/i)).toHaveValue("2026-02");
+    });
+
+    expect(screen.getByLabelText(/Valor líquido/i)).toHaveValue(1412);
+    expect(screen.getByLabelText(/Data de pagamento/i)).toHaveValue("2026-02-25");
+  });
+
+  it("auto-selects single source", async () => {
+    vi.mocked(incomeSourcesService.list).mockResolvedValue([buildSource()]);
+
+    render(<IncomeStatementQuickModal isOpen onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("combobox", { name: /Fonte de renda/i })).toHaveValue("1");
+    });
+  });
+
+  it("submits and shows success state", async () => {
+    vi.mocked(incomeSourcesService.list).mockResolvedValue([buildSource()]);
+    vi.mocked(incomeSourcesService.createStatement).mockResolvedValue({
+      statement: {
+        id: 10,
+        incomeSourceId: 1,
+        referenceMonth: "2026-02",
+        netAmount: 1412,
+        totalDeductions: 0,
+        paymentDate: null,
+        status: "draft",
+        postedTransactionId: null,
+        createdAt: "2026-02-25T00:00:00Z",
+        updatedAt: "2026-02-25T00:00:00Z",
+      },
+      deductions: [],
+    });
+
+    const onCreated = vi.fn();
+
+    render(
+      <IncomeStatementQuickModal
+        isOpen
+        onClose={vi.fn()}
+        prefill={{ referenceMonth: "2026-02", netAmount: 1412 }}
+        onCreated={onCreated}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("combobox", { name: /Fonte de renda/i })).toHaveValue("1");
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Registrar" }));
+
+    await waitFor(() => {
+      expect(incomeSourcesService.createStatement).toHaveBeenCalledWith(1, {
+        referenceMonth: "2026-02",
+        netAmount: 1412,
+        paymentDate: null,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Lançamento registrado com sucesso.")).toBeInTheDocument();
+    });
+
+    expect(onCreated).toHaveBeenCalled();
+  });
+
+  it("shows error message when createStatement rejects", async () => {
+    vi.mocked(incomeSourcesService.list).mockResolvedValue([buildSource()]);
+    vi.mocked(incomeSourcesService.createStatement).mockRejectedValue(
+      new Error("Falha de rede"),
+    );
+
+    render(
+      <IncomeStatementQuickModal
+        isOpen
+        onClose={vi.fn()}
+        prefill={{ referenceMonth: "2026-02", netAmount: 1412 }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("combobox", { name: /Fonte de renda/i })).toHaveValue("1");
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Registrar" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Falha de rede")).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/IncomeStatementQuickModal.tsx
+++ b/apps/web/src/components/IncomeStatementQuickModal.tsx
@@ -1,0 +1,266 @@
+import { useEffect, useState } from "react";
+import {
+  incomeSourcesService,
+  type IncomeSourceWithDeductions,
+} from "../services/incomeSources.service";
+import { getApiErrorMessage } from "../utils/apiError";
+
+export interface IncomeStatementPrefill {
+  referenceMonth?: string;
+  netAmount?: number;
+  paymentDate?: string;
+}
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  prefill?: IncomeStatementPrefill | null;
+  onCreated?: () => void;
+}
+
+export default function IncomeStatementQuickModal({
+  isOpen,
+  onClose,
+  prefill,
+  onCreated,
+}: Props) {
+  const [sources, setSources] = useState<IncomeSourceWithDeductions[]>([]);
+  const [isLoadingSources, setIsLoadingSources] = useState(false);
+  const [sourceId, setSourceId] = useState("");
+  const [referenceMonth, setReferenceMonth] = useState("");
+  const [netAmount, setNetAmount] = useState("");
+  const [paymentDate, setPaymentDate] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+  const [success, setSuccess] = useState(false);
+
+  // Reset + fetch sources on open
+  useEffect(() => {
+    if (!isOpen) {
+      setSourceId("");
+      setReferenceMonth("");
+      setNetAmount("");
+      setPaymentDate("");
+      setErrorMessage("");
+      setSuccess(false);
+      setSources([]);
+      return;
+    }
+
+    // Apply prefill
+    setReferenceMonth(prefill?.referenceMonth ?? "");
+    setNetAmount(prefill?.netAmount != null ? String(prefill.netAmount) : "");
+    setPaymentDate(prefill?.paymentDate ?? "");
+
+    setIsLoadingSources(true);
+    incomeSourcesService
+      .list()
+      .then((list) => {
+        setSources(list);
+        if (list.length === 1) {
+          setSourceId(String(list[0].id));
+        }
+      })
+      .catch(() => {})
+      .finally(() => setIsLoadingSources(false));
+  }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const parsedSourceId = Number(sourceId);
+    if (!parsedSourceId) {
+      setErrorMessage("Selecione uma fonte de renda.");
+      return;
+    }
+
+    if (!referenceMonth.trim()) {
+      setErrorMessage("Informe a competência.");
+      return;
+    }
+
+    const parsedNet = Number(netAmount);
+    if (!Number.isFinite(parsedNet) || parsedNet <= 0) {
+      setErrorMessage("Informe um valor líquido válido.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setErrorMessage("");
+    try {
+      await incomeSourcesService.createStatement(parsedSourceId, {
+        referenceMonth: referenceMonth.trim(),
+        netAmount: parsedNet,
+        paymentDate: paymentDate.trim() || null,
+      });
+      setSuccess(true);
+      onCreated?.();
+    } catch (err) {
+      setErrorMessage(getApiErrorMessage(err, "Não foi possível registrar o lançamento."));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex min-h-screen items-start justify-center bg-black/50 p-6 sm:items-center"
+      role="presentation"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        className="w-full max-w-md rounded-lg bg-cf-surface p-4 sm:p-6"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="income-quick-modal-title"
+      >
+        <div className="mb-4 flex items-center justify-between">
+          <h2
+            id="income-quick-modal-title"
+            className="text-base font-semibold text-cf-text-primary"
+          >
+            Registrar no histórico de renda
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-cf-text-secondary hover:text-cf-text-primary"
+            aria-label="Fechar"
+          >
+            ✕
+          </button>
+        </div>
+
+        {success ? (
+          <div className="rounded border border-green-200 bg-green-50 px-3 py-3 dark:border-green-800 dark:bg-green-950/40">
+            <p className="mb-3 text-sm font-semibold text-green-700 dark:text-green-400">
+              Lançamento registrado com sucesso.
+            </p>
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded border border-green-400 bg-green-100 px-3 py-1.5 text-sm font-semibold text-green-700 hover:bg-green-200 dark:border-green-700 dark:bg-green-900/40 dark:text-green-300"
+            >
+              Fechar
+            </button>
+          </div>
+        ) : (
+          <>
+            {isLoadingSources ? (
+              <p className="mb-3 text-sm text-cf-text-secondary">Carregando fontes de renda...</p>
+            ) : sources.length === 0 ? (
+              <div className="mb-3 rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-400">
+                Nenhuma fonte de renda cadastrada. Cadastre uma fonte antes de registrar um
+                lançamento.
+              </div>
+            ) : null}
+
+            <form onSubmit={handleSubmit} className="space-y-3">
+              <div>
+                <label
+                  htmlFor="income-quick-source"
+                  className="mb-1 block text-sm font-medium text-cf-text-primary"
+                >
+                  Fonte de renda
+                </label>
+                <select
+                  id="income-quick-source"
+                  value={sourceId}
+                  onChange={(e) => setSourceId(e.target.value)}
+                  disabled={isLoadingSources || sources.length === 0}
+                  className="w-full rounded border border-cf-border bg-cf-surface px-2 py-1.5 text-sm text-cf-text-primary disabled:opacity-60"
+                >
+                  <option value="">— Selecione —</option>
+                  {sources.map((s) => (
+                    <option key={s.id} value={s.id}>
+                      {s.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label
+                  htmlFor="income-quick-month"
+                  className="mb-1 block text-sm font-medium text-cf-text-primary"
+                >
+                  Competência
+                </label>
+                <input
+                  id="income-quick-month"
+                  type="text"
+                  placeholder="AAAA-MM"
+                  value={referenceMonth}
+                  onChange={(e) => setReferenceMonth(e.target.value)}
+                  className="w-full rounded border border-cf-border bg-cf-surface px-2 py-1.5 text-sm text-cf-text-primary"
+                />
+              </div>
+
+              <div>
+                <label
+                  htmlFor="income-quick-net"
+                  className="mb-1 block text-sm font-medium text-cf-text-primary"
+                >
+                  Valor líquido (R$)
+                </label>
+                <input
+                  id="income-quick-net"
+                  type="number"
+                  step="0.01"
+                  min="0.01"
+                  value={netAmount}
+                  onChange={(e) => setNetAmount(e.target.value)}
+                  className="w-full rounded border border-cf-border bg-cf-surface px-2 py-1.5 text-sm text-cf-text-primary"
+                />
+              </div>
+
+              <div>
+                <label
+                  htmlFor="income-quick-date"
+                  className="mb-1 block text-sm font-medium text-cf-text-primary"
+                >
+                  Data de pagamento{" "}
+                  <span className="font-normal text-cf-text-secondary">(opcional)</span>
+                </label>
+                <input
+                  id="income-quick-date"
+                  type="date"
+                  value={paymentDate}
+                  onChange={(e) => setPaymentDate(e.target.value)}
+                  className="w-full rounded border border-cf-border bg-cf-surface px-2 py-1.5 text-sm text-cf-text-primary"
+                />
+              </div>
+
+              {errorMessage ? (
+                <p className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-400">
+                  {errorMessage}
+                </p>
+              ) : null}
+
+              <div className="flex gap-2 pt-1">
+                <button
+                  type="submit"
+                  disabled={isSubmitting || sources.length === 0}
+                  className="rounded border border-brand-1 bg-brand-1 px-3 py-1.5 text-sm font-semibold text-white hover:bg-brand-2 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isSubmitting ? "Registrando..." : "Registrar"}
+                </button>
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-1.5 text-sm font-semibold text-cf-text-secondary"
+                >
+                  Cancelar
+                </button>
+              </div>
+            </form>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## O que faz

Quando o usuário importa um comprovante INSS (`income_statement_inss`), o painel de sugestão já exibia os dados extraídos (competência, valor líquido, data de pagamento). Este PR fecha o loop: o usuário pode registrar esses dados diretamente no histórico de renda sem sair do modal de importação.

## Mudanças

### `IncomeStatementQuickModal.tsx` (novo)
- Modal leve, independente do `IncomeStatementModal` existente (que exige `sourceId` + `activeDeductions` upfront)
- Busca fontes de renda via `incomeSourcesService.list()` ao abrir
- Auto-seleciona quando há uma única fonte cadastrada
- Exibe orientação quando nenhuma fonte existe (sem quebrar o fluxo)
- Pré-preenche `referenceMonth`, `netAmount`, `paymentDate` via prop `prefill`
- Submete via `incomeSourcesService.createStatement(sourceId, payload)` — cria rascunho; `postedTransactionId` linkage fica para follow-up
- z-index `[60]` para sobrepor o `ImportCsvModal` (z-50)

### `ImportCsvModal.jsx`
- Importa `IncomeStatementQuickModal`
- Novos estados: `isIncomeModalOpen`, `incomeStatementCreated`
- `incomePrefill` memo: extrai `referenceMonth`, `netAmount`, `paymentDate` de `suggestion.type === "profile"`
- Botão **"Registrar no histórico de renda"** no card de sugestão do comprovante INSS
- Após criação bem-sucedida: exibe confirmação inline, esconde o botão

## Cobertura

| Arquivo | Testes |
|---|---|
| `IncomeStatementQuickModal.test.tsx` | 6 (não renderiza fechado, sem fontes, pré-preenchimento, auto-seleção, submit com sucesso, erro de rede) |
| `ImportCsvModal.test.jsx` | +2 (botão visível para suggestion profile, modal abre com pré-preenchimento) |

**Suite web: 279 testes passando** (eram 266 pré-sprint, +13 neste PR)

## Decisões de design

- **Sem auto-criação**: o registro só acontece após confirmação explícita do usuário — princípio estabelecido na sprint anterior
- **Draft sem post**: não chama `postStatement` para não duplicar a transação já importada; linkagem via `posted_transaction_id` fica para PR subsequente quando o backend expuser o endpoint correto
- **Modal independente**: reutilizar `IncomeStatementModal` exigiria refatorar sua assinatura; o `QuickModal` é autocontido e não polui o contrato existente