### PR TITLE
feat(import): expose createdTransactions in commit response

### DIFF
--- a/apps/api/src/import.test.js
+++ b/apps/api/src/import.test.js
@@ -1142,6 +1142,52 @@ describe("transaction imports", () => {
     expect(commitResponse.body.imported).toBe(1);
   });
 
+  it("POST /transactions/import/commit retorna createdTransactions com id e line", async () => {
+    const token = await registerAndLogin("import-created-txs@controlfinance.dev");
+    await makeProUser("import-created-txs@controlfinance.dev");
+
+    const csv = csvFile(
+      "date,type,value,description\n2026-03-01,Entrada,1412.00,INSS Credito\n2026-03-02,Saida,80.00,Supermercado",
+    );
+
+    const dryRunResponse = await request(app)
+      .post("/transactions/import/dry-run")
+      .set("Authorization", `Bearer ${token}`)
+      .attach("file", csv.buffer, { filename: csv.fileName, contentType: "text/csv" });
+
+    expect(dryRunResponse.status).toBe(200);
+
+    const commitResponse = await request(app)
+      .post("/transactions/import/commit")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ importId: dryRunResponse.body.importId });
+
+    expect(commitResponse.status).toBe(200);
+    expect(commitResponse.body.imported).toBe(2);
+
+    const { createdTransactions } = commitResponse.body;
+    expect(Array.isArray(createdTransactions)).toBe(true);
+    expect(createdTransactions).toHaveLength(2);
+
+    const entry = createdTransactions.find((tx) => tx.type === "Entrada");
+    expect(entry).toMatchObject({
+      type: "Entrada",
+      value: 1412,
+      date: "2026-03-01",
+      description: "INSS Credito",
+    });
+    expect(typeof entry.id).toBe("number");
+    expect(entry.id).toBeGreaterThan(0);
+    expect(entry.line).toBeGreaterThan(0);
+
+    const exit = createdTransactions.find((tx) => tx.type === "Saida");
+    expect(exit).toMatchObject({
+      type: "Saida",
+      value: 80,
+      date: "2026-03-02",
+    });
+  });
+
   it("DELETE /transactions/imports/:sessionId desfaz importacao por sessao", async () => {
     const token = await registerAndLogin("import-undo@controlfinance.dev");
     await makeProUser("import-undo@controlfinance.dev");

--- a/apps/api/src/routes/transactions.routes.js
+++ b/apps/api/src/routes/transactions.routes.js
@@ -408,6 +408,7 @@ router.post("/import/commit", importRateLimiter, requireFeature("csv_import"), a
     res.status(200).json({
       imported: commitResult.imported,
       importSessionId: commitResult.importSessionId,
+      createdTransactions: commitResult.createdTransactions ?? [],
       summary: commitResult.summary,
     });
   } catch (error) {

--- a/apps/api/src/services/transactions-import.service.js
+++ b/apps/api/src/services/transactions-import.service.js
@@ -166,6 +166,16 @@ const toIsoDateString = (value) => {
   return parsedDate.toISOString();
 };
 
+const toISODateOnly = (value) => {
+  if (!value) return null;
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return null;
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+};
+
 const parsePayloadJson = (payloadJson) => {
   if (!payloadJson) {
     return {};
@@ -881,7 +891,7 @@ export const commitTransactionsImportForUser = async (userId, importId, category
       `
         INSERT INTO transactions (user_id, type, value, date, description, notes, category_id, import_fingerprint, import_session_id, imported_at, import_file_name, import_document_type)
         VALUES ${insertValuesPlaceholders}
-        RETURNING type, value
+        RETURNING id, type, value, date, description
       `,
       insertParams,
     );
@@ -902,16 +912,29 @@ export const commitTransactionsImportForUser = async (userId, importId, category
       return total + Number(insertedRow.value || 0);
     }, 0);
 
+    // Zip returned rows with normalizedRows to associate each created
+    // transaction id with the original CSV line number.
+    const createdTransactions = insertResult.rows.map((row, i) => ({
+      id: Number(row.id),
+      line: normalizedRows[i]?.line ?? null,
+      type: String(row.type),
+      value: Number(row.value),
+      date: toISODateOnly(row.date),
+      description: row.description != null ? String(row.description) : null,
+    }));
+
     return {
       imported,
       income,
       expense,
+      createdTransactions,
     };
   });
 
   return {
     imported: commitOutcome.imported,
     importSessionId: normalizedImportId,
+    createdTransactions: commitOutcome.createdTransactions ?? [],
     summary: {
       income: commitOutcome.income,
       expense: commitOutcome.expense,

--- a/apps/web/src/services/transactions.service.ts
+++ b/apps/web/src/services/transactions.service.ts
@@ -172,9 +172,19 @@ export interface ImportDryRunResult {
   rows: ImportDryRunRow[];
 }
 
+export interface ImportCommitTransaction {
+  id: number;
+  line: number | null;
+  type: string;
+  value: number;
+  date: string;
+  description: string | null;
+}
+
 export interface ImportCommitResult {
   imported: number;
   importSessionId: string;
+  createdTransactions: ImportCommitTransaction[];
   summary: {
     income: number;
     expense: number;
@@ -331,6 +341,14 @@ interface ImportDryRunApiResponse {
 interface ImportCommitApiResponse {
   imported?: unknown;
   importSessionId?: unknown;
+  createdTransactions?: Array<{
+    id?: unknown;
+    line?: unknown;
+    type?: unknown;
+    value?: unknown;
+    date?: unknown;
+    description?: unknown;
+  }>;
   summary?: {
     income?: unknown;
     expense?: unknown;
@@ -730,9 +748,23 @@ export const transactionsService = {
     const { data } = await api.post("/transactions/import/commit", { importId, categoryOverrides });
     const responseBody = data as ImportCommitApiResponse;
 
+    const createdTransactions: ImportCommitTransaction[] = Array.isArray(
+      responseBody.createdTransactions,
+    )
+      ? responseBody.createdTransactions.map((tx) => ({
+          id: Number(tx.id) || 0,
+          line: tx.line != null ? Number(tx.line) : null,
+          type: typeof tx.type === "string" ? tx.type : "",
+          value: Number(tx.value) || 0,
+          date: typeof tx.date === "string" ? tx.date : "",
+          description: typeof tx.description === "string" ? tx.description : null,
+        }))
+      : [];
+
     return {
       imported: Number(responseBody.imported) || 0,
       importSessionId: String(responseBody.importSessionId || ""),
+      createdTransactions,
       summary: {
         income: Number(responseBody.summary?.income) || 0,
         expense: Number(responseBody.summary?.expense) || 0,


### PR DESCRIPTION
## Objetivo

Fecha o último gap de contexto entre o commit de importação e o wiring do `IncomeStatementQuickModal → linkTransaction`. A resposta do commit agora devolve os IDs e metadados de cada transação criada, permitindo que o frontend identifique a transação de renda e passe seu `id` para o endpoint de linkagem sem nenhum roundtrip extra.

## Mudança de contrato

**Antes:**
```json
{
  "imported": 2,
  "importSessionId": "imp_xxx",
  "summary": { "income": 1412, "expense": 80, "balance": 1332 }
}
```

**Depois:**
```json
{
  "imported": 2,
  "importSessionId": "imp_xxx",
  "createdTransactions": [
    { "id": 101, "line": 2, "type": "Entrada", "value": 1412.00, "date": "2026-03-01", "description": "INSS Credito" },
    { "id": 102, "line": 3, "type": "Saida",   "value": 80.00,   "date": "2026-03-02", "description": "Supermercado" }
  ],
  "summary": { "income": 1412, "expense": 80, "balance": 1332 }
}
```

Backwards-compatible: `summary`, `imported` e `importSessionId` não mudaram.

## Implementação

- `RETURNING type, value` → `RETURNING id, type, value, date, description` no INSERT de transações
- `createdTransactions` montado via zip entre `insertResult.rows` e `normalizedRows` (preserva `line` da sessão de dry-run)
- `toISODateOnly` helper adicionado para normalizar datas `pg`/`pg-mem` → `YYYY-MM-DD`
- Route serializa `commitResult.createdTransactions ?? []`

## Frontend

`ImportCommitTransaction` interface + `ImportCommitResult.createdTransactions` tipados e normalizados em `commitImportCsv`. Pronto para uso no wiring UI do próximo PR.

## Testes

1 novo teste de integração em `import.test.js`:
- Commit de 2 linhas (Entrada + Saida)
- Verifica `createdTransactions.length === 2`
- Verifica `id > 0`, `line > 0`, `type`, `value`, `date` (`YYYY-MM-DD`), `description` em ambas as linhas

**Suite: 44 import tests passando (+1)**

## Dependências de PR

| PR | Estado | Relação |
|---|---|---|
| #284 `feat/inss-income-bridge` | ⏳ open | adiciona `IncomeStatementQuickModal` |
| #285 `feat/income-link-transaction` | ⏳ open | adiciona `linkTransaction` endpoint |
| este (#286) | ⏳ open | expõe `transactionId` no commit |

O wiring UI (`IncomeStatementQuickModal` → `linkTransaction` com `transactionId` do commit) entra no PR seguinte, após #284 + #285 + este mergearem.