### PR TITLE
feat(income): link statement to imported transaction (Follow-up A)

### DIFF
--- a/apps/api/src/income-sources.test.js
+++ b/apps/api/src/income-sources.test.js
@@ -601,4 +601,209 @@ describe("income-sources", () => {
 
     expectErrorResponseWithRequestId(res, 409, "Extrato ja foi lancado.");
   });
+
+  // ─── Link statement to transaction ───────────────────────────────────────────
+
+  const setupStatementAndTransaction = async (email, opts = {}) => {
+    const token = await registerAndLogin(email);
+
+    const srcRes = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "INSS Beneficio" });
+    const sourceId = srcRes.body.id;
+
+    const netAmount = opts.netAmount ?? 1412.0;
+    const stmtRes = await request(app)
+      .post(`/income-sources/${sourceId}/statements`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        referenceMonth: opts.referenceMonth ?? "2026-02",
+        netAmount,
+        paymentDate: opts.paymentDate ?? "2026-02-25",
+      });
+    const statementId = stmtRes.body.statement.id;
+
+    // Create matching income transaction directly in DB
+    const txDate = opts.txDate ?? "2026-02-25";
+    const txValue = opts.txValue ?? netAmount;
+    const txType = opts.txType ?? "Entrada";
+    const { rows } = await dbQuery(
+      `INSERT INTO transactions (user_id, type, value, date, description)
+       VALUES ((SELECT id FROM users WHERE email = $1), $2, $3, $4, $5)
+       RETURNING id`,
+      [email, txType, txValue, txDate, "INSS Credito"],
+    );
+    const transactionId = Number(rows[0].id);
+
+    return { token, statementId, transactionId };
+  };
+
+  it("POST /income-sources/statements/:id/link-transaction vincula com sucesso", async () => {
+    const { token, statementId, transactionId } = await setupStatementAndTransaction(
+      "inss-link-ok@test.dev",
+    );
+
+    const res = await request(app)
+      .post(`/income-sources/statements/${statementId}/link-transaction`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionId });
+
+    expect(res.status).toBe(200);
+    expect(res.body.statement).toMatchObject({
+      id: statementId,
+      postedTransactionId: transactionId,
+      status: "posted",
+    });
+  });
+
+  it("POST .../link-transaction e idempotente ao revincular mesma transacao", async () => {
+    const { token, statementId, transactionId } = await setupStatementAndTransaction(
+      "inss-link-idem@test.dev",
+    );
+
+    await request(app)
+      .post(`/income-sources/statements/${statementId}/link-transaction`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionId });
+
+    const res = await request(app)
+      .post(`/income-sources/statements/${statementId}/link-transaction`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionId });
+
+    expect(res.status).toBe(200);
+    expect(res.body.statement.postedTransactionId).toBe(transactionId);
+  });
+
+  it("POST .../link-transaction retorna 404 para extrato de outro usuario", async () => {
+    const { statementId } = await setupStatementAndTransaction("inss-link-other-stmt@test.dev");
+    const token2 = await registerAndLogin("inss-link-other-user@test.dev");
+
+    // create a transaction for user2
+    const { rows } = await dbQuery(
+      `INSERT INTO transactions (user_id, type, value, date, description)
+       VALUES ((SELECT id FROM users WHERE email = $1), $2, $3, $4, $5)
+       RETURNING id`,
+      ["inss-link-other-user@test.dev", "Entrada", 1412, "2026-02-25", "Outro"],
+    );
+    const txId = Number(rows[0].id);
+
+    const res = await request(app)
+      .post(`/income-sources/statements/${statementId}/link-transaction`)
+      .set("Authorization", `Bearer ${token2}`)
+      .send({ transactionId: txId });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("POST .../link-transaction retorna 404 para transacao de outro usuario", async () => {
+    const { token, statementId } = await setupStatementAndTransaction(
+      "inss-link-other-tx@test.dev",
+    );
+
+    // create a transaction for a different user
+    await registerAndLogin("inss-link-other-tx-owner@test.dev");
+    const { rows } = await dbQuery(
+      `INSERT INTO transactions (user_id, type, value, date, description)
+       VALUES ((SELECT id FROM users WHERE email = $1), $2, $3, $4, $5)
+       RETURNING id`,
+      ["inss-link-other-tx-owner@test.dev", "Entrada", 1412, "2026-02-25", "Outro"],
+    );
+    const txId = Number(rows[0].id);
+
+    const res = await request(app)
+      .post(`/income-sources/statements/${statementId}/link-transaction`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionId: txId });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("POST .../link-transaction retorna 422 para transacao tipo Saida", async () => {
+    const { token, statementId, transactionId: _ } = await setupStatementAndTransaction(
+      "inss-link-exit@test.dev",
+      { txType: "Saida" },
+    );
+
+    const { rows } = await dbQuery(
+      `SELECT id FROM transactions WHERE user_id = (SELECT id FROM users WHERE email = $1) LIMIT 1`,
+      ["inss-link-exit@test.dev"],
+    );
+    const txId = Number(rows[0].id);
+
+    const res = await request(app)
+      .post(`/income-sources/statements/${statementId}/link-transaction`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionId: txId });
+
+    expectErrorResponseWithRequestId(res, 422, "A transacao deve ser do tipo Entrada.");
+  });
+
+  it("POST .../link-transaction retorna 422 quando valor difere mais de 5%", async () => {
+    const { token, statementId } = await setupStatementAndTransaction(
+      "inss-link-amt@test.dev",
+      { netAmount: 1000, txValue: 1100 }, // 10% diff
+    );
+
+    const { rows } = await dbQuery(
+      `SELECT id FROM transactions WHERE user_id = (SELECT id FROM users WHERE email = $1) LIMIT 1`,
+      ["inss-link-amt@test.dev"],
+    );
+    const txId = Number(rows[0].id);
+
+    const res = await request(app)
+      .post(`/income-sources/statements/${statementId}/link-transaction`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionId: txId });
+
+    expect(res.status).toBe(422);
+  });
+
+  it("POST .../link-transaction retorna 422 quando data difere mais de 10 dias", async () => {
+    const { token, statementId } = await setupStatementAndTransaction(
+      "inss-link-date@test.dev",
+      { paymentDate: "2026-02-25", txDate: "2026-03-10" }, // 13 days diff
+    );
+
+    const { rows } = await dbQuery(
+      `SELECT id FROM transactions WHERE user_id = (SELECT id FROM users WHERE email = $1) LIMIT 1`,
+      ["inss-link-date@test.dev"],
+    );
+    const txId = Number(rows[0].id);
+
+    const res = await request(app)
+      .post(`/income-sources/statements/${statementId}/link-transaction`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionId: txId });
+
+    expect(res.status).toBe(422);
+  });
+
+  it("POST .../link-transaction retorna 409 ao tentar vincular outra transacao em extrato ja vinculado", async () => {
+    const { token, statementId, transactionId } = await setupStatementAndTransaction(
+      "inss-link-conflict@test.dev",
+    );
+
+    await request(app)
+      .post(`/income-sources/statements/${statementId}/link-transaction`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionId });
+
+    // create a second transaction for the same user
+    const { rows } = await dbQuery(
+      `INSERT INTO transactions (user_id, type, value, date, description)
+       VALUES ((SELECT id FROM users WHERE email = $1), $2, $3, $4, $5)
+       RETURNING id`,
+      ["inss-link-conflict@test.dev", "Entrada", 1412, "2026-02-25", "Outro credito"],
+    );
+    const txId2 = Number(rows[0].id);
+
+    const res = await request(app)
+      .post(`/income-sources/statements/${statementId}/link-transaction`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionId: txId2 });
+
+    expectErrorResponseWithRequestId(res, 409, "Extrato ja vinculado a outra transacao.");
+  });
 });

--- a/apps/api/src/income-sources.test.js
+++ b/apps/api/src/income-sources.test.js
@@ -721,7 +721,7 @@ describe("income-sources", () => {
   });
 
   it("POST .../link-transaction retorna 422 para transacao tipo Saida", async () => {
-    const { token, statementId, transactionId: _ } = await setupStatementAndTransaction(
+    const { token, statementId } = await setupStatementAndTransaction(
       "inss-link-exit@test.dev",
       { txType: "Saida" },
     );

--- a/apps/api/src/routes/income-sources.routes.js
+++ b/apps/api/src/routes/income-sources.routes.js
@@ -14,6 +14,7 @@ import {
   updateStatementForSource,
   postStatementForSource,
   listStatementsForSource,
+  linkStatementToTransaction,
 } from "../services/income-sources.service.js";
 
 const router = Router();
@@ -140,6 +141,23 @@ router.post(
     try {
       const result = await postStatementForSource(req.user.id, req.params.statementId);
       res.status(200).json(result);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.post(
+  "/statements/:statementId/link-transaction",
+  incomeSourcesWriteRateLimiter,
+  async (req, res, next) => {
+    try {
+      const statement = await linkStatementToTransaction(
+        req.user.id,
+        req.params.statementId,
+        req.body?.transactionId,
+      );
+      res.status(200).json({ statement });
     } catch (error) {
       next(error);
     }

--- a/apps/api/src/services/income-sources.service.js
+++ b/apps/api/src/services/income-sources.service.js
@@ -614,6 +614,93 @@ export const postStatementForSource = async (userId, statementId) => {
   });
 };
 
+// ─── Link Statement to Transaction ────────────────────────────────────────────
+
+const LINK_AMOUNT_TOLERANCE = 0.05; // 5%
+const LINK_DATE_TOLERANCE_DAYS = 10;
+
+const normalizeTransactionId = (value) => {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw createError(400, "ID de transacao invalido.");
+  }
+  return parsed;
+};
+
+export const linkStatementToTransaction = async (userId, statementId, transactionId) => {
+  const uid = normalizeUserId(userId);
+  const stid = normalizeStatementId(statementId);
+  const txid = normalizeTransactionId(transactionId);
+
+  // Fetch statement (ownership via JOIN with income_sources)
+  const { rows: stmtRows } = await dbQuery(
+    `SELECT st.*
+     FROM income_statements st
+     JOIN income_sources s ON s.id = st.income_source_id
+     WHERE st.id = $1 AND s.user_id = $2`,
+    [stid, uid],
+  );
+  if (!stmtRows[0]) throw createError(404, "Extrato nao encontrado.");
+  const stmt = stmtRows[0];
+
+  // Fetch transaction (ownership)
+  const { rows: txRows } = await dbQuery(
+    `SELECT * FROM transactions WHERE id = $1 AND user_id = $2`,
+    [txid, uid],
+  );
+  if (!txRows[0]) throw createError(404, "Transacao nao encontrada.");
+  const tx = txRows[0];
+
+  // Must be an income transaction
+  if (String(tx.type) !== TRANSACTION_TYPE_ENTRY) {
+    throw createError(422, "A transacao deve ser do tipo Entrada.");
+  }
+
+  // Amount compatibility: abs difference must be <= 5% of statement net_amount
+  const stmtAmount = toMoney(stmt.net_amount);
+  const txAmount = toMoney(tx.value);
+  const diff = Math.abs(txAmount - stmtAmount);
+  if (stmtAmount > 0 && diff / stmtAmount > LINK_AMOUNT_TOLERANCE) {
+    throw createError(
+      422,
+      `Valor da transacao (${txAmount.toFixed(2)}) difere mais de ${LINK_AMOUNT_TOLERANCE * 100}% do extrato (${stmtAmount.toFixed(2)}).`,
+    );
+  }
+
+  // Date compatibility: if payment_date set, transaction date must be within ±10 days
+  if (stmt.payment_date != null) {
+    const paymentMs = new Date(`${toISODate(stmt.payment_date)}T00:00:00Z`).getTime();
+    const txMs = new Date(`${toISODate(tx.date)}T00:00:00Z`).getTime();
+    const diffDays = Math.abs(paymentMs - txMs) / (1000 * 60 * 60 * 24);
+    if (diffDays > LINK_DATE_TOLERANCE_DAYS) {
+      throw createError(
+        422,
+        `Data da transacao difere mais de ${LINK_DATE_TOLERANCE_DAYS} dias da data de pagamento do extrato.`,
+      );
+    }
+  }
+
+  // If already linked to a different transaction, reject
+  if (stmt.posted_transaction_id != null && Number(stmt.posted_transaction_id) !== txid) {
+    throw createError(409, "Extrato ja vinculado a outra transacao.");
+  }
+
+  // Idempotent: already linked to same transaction
+  if (stmt.posted_transaction_id != null && Number(stmt.posted_transaction_id) === txid) {
+    return mapStatementRow(stmt);
+  }
+
+  const { rows: updatedRows } = await dbQuery(
+    `UPDATE income_statements
+     SET posted_transaction_id = $1, status = 'posted', updated_at = NOW()
+     WHERE id = $2
+     RETURNING *`,
+    [txid, stid],
+  );
+
+  return mapStatementRow(updatedRows[0]);
+};
+
 export const listStatementsForSource = async (userId, sourceId) => {
   const uid = normalizeUserId(userId);
   const sid = normalizeSourceId(sourceId);

--- a/apps/web/src/services/incomeSources.service.ts
+++ b/apps/web/src/services/incomeSources.service.ts
@@ -273,6 +273,18 @@ export const incomeSourcesService = {
     return normalizeStatementWithDeductions(data as { statement?: unknown; deductions?: unknown });
   },
 
+  linkTransaction: async (
+    statementId: number,
+    transactionId: number,
+  ): Promise<IncomeStatement> => {
+    const { data } = await api.post(
+      `/income-sources/statements/${statementId}/link-transaction`,
+      { transactionId },
+    );
+    const raw = data as { statement?: unknown };
+    return normalizeStatement((raw.statement ?? data) as RawStatement);
+  },
+
   postStatement: async (statementId: number): Promise<PostStatementResult> => {
     const { data } = await api.post(`/income-sources/statements/${statementId}/post`);
     const raw = data as {


### PR DESCRIPTION
## Objetivo

Fecha o gap semântico deixado pelo #284: um `income_statement` draft criado a partir de um comprovante INSS agora pode ser vinculado com segurança à transação que já existe no extrato importado — sem repostar receita, sem duplicar lançamento.

## Endpoint

```
POST /income-sources/statements/:statementId/link-transaction
{ "transactionId": 123 }
```

```json
{
  "statement": {
    "id": 45,
    "postedTransactionId": 123,
    "status": "posted"
  }
}
```

## Validações implementadas

| Regra | Erro |
|---|---|
| Statement pertence ao usuário autenticado | 404 |
| Transação pertence ao usuário autenticado | 404 |
| `transaction.type === "Entrada"` | 422 |
| `abs(tx.value − stmt.net_amount) / stmt.net_amount ≤ 5%` | 422 |
| `abs(tx.date − stmt.payment_date) ≤ 10 dias` (quando `payment_date` definido) | 422 |
| Statement já vinculado a **outra** transação | 409 |
| Statement já vinculado à **mesma** transação (re-call) | 200 idempotente |

## Cobertura

8 novos testes de integração em `income-sources.test.js`:

- vincula com sucesso + verifica `postedTransactionId` e `status: posted`
- idempotência (mesmo `transactionId` duas vezes → 200)
- cross-user isolation: extrato de outro usuário → 404
- cross-user isolation: transação de outro usuário → 404
- tipo `Saida` → 422
- valor fora de tolerância (10% > 5%) → 422
- data fora de tolerância (13 dias > 10 dias) → 422
- conflito: extrato já vinculado a outra transação → 409

**Suite API: 34 testes passando** em `income-sources.test.js`

## Frontend

`incomeSourcesService.linkTransaction(statementId, transactionId): Promise<IncomeStatement>` adicionado ao service. A UI que chama o endpoint fica para o próximo PR (precisa do `transactionId` disponível no contexto certo — ver seção de limitações).

## Limitações atuais / follow-ups

- **UI não exposta ainda**: o `transactionId` não está disponível no `IncomeStatementQuickModal` pois o `commitImportCsv` não retorna IDs individuais das transações criadas. O wiring de UI depende de: (a) expor IDs na resposta do commit, ou (b) buscar a transação por `import_session_id + payment_date` após o commit.
- **Follow-up B**: `CreateDetailedStatementPayload` com `grossAmount`, `deductions[]`, `benefitKind` — não entra aqui.
- **Follow-up C**: forecast engine consumir statements `posted` como `income_adj` — não entra aqui.

## Decisões de design

- **Tolerâncias explícitas**: 5% em valor e 10 dias em data são constantes nomeadas no service (`LINK_AMOUNT_TOLERANCE`, `LINK_DATE_TOLERANCE_DAYS`), não números mágicos.
- **Sem `postStatement`**: o endpoint não cria transação nova — apenas grava o vínculo. Evita duplicidade com o lançamento já gerado pelo import.
- **Status → `posted` na linkagem**: semanticamente correto — um statement vinculado a uma transação real está "lançado", mesmo que a transação não tenha sido criada por ele.