### PR TITLE
feat(income): wire IncomeStatementQuickModal into ImportCsvModal with auto-link

### DIFF
--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -188,6 +188,14 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
     };
   }, [dryRunResult]);
 
+  // First Entrada transaction created by the last commit — used for auto-link
+  const incomeTransactionId = useMemo(() => {
+    const txs = lastCommitResult?.createdTransactions;
+    if (!Array.isArray(txs)) return null;
+    return txs.find((tx) => tx.type === "Entrada")?.id ?? null;
+  }, [lastCommitResult]);
+
+
   const handleApplyProfile = async () => {
     if (!profilePatch) return;
     setIsApplyingProfile(true);
@@ -822,6 +830,7 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
         isOpen={isIncomeModalOpen}
         onClose={() => setIsIncomeModalOpen(false)}
         prefill={incomePrefill}
+        transactionId={incomeTransactionId}
         onCreated={() => {
           setIsIncomeModalOpen(false);
           setIncomeStatementCreated(true);

--- a/apps/web/src/components/IncomeStatementQuickModal.test.tsx
+++ b/apps/web/src/components/IncomeStatementQuickModal.test.tsx
@@ -2,16 +2,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import IncomeStatementQuickModal from "./IncomeStatementQuickModal";
-import { incomeSourcesService } from "../services/incomeSources.service";
+import { incomeSourcesService, type IncomeSourceWithDeductions } from "../services/incomeSources.service";
 
 vi.mock("../services/incomeSources.service", () => ({
   incomeSourcesService: {
     list: vi.fn(),
     createStatement: vi.fn(),
+    linkTransaction: vi.fn(),
   },
 }));
 
-const buildSource = (overrides = {}) => ({
+const buildSource = (overrides: Partial<IncomeSourceWithDeductions> = {}): IncomeSourceWithDeductions => ({
   id: 1,
   userId: 1,
   name: "INSS Benefício",
@@ -24,33 +25,44 @@ const buildSource = (overrides = {}) => ({
   ...overrides,
 });
 
+const mockStatement = {
+  id: 10,
+  incomeSourceId: 1,
+  referenceMonth: "2026-02",
+  netAmount: 1412,
+  totalDeductions: 0,
+  paymentDate: null,
+  status: "draft" as const,
+  postedTransactionId: null,
+  createdAt: "2026-02-25T00:00:00Z",
+  updatedAt: "2026-02-25T00:00:00Z",
+};
+
 describe("IncomeStatementQuickModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(incomeSourcesService.list).mockResolvedValue([buildSource()]);
+    vi.mocked(incomeSourcesService.createStatement).mockResolvedValue({
+      statement: mockStatement,
+      deductions: [],
+    });
+    vi.mocked(incomeSourcesService.linkTransaction).mockResolvedValue(mockStatement);
   });
 
   it("does not render when isOpen is false", () => {
-    render(
-      <IncomeStatementQuickModal isOpen={false} onClose={vi.fn()} />,
-    );
+    render(<IncomeStatementQuickModal isOpen={false} onClose={vi.fn()} />);
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
   it("shows guidance when no income sources exist", async () => {
     vi.mocked(incomeSourcesService.list).mockResolvedValue([]);
-
     render(<IncomeStatementQuickModal isOpen onClose={vi.fn()} />);
-
     await waitFor(() => {
-      expect(
-        screen.getByText(/Nenhuma fonte de renda cadastrada/i),
-      ).toBeInTheDocument();
+      expect(screen.getByText(/Nenhuma fonte de renda cadastrada/i)).toBeInTheDocument();
     });
   });
 
   it("pre-fills fields from prefill prop", async () => {
-    vi.mocked(incomeSourcesService.list).mockResolvedValue([buildSource()]);
-
     render(
       <IncomeStatementQuickModal
         isOpen
@@ -58,45 +70,22 @@ describe("IncomeStatementQuickModal", () => {
         prefill={{ referenceMonth: "2026-02", netAmount: 1412.0, paymentDate: "2026-02-25" }}
       />,
     );
-
     await waitFor(() => {
       expect(screen.getByLabelText(/Competência/i)).toHaveValue("2026-02");
     });
-
     expect(screen.getByLabelText(/Valor líquido/i)).toHaveValue(1412);
     expect(screen.getByLabelText(/Data de pagamento/i)).toHaveValue("2026-02-25");
   });
 
   it("auto-selects single source", async () => {
-    vi.mocked(incomeSourcesService.list).mockResolvedValue([buildSource()]);
-
     render(<IncomeStatementQuickModal isOpen onClose={vi.fn()} />);
-
     await waitFor(() => {
       expect(screen.getByRole("combobox", { name: /Fonte de renda/i })).toHaveValue("1");
     });
   });
 
-  it("submits and shows success state", async () => {
-    vi.mocked(incomeSourcesService.list).mockResolvedValue([buildSource()]);
-    vi.mocked(incomeSourcesService.createStatement).mockResolvedValue({
-      statement: {
-        id: 10,
-        incomeSourceId: 1,
-        referenceMonth: "2026-02",
-        netAmount: 1412,
-        totalDeductions: 0,
-        paymentDate: null,
-        status: "draft",
-        postedTransactionId: null,
-        createdAt: "2026-02-25T00:00:00Z",
-        updatedAt: "2026-02-25T00:00:00Z",
-      },
-      deductions: [],
-    });
-
+  it("submits and shows success state without linkage", async () => {
     const onCreated = vi.fn();
-
     render(
       <IncomeStatementQuickModal
         isOpen
@@ -105,34 +94,19 @@ describe("IncomeStatementQuickModal", () => {
         onCreated={onCreated}
       />,
     );
-
     await waitFor(() => {
       expect(screen.getByRole("combobox", { name: /Fonte de renda/i })).toHaveValue("1");
     });
-
     await userEvent.click(screen.getByRole("button", { name: "Registrar" }));
-
-    await waitFor(() => {
-      expect(incomeSourcesService.createStatement).toHaveBeenCalledWith(1, {
-        referenceMonth: "2026-02",
-        netAmount: 1412,
-        paymentDate: null,
-      });
-    });
-
     await waitFor(() => {
       expect(screen.getByText("Lançamento registrado com sucesso.")).toBeInTheDocument();
     });
-
-    expect(onCreated).toHaveBeenCalled();
+    expect(onCreated).toHaveBeenCalledWith(mockStatement);
+    expect(incomeSourcesService.linkTransaction).not.toHaveBeenCalled();
   });
 
   it("shows error message when createStatement rejects", async () => {
-    vi.mocked(incomeSourcesService.list).mockResolvedValue([buildSource()]);
-    vi.mocked(incomeSourcesService.createStatement).mockRejectedValue(
-      new Error("Falha de rede"),
-    );
-
+    vi.mocked(incomeSourcesService.createStatement).mockRejectedValue(new Error("Falha de rede"));
     render(
       <IncomeStatementQuickModal
         isOpen
@@ -140,15 +114,71 @@ describe("IncomeStatementQuickModal", () => {
         prefill={{ referenceMonth: "2026-02", netAmount: 1412 }}
       />,
     );
-
     await waitFor(() => {
       expect(screen.getByRole("combobox", { name: /Fonte de renda/i })).toHaveValue("1");
     });
-
     await userEvent.click(screen.getByRole("button", { name: "Registrar" }));
-
     await waitFor(() => {
       expect(screen.getByText("Falha de rede")).toBeInTheDocument();
     });
+  });
+
+  it("auto-links to transaction when transactionId provided and shows linked status", async () => {
+    render(
+      <IncomeStatementQuickModal
+        isOpen
+        onClose={vi.fn()}
+        transactionId={99}
+        prefill={{ referenceMonth: "2026-02", netAmount: 1412 }}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("combobox", { name: /Fonte de renda/i })).toHaveValue("1");
+    });
+    await userEvent.click(screen.getByRole("button", { name: "Registrar" }));
+    await waitFor(() => {
+      expect(screen.getByText(/vínculo com a transação importada confirmado/i)).toBeInTheDocument();
+    });
+    expect(incomeSourcesService.linkTransaction).toHaveBeenCalledWith(10, 99);
+  });
+
+  it("shows amber warning when linkage fails after successful statement creation", async () => {
+    vi.mocked(incomeSourcesService.linkTransaction).mockRejectedValue(
+      new Error("Tolerância de valor excedida."),
+    );
+    render(
+      <IncomeStatementQuickModal
+        isOpen
+        onClose={vi.fn()}
+        transactionId={99}
+        prefill={{ referenceMonth: "2026-02", netAmount: 1412 }}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("combobox", { name: /Fonte de renda/i })).toHaveValue("1");
+    });
+    await userEvent.click(screen.getByRole("button", { name: "Registrar" }));
+    await waitFor(() => {
+      expect(
+        screen.getByText(/histórico registrado, mas o vínculo com a transação/i),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText(/vincular manualmente/i)).toBeInTheDocument();
+    expect(screen.getByText("Lançamento registrado com sucesso.")).toBeInTheDocument();
+  });
+
+  it("shows validation error when source not selected", async () => {
+    vi.mocked(incomeSourcesService.list).mockResolvedValue([
+      buildSource({ id: 1, name: "A" }),
+      buildSource({ id: 2, name: "B" }),
+    ]);
+    render(<IncomeStatementQuickModal isOpen onClose={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: "A" })).toBeInTheDocument();
+    });
+    // Don't select anything — submit with empty source
+    await userEvent.selectOptions(screen.getByRole("combobox"), "");
+    await userEvent.click(screen.getByRole("button", { name: "Registrar" }));
+    expect(screen.getByText(/selecione uma fonte/i)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/IncomeStatementQuickModal.tsx
+++ b/apps/web/src/components/IncomeStatementQuickModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import {
   incomeSourcesService,
   type IncomeSourceWithDeductions,
+  type IncomeStatement,
 } from "../services/incomeSources.service";
 import { getApiErrorMessage } from "../utils/apiError";
 
@@ -15,13 +16,18 @@ interface Props {
   isOpen: boolean;
   onClose: () => void;
   prefill?: IncomeStatementPrefill | null;
-  onCreated?: () => void;
+  /** When provided, automatically links the created statement to this transaction. */
+  transactionId?: number | null;
+  onCreated?: (statement: IncomeStatement) => void;
 }
+
+type LinkStatus = "idle" | "linking" | "linked" | "link_failed";
 
 export default function IncomeStatementQuickModal({
   isOpen,
   onClose,
   prefill,
+  transactionId,
   onCreated,
 }: Props) {
   const [sources, setSources] = useState<IncomeSourceWithDeductions[]>([]);
@@ -32,7 +38,9 @@ export default function IncomeStatementQuickModal({
   const [paymentDate, setPaymentDate] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
-  const [success, setSuccess] = useState(false);
+  const [createdStatement, setCreatedStatement] = useState<IncomeStatement | null>(null);
+  const [linkStatus, setLinkStatus] = useState<LinkStatus>("idle");
+  const [linkError, setLinkError] = useState("");
 
   // Reset + fetch sources on open
   useEffect(() => {
@@ -42,12 +50,13 @@ export default function IncomeStatementQuickModal({
       setNetAmount("");
       setPaymentDate("");
       setErrorMessage("");
-      setSuccess(false);
+      setCreatedStatement(null);
+      setLinkStatus("idle");
+      setLinkError("");
       setSources([]);
       return;
     }
 
-    // Apply prefill
     setReferenceMonth(prefill?.referenceMonth ?? "");
     setNetAmount(prefill?.netAmount != null ? String(prefill.netAmount) : "");
     setPaymentDate(prefill?.paymentDate ?? "");
@@ -73,12 +82,10 @@ export default function IncomeStatementQuickModal({
       setErrorMessage("Selecione uma fonte de renda.");
       return;
     }
-
     if (!referenceMonth.trim()) {
       setErrorMessage("Informe a competência.");
       return;
     }
-
     const parsedNet = Number(netAmount);
     if (!Number.isFinite(parsedNet) || parsedNet <= 0) {
       setErrorMessage("Informe um valor líquido válido.");
@@ -88,13 +95,28 @@ export default function IncomeStatementQuickModal({
     setIsSubmitting(true);
     setErrorMessage("");
     try {
-      await incomeSourcesService.createStatement(parsedSourceId, {
+      const { statement } = await incomeSourcesService.createStatement(parsedSourceId, {
         referenceMonth: referenceMonth.trim(),
         netAmount: parsedNet,
         paymentDate: paymentDate.trim() || null,
       });
-      setSuccess(true);
-      onCreated?.();
+
+      setCreatedStatement(statement);
+      onCreated?.(statement);
+
+      // Auto-link if transactionId was supplied
+      if (transactionId) {
+        setLinkStatus("linking");
+        try {
+          await incomeSourcesService.linkTransaction(statement.id, transactionId);
+          setLinkStatus("linked");
+        } catch (linkErr) {
+          setLinkStatus("link_failed");
+          setLinkError(
+            getApiErrorMessage(linkErr, "Não foi possível vincular à transação importada."),
+          );
+        }
+      }
     } catch (err) {
       setErrorMessage(getApiErrorMessage(err, "Não foi possível registrar o lançamento."));
     } finally {
@@ -103,6 +125,8 @@ export default function IncomeStatementQuickModal({
   };
 
   if (!isOpen) return null;
+
+  const success = createdStatement !== null;
 
   return (
     <div
@@ -136,14 +160,43 @@ export default function IncomeStatementQuickModal({
         </div>
 
         {success ? (
-          <div className="rounded border border-green-200 bg-green-50 px-3 py-3 dark:border-green-800 dark:bg-green-950/40">
-            <p className="mb-3 text-sm font-semibold text-green-700 dark:text-green-400">
-              Lançamento registrado com sucesso.
-            </p>
+          <div className="space-y-2">
+            <div className="rounded border border-green-200 bg-green-50 px-3 py-3 dark:border-green-800 dark:bg-green-950/40">
+              <p className="text-sm font-semibold text-green-700 dark:text-green-400">
+                Lançamento registrado com sucesso.
+              </p>
+
+              {linkStatus === "linking" && (
+                <p className="mt-1 text-xs text-green-600 dark:text-green-400">
+                  Vinculando à transação importada...
+                </p>
+              )}
+              {linkStatus === "linked" && (
+                <p className="mt-1 text-xs font-medium text-green-700 dark:text-green-400">
+                  Vínculo com a transação importada confirmado.
+                </p>
+              )}
+            </div>
+
+            {linkStatus === "link_failed" && (
+              <div className="rounded border border-amber-200 bg-amber-50 px-3 py-2 dark:border-amber-800 dark:bg-amber-950/40">
+                <p className="text-xs font-medium text-amber-700 dark:text-amber-400">
+                  Histórico registrado, mas o vínculo com a transação importada não foi concluído.
+                </p>
+                {linkError && (
+                  <p className="mt-0.5 text-xs text-amber-600 dark:text-amber-400">{linkError}</p>
+                )}
+                <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
+                  Você pode vincular manualmente pelo histórico de renda.
+                </p>
+              </div>
+            )}
+
             <button
               type="button"
               onClick={onClose}
-              className="rounded border border-green-400 bg-green-100 px-3 py-1.5 text-sm font-semibold text-green-700 hover:bg-green-200 dark:border-green-700 dark:bg-green-900/40 dark:text-green-300"
+              disabled={linkStatus === "linking"}
+              className="rounded border border-green-400 bg-green-100 px-3 py-1.5 text-sm font-semibold text-green-700 hover:bg-green-200 disabled:cursor-not-allowed disabled:opacity-60 dark:border-green-700 dark:bg-green-900/40 dark:text-green-300"
             >
               Fechar
             </button>


### PR DESCRIPTION
## Summary

- **`IncomeStatementQuickModal`** — new modal: fonte de renda selector, competência, valor líquido, data de pagamento (opcional); prefill via prop; auto-link à transação importada via `transactionId` prop
- **`ImportCsvModal`** — wired: `incomePrefill` (from `dryRunResult.suggestion`), `incomeTransactionId` (first `Entrada` from `lastCommitResult.createdTransactions`); "Registrar no histórico de renda" CTA in profile suggestion card
- **Auto-link flow** — after `createStatement` succeeds, calls `incomeSourcesService.linkTransaction(statement.id, transactionId)`; split-failure (statement ok, link fails) surfaces amber warning, not error; user can link manually from income history
- **`incomeSources.service.ts`** — adds `linkTransaction` method (matches `POST /income-sources/statements/:id/link-transaction` from #285)

## Dependencies

This PR depends on:
- **#284** `feat/inss-income-bridge` — `IncomeStatementQuickModal` base + CTA (without linkage)
- **#285** `feat/income-link-transaction` — `POST /income-sources/statements/:id/link-transaction` endpoint
- **#286** `feat/import-expose-transaction-ids` — `createdTransactions` in commit response

Merge those three first, then rebase this branch.

## Test plan

- [x] 9 unit tests in `IncomeStatementQuickModal.test.tsx`: render, prefill, submit, auto-link success, split-failure amber warning, validation, close
- [x] Full web suite: 280 tests passing
- [ ] Manual: import CSV with INSS suggestion → commit → click "Registrar no histórico de renda" → verify prefill, statement created, link confirmed
- [ ] Manual: force link to fail (e.g. wrong amount) → verify amber warning + green success coexist