### PR TITLE
feat(forecast): Follow-up C — statement-aware income (v2 engine)

### DIFF
--- a/apps/api/src/forecast.test.js
+++ b/apps/api/src/forecast.test.js
@@ -97,7 +97,7 @@ describe("POST /forecasts/recompute", () => {
     expect(typeof res.body.dailyAvgSpending).toBe("number");
     expect(typeof res.body.daysRemaining).toBe("number");
     expect(typeof res.body.flipDetected).toBe("boolean");
-    expect(res.body.engineVersion).toBe("v1");
+    expect(res.body.engineVersion).toBe("v2");
     expect(res.body.incomeExpected).toBeNull();
   });
 
@@ -459,5 +459,181 @@ describe("forecast — bills integration", () => {
       res.body.projectedBalance - 1450.4,
       1,
     );
+  });
+});
+
+// ─── Forecast — statement-aware income (deterministic) ───────────────────────
+
+// Helpers: insert an income_source + statement for a given user
+const insertIncomeSource = async (userId, name = "Salário") => {
+  const { rows } = await dbQuery(
+    `INSERT INTO income_sources (user_id, name) VALUES ($1, $2) RETURNING id`,
+    [userId, name],
+  );
+  return Number(rows[0].id);
+};
+
+const insertStatement = async (sourceId, { referenceMonth, netAmount, paymentDate, status = "draft" }) => {
+  const { rows } = await dbQuery(
+    `INSERT INTO income_statements
+       (income_source_id, reference_month, net_amount, total_deductions, payment_date, status)
+     VALUES ($1, $2, $3, 0, $4, $5)
+     RETURNING id`,
+    [sourceId, referenceMonth, netAmount, paymentDate ?? null, status],
+  );
+  return Number(rows[0].id);
+};
+
+describe("computeForecast — statement-aware income (deterministic)", () => {
+  // FIXED_NOW = 2026-03-10; mEnd = 2026-03-31; currentMonth = '2026-03'
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await clearDbClientForTests(); });
+  beforeEach(resetState);
+
+  it("sem statements: fallback para salary quando payday ainda nao chegou", async () => {
+    await registerAndLogin("fc-stmt-fallback@test.dev");
+    const userId = await getUserIdByEmail("fc-stmt-fallback@test.dev");
+
+    await dbQuery(
+      `INSERT INTO user_profiles (user_id, salary_monthly, payday) VALUES ($1, 4000, 31)`,
+      [userId],
+    );
+
+    const result = await computeForecast(userId, { now: FIXED_NOW });
+
+    expect(result.incomeExpected).toBe(4000);
+    expect(result.projectedBalance).toBe(4000); // netToDate=0, adj=4000, daily=0
+  });
+
+  it("statement posted no mes: incomeAdjustment=0, incomeExpected=net_amount", async () => {
+    await registerAndLogin("fc-stmt-posted@test.dev");
+    const userId = await getUserIdByEmail("fc-stmt-posted@test.dev");
+
+    // salary exists but statement should win
+    await dbQuery(
+      `INSERT INTO user_profiles (user_id, salary_monthly, payday) VALUES ($1, 9000, 31)`,
+      [userId],
+    );
+
+    const sid = await insertIncomeSource(userId);
+    await insertStatement(sid, {
+      referenceMonth: "2026-03",
+      netAmount: 5000,
+      paymentDate: "2026-03-05", // already past, but status=posted
+      status: "posted",
+    });
+
+    const result = await computeForecast(userId, { now: FIXED_NOW });
+
+    // incomeExpected = 5000 (statement), not 9000 (salary)
+    expect(result.incomeExpected).toBe(5000);
+    // posted statement already in transactions — no cash adjustment
+    expect(result.projectedBalance).toBe(0); // netToDate=0, adj=0, daily=0
+  });
+
+  it("statement draft com payment_date futuro: incomeAdjustment=net_amount", async () => {
+    await registerAndLogin("fc-stmt-draft-future@test.dev");
+    const userId = await getUserIdByEmail("fc-stmt-draft-future@test.dev");
+
+    const sid = await insertIncomeSource(userId);
+    await insertStatement(sid, {
+      referenceMonth: "2026-03",
+      netAmount: 3500,
+      paymentDate: "2026-03-25", // future: > 2026-03-10
+      status: "draft",
+    });
+
+    const result = await computeForecast(userId, { now: FIXED_NOW });
+
+    expect(result.incomeExpected).toBe(3500);
+    expect(result.projectedBalance).toBe(3500); // netToDate=0, adj=3500, daily=0
+  });
+
+  it("statement draft com payment_date passada: incomeAdjustment=0", async () => {
+    await registerAndLogin("fc-stmt-draft-past@test.dev");
+    const userId = await getUserIdByEmail("fc-stmt-draft-past@test.dev");
+
+    const sid = await insertIncomeSource(userId);
+    await insertStatement(sid, {
+      referenceMonth: "2026-03",
+      netAmount: 3500,
+      paymentDate: "2026-03-05", // past: < 2026-03-10
+      status: "draft",
+    });
+
+    const result = await computeForecast(userId, { now: FIXED_NOW });
+
+    // incomeExpected = statement net_amount (competence)
+    expect(result.incomeExpected).toBe(3500);
+    // but no cash adjustment (payment date already passed without posting)
+    expect(result.projectedBalance).toBe(0);
+  });
+
+  it("statement draft com payment_date em abril: nao entra no caixa de marco", async () => {
+    await registerAndLogin("fc-stmt-next-month@test.dev");
+    const userId = await getUserIdByEmail("fc-stmt-next-month@test.dev");
+
+    const sid = await insertIncomeSource(userId);
+    // reference_month = 2026-03 (competência março), mas cai no caixa de abril
+    await insertStatement(sid, {
+      referenceMonth: "2026-03",
+      netAmount: 4200,
+      paymentDate: "2026-04-02", // next month: > mEnd (2026-03-31)
+      status: "draft",
+    });
+
+    const result = await computeForecast(userId, { now: FIXED_NOW });
+
+    // income_expected de março = 4200 (competência)
+    expect(result.incomeExpected).toBe(4200);
+    // mas não entra no caixa projetado de março
+    expect(result.projectedBalance).toBe(0);
+  });
+
+  it("statement draft sem payment_date: nao entra no incomeAdjustment", async () => {
+    await registerAndLogin("fc-stmt-no-date@test.dev");
+    const userId = await getUserIdByEmail("fc-stmt-no-date@test.dev");
+
+    const sid = await insertIncomeSource(userId);
+    await insertStatement(sid, {
+      referenceMonth: "2026-03",
+      netAmount: 2800,
+      paymentDate: null,
+      status: "draft",
+    });
+
+    const result = await computeForecast(userId, { now: FIXED_NOW });
+
+    expect(result.incomeExpected).toBe(2800);
+    expect(result.projectedBalance).toBe(0); // sem data, sem ajuste de caixa
+  });
+
+  it("multiplas fontes: soma corretamente em income_expected e incomeAdjustment", async () => {
+    await registerAndLogin("fc-stmt-multi@test.dev");
+    const userId = await getUserIdByEmail("fc-stmt-multi@test.dev");
+
+    const sid1 = await insertIncomeSource(userId, "Emprego principal");
+    const sid2 = await insertIncomeSource(userId, "Freela");
+
+    // posted — já na transação, não entra em adjustment
+    await insertStatement(sid1, {
+      referenceMonth: "2026-03",
+      netAmount: 5000,
+      paymentDate: "2026-03-05",
+      status: "posted",
+    });
+
+    // draft com data futura — entra em adjustment
+    await insertStatement(sid2, {
+      referenceMonth: "2026-03",
+      netAmount: 1500,
+      paymentDate: "2026-03-20",
+      status: "draft",
+    });
+
+    const result = await computeForecast(userId, { now: FIXED_NOW });
+
+    expect(result.incomeExpected).toBe(6500); // 5000 + 1500
+    expect(result.projectedBalance).toBe(1500); // adj = apenas draft futuro
   });
 });

--- a/apps/api/src/services/forecast.service.js
+++ b/apps/api/src/services/forecast.service.js
@@ -1,7 +1,7 @@
 import { dbQuery } from "../db/index.js";
 import { getPendingBillsDueByDate } from "./bills.service.js";
 
-const ENGINE_VERSION = "v1";
+const ENGINE_VERSION = "v2";
 
 const createError = (status, message) => {
   const error = new Error(message);
@@ -71,6 +71,8 @@ export const computeForecast = async (userId, { now = new Date() } = {}) => {
   const mStart = monthStartStr(now);
   const mEnd = monthEndStr(now);
   const todayDay = now.getUTCDate();
+  const todayStr = now.toISOString().slice(0, 10);
+  const currentMonth = mStart.slice(0, 7); // 'YYYY-MM'
   const daysRemaining = calcDaysRemaining(now);
 
   // 1. Profile (salary + payday)
@@ -113,10 +115,41 @@ export const computeForecast = async (userId, { now = new Date() } = {}) => {
   const total60d = Number(dailyResult.rows[0].total_60d);
   const dailyAvgSpending = total60d / 60;
 
-  // 4. Expected income for rest of month:
-  //    Add salary only if payday is still upcoming this month
-  const incomeAdjustment =
-    salaryMonthly != null && payday != null && payday > todayDay
+  // 4a. income_expected — competence-based: all statements for reference_month = current month
+  const stmtExpectedResult = await dbQuery(
+    `SELECT COALESCE(SUM(st.net_amount), 0) AS total
+     FROM income_statements st
+     JOIN income_sources s ON s.id = st.income_source_id
+     WHERE s.user_id = $1
+       AND st.reference_month = $2`,
+    [uid, currentMonth],
+  );
+  const statementsExpected = Number(stmtExpectedResult.rows[0].total);
+
+  // 4b. incomeAdjustment — cash-flow-based: draft statements whose payment_date
+  //     is still upcoming within the current month (posted ones already live in transactions)
+  const stmtCashResult = await dbQuery(
+    `SELECT COALESCE(SUM(st.net_amount), 0) AS total
+     FROM income_statements st
+     JOIN income_sources s ON s.id = st.income_source_id
+     WHERE s.user_id = $1
+       AND st.status = 'draft'
+       AND st.payment_date > $2
+       AND st.payment_date <= $3`,
+    [uid, todayStr, mEnd],
+  );
+  const statementsCashPending = Number(stmtCashResult.rows[0].total);
+
+  // 4c. Resolve incomeExpected and incomeAdjustment.
+  //     Statements win over salary; salary is fallback only.
+  //     Posted statements are never added to incomeAdjustment (already in incomeToDate).
+  const hasStatementsThisMonth = statementsExpected > 0;
+  const incomeExpected = hasStatementsThisMonth
+    ? statementsExpected
+    : salaryMonthly;
+  const incomeAdjustment = hasStatementsThisMonth
+    ? statementsCashPending
+    : salaryMonthly != null && payday != null && payday > todayDay
       ? salaryMonthly
       : 0;
 
@@ -164,7 +197,7 @@ export const computeForecast = async (userId, { now = new Date() } = {}) => {
        flip_detected      = EXCLUDED.flip_detected,
        flip_direction     = EXCLUDED.flip_direction,
        generated_at       = EXCLUDED.generated_at`,
-    [uid, mStart, ENGINE_VERSION, pb, salaryMonthly, spendingToDate.toFixed(2), da, daysRemaining, flipDetected, flipDirection],
+    [uid, mStart, ENGINE_VERSION, pb, incomeExpected, spendingToDate.toFixed(2), da, daysRemaining, flipDetected, flipDirection],
   );
 
   const monthEnd = monthEndStr(now);
@@ -175,7 +208,7 @@ export const computeForecast = async (userId, { now = new Date() } = {}) => {
     month: mStart.slice(0, 7),
     engineVersion: ENGINE_VERSION,
     projectedBalance: pb,
-    incomeExpected: salaryMonthly,
+    incomeExpected,
     spendingToDate: Number(spendingToDate.toFixed(2)),
     dailyAvgSpending: da,
     daysRemaining,


### PR DESCRIPTION
## O que muda

O engine de forecast (`computeForecast`) usava `salary_monthly` como proxy de renda esperada. Agora statements do domínio `income_sources` são a fonte de verdade; salary vira fallback.

### Duas visões separadas (evita confusão competência × caixa)

| Visão | Base | Quem entra |
|---|---|---|
| `income_expected` | `reference_month = mês corrente` | todos os statements (draft ou posted) |
| `incomeAdjustment` | `payment_date > hoje` e `payment_date ≤ fim do mês` | apenas `draft` |

**Guard de double-count:** statements `posted` já têm `posted_transaction_id` → a transação já vive em `incomeToDate` → nunca entram em `incomeAdjustment`.

### Exemplo do bug que isso previne

Statement de março pago em abril:
- entra em `income_expected` de março (competência) ✓
- **não** entra no caixa projetado de março (cash flow) ✓

Com query única de `reference_month` esse statement seria indevidamente somado ao `incomeAdjustment` de março.

### Fallback

Sem statements para o mês corrente → comportamento idêntico ao anterior (salary + payday logic). Nenhum usuário sem income sources é afetado.

## Arquivos

- `apps/api/src/services/forecast.service.js` — ENGINE_VERSION v2, queries 4a/4b, lógica 4c
- `apps/api/src/forecast.test.js` — 7 novos cenários determinísticos + atualização de engineVersion

## Testes

28/28 passando (`forecast.test.js`), incluindo todos os existentes (zero regressões).

## Cenários cobertos

- Sem statements → salary fallback (regressão)
- Statement posted → `incomeAdjustment=0`, `incomeExpected=net_amount`
- Draft com `payment_date` futura → entra no caixa
- Draft com `payment_date` passada → excluído do caixa
- Draft com `payment_date` em abril → excluído do caixa de março
- Draft sem `payment_date` → excluído do caixa
- Múltiplas fontes → posted + draft futuro somados corretamente