### PR TITLE
docs: update Central do Leão documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,11 @@ CORS_ORIGIN=http://localhost:5173
 # OCR for low-signal statement PDFs. Keep disabled on small hosts.
 # Enable only on hosts with at least 1GB RAM available to the API service.
 IMPORT_OCR_ENABLED=false
+# Central do Leão (IRPF)
+# Persist fiscal uploads outside the temp directory in production.
+# TAX_DOCUMENTS_STORAGE_DIR=/var/data/control-finance/tax-documents
+# Optional max upload size in bytes (default: 10 MB)
+# TAX_DOCUMENT_MAX_FILE_SIZE_BYTES=10485760
 # Ops endpoint guard (non-production only; required for /ops/force-plan)
 # OPS_TOKEN=troque-isto-por-um-token-forte
 # Stripe checkout (billing)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.31.0] - 2026-03-26
+## [Unreleased]
 
 ### Title
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,72 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.31.0] - 2026-03-26
+
+### Title
+
+v1.31.0 - Central do Leão (IRPF MVP)
+
+### Added
+
+#### Central do Leão API (PR #290)
+
+- Novo domínio fiscal isolado em `/tax`
+- Migrations `100` a `105` para:
+  - `tax_documents`
+  - `tax_document_extractions`
+  - `tax_facts`
+  - `tax_reviews`
+  - `tax_rule_sets`
+  - `tax_summaries`
+- Pipeline fiscal completo no backend:
+  - upload de documentos
+  - classificação
+  - extração
+  - normalização em fatos fiscais
+  - review queue
+  - obrigatoriedade por exercício
+  - resumo anual snapshotado
+  - lifecycle documental (retry/delete)
+- Export oficial do dossiê fiscal:
+  - `GET /tax/export/:taxYear?format=json`
+  - `GET /tax/export/:taxYear?format=csv`
+- Manifesto mínimo no export com:
+  - `summarySnapshotVersion`
+  - `factsIncluded`
+  - `engineVersion`
+  - `dataHash`
+- Storage documental fiscal com:
+  - `TAX_DOCUMENTS_STORAGE_DIR`
+  - `TAX_DOCUMENT_MAX_FILE_SIZE_BYTES`
+
+#### Central do Leão Web (PR #290)
+
+- Nova área protegida:
+  - `/app/tax`
+  - `/app/tax/:taxYear`
+- Dashboard fiscal com:
+  - obrigatoriedade
+  - warnings
+  - snapshot anual
+  - fila de revisão
+- Upload fiscal dentro da `TaxPage`
+- Reprocessamento, exclusão e rebuild automático do summary após ações documentais
+- Download oficial de `JSON` e `CSV` via backend, substituindo o export montado localmente no frontend
+
+### Changed
+
+- A trilha fiscal passou a usar um contrato oficial de export no backend, sem side effect implícito de rebuild
+- O produto agora inclui uma frente explícita de preparação do IRPF, com guardrail claro: organiza e prepara, mas não transmite DIRPF
+
+### Quality
+
+- `npm test` na raiz verde
+- `npm run lint` na raiz verde
+- `npm run build` na raiz verde
+- API: `695/695` testes passando
+- Web: `291/291` testes passando
+
 ## [1.30.0] - 2026-03-25
 
 **Especialista IA + Metas de Poupança + Dashboard executivo**

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 **Control Finance: seu Copiloto Financeiro com IA.**
 
 Não é só um app para registrar entradas e saídas.
-É um cockpit financeiro pessoal para acompanhar o presente, visualizar a trajetória do mês e tomar decisões com mais clareza usando metas, projeções e insights acionáveis.
+É um cockpit financeiro pessoal para acompanhar o presente, visualizar a trajetória do mês e tomar decisões com mais clareza usando metas, projeções, insights acionáveis e uma trilha fiscal assistida para preparação do IRPF.
 
 ## Proposta de valor
 
@@ -17,6 +17,7 @@ O Control Finance evoluiu de um gerenciador de gastos para uma experiência de *
 * destaca sinais de risco antes do problema explodir
 * conecta metas de poupança ao contexto financeiro real
 * entrega um insight objetivo do **Especialista IA** no dashboard
+* organiza o **IRPF** com a Central do Leão: documentos, revisão, resumo anual e dossiê fiscal exportável
 
 ## O que o produto entrega
 
@@ -68,6 +69,15 @@ O Control Finance evoluiu de um gerenciador de gastos para uma experiência de *
   * defina suas metas de poupança
   * ouça o Especialista IA
 
+### 7. Central do Leão (IRPF MVP)
+
+* rota dedicada em `/app/tax` e `/app/tax/:taxYear`
+* upload fiscal de `PDF`, `CSV`, `PNG` e `JPG`
+* pipeline determinístico: documento -> classificação -> extração -> fatos fiscais -> revisão
+* comparação de obrigatoriedade e resumo anual por exercício
+* rebuild explícito de snapshot fiscal e export oficial de dossiê em `JSON` e `CSV`
+* guardrail de produto: prepara e organiza o IRPF, mas **não** transmite DIRPF nem substitui os canais oficiais da Receita
+
 ## Stack
 
 ### Web
@@ -117,6 +127,7 @@ API (apps/api)
   -> auth
   -> transactions
   -> goals
+  -> tax (Central do Leao / IRPF)
   -> export CSV
   -> insight de IA
   -> Postgres
@@ -144,6 +155,14 @@ API (apps/api)
 * acompanhar progresso percentual
 * visualizar valor restante
 * saber exatamente quanto precisa guardar por mês
+
+### Central do Leão
+
+* subir documentos fiscais e reprocessar quando necessário
+* revisar fatos fiscais aprovando, corrigindo ou rejeitando
+* rebuildar o resumo anual do exercício com snapshot versionado
+* baixar o dossiê oficial do produto em `JSON` e `CSV`
+* trabalhar com um fluxo honesto de preparação do IRPF sem prometer envio oficial à Receita
 
 ### Segurança e resiliência
 
@@ -201,6 +220,8 @@ AUTH_RATE_LIMIT_WINDOW_MS=
 AUTH_BRUTE_FORCE_MAX_ATTEMPTS=
 AUTH_BRUTE_FORCE_WINDOW_MS=
 AUTH_BRUTE_FORCE_LOCK_MS=
+TAX_DOCUMENTS_STORAGE_DIR=
+TAX_DOCUMENT_MAX_FILE_SIZE_BYTES=10485760
 ```
 
 ### IA
@@ -250,6 +271,7 @@ Configuração recomendada:
 * login e registro funcionam
 * `VITE_API_URL` aponta para a API pública
 * `ANTHROPIC_API_KEY` está configurada na API se a camada de IA estiver habilitada
+* `TAX_DOCUMENTS_STORAGE_DIR` aponta para storage persistente se a Central do Leão estiver habilitada em produção
 
 ## Scripts
 
@@ -290,6 +312,8 @@ npm -w apps/web run build
 
 * `docs/roadmap-execution.md` — mapa interno de execução: estado atual, próximo sprint, backlog e decisões arquiteturais
 
+* `docs/architecture/v1.31.0-central-do-leao-irpf.md`
+* `docs/architecture/v1.6.11-billing-state-machine.md`
 * `docs/architecture/v1.3.0.md`
 * `docs/architecture/v1.3.0-auth.md`
 * `docs/architecture/v1.3.1-transactions.md`
@@ -297,7 +321,7 @@ npm -w apps/web run build
 * `docs/architecture/v1.4.2-auth-hardening.md`
 * `docs/architecture/v1.4.3-transactions-crud-plus.md`
 * `docs/architecture/v1.5.0-export-csv.md`
-* `docs/architecture/v1.5.1-export-polish.md`
+* `docs/architecture/v1.6.6-web-typescript-services-and-routes.md`
 
 ## Roadmap
 
@@ -308,6 +332,7 @@ npm -w apps/web run build
 * [x] Health Overview
 * [x] Saving Goals
 * [x] Especialista IA
+* [x] Central do Leão (IRPF MVP)
 * [x] Onboarding orientado a valor
 * [ ] Importação com revisão assistida
 * [ ] Simulações "e se?"

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -45,3 +45,8 @@ AUTH_BRUTE_FORCE_LOCK_MS=900000
 # Rate limit: chamadas ao /ai/insight por usuário (padrão: 10 calls / 10 min)
 # AI_RATE_LIMIT_MAX=10
 # AI_RATE_LIMIT_WINDOW_MS=600000
+# Central do Leão (IRPF)
+# Persist fiscal uploads outside the temp directory in production.
+# TAX_DOCUMENTS_STORAGE_DIR=/var/data/control-finance/tax-documents
+# Optional max upload size in bytes (default: 10 MB)
+# TAX_DOCUMENT_MAX_FILE_SIZE_BYTES=10485760

--- a/docs/architecture/v1.31.0-central-do-leao-irpf.md
+++ b/docs/architecture/v1.31.0-central-do-leao-irpf.md
@@ -1,0 +1,80 @@
+# Arquitetura v1.31.0 (Central do Leão — IRPF MVP)
+
+## Objetivo
+
+Adicionar ao Control Finance uma trilha fiscal de preparação do IRPF sem acoplar o produto à API da Receita no MVP.
+
+## Escopo
+
+- domínio isolado em `/tax`
+- ingestão documental fiscal com storage próprio
+- classificação e extração determinística por tipo de documento
+- normalização em `tax_facts`
+- revisão humana com trilha de auditoria
+- regras anuais, obrigatoriedade e resumo snapshotado
+- export oficial do dossiê fiscal em `JSON` e `CSV`
+
+## Domínio Backend
+
+### Migrations
+
+- `100_tax_documents.sql`
+- `101_tax_document_extractions.sql`
+- `102_tax_facts.sql`
+- `103_tax_reviews.sql`
+- `104_tax_rule_sets.sql`
+- `105_tax_summaries.sql`
+
+### Pipeline
+
+```text
+upload
+  -> tax_documents
+  -> classificação
+  -> tax_document_extractions
+  -> normalização
+  -> tax_facts
+  -> revisão humana
+  -> tax_summaries
+  -> export oficial
+```
+
+### Contratos principais
+
+- `POST /tax/documents`
+- `POST /tax/documents/:id/reprocess`
+- `DELETE /tax/documents/:id`
+- `GET /tax/facts`
+- `PATCH /tax/facts/:id/review`
+- `POST /tax/facts/bulk-review`
+- `GET /tax/rules/:taxYear`
+- `GET /tax/obligation/:taxYear`
+- `GET /tax/summary/:taxYear`
+- `POST /tax/summary/:taxYear/rebuild`
+- `GET /tax/export/:taxYear?format=json|csv`
+
+## Domínio Web
+
+- rota protegida em `/app/tax`
+- rota por exercício em `/app/tax/:taxYear`
+- dashboard da Central do Leão
+- modal de upload fiscal
+- fila de revisão
+- rebuild de resumo
+- retry/delete por documento
+- download do dossiê oficial pelo backend
+
+## Guardrails de Produto
+
+- não transmite DIRPF
+- não depende de pré-preenchida oficial
+- export não recalcula snapshot implicitamente
+- summary considera apenas fatos `approved` e `corrected`
+- erro `TAX_SUMMARY_NOT_GENERATED` quando o dossiê ainda não está pronto
+
+## Notas Operacionais
+
+- `TAX_DOCUMENTS_STORAGE_DIR` define o storage dos documentos fiscais
+- `TAX_DOCUMENT_MAX_FILE_SIZE_BYTES` controla o limite de upload
+- formatos aceitos no MVP: `PDF`, `CSV`, `PNG`, `JPG`
+- cleanup físico de documento é `best effort`; consistência do banco vem primeiro

--- a/docs/roadmap-execution.md
+++ b/docs/roadmap-execution.md
@@ -15,6 +15,7 @@ O produto é um **Copiloto Financeiro**:
 - lê a saúde financeira de forma executiva (HealthOverview + gauge)
 - gera insights contextuais via Claude Haiku (Especialista IA)
 - acompanha metas de poupança com cálculo automático de necessidade mensal
+- prepara o IRPF com a Central do Leão sem depender da Receita no MVP
 - prepara o terreno para automações mais inteligentes sem inflar escopo cedo demais
 
 ### Regra central
@@ -23,7 +24,7 @@ O produto é um **Copiloto Financeiro**:
 
 ---
 
-## 2. Estado atual confirmado (v1.30.0)
+## 2. Estado atual confirmado (v1.31.0)
 
 ### Monorepo
 
@@ -54,6 +55,11 @@ npm run preview
 - Claude Haiku: `GET /ai/insight` com contexto de forecast + categorias + metas
 - Saving Goals: CRUD completo + `calcMonthlyNeeded` + `getGoalsSummaryForAI`
 - Billing: Stripe + trial + paywall por feature flag
+- Central do Leão:
+  - `/tax` com upload, classificação, extração, normalização e review queue
+  - regras anuais de IRPF, obrigatoriedade e resumo snapshotado
+  - lifecycle documental com retry/delete
+  - export oficial do dossiê em `JSON` e `CSV`
 - Migrations automáticas no startup com advisory lock
 - `GET /health` com status de migrations
 
@@ -66,13 +72,18 @@ npm run preview
 - Bills summary widget
 - Onboarding: WelcomeCard v2 com funil de 4 etapas
 - Modo Discreto: `DiscreetModeContext` com `isDiscreetMode`/`toggleDiscreetMode`/`useMaskedCurrency`
+- Central do Leão em `/app/tax`:
+  - upload e reprocessamento de documentos fiscais
+  - review queue de fatos fiscais
+  - rebuild do resumo por exercício
+  - export oficial via backend
 
 ### Placar de testes
 
 | Suite | Testes |
 |-------|--------|
-| API   | 552    |
-| Web   | 261    |
+| API   | 695    |
+| Web   | 291    |
 
 ---
 
@@ -162,7 +173,37 @@ Toda entrega nova deve responder a pelo menos um destes critérios:
 
 ---
 
-## 6. Melhorias incrementais de produto (backlog)
+## 6. Marco entregue depois da Sprint B — Central do Leão (mergeado em main — PR #290)
+
+### O que foi entregue
+
+**IRPF MVP** como subdomínio próprio, sem contaminar `transactions`.
+
+**Backend**
+- schema fiscal próprio com migrations `100` a `105`
+- pipeline documental: upload -> classificação -> extração -> normalização -> revisão -> summary -> export
+- review queue com trilha em `tax_reviews`
+- obrigatoriedade e resumo anual calculados a partir de fatos revisados
+- lifecycle documental com deleção lógica completa e cleanup físico `best effort`
+- export oficial do dossiê fiscal em `JSON` e `CSV`
+
+**Frontend**
+- rota protegida `/app/tax` com navegação pelo dashboard
+- dashboard da Central do Leão com warnings, resumo e fila de revisão
+- modal de upload fiscal com reprocessamento automático
+- retry/delete por documento com rebuild de snapshot
+- download oficial do dossiê pelo backend
+
+### Guardrails fixados
+
+- não transmitir DIRPF no MVP
+- não depender de API da Receita
+- export nunca recalcula snapshot escondido
+- CSV = fatos revisados; JSON = dossiê completo
+
+---
+
+## 7. Melhorias incrementais de produto (backlog)
 
 Estas melhorias são diretas, de baixo risco e de alto valor percebido.
 
@@ -188,7 +229,7 @@ Botão que navega para `/app/settings/security` — rota já existe e `SecurityS
 
 ---
 
-## 7. Roadmap de produto — próxima liga
+## 8. Roadmap de produto — próxima liga
 
 ### Simulador de Impacto ("Posso comprar isso?")
 
@@ -211,7 +252,10 @@ Reusa `transactions` sem nova infra.
 
 ---
 
-## 8. Importação Inteligente de Documentos (roadmap — não abre agora)
+## 9. Importação Inteligente de Documentos fora da trilha fiscal (roadmap — não abre agora)
+
+> Observação: a trilha fiscal IRPF já abriu seu subdomínio próprio em `/tax`.
+> Esta nota vale para futuras frentes documentais fora da Central do Leão.
 
 Se essa frente for aberta no futuro, deve nascer como **subdomínio próprio**, não como extensão de `transactions`.
 
@@ -233,7 +277,7 @@ Se essa frente for aberta no futuro, deve nascer como **subdomínio próprio**, 
 
 ---
 
-## 9. Decisões arquiteturais fixadas
+## 10. Decisões arquiteturais fixadas
 
 | Decisão | Motivo |
 |---|---|
@@ -242,18 +286,18 @@ Se essa frente for aberta no futuro, deve nascer como **subdomínio próprio**, 
 | `DiscreetModeContext` separado de `AuthContext` | Responsabilidade única; preferência de UI ≠ sessão de autenticação |
 | Fallback de assinatura neutro ("Acesso ativo") | Sem prometer entitlement que o backend não confirmou |
 | pg-mem para testes de API | Sem banco real em CI; compatível com o subset de SQL usado |
-| Squash merge sempre | Histórico limpo; cherry-pick limpo quando branches divergem |
+| Preferir merges lineares (rebase/ff) em stacks | Preserva slices encadeados e reduz merge bubble em épicos longos |
 
 ---
 
-## 10. Frase-guia para não perder o trilho
+## 11. Frase-guia para não perder o trilho
 
 > **O Control Finance já pensa como copiloto.**
 > **Os próximos passos devem fazê-lo agir como copiloto — sem sacrificar foco, clareza e qualidade estrutural.**
 
 ---
 
-## 11. Visão de produto — O Copiloto da Vida Real
+## 12. Visão de produto — O Copiloto da Vida Real
 
 O Control Finance tem potencial de ser o app financeiro mais útil para a maioria dos brasileiros:
 trabalhadores com renda mensal entre R$ 2.000 e R$ 8.000, que vivem o fluxo de caixa mês a mês,
@@ -277,7 +321,7 @@ não têm assessor financeiro, e precisam de clareza — não de palestra.
 
 ---
 
-## 12. Regra de Ouro de UX — Modo Sem Humilhação
+## 13. Regra de Ouro de UX — Modo Sem Humilhação
 
 > **Nunca fazer o usuário se sentir burro, pobre ou irresponsável.**
 
@@ -304,7 +348,7 @@ Copywriting errado quebra a relação com o produto.
 
 ---
 
-## 13. Backlog estratégico — Faixa 1: Sobrevivência e Controle de Dano
+## 14. Backlog estratégico — Faixa 1: Sobrevivência e Controle de Dano
 
 Features que evitam que o usuário "se afogue" no mês. Alto impacto emocional, baixo esforço técnico.
 
@@ -385,7 +429,7 @@ Requer: tabela `financial_calendar_events` com tipo, mês, valor estimado.
 
 ---
 
-## 14. Backlog estratégico — Faixa 2: Otimização de Fluxo de Caixa
+## 15. Backlog estratégico — Faixa 2: Otimização de Fluxo de Caixa
 
 Features que melhoram como o dinheiro flui — sem exigir disciplina extra do usuário.
 
@@ -451,7 +495,7 @@ Requer: detecção de sazonalidade + prompt especializado para IA.
 
 ---
 
-## 15. Backlog estratégico — Faixa 3: Inteligência Avançada
+## 16. Backlog estratégico — Faixa 3: Inteligência Avançada
 
 Features que transformam dados em decisões. Requerem mais dados acumulados para funcionar bem.
 
@@ -513,7 +557,7 @@ Requer: contexto enriquecido (transações + metas + forecast) + interface de ch
 
 ---
 
-## 16. Decisões de não fazer (e por quê)
+## 17. Decisões de não fazer (e por quê)
 
 | Feature | Por que não agora |
 |---|---|
@@ -526,7 +570,7 @@ Requer: contexto enriquecido (transações + metas + forecast) + interface de ch
 
 ---
 
-## 17. Notas de produto para não esquecer
+## 18. Notas de produto para não esquecer
 
 - **Payday é sagrado**: tudo no produto orbita em torno do dia de pagamento do usuário. Forecast, metas, alertas — tudo usa `payday` como âncora.
 - **O mês do usuário não é o mês do calendário**: se o usuário recebe dia 15, o "mês financeiro" dele é de 15 a 14.


### PR DESCRIPTION
## Summary
- update the public README with the Central do Leao IRPF capability and fiscal env variables
- add the architecture note for the IRPF MVP and refresh the internal roadmap/memory
- keep the changelog entry as Unreleased until a formal 1.31.0 tag/release exists

## Notes
- docs and env examples only
- no runtime behavior changes