### PR TITLE
fix(tax): handle annual INSS and bank reports in fiscal pipeline

### DIFF
--- a/apps/api/src/domain/tax/tax-document-classifier.js
+++ b/apps/api/src/domain/tax/tax-document-classifier.js
@@ -5,6 +5,7 @@ const normalizeForClassification = (text) =>
   String(text || "")
     .normalize("NFD")
     .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[º°]/g, "o")
     .toLowerCase()
     .replace(/\s+/g, " ")
     .trim();
@@ -55,6 +56,14 @@ const INSS_SIGNALS = [
   "meu.inss.gov.br",
   "especie",
   "nb:",
+];
+
+const INSS_ANNUAL_SIGNALS = [
+  "fundo do regime geral de previdencia social",
+  "numero do beneficio",
+  "natureza do rendimento",
+  "parcela isenta do 13o",
+  "proventos de aposentadoria",
 ];
 
 const BANK_INCOME_REPORT_SIGNALS = [
@@ -126,6 +135,11 @@ const isInssIncomeReport = (normalizedText) =>
   normalizedText.includes("instituto nacional do seguro social") &&
   countMatches(normalizedText, INSS_SIGNALS) >= 2;
 
+const isInssAnnualIncomeReport = (normalizedText) =>
+  normalizedText.includes("comprovante de rendimentos pagos e de") &&
+  normalizedText.includes("imposto sobre a renda retido na fonte") &&
+  countMatches(normalizedText, INSS_ANNUAL_SIGNALS) >= 2;
+
 const isBankIncomeReport = (normalizedText) =>
   normalizedText.includes("informe de rendimentos") &&
   (
@@ -180,12 +194,17 @@ export const classifyTaxDocument = ({
 
   if (
     detectImportDocumentType({ text, extension }) === "income_statement_inss" ||
-    isInssIncomeReport(normalizedText)
+    isInssIncomeReport(normalizedText) ||
+    isInssAnnualIncomeReport(normalizedText)
   ) {
     return createClassification({
       documentType: "income_report_inss",
       confidenceScore: 0.99,
-      reasons: ["matched_import_classifier:income_statement_inss"],
+      reasons: [
+        detectImportDocumentType({ text, extension }) === "income_statement_inss"
+          ? "matched_import_classifier:income_statement_inss"
+          : "matched_inss_income_report_signals",
+      ],
       sourceLabelSuggestion: "INSS",
     });
   }

--- a/apps/api/src/domain/tax/tax-document-classifier.test.js
+++ b/apps/api/src/domain/tax/tax-document-classifier.test.js
@@ -47,6 +47,23 @@ describe("tax document classifier", () => {
     expect(result.sourceLabelSuggestion).toBe("INSS");
   });
 
+  it("detecta comprovante anual do INSS antes de cair no classifier de empregador", () => {
+    const result = classifyTaxDocument({
+      originalFileName: "inss-anual.pdf",
+      text: [
+        "Ministerio da Economia Comprovante de Rendimentos Pagos e de",
+        "Imposto sobre a Renda Retido na Fonte",
+        "Exercicio de 2026 Ano-calendario de 2025",
+        "16.727.230/0001-97 Fundo do Regime Geral de Previdencia Social",
+        "Numero do Beneficio",
+        "Parcela isenta do 13o salario de aposentadoria 1.903,98",
+      ].join("\n"),
+    });
+
+    expect(result.documentType).toBe("income_report_inss");
+    expect(result.sourceLabelSuggestion).toBe("INSS");
+  });
+
   it("detecta demonstrativo medico", () => {
     const result = classifyTaxDocument({
       originalFileName: "unimed.csv",

--- a/apps/api/src/domain/tax/tax-document-extractors.js
+++ b/apps/api/src/domain/tax/tax-document-extractors.js
@@ -3,22 +3,31 @@ import {
   parseInssCreditHistoryPdfText,
 } from "../imports/statement-import.js";
 
-const EXTRACTOR_VERSION = "1.0.0";
+const EXTRACTOR_VERSION = "1.1.0";
 const MAX_PREVIEW_LINES = 8;
 
 const normalizeText = (text) =>
   String(text || "")
     .normalize("NFD")
     .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[º°]/g, "o")
     .toLowerCase();
 
-const getPreviewLines = (text, limit = MAX_PREVIEW_LINES) =>
+const getLineEntries = (text) =>
   String(text || "")
     .replace(/\r/g, "")
     .split("\n")
-    .map((line) => line.trim())
+    .map((raw) => raw.trim())
     .filter(Boolean)
-    .slice(0, limit);
+    .map((raw) => ({
+      raw,
+      normalized: normalizeText(raw),
+    }));
+
+const getPreviewLines = (text, limit = MAX_PREVIEW_LINES) =>
+  getLineEntries(text)
+    .slice(0, limit)
+    .map((entry) => entry.raw);
 
 const parseSignedAmount = (value) => {
   const normalizedValue = String(value || "").trim().replace(/^R\$\s*/i, "");
@@ -52,27 +61,6 @@ const parseSignedAmount = (value) => {
   return Number(parsedValue.toFixed(2));
 };
 
-const extractYear = (text) => {
-  const yearMatch =
-    String(text || "").match(/ano[-\s]?calendario[:\s]+(20\d{2})/i) ||
-    String(text || "").match(/31\/12\/(20\d{2})/i) ||
-    String(text || "").match(/\b(20\d{2})\b/);
-
-  return yearMatch ? Number(yearMatch[1]) : null;
-};
-
-const extractAllBalances = (text) => {
-  const matches = String(text || "").matchAll(/(31\/12\/20\d{2}).{0,60}?r?\$?\s*([\d.,]+)/gi);
-
-  return [...matches]
-    .map((match) => ({
-      date: match[1],
-      amount: parseSignedAmount(match[2]),
-    }))
-    .filter((item) => item.amount !== null)
-    .slice(0, 4);
-};
-
 const extractFirstMatch = (text, regex) => {
   const match = String(text || "").match(regex);
   return match ? match[1].trim() : null;
@@ -97,81 +85,236 @@ const extractAmountByPatterns = (text, patterns) => {
 };
 
 const buildSectionFlags = (normalizedText, descriptors) =>
-  descriptors.filter((descriptor) => normalizedText.includes(descriptor)).map((descriptor) => descriptor);
+  descriptors.filter((descriptor) => normalizedText.includes(descriptor));
 
-const extractBankIncomeReport = (text, classification) => {
+const extractYearFromLine = (value) => {
+  const yearMatch = String(value || "").match(/\b(20\d{2})\b/);
+  return yearMatch ? Number(yearMatch[1]) : null;
+};
+
+const extractCalendarYear = (text) => {
   const normalizedText = normalizeText(text);
+  const directMatch =
+    normalizedText.match(/ano[-\s]?calendario(?:\s+de|[:\s]+)\s*(20\d{2})/i) ||
+    normalizedText.match(/exercicio\s+de\s+20\d{2}\s+ano[-\s]?calendario(?:\s+de|[:\s]+)\s*(20\d{2})/i);
+
+  if (directMatch) {
+    return Number(directMatch[1]);
+  }
+
+  const lineEntries = getLineEntries(text);
+
+  for (let index = 0; index < lineEntries.length; index += 1) {
+    const entry = lineEntries[index];
+
+    if (!entry.normalized.includes("ano calendario")) {
+      continue;
+    }
+
+    const nearbyYears = [
+      extractYearFromLine(entry.raw),
+      extractYearFromLine(lineEntries[index - 1]?.raw),
+      extractYearFromLine(lineEntries[index + 1]?.raw),
+    ].filter((value) => Number.isInteger(value));
+
+    if (nearbyYears.length > 0) {
+      return nearbyYears[0];
+    }
+  }
+
+  return null;
+};
+
+const extractGenericYearEndBalances = (text) => {
+  const lineEntries = getLineEntries(text);
+  const balances = [];
+
+  for (const entry of lineEntries) {
+    const sameLineMatch = entry.normalized.match(
+      /saldo em 31\/12\/(20\d{2})(?:\s+saldo em 31\/12\/(20\d{2}))?.*?r\$\s*([\d.,]+)(?:\s+r\$\s*([\d.,]+))?/i,
+    );
+
+    if (!sameLineMatch) {
+      continue;
+    }
+
+    const [, firstYear, secondYear, firstAmount, secondAmount] = sameLineMatch;
+    const firstParsedAmount = parseSignedAmount(firstAmount);
+    const secondParsedAmount = parseSignedAmount(secondAmount);
+
+    if (firstParsedAmount !== null) {
+      balances.push({
+        date: `31/12/${firstYear}`,
+        amount: firstParsedAmount,
+      });
+    }
+
+    if (secondYear && secondParsedAmount !== null) {
+      balances.push({
+        date: `31/12/${secondYear}`,
+        amount: secondParsedAmount,
+      });
+    }
+  }
+
+  return balances.slice(0, 4);
+};
+
+const sumAmounts = (items, selector) =>
+  Number(
+    (Array.isArray(items) ? items : []).reduce((total, item) => {
+      const value = Number(selector(item) || 0);
+      return Number.isFinite(value) ? total + value : total;
+    }, 0).toFixed(2),
+  );
+
+const hasMatchingSectionTotal = (items, expectedValue, selector) => {
+  if (!Number.isFinite(Number(expectedValue))) {
+    return true;
+  }
+
+  return Math.abs(sumAmounts(items, selector) - Number(expectedValue)) < 0.01;
+};
+
+const parseInstitutionLine = (lineEntries, lineMatcher) => {
+  const entry = lineEntries.find((item) => lineMatcher.test(item.normalized));
+
+  if (!entry) {
+    return {
+      name: null,
+      document: null,
+    };
+  }
+
+  const match = entry.raw.match(
+    /(?:fonte pagadora|credor):\s*(.+?)\s+cnpj:\s*(\d{2}\.?\d{3}\.?\d{3}\/?\d{4}-?\d{2})/i,
+  );
+
+  if (!match) {
+    return {
+      name: null,
+      document: null,
+    };
+  }
 
   return {
-    extractorName: "income-report-bank",
+    name: match[1].trim(),
+    document: match[2].trim(),
+  };
+};
+
+const parseCustomerInfo = (lineEntries) => {
+  const clientEntry = lineEntries.find((entry) => entry.normalized.startsWith("cliente:"));
+
+  if (clientEntry) {
+    const clientMatch = clientEntry.raw.match(
+      /cliente:\s*(.+?)\s+cpf:\s*(\d{3}\.?\d{3}\.?\d{3}-?\d{2})/i,
+    );
+
+    if (clientMatch) {
+      return {
+        name: clientMatch[1].trim(),
+        cpf: clientMatch[2].trim(),
+      };
+    }
+  }
+
+  const cpfIndex = lineEntries.findIndex((entry) => entry.normalized === "cpf:");
+  const nameIndex = lineEntries.findIndex((entry) => entry.normalized === "nome completo:");
+
+  return {
+    name:
+      nameIndex >= 0 && lineEntries[nameIndex + 1]
+        ? lineEntries[nameIndex + 1].raw
+        : null,
+    cpf:
+      cpfIndex >= 0 && lineEntries[cpfIndex + 1]
+        ? lineEntries[cpfIndex + 1].raw
+        : null,
+  };
+};
+
+const extractAnnualInssIncomeReport = (text) => {
+  const normalizedText = normalizeText(text);
+  const collapsedText = normalizedText.replace(/\s+/g, " ");
+
+  if (
+    !collapsedText.includes("comprovante de rendimentos pagos e de") ||
+    !collapsedText.includes("imposto sobre a renda retido na fonte")
+  ) {
+    return null;
+  }
+
+  const lineEntries = getLineEntries(text);
+  const payerLine = lineEntries.find((entry) =>
+    /\d{2}\.?\d{3}\.?\d{3}\/?\d{4}-?\d{2}/.test(entry.raw),
+  );
+  const beneficiaryLine = lineEntries.find((entry) =>
+    /\d{3}\.?\d{3}\.?\d{3}-?\d{2}.+\d{8,}/.test(entry.raw),
+  );
+  const natureLine = lineEntries.find((entry) => /^\d{4}[-–]/.test(entry.raw));
+
+  const payerMatch = payerLine?.raw.match(
+    /(\d{2}\.?\d{3}\.?\d{3}\/?\d{4}-?\d{2})\s+(.+)/,
+  );
+  const beneficiaryMatch = beneficiaryLine?.raw.match(
+    /(\d{3}\.?\d{3}\.?\d{3}-?\d{2})\s+(.+?)\s+(\d{8,})$/,
+  );
+  const natureMatch = natureLine?.raw.match(/^(\d{4})[-–](.+)$/);
+
+  return {
+    extractorName: "income-report-inss",
     extractorVersion: EXTRACTOR_VERSION,
     payload: {
-      reportYear: extractYear(text),
-      institutionName: classification.sourceLabelSuggestion,
-      institutionDocument: extractFirstMatch(text, /\b(\d{2}\.?\d{3}\.?\d{3}\/?\d{4}-?\d{2})\b/),
-      exclusiveTaxIncomeTotal: extractAmountByPatterns(text, [
-        /(?:rendimentos sujeitos a\s+)?tributacao exclusiva(?:[^\n\r]{0,80}?)r?\$?\s*([\d.,]+)/i,
+      reportProfile: "annual",
+      reportYear: extractCalendarYear(text),
+      payerName: payerMatch?.[2]?.trim() || "INSS",
+      payerDocument: payerMatch?.[1]?.trim() || null,
+      beneficiaryName: beneficiaryMatch?.[2]?.trim() || null,
+      beneficiaryDocument: beneficiaryMatch?.[1]?.trim() || null,
+      benefitNumber: beneficiaryMatch?.[3]?.trim() || null,
+      incomeNatureCode: natureMatch?.[1]?.trim() || null,
+      incomeNatureDescription: natureMatch?.[2]?.trim() || null,
+      taxableIncome: extractAmountByPatterns(normalizedText, [
+        /1\.\s*total dos rendimentos \(inclusive ferias\)\s+([\d.]*,\d{2})/i,
       ]),
-      exemptIncomeTotal: extractAmountByPatterns(text, [
-        /rendimentos isentos(?:\s+e\s+nao\s+tributaveis)?(?:[^\n\r]{0,80}?)r?\$?\s*([\d.,]+)/i,
+      officialSocialSecurity: extractAmountByPatterns(normalizedText, [
+        /2\.\s*contribuicao previdenciaria oficial\s+([\d.]*,\d{2})/i,
       ]),
-      withheldTaxTotal: extractAmountByPatterns(text, [
-        /imposto(?:\s+sobre\s+a\s+renda)?\s+retido\s+na\s+fonte(?:[^\n\r]{0,80}?)r?\$?\s*([\d.,]+)/i,
+      privatePensionOrFapi: extractAmountByPatterns(normalizedText, [
+        /3\.\s*contribuicoes a entidades de previdencia complementar.*?\s+([\d.]*,\d{2})/i,
       ]),
-      detectedSections: buildSectionFlags(normalizedText, [
-        "rendimentos sujeitos",
-        "tributacao exclusiva",
-        "rendimentos isentos",
-        "31/12/",
+      alimony: extractAmountByPatterns(normalizedText, [
+        /4\.\s*pensao alimenticia.*?\s+([\d.]*,\d{2})/i,
       ]),
-      yearEndBalances: extractAllBalances(text),
+      withheldTax: extractAmountByPatterns(normalizedText, [
+        /5\.\s*imposto sobre a renda retido na fonte\s+([\d.]*,\d{2})/i,
+      ]),
+      retirement65PlusExempt: extractAmountByPatterns(normalizedText, [
+        /1\.\s*parcela isenta dos proventos de aposentadoria.*?\s+([\d.]*,\d{2})/i,
+      ]),
+      retirement65PlusThirteenthExempt: extractAmountByPatterns(normalizedText, [
+        /2\.\s*parcela isenta do 13o salario.*?\s+([\d.]*,\d{2})/i,
+      ]),
+      thirteenthSalary: extractAmountByPatterns(normalizedText, [
+        /1\.\s*decimo terceiro salario\s+([\d.]*,\d{2})/i,
+      ]),
+      thirteenthWithheldTax: extractAmountByPatterns(normalizedText, [
+        /2\.\s*imposto sobre a renda retido na fonte sobre 13o salario\s+([\d.]*,\d{2})/i,
+      ]),
+      annualSimplifiedDiscount: extractAmountByPatterns(normalizedText, [
+        /desconto simplificado.*?valor anual r\$\s*([\d.]*,\d{2})/i,
+      ]),
+      thirteenthSimplifiedDiscount: extractAmountByPatterns(normalizedText, [
+        /desconto simplificado.*?valor de 13o r\$\s*([\d.]*,\d{2})/i,
+      ]),
       previewLines: getPreviewLines(text),
     },
     warnings: [],
   };
 };
 
-const extractEmployerIncomeReport = (text) => {
-  const normalizedText = normalizeText(text);
-
-  return {
-    extractorName: "income-report-employer",
-    extractorVersion: EXTRACTOR_VERSION,
-    payload: {
-      reportYear: extractYear(text),
-      payerName:
-        extractFirstMatch(text, /fonte pagadora[:\s]+([^\n\r]{3,120})/i) ||
-        extractFirstMatch(text, /nome empresarial[:\s]+([^\n\r]{3,120})/i),
-      payerDocument: extractFirstMatch(text, /\b(\d{2}\.?\d{3}\.?\d{3}\/?\d{4}-?\d{2})\b/),
-      beneficiaryName: extractFirstMatch(text, /benefici[aá]ri[oa][:\s]+([^\n\r]{3,120})/i),
-      beneficiaryDocument: extractFirstMatch(text, /\b(\d{3}\.?\d{3}\.?\d{3}-?\d{2})\b/),
-      taxableIncome: extractAmountByPatterns(text, [
-        /rendimentos tributaveis(?:[^\n\r]{0,80}?)r?\$?\s*([\d.,]+)/i,
-        /total de rendimentos tributaveis(?:[^\n\r]{0,80}?)r?\$?\s*([\d.,]+)/i,
-      ]),
-      withheldTax: extractAmountByPatterns(text, [
-        /imposto(?:\s+sobre\s+a\s+renda)?\s+retido\s+na\s+fonte(?:[^\n\r]{0,80}?)r?\$?\s*([\d.,]+)/i,
-        /\birrf(?:\s+total)?(?:[^\n\r]{0,80}?)r?\$?\s*([\d.,]+)/i,
-      ]),
-      officialSocialSecurity: extractAmountByPatterns(text, [
-        /contribuicao previdenciaria oficial(?:[^\n\r]{0,80}?)r?\$?\s*([\d.,]+)/i,
-      ]),
-      thirteenthSalary: extractAmountByPatterns(text, [
-        /(?:decimo terceiro|13o salario|13º salario)(?:[^\n\r]{0,80}?)r?\$?\s*([\d.,]+)/i,
-      ]),
-      detectedSections: buildSectionFlags(normalizedText, [
-        "rendimentos tributaveis",
-        "imposto sobre a renda retido na fonte",
-        "contribuicao previdenciaria oficial",
-        "decimo terceiro",
-      ]),
-      previewLines: getPreviewLines(text),
-    },
-    warnings: [],
-  };
-};
-
-const extractIncomeReportInss = (text) => {
+const extractLegacyInssIncomeReport = (text) => {
   const warnings = [];
   let creditRowsPreview = [];
 
@@ -187,7 +330,8 @@ const extractIncomeReportInss = (text) => {
     extractorName: "income-report-inss",
     extractorVersion: EXTRACTOR_VERSION,
     payload: {
-      reportYear: extractYear(text),
+      reportProfile: "credit_history",
+      reportYear: extractCalendarYear(text),
       profileSuggestion: extractInssSuggestion(text),
       creditRowsPreview,
       previewLines: getPreviewLines(text),
@@ -196,16 +340,478 @@ const extractIncomeReportInss = (text) => {
   };
 };
 
+const extractIncomeReportInss = (text) =>
+  extractAnnualInssIncomeReport(text) || extractLegacyInssIncomeReport(text);
+
+const extractItauStyleAnnualBankIncomeReport = (text, classification) => {
+  const normalizedText = normalizeText(text);
+
+  if (!normalizedText.includes("ficha da declaracao: bens e direitos")) {
+    return null;
+  }
+
+  const lineEntries = getLineEntries(text);
+  const customer = parseCustomerInfo(lineEntries);
+  const institution = parseInstitutionLine(lineEntries, /fonte pagadora:/);
+  const debtInstitution = parseInstitutionLine(lineEntries, /credor:/);
+  const warnings = [];
+  const exclusiveIncomeItems = [];
+  const assetItems = [];
+  const debtItems = [];
+  const sectionTotals = {
+    exclusiveIncomeGrossTotal: null,
+    exclusiveIncomeDeclarableTotal: null,
+    assetBalancePrevTotal: null,
+    assetBalanceCurrTotal: null,
+    debtBalancePrevTotal: null,
+    debtBalanceCurrTotal: null,
+  };
+  let section = null;
+
+  for (let index = 0; index < lineEntries.length; index += 1) {
+    const entry = lineEntries[index];
+
+    if (entry.normalized.includes("ficha da declaracao: rendimentos sujeitos")) {
+      section = "exclusive_income";
+      continue;
+    }
+
+    if (entry.normalized.includes("ficha da declaracao: bens e direitos")) {
+      section = "assets";
+      continue;
+    }
+
+    if (entry.normalized.includes("ficha da declaracao: dividas e onus reais")) {
+      section = "debts";
+      continue;
+    }
+
+    if (entry.normalized.startsWith("total:")) {
+      if (section === "exclusive_income") {
+        const match = entry.raw.match(/Total:\s*([\d.,]+)\s+([\d.,]+)\s+([\d.,]+)/i);
+
+        if (match) {
+          sectionTotals.exclusiveIncomeGrossTotal = parseSignedAmount(match[1]);
+          sectionTotals.exclusiveIncomeDeclarableTotal = parseSignedAmount(match[3]);
+        }
+      }
+
+      if (section === "assets") {
+        const match = entry.raw.match(/Total:\s*([\d.,]+)\s+([\d.,]+)/i);
+
+        if (match) {
+          sectionTotals.assetBalancePrevTotal = parseSignedAmount(match[1]);
+          sectionTotals.assetBalanceCurrTotal = parseSignedAmount(match[2]);
+        }
+      }
+
+      if (section === "debts") {
+        const match = entry.raw.match(/Total:\s*([\d.,]+)\s+([\d.,]+)/i);
+
+        if (match) {
+          sectionTotals.debtBalancePrevTotal = parseSignedAmount(match[1]);
+          sectionTotals.debtBalanceCurrTotal = parseSignedAmount(match[2]);
+        }
+      }
+
+      continue;
+    }
+
+    if (section === "exclusive_income") {
+      const match = entry.raw.match(
+        /^(\d{4}\/[\d-]+)\s+(\d{2})\s+(.+?)\s+([\d.,]+)\s+([\d.,]+)\s+([\d.,]+)$/i,
+      );
+
+      if (match) {
+        exclusiveIncomeItems.push({
+          branchAccount: match[1],
+          incomeTypeCode: match[2],
+          product: match[3].trim(),
+          grossIncome: parseSignedAmount(match[4]),
+          withheldTax: parseSignedAmount(match[5]),
+          declarableAmount: parseSignedAmount(match[6]),
+          institutionName: institution.name || classification.sourceLabelSuggestion || null,
+          institutionDocument: institution.document,
+        });
+      }
+
+      continue;
+    }
+
+    if (section === "assets") {
+      const match = entry.raw.match(
+        /^(\d{4}\/[\d-]+)\s+(\d{2})\s+(\d{2})\s+(.+?)\s+([\d.,]+)\s+([\d.,]+)$/i,
+      );
+
+      if (match) {
+        assetItems.push({
+          branchAccount: match[1],
+          groupCode: match[2],
+          itemCode: match[3],
+          product: match[4].trim(),
+          balancePrevYear: parseSignedAmount(match[5]),
+          balanceCurrYear: parseSignedAmount(match[6]),
+          institutionName: institution.name || classification.sourceLabelSuggestion || null,
+          institutionDocument: institution.document,
+        });
+      }
+
+      continue;
+    }
+
+    if (section === "debts") {
+      const combinedLine = `${entry.raw} ${lineEntries[index + 1]?.raw || ""}`.trim();
+      const match = combinedLine.match(
+        /^(\d{4}\/[\d-]+)\s+(\d{2})\s+(.+?)\s+(\d{9,})\s+(\d{2}\/\d{2}\/\d{4})\s+([\d.,]+)\s+([\d.,]+)$/i,
+      );
+
+      if (match) {
+        debtItems.push({
+          branchAccount: match[1],
+          productCode: match[2],
+          product: match[3].trim(),
+          contractNumber: match[4],
+          contractingDate: match[5],
+          balancePrevYear: parseSignedAmount(match[6]),
+          balanceCurrYear: parseSignedAmount(match[7]),
+          institutionName:
+            debtInstitution.name || institution.name || classification.sourceLabelSuggestion || null,
+          institutionDocument: debtInstitution.document || institution.document,
+        });
+        index += 1;
+      }
+    }
+  }
+
+  if (exclusiveIncomeItems.length === 0 && assetItems.length === 0 && debtItems.length === 0) {
+    return null;
+  }
+
+  if (
+    !hasMatchingSectionTotal(
+      exclusiveIncomeItems,
+      sectionTotals.exclusiveIncomeDeclarableTotal,
+      (item) => item.declarableAmount,
+    )
+  ) {
+    warnings.push("annual_bank_exclusive_income_total_mismatch");
+  }
+
+  if (
+    !hasMatchingSectionTotal(
+      assetItems,
+      sectionTotals.assetBalanceCurrTotal,
+      (item) => item.balanceCurrYear,
+    )
+  ) {
+    warnings.push("annual_bank_asset_total_mismatch");
+  }
+
+  if (
+    !hasMatchingSectionTotal(
+      debtItems,
+      sectionTotals.debtBalanceCurrTotal,
+      (item) => item.balanceCurrYear,
+    )
+  ) {
+    warnings.push("annual_bank_debt_total_mismatch");
+  }
+
+  return {
+    extractorName: "income-report-bank",
+    extractorVersion: EXTRACTOR_VERSION,
+    payload: {
+      reportProfile: "annual",
+      reportYear: extractCalendarYear(text),
+      institutionName: institution.name || classification.sourceLabelSuggestion || null,
+      institutionDocument: institution.document,
+      customerName: customer.name,
+      customerDocument: customer.cpf,
+      exclusiveIncomeItems,
+      assetItems,
+      debtItems,
+      sectionTotals,
+      detectedSections: buildSectionFlags(normalizedText, [
+        "rendimentos sujeitos",
+        "tributacao exclusiva",
+        "bens e direitos",
+        "dividas e onus reais",
+      ]),
+      previewLines: getPreviewLines(text),
+    },
+    warnings,
+  };
+};
+
+const isBlockMetadataLine = (normalizedLine) =>
+  [
+    "nome",
+    "cnpj",
+    "cpf:",
+    "cpf",
+    "nome completo:",
+    "nome completo",
+    "pessoa fisica beneficiaria",
+    "ano calendario",
+    "bens e direitos",
+    "informacoes para declaracao",
+    "rendimentos sujeitos a tributacao exclusiva",
+    "valor",
+  ].includes(normalizedLine) || /^\d{4}$/.test(normalizedLine);
+
+const findBlockInstitutionData = (lineEntries, blockStartIndex) => {
+  let institutionDocument = null;
+  let institutionName = null;
+
+  for (let index = blockStartIndex - 1; index >= Math.max(0, blockStartIndex - 8); index -= 1) {
+    const documentMatch = lineEntries[index].raw.match(
+      /(\d{2}\.?\d{3}\.?\d{3}\/?\d{4}-?\d{2})/,
+    );
+
+    if (!documentMatch) {
+      continue;
+    }
+
+    institutionDocument = documentMatch[1];
+
+    for (let cursor = index - 1; cursor >= Math.max(0, index - 4); cursor -= 1) {
+      const candidate = lineEntries[cursor];
+
+      if (
+        !candidate ||
+        isBlockMetadataLine(candidate.normalized) ||
+        /(\d{2}\.?\d{3}\.?\d{3}\/?\d{4}-?\d{2})/.test(candidate.raw)
+      ) {
+        continue;
+      }
+
+      institutionName = candidate.raw;
+      break;
+    }
+
+    break;
+  }
+
+  return {
+    institutionName,
+    institutionDocument,
+  };
+};
+
+const extractPicPayStyleAnnualBankIncomeReport = (text, classification) => {
+  const normalizedText = normalizeText(text);
+
+  if (
+    !/fonte pagadora \d+\/\d+:/i.test(normalizedText) ||
+    !normalizedText.includes("bens e direitos")
+  ) {
+    return null;
+  }
+
+  const lineEntries = getLineEntries(text);
+  const customer = parseCustomerInfo(lineEntries);
+  const blockStartIndexes = lineEntries.reduce((indexes, entry, index) => {
+    if (entry.normalized.startsWith("fonte pagadora ")) {
+      indexes.push(index);
+    }
+
+    return indexes;
+  }, []);
+  const exclusiveIncomeItems = [];
+  const assetItems = [];
+
+  for (let blockIndex = 0; blockIndex < blockStartIndexes.length; blockIndex += 1) {
+    const blockStartIndex = blockStartIndexes[blockIndex];
+    const blockEndIndex =
+      blockIndex + 1 < blockStartIndexes.length ? blockStartIndexes[blockIndex + 1] : lineEntries.length;
+    const blockLines = lineEntries.slice(blockStartIndex, blockEndIndex);
+    const { institutionName, institutionDocument } = findBlockInstitutionData(
+      lineEntries,
+      blockStartIndex,
+    );
+    const assetCodeMatch = blockLines
+      .map((entry) => entry.raw.match(/C[oó]digo:\s*(\d{2})\s*-\s*(.+)$/i))
+      .find(Boolean);
+    const groupCodeMatch = blockLines
+      .map((entry) => entry.raw.match(/Grupo de bens:\s*(\d{2})\s*-\s*(.+)$/i))
+      .find(Boolean);
+    const balancesIndex = blockLines.findIndex((entry) =>
+      entry.normalized.includes("saldo em 31/12/2024 saldo em 31/12/2025"),
+    );
+    const balancesLine = balancesIndex >= 0 ? blockLines[balancesIndex + 1] : null;
+    const balanceMatch = balancesLine?.raw.match(
+      /R\$\s*([\d.,]+)\s+R\$\s*([\d.,]+)(?:\s+(.+))?/i,
+    );
+    const incomeCodeMatch = blockLines
+      .slice(assetCodeMatch ? blockLines.indexOf(blockLines.find((entry) => entry.raw.includes(assetCodeMatch[0]))) + 1 : 0)
+      .map((entry) => entry.raw.match(/C[oó]digo:\s*(\d{2})\s*-\s*(.+)$/i))
+      .find(Boolean);
+    const incomeValueIndex = blockLines.findIndex((entry) => entry.normalized === "valor");
+    const incomeValueLine = incomeValueIndex >= 0 ? blockLines[incomeValueIndex + 1] : null;
+    const incomeValueMatch = incomeValueLine?.raw.match(/R\$\s*([\d.,]+)(?:\s+(.+))?/i);
+    const trailingAssetDescription =
+      balanceMatch?.[3]?.trim() ||
+      (balancesIndex >= 0 &&
+      blockLines[balancesIndex + 2] &&
+      !blockLines[balancesIndex + 2].normalized.includes("rendimentos sujeitos")
+        ? blockLines[balancesIndex + 2].raw
+        : null);
+
+    if (assetCodeMatch && groupCodeMatch && balanceMatch) {
+      assetItems.push({
+        branchAccount: null,
+        groupCode: groupCodeMatch[1],
+        itemCode: assetCodeMatch[1],
+        product: trailingAssetDescription || assetCodeMatch[2].trim(),
+        balancePrevYear: parseSignedAmount(balanceMatch[1]),
+        balanceCurrYear: parseSignedAmount(balanceMatch[2]),
+        institutionName: institutionName || classification.sourceLabelSuggestion || null,
+        institutionDocument,
+      });
+    }
+
+    if (incomeCodeMatch && incomeValueMatch) {
+      exclusiveIncomeItems.push({
+        branchAccount: null,
+        incomeTypeCode: incomeCodeMatch[1],
+        product: incomeValueMatch[2]?.trim() || incomeCodeMatch[2].trim(),
+        grossIncome: parseSignedAmount(incomeValueMatch[1]),
+        withheldTax: 0,
+        declarableAmount: parseSignedAmount(incomeValueMatch[1]),
+        institutionName: institutionName || classification.sourceLabelSuggestion || null,
+        institutionDocument,
+      });
+    }
+  }
+
+  if (exclusiveIncomeItems.length === 0 && assetItems.length === 0) {
+    return null;
+  }
+
+  return {
+    extractorName: "income-report-bank",
+    extractorVersion: EXTRACTOR_VERSION,
+    payload: {
+      reportProfile: "annual",
+      reportYear: extractCalendarYear(text),
+      institutionName: classification.sourceLabelSuggestion || null,
+      institutionDocument: null,
+      customerName: customer.name,
+      customerDocument: customer.cpf,
+      exclusiveIncomeItems,
+      assetItems,
+      debtItems: [],
+      sectionTotals: {
+        exclusiveIncomeGrossTotal: sumAmounts(exclusiveIncomeItems, (item) => item.grossIncome),
+        exclusiveIncomeDeclarableTotal: sumAmounts(
+          exclusiveIncomeItems,
+          (item) => item.declarableAmount,
+        ),
+        assetBalancePrevTotal: sumAmounts(assetItems, (item) => item.balancePrevYear),
+        assetBalanceCurrTotal: sumAmounts(assetItems, (item) => item.balanceCurrYear),
+        debtBalancePrevTotal: 0,
+        debtBalanceCurrTotal: 0,
+      },
+      detectedSections: buildSectionFlags(normalizedText, [
+        "bens e direitos",
+        "rendimentos sujeitos a tributacao exclusiva",
+      ]),
+      previewLines: getPreviewLines(text),
+    },
+    warnings: [],
+  };
+};
+
+const extractGenericBankIncomeReport = (text, classification) => {
+  const normalizedText = normalizeText(text);
+
+  return {
+    extractorName: "income-report-bank",
+    extractorVersion: EXTRACTOR_VERSION,
+    payload: {
+      reportProfile: "generic",
+      reportYear: extractCalendarYear(text),
+      institutionName: classification.sourceLabelSuggestion,
+      institutionDocument: extractFirstMatch(text, /\b(\d{2}\.?\d{3}\.?\d{3}\/?\d{4}-?\d{2})\b/),
+      exclusiveTaxIncomeTotal: extractAmountByPatterns(normalizedText, [
+        /(?:rendimentos sujeitos a\s+)?tributacao exclusiva(?:[^\n\r]{0,80}?)r?\$?\s*([\d.,]+)/i,
+      ]),
+      exemptIncomeTotal: extractAmountByPatterns(normalizedText, [
+        /rendimentos isentos(?:\s+e\s+nao\s+tributaveis)?(?:[^\n\r]{0,80}?)r?\$?\s*([\d.,]+)/i,
+      ]),
+      withheldTaxTotal: extractAmountByPatterns(normalizedText, [
+        /imposto(?:\s+sobre\s+a\s+renda)?\s+retido\s+na\s+fonte(?:[^\n\r]{0,80}?)r?\$?\s*([\d.,]+)/i,
+      ]),
+      detectedSections: buildSectionFlags(normalizedText, [
+        "rendimentos sujeitos",
+        "tributacao exclusiva",
+        "rendimentos isentos",
+        "31/12/",
+      ]),
+      yearEndBalances: extractGenericYearEndBalances(text),
+      previewLines: getPreviewLines(text),
+    },
+    warnings: [],
+  };
+};
+
+const extractBankIncomeReport = (text, classification) =>
+  extractItauStyleAnnualBankIncomeReport(text, classification) ||
+  extractPicPayStyleAnnualBankIncomeReport(text, classification) ||
+  extractGenericBankIncomeReport(text, classification);
+
+const extractEmployerIncomeReport = (text) => {
+  const normalizedText = normalizeText(text);
+
+  return {
+    extractorName: "income-report-employer",
+    extractorVersion: EXTRACTOR_VERSION,
+    payload: {
+      reportYear: extractCalendarYear(text),
+      payerName:
+        extractFirstMatch(text, /fonte pagadora[:\s]+([^\n\r]{3,120})/i) ||
+        extractFirstMatch(text, /nome empresarial[:\s]+([^\n\r]{3,120})/i),
+      payerDocument: extractFirstMatch(text, /\b(\d{2}\.?\d{3}\.?\d{3}\/?\d{4}-?\d{2})\b/),
+      beneficiaryName: extractFirstMatch(text, /benefici[aá]ri[oa][:\s]+([^\n\r]{3,120})/i),
+      beneficiaryDocument: extractFirstMatch(text, /\b(\d{3}\.?\d{3}\.?\d{3}-?\d{2})\b/),
+      taxableIncome: extractAmountByPatterns(normalizedText, [
+        /rendimentos tributaveis(?:[^\n\r]{0,80}?)r?\$?\s*([\d.,]+)/i,
+        /total de rendimentos tributaveis(?:[^\n\r]{0,80}?)r?\$?\s*([\d.,]+)/i,
+      ]),
+      withheldTax: extractAmountByPatterns(normalizedText, [
+        /imposto(?:\s+sobre\s+a\s+renda)?\s+retido\s+na\s+fonte(?:[^\n\r]{0,80}?)r?\$?\s*([\d.,]+)/i,
+        /\birrf(?:\s+total)?(?:[^\n\r]{0,80}?)r?\$?\s*([\d.,]+)/i,
+      ]),
+      officialSocialSecurity: extractAmountByPatterns(normalizedText, [
+        /contribuicao previdenciaria oficial(?:[^\n\r]{0,80}?)r?\$?\s*([\d.,]+)/i,
+      ]),
+      thirteenthSalary: extractAmountByPatterns(normalizedText, [
+        /(?:decimo terceiro|13o salario)(?:[^\n\r]{0,80}?)r?\$?\s*([\d.,]+)/i,
+      ]),
+      detectedSections: buildSectionFlags(normalizedText, [
+        "rendimentos tributaveis",
+        "imposto sobre a renda retido na fonte",
+        "contribuicao previdenciaria oficial",
+        "decimo terceiro",
+      ]),
+      previewLines: getPreviewLines(text),
+    },
+    warnings: [],
+  };
+};
+
 const extractMedicalStatement = (text, classification) => {
   const normalizedText = normalizeText(text);
-  const totalAmount =
-    extractFirstMatch(text, /(?:valor pago|total pago|total de despesas|despesa total)[:\s]*r?\$?\s*([\d.,]+)/i);
+  const totalAmount = extractFirstMatch(
+    text,
+    /(?:valor pago|total pago|total de despesas|despesa total)[:\s]*r?\$?\s*([\d.,]+)/i,
+  );
 
   return {
     extractorName: "medical-statement",
     extractorVersion: EXTRACTOR_VERSION,
     payload: {
-      reportYear: extractYear(text),
+      reportYear: extractCalendarYear(text),
       providerName: classification.sourceLabelSuggestion,
       beneficiaryName: extractFirstMatch(text, /benefici[aá]ri[oa][:\s]+([^\n\r]{3,120})/i),
       totalAmount: totalAmount ? parseSignedAmount(totalAmount) : null,
@@ -218,14 +824,16 @@ const extractMedicalStatement = (text, classification) => {
 };
 
 const extractEducationReceipt = (text) => {
-  const totalAmount =
-    extractFirstMatch(text, /(?:valor pago|total pago|mensalidade|valor total)[:\s]*r?\$?\s*([\d.,]+)/i);
+  const totalAmount = extractFirstMatch(
+    text,
+    /(?:valor pago|total pago|mensalidade|valor total)[:\s]*r?\$?\s*([\d.,]+)/i,
+  );
 
   return {
     extractorName: "education-receipt",
     extractorVersion: EXTRACTOR_VERSION,
     payload: {
-      reportYear: extractYear(text),
+      reportYear: extractCalendarYear(text),
       institutionName:
         extractFirstMatch(text, /institui[cç][aã]o de ensino[:\s]+([^\n\r]{3,120})/i) ||
         getPreviewLines(text, 1)[0] ||

--- a/apps/api/src/domain/tax/tax-document-extractors.test.js
+++ b/apps/api/src/domain/tax/tax-document-extractors.test.js
@@ -50,6 +50,38 @@ describe("tax document extractors", () => {
     expect(result.payload.thirteenthSalary).toBe(5000);
   });
 
+  it("extrai payload anual do INSS para IRPF", () => {
+    const result = runTaxExtractorForDocument({
+      documentType: "income_report_inss",
+      text: [
+        "Ministerio da Economia Comprovante de Rendimentos Pagos e de",
+        "Imposto sobre a Renda Retido na Fonte",
+        "Exercicio de 2026 Ano-calendario de 2025",
+        "16.727.230/0001-97 Fundo do Regime Geral de Previdencia Social",
+        "433.427.604-00 MARIA EDLEUSA MONSAO DA SILVA 1776829899",
+        "3533-PROVENTOS DE APOSENT., RESERVA, REFORMA OU PENSAO PAGOS PELA PREV. SOCIAL",
+        "1. Total dos rendimentos (inclusive ferias) 34.287,13",
+        "5. Imposto sobre a renda retido na fonte 13,36",
+        "1. Parcela isenta dos proventos de aposentadoria, reserva remunerada, reforma e pensao (65 anos ou mais), exceto a 22.847,76",
+        "2. Parcela isenta do 13o salario de aposentadoria, reserva remunerada, reforma e pensao (65 anos ou mais). 1.903,98",
+        "1. Decimo terceiro salario 2.868,57",
+        "2. Imposto sobre a renda retido na fonte sobre 13o salario 0,00",
+      ].join("\n"),
+    });
+
+    expect(result.extractorName).toBe("income-report-inss");
+    expect(result.payload.reportProfile).toBe("annual");
+    expect(result.payload.reportYear).toBe(2025);
+    expect(result.payload.payerDocument).toBe("16.727.230/0001-97");
+    expect(result.payload.beneficiaryDocument).toBe("433.427.604-00");
+    expect(result.payload.benefitNumber).toBe("1776829899");
+    expect(result.payload.taxableIncome).toBe(34287.13);
+    expect(result.payload.withheldTax).toBe(13.36);
+    expect(result.payload.retirement65PlusExempt).toBe(22847.76);
+    expect(result.payload.retirement65PlusThirteenthExempt).toBe(1903.98);
+    expect(result.payload.thirteenthSalary).toBe(2868.57);
+  });
+
   it("extrai sugestao estruturada do INSS", () => {
     const result = runTaxExtractorForDocument({
       documentType: "income_report_inss",
@@ -64,5 +96,120 @@ describe("tax document extractors", () => {
     expect(result.extractorName).toBe("income-report-inss");
     expect(result.payload.profileSuggestion.referenceMonth).toBe("01/2026");
     expect(Array.isArray(result.payload.previewLines)).toBe(true);
+  });
+
+  it("extrai informe anual bancario itemizado no layout do Itau", () => {
+    const result = runTaxExtractorForDocument({
+      documentType: "income_report_bank",
+      text: [
+        "Informe de Rendimentos",
+        "Ano Calendario 2025",
+        "Cliente: Maria Edileusa Moncao da Silva CPF: 433.427.604-00",
+        "Ficha da Declaracao: Rendimentos Sujeitos a Tributacao Exclusiva/Definitiva",
+        "Fonte Pagadora: Itau Unibanco S.A. CNPJ: 60.701.190/0001-04",
+        "3613/0042196-9 06 RDB/CDB 0,16 0,00 0,16",
+        "Total: 0,16 0,00 0,16",
+        "Ficha da Declaracao: Bens e Direitos",
+        "3613/0042196-9 06 01 CONTA CORRENTE 0,00 1,00",
+        "3613/0042196-9 04 02 RDB/CDB 0,00 1.052,16",
+        "Total: 0,00 1.053,16",
+        "Ficha da Declaracao: Dividas e Onus Reais",
+        "Credor: Itau Unibanco S.A. CNPJ: 60.701.190/0001-04",
+        "3613/0042196-9 11 CREDITO CONSIGNADO",
+        "INTERNO INSS 000002653219945 19/02/2025 0,00 3.308,88",
+        "Total: 0,00 3.308,88",
+      ].join("\n"),
+      classification: {
+        sourceLabelSuggestion: "Itau",
+      },
+    });
+
+    expect(result.extractorName).toBe("income-report-bank");
+    expect(result.payload.reportProfile).toBe("annual");
+    expect(result.payload.reportYear).toBe(2025);
+    expect(result.payload.institutionDocument).toBe("60.701.190/0001-04");
+    expect(result.payload.customerDocument).toBe("433.427.604-00");
+    expect(result.payload.exclusiveIncomeItems).toEqual([
+      expect.objectContaining({
+        branchAccount: "3613/0042196-9",
+        incomeTypeCode: "06",
+        product: "RDB/CDB",
+        declarableAmount: 0.16,
+      }),
+    ]);
+    expect(result.payload.assetItems).toEqual([
+      expect.objectContaining({
+        groupCode: "06",
+        itemCode: "01",
+        balanceCurrYear: 1,
+      }),
+      expect.objectContaining({
+        groupCode: "04",
+        itemCode: "02",
+        balanceCurrYear: 1052.16,
+      }),
+    ]);
+    expect(result.payload.debtItems).toEqual([
+      expect.objectContaining({
+        productCode: "11",
+        contractNumber: "000002653219945",
+        balanceCurrYear: 3308.88,
+      }),
+    ]);
+  });
+
+  it("extrai informe anual bancario label-based no layout do PicPay", () => {
+    const result = runTaxExtractorForDocument({
+      documentType: "income_report_bank",
+      text: [
+        "Pessoa fisica beneficiaria",
+        "Nome completo:",
+        "Amaro Valerio Da Silva Junior",
+        "CPF:",
+        "214.679.738-07",
+        "2025",
+        "Ano Calendario",
+        "Nome",
+        "PicPay Bank Banco Multiplo S.A.",
+        "CNPJ",
+        "09.516.419/0001-75",
+        "Fonte pagadora 2/2:",
+        "Bens e Direitos",
+        "Informacoes para Declaracao",
+        "Codigo: 02 - Titulos publicos e privados sujeitos a tributacao",
+        "Grupo de bens: 04 - Aplicacoes e investimentos",
+        "Saldo em 31/12/2024 Saldo em 31/12/2025",
+        "R$ 371,40 R$ 346,96 Conta e Cofrinhos",
+        "Rendimentos Sujeitos a Tributacao Exclusiva",
+        "Informacoes para declaracao",
+        "Codigo: 06 - Rendimentos de aplicacoes financeiras",
+        "Valor",
+        "R$ 13,49 Conta e cofrinhos",
+      ].join("\n"),
+      classification: {
+        sourceLabelSuggestion: "PicPay",
+      },
+    });
+
+    expect(result.extractorName).toBe("income-report-bank");
+    expect(result.payload.reportProfile).toBe("annual");
+    expect(result.payload.reportYear).toBe(2025);
+    expect(result.payload.customerDocument).toBe("214.679.738-07");
+    expect(result.payload.exclusiveIncomeItems).toEqual([
+      expect.objectContaining({
+        institutionDocument: "09.516.419/0001-75",
+        product: "Conta e cofrinhos",
+        declarableAmount: 13.49,
+      }),
+    ]);
+    expect(result.payload.assetItems).toEqual([
+      expect.objectContaining({
+        institutionDocument: "09.516.419/0001-75",
+        groupCode: "04",
+        itemCode: "02",
+        balancePrevYear: 371.4,
+        balanceCurrYear: 346.96,
+      }),
+    ]);
   });
 });

--- a/apps/api/src/domain/tax/tax-fact-normalizer.js
+++ b/apps/api/src/domain/tax/tax-fact-normalizer.js
@@ -1,8 +1,11 @@
 import { createHash } from "node:crypto";
 
-const TAX_FACT_NORMALIZER_VERSION = "1.0.0";
+const TAX_FACT_NORMALIZER_VERSION = "1.1.0";
 
-const normalizeTrimmedText = (value) => String(value || "").trim();
+const normalizeTrimmedText = (value) =>
+  String(value || "")
+    .replace(/[º°]/g, "o")
+    .trim();
 
 const normalizeDocumentNumber = (value) => normalizeTrimmedText(value).replace(/\D/g, "");
 
@@ -83,6 +86,7 @@ export const generateTaxFactDedupeKey = ({
   payerDocument = "",
   referencePeriod = "",
   amount,
+  dedupeDiscriminator = "",
 }) =>
   createHash("sha256")
     .update(
@@ -93,6 +97,7 @@ export const generateTaxFactDedupeKey = ({
         normalizeDocumentNumber(payerDocument) || "none",
         normalizeTrimmedText(referencePeriod) || "none",
         Number(amount).toFixed(2),
+        normalizeTrimmedText(dedupeDiscriminator) || "none",
       ].join("|"),
     )
     .digest("hex");
@@ -108,6 +113,7 @@ const buildNormalizedFact = ({
   referencePeriod = "",
   amount,
   metadata = {},
+  dedupeDiscriminator = "",
 }) => {
   const normalizedAmount = normalizeRoundedAmount(amount);
 
@@ -118,6 +124,7 @@ const buildNormalizedFact = ({
   const normalizedPayerName = normalizeTrimmedText(payerName);
   const normalizedPayerDocument = normalizeDocumentNumber(payerDocument);
   const normalizedReferencePeriod = normalizeTrimmedText(referencePeriod);
+  const normalizedDedupeDiscriminator = normalizeTrimmedText(dedupeDiscriminator);
 
   return {
     userId: Number(userId),
@@ -139,6 +146,7 @@ const buildNormalizedFact = ({
       payerDocument: normalizedPayerDocument,
       referencePeriod: normalizedReferencePeriod,
       amount: normalizedAmount,
+      dedupeDiscriminator: normalizedDedupeDiscriminator,
     }),
     dedupeStrength: "strong",
     metadataJson: compactObject({
@@ -147,6 +155,7 @@ const buildNormalizedFact = ({
       sourceExtractionId: extraction.id,
       sourceExtractorName: extraction.extractorName,
       sourceClassification: extraction.classification,
+      dedupeDiscriminator: normalizedDedupeDiscriminator || undefined,
       ...metadata,
     }),
     reviewStatus: "pending",
@@ -204,15 +213,141 @@ const normalizeEmployerExtraction = ({ userId, document, extraction, payload }) 
   ].filter(Boolean);
 };
 
-const normalizeBankIncomeReport = ({ userId, document, extraction, payload }) => {
+const getAssetSubcategory = (item = {}) => {
+  if (item.groupCode === "06" && item.itemCode === "01") {
+    return "bank_account_balance";
+  }
+
+  if (item.groupCode === "04") {
+    return "bank_investment_balance";
+  }
+
+  return "bank_asset_balance";
+};
+
+const normalizeAnnualBankIncomeReport = ({ userId, document, extraction, payload }) => {
+  const reportYear = resolveReportYear(payload.reportYear, document.taxYear);
+  const annualReferencePeriod = `${reportYear}-annual`;
+  const yearEndReferencePeriod = `${reportYear}-12-31`;
+  const baseMetadata = compactObject({
+    reportYear,
+    reportProfile: payload.reportProfile,
+    customerName: normalizeTrimmedText(payload.customerName),
+    customerDocument: normalizeDocumentNumber(payload.customerDocument),
+    detectedSections: Array.isArray(payload.detectedSections) ? payload.detectedSections : [],
+  });
+  const exclusiveIncomeFacts = Array.isArray(payload.exclusiveIncomeItems)
+    ? payload.exclusiveIncomeItems
+        .map((item) =>
+          buildNormalizedFact({
+            userId,
+            document,
+            extraction,
+            factType: "exclusive_tax_income",
+            subcategory: "bank_annual_exclusive_income",
+            payerName: item.institutionName || payload.institutionName,
+            payerDocument: item.institutionDocument || payload.institutionDocument,
+            referencePeriod: annualReferencePeriod,
+            amount: item.declarableAmount ?? item.grossIncome,
+            dedupeDiscriminator: [
+              item.incomeTypeCode,
+              item.product,
+              item.branchAccount,
+            ]
+              .filter(Boolean)
+              .join("|"),
+            metadata: compactObject({
+              ...baseMetadata,
+              incomeTypeCode: normalizeTrimmedText(item.incomeTypeCode),
+              product: normalizeTrimmedText(item.product),
+              branchAccount: normalizeTrimmedText(item.branchAccount),
+              grossIncome: normalizeRoundedAmount(item.grossIncome),
+              withheldTax: normalizeRoundedAmount(item.withheldTax),
+            }),
+          }),
+        )
+        .filter(Boolean)
+    : [];
+  const assetFacts = Array.isArray(payload.assetItems)
+    ? payload.assetItems
+        .map((item) =>
+          buildNormalizedFact({
+            userId,
+            document,
+            extraction,
+            factType: "asset_balance",
+            subcategory: getAssetSubcategory(item),
+            payerName: item.institutionName || payload.institutionName,
+            payerDocument: item.institutionDocument || payload.institutionDocument,
+            referencePeriod: yearEndReferencePeriod,
+            amount: item.balanceCurrYear,
+            dedupeDiscriminator: [
+              item.groupCode,
+              item.itemCode,
+              item.product,
+              item.branchAccount,
+            ]
+              .filter(Boolean)
+              .join("|"),
+            metadata: compactObject({
+              ...baseMetadata,
+              groupCode: normalizeTrimmedText(item.groupCode),
+              itemCode: normalizeTrimmedText(item.itemCode),
+              product: normalizeTrimmedText(item.product),
+              branchAccount: normalizeTrimmedText(item.branchAccount),
+              balancePrevYear: normalizeRoundedAmount(item.balancePrevYear),
+            }),
+          }),
+        )
+        .filter(Boolean)
+    : [];
+  const debtFacts = Array.isArray(payload.debtItems)
+    ? payload.debtItems
+        .map((item) =>
+          buildNormalizedFact({
+            userId,
+            document,
+            extraction,
+            factType: "debt_balance",
+            subcategory: "bank_debt_balance",
+            payerName: item.institutionName || payload.institutionName,
+            payerDocument: item.institutionDocument || payload.institutionDocument,
+            referencePeriod: yearEndReferencePeriod,
+            amount: item.balanceCurrYear,
+            dedupeDiscriminator: [
+              item.contractNumber,
+              item.productCode,
+              item.branchAccount,
+            ]
+              .filter(Boolean)
+              .join("|"),
+            metadata: compactObject({
+              ...baseMetadata,
+              productCode: normalizeTrimmedText(item.productCode),
+              product: normalizeTrimmedText(item.product),
+              contractNumber: normalizeTrimmedText(item.contractNumber),
+              contractingDate: parseBrDateToIsoDate(item.contractingDate),
+              branchAccount: normalizeTrimmedText(item.branchAccount),
+              balancePrevYear: normalizeRoundedAmount(item.balancePrevYear),
+            }),
+          }),
+        )
+        .filter(Boolean)
+    : [];
+
+  return [...exclusiveIncomeFacts, ...assetFacts, ...debtFacts];
+};
+
+const normalizeGenericBankIncomeReport = ({ userId, document, extraction, payload }) => {
   const reportYear = resolveReportYear(payload.reportYear, document.taxYear);
   const baseMetadata = compactObject({
     reportYear,
     detectedSections: Array.isArray(payload.detectedSections) ? payload.detectedSections : [],
+    reportProfile: payload.reportProfile,
   });
   const balanceFacts = Array.isArray(payload.yearEndBalances)
     ? payload.yearEndBalances
-        .map((balance) =>
+        .map((balance, index) =>
           buildNormalizedFact({
             userId,
             document,
@@ -223,6 +358,7 @@ const normalizeBankIncomeReport = ({ userId, document, extraction, payload }) =>
             payerDocument: payload.institutionDocument,
             referencePeriod: parseBrDateToIsoDate(balance?.date),
             amount: balance?.amount,
+            dedupeDiscriminator: `${index}|${normalizeTrimmedText(balance?.date)}`,
             metadata: compactObject({
               ...baseMetadata,
               originalBalanceDate: normalizeTrimmedText(balance?.date),
@@ -273,6 +409,31 @@ const normalizeBankIncomeReport = ({ userId, document, extraction, payload }) =>
   ].filter(Boolean);
 };
 
+const normalizeBankIncomeReport = ({ userId, document, extraction, payload }) => {
+  if (
+    payload?.reportProfile === "annual" &&
+    (
+      (Array.isArray(payload.exclusiveIncomeItems) && payload.exclusiveIncomeItems.length > 0) ||
+      (Array.isArray(payload.assetItems) && payload.assetItems.length > 0) ||
+      (Array.isArray(payload.debtItems) && payload.debtItems.length > 0)
+    )
+  ) {
+    return normalizeAnnualBankIncomeReport({
+      userId,
+      document,
+      extraction,
+      payload,
+    });
+  }
+
+  return normalizeGenericBankIncomeReport({
+    userId,
+    document,
+    extraction,
+    payload,
+  });
+};
+
 const normalizeMedicalStatement = ({ userId, document, extraction, payload }) => {
   const reportYear = resolveReportYear(payload.reportYear, document.taxYear);
 
@@ -318,7 +479,107 @@ const normalizeEducationReceipt = ({ userId, document, extraction, payload }) =>
   ].filter(Boolean);
 };
 
-const normalizeInssReport = ({ userId, document, extraction, payload }) => {
+const normalizeAnnualInssReport = ({ userId, document, extraction, payload }) => {
+  const reportYear = resolveReportYear(payload.reportYear, document.taxYear);
+  const referencePeriod = `${reportYear}-annual`;
+  const baseMetadata = compactObject({
+    reportYear,
+    reportProfile: payload.reportProfile,
+    beneficiaryName: normalizeTrimmedText(payload.beneficiaryName),
+    beneficiaryDocument: normalizeDocumentNumber(payload.beneficiaryDocument),
+    benefitNumber: normalizeTrimmedText(payload.benefitNumber),
+    incomeNatureCode: normalizeTrimmedText(payload.incomeNatureCode),
+    incomeNatureDescription: normalizeTrimmedText(payload.incomeNatureDescription),
+    officialSocialSecurity: normalizeRoundedAmount(payload.officialSocialSecurity),
+    privatePensionOrFapi: normalizeRoundedAmount(payload.privatePensionOrFapi),
+    alimony: normalizeRoundedAmount(payload.alimony),
+    annualSimplifiedDiscount: normalizeRoundedAmount(payload.annualSimplifiedDiscount),
+    thirteenthSimplifiedDiscount: normalizeRoundedAmount(payload.thirteenthSimplifiedDiscount),
+  });
+
+  return [
+    buildNormalizedFact({
+      userId,
+      document,
+      extraction,
+      factType: "taxable_income",
+      subcategory: "inss_annual_taxable_income",
+      payerName: payload.payerName,
+      payerDocument: payload.payerDocument,
+      referencePeriod,
+      amount: payload.taxableIncome,
+      dedupeDiscriminator: "taxable_income",
+      metadata: baseMetadata,
+    }),
+    buildNormalizedFact({
+      userId,
+      document,
+      extraction,
+      factType: "withheld_tax",
+      subcategory: "inss_annual_withheld_tax",
+      payerName: payload.payerName,
+      payerDocument: payload.payerDocument,
+      referencePeriod,
+      amount: payload.withheldTax,
+      dedupeDiscriminator: "withheld_tax",
+      metadata: baseMetadata,
+    }),
+    buildNormalizedFact({
+      userId,
+      document,
+      extraction,
+      factType: "exempt_income",
+      subcategory: "inss_retirement_65_plus_exempt",
+      payerName: payload.payerName,
+      payerDocument: payload.payerDocument,
+      referencePeriod,
+      amount: payload.retirement65PlusExempt,
+      dedupeDiscriminator: "retirement_65_plus_exempt",
+      metadata: baseMetadata,
+    }),
+    buildNormalizedFact({
+      userId,
+      document,
+      extraction,
+      factType: "exempt_income",
+      subcategory: "inss_retirement_65_plus_thirteenth_exempt",
+      payerName: payload.payerName,
+      payerDocument: payload.payerDocument,
+      referencePeriod,
+      amount: payload.retirement65PlusThirteenthExempt,
+      dedupeDiscriminator: "retirement_65_plus_thirteenth_exempt",
+      metadata: baseMetadata,
+    }),
+    buildNormalizedFact({
+      userId,
+      document,
+      extraction,
+      factType: "exclusive_tax_income",
+      subcategory: "inss_thirteenth_salary_exclusive",
+      payerName: payload.payerName,
+      payerDocument: payload.payerDocument,
+      referencePeriod,
+      amount: payload.thirteenthSalary,
+      dedupeDiscriminator: "thirteenth_salary",
+      metadata: baseMetadata,
+    }),
+    buildNormalizedFact({
+      userId,
+      document,
+      extraction,
+      factType: "withheld_tax",
+      subcategory: "inss_thirteenth_withheld_tax",
+      payerName: payload.payerName,
+      payerDocument: payload.payerDocument,
+      referencePeriod,
+      amount: payload.thirteenthWithheldTax,
+      dedupeDiscriminator: "thirteenth_withheld_tax",
+      metadata: baseMetadata,
+    }),
+  ].filter(Boolean);
+};
+
+const normalizeLegacyInssReport = ({ userId, document, extraction, payload }) => {
   const profileSuggestion = payload?.profileSuggestion;
 
   if (!profileSuggestion || typeof profileSuggestion !== "object") {
@@ -344,6 +605,7 @@ const normalizeInssReport = ({ userId, document, extraction, payload }) => {
       referencePeriod: parseReferenceMonthToIsoMonth(profileSuggestion.referenceMonth),
       amount,
       metadata: compactObject({
+        reportProfile: payload.reportProfile,
         benefitId: normalizeTrimmedText(profileSuggestion.benefitId),
         benefitKind: normalizeTrimmedText(profileSuggestion.benefitKind),
         paymentDate: parseBrDateToIsoDate(profileSuggestion.paymentDate),
@@ -354,6 +616,24 @@ const normalizeInssReport = ({ userId, document, extraction, payload }) => {
       }),
     }),
   ].filter(Boolean);
+};
+
+const normalizeInssReport = ({ userId, document, extraction, payload }) => {
+  if (payload?.reportProfile === "annual" && payload?.taxableIncome !== undefined) {
+    return normalizeAnnualInssReport({
+      userId,
+      document,
+      extraction,
+      payload,
+    });
+  }
+
+  return normalizeLegacyInssReport({
+    userId,
+    document,
+    extraction,
+    payload,
+  });
 };
 
 const NORMALIZERS_BY_DOCUMENT_TYPE = Object.freeze({

--- a/apps/api/src/domain/tax/tax-fact-normalizer.test.js
+++ b/apps/api/src/domain/tax/tax-fact-normalizer.test.js
@@ -110,6 +110,177 @@ describe("tax fact normalizer", () => {
     );
   });
 
+  it("normaliza informe anual do INSS em fatos fiscais atomicos", () => {
+    const facts = normalizeTaxExtractionToFacts({
+      userId: 7,
+      document: {
+        id: 21,
+        taxYear: 2026,
+        documentType: "income_report_inss",
+      },
+      extraction: {
+        id: 102,
+        extractorName: "income-report-inss",
+        classification: "income_report_inss",
+        confidenceScore: 0.99,
+        rawJson: {
+          extraction: {
+            reportProfile: "annual",
+            reportYear: 2025,
+            payerName: "Fundo do Regime Geral de Previdencia Social",
+            payerDocument: "16.727.230/0001-97",
+            beneficiaryName: "Maria Edleusa Monsao da Silva",
+            beneficiaryDocument: "433.427.604-00",
+            benefitNumber: "1776829899",
+            incomeNatureCode: "3533",
+            incomeNatureDescription: "Proventos de aposentadoria",
+            taxableIncome: 34287.13,
+            withheldTax: 13.36,
+            retirement65PlusExempt: 22847.76,
+            retirement65PlusThirteenthExempt: 1903.98,
+            thirteenthSalary: 2868.57,
+            thirteenthWithheldTax: 0,
+          },
+        },
+      },
+    });
+
+    expect(facts).toHaveLength(5);
+    expect(facts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          factType: "taxable_income",
+          subcategory: "inss_annual_taxable_income",
+          payerDocument: "16727230000197",
+          referencePeriod: "2025-annual",
+          amount: 34287.13,
+        }),
+        expect.objectContaining({
+          factType: "withheld_tax",
+          subcategory: "inss_annual_withheld_tax",
+          amount: 13.36,
+        }),
+        expect.objectContaining({
+          factType: "exempt_income",
+          subcategory: "inss_retirement_65_plus_exempt",
+          amount: 22847.76,
+        }),
+        expect.objectContaining({
+          factType: "exempt_income",
+          subcategory: "inss_retirement_65_plus_thirteenth_exempt",
+          amount: 1903.98,
+        }),
+        expect.objectContaining({
+          factType: "exclusive_tax_income",
+          subcategory: "inss_thirteenth_salary_exclusive",
+          amount: 2868.57,
+        }),
+      ]),
+    );
+  });
+
+  it("normaliza informe anual bancario em rendimentos, bens e dividas por item", () => {
+    const facts = normalizeTaxExtractionToFacts({
+      userId: 7,
+      document: {
+        id: 22,
+        taxYear: 2026,
+        documentType: "income_report_bank",
+      },
+      extraction: {
+        id: 103,
+        extractorName: "income-report-bank",
+        classification: "income_report_bank",
+        confidenceScore: 0.97,
+        rawJson: {
+          extraction: {
+            reportProfile: "annual",
+            reportYear: 2025,
+            institutionName: "Itau Unibanco S.A.",
+            institutionDocument: "60.701.190/0001-04",
+            exclusiveIncomeItems: [
+              {
+                branchAccount: "3613/0042196-9",
+                incomeTypeCode: "06",
+                product: "RDB/CDB",
+                grossIncome: 0.16,
+                withheldTax: 0,
+                declarableAmount: 0.16,
+                institutionName: "Itau Unibanco S.A.",
+                institutionDocument: "60.701.190/0001-04",
+              },
+            ],
+            assetItems: [
+              {
+                branchAccount: "3613/0042196-9",
+                groupCode: "06",
+                itemCode: "01",
+                product: "CONTA CORRENTE",
+                balancePrevYear: 0,
+                balanceCurrYear: 1,
+                institutionName: "Itau Unibanco S.A.",
+                institutionDocument: "60.701.190/0001-04",
+              },
+              {
+                branchAccount: "3613/0042196-9",
+                groupCode: "04",
+                itemCode: "02",
+                product: "RDB/CDB",
+                balancePrevYear: 0,
+                balanceCurrYear: 1052.16,
+                institutionName: "Itau Unibanco S.A.",
+                institutionDocument: "60.701.190/0001-04",
+              },
+            ],
+            debtItems: [
+              {
+                branchAccount: "3613/0042196-9",
+                productCode: "11",
+                product: "CREDITO CONSIGNADO INTERNO INSS",
+                contractNumber: "000002653219945",
+                contractingDate: "19/02/2025",
+                balancePrevYear: 0,
+                balanceCurrYear: 3308.88,
+                institutionName: "Itau Unibanco S.A.",
+                institutionDocument: "60.701.190/0001-04",
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(facts).toHaveLength(4);
+    expect(facts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          factType: "exclusive_tax_income",
+          subcategory: "bank_annual_exclusive_income",
+          referencePeriod: "2025-annual",
+          amount: 0.16,
+        }),
+        expect.objectContaining({
+          factType: "asset_balance",
+          subcategory: "bank_account_balance",
+          referencePeriod: "2025-12-31",
+          amount: 1,
+        }),
+        expect.objectContaining({
+          factType: "asset_balance",
+          subcategory: "bank_investment_balance",
+          referencePeriod: "2025-12-31",
+          amount: 1052.16,
+        }),
+        expect.objectContaining({
+          factType: "debt_balance",
+          subcategory: "bank_debt_balance",
+          referencePeriod: "2025-12-31",
+          amount: 3308.88,
+        }),
+      ]),
+    );
+  });
+
   it("gera dedupe key estavel para a mesma chave logica", () => {
     const keyA = generateTaxFactDedupeKey({
       userId: 7,

--- a/apps/api/src/tax.test.js
+++ b/apps/api/src/tax.test.js
@@ -695,6 +695,220 @@ describe("Tax API foundation", () => {
     ]);
   });
 
+  it("POST /tax/documents/:id/reprocess normaliza comprovante anual do INSS e o resumo deixa de zerar apos revisao", async () => {
+    const token = await registerAndLogin("tax-reprocess-inss-annual@test.dev");
+    const uploadResponse = await request(app)
+      .post("/tax/documents")
+      .set("Authorization", `Bearer ${token}`)
+      .field("taxYear", "2026")
+      .attach(
+        "file",
+        Buffer.from(
+          [
+            "Ministerio da Economia Comprovante de Rendimentos Pagos e de",
+            "Imposto sobre a Renda Retido na Fonte",
+            "Exercicio de 2026 Ano-calendario de 2025",
+            "16.727.230/0001-97 Fundo do Regime Geral de Previdencia Social",
+            "433.427.604-00 MARIA EDLEUSA MONSAO DA SILVA 1776829899",
+            "3533-PROVENTOS DE APOSENT., RESERVA, REFORMA OU PENSAO PAGOS PELA PREV. SOCIAL",
+            "1. Total dos rendimentos (inclusive ferias) 34.287,13",
+            "2. Contribuicao previdenciaria oficial 0,00",
+            "3. Contribuicoes a entidades de previdencia complementar e a fundos de aposentadoria programada Individual (FAPI) 0,00",
+            "4. Pensao alimenticia (Informar o beneficiario no quadro 7) 0,00",
+            "5. Imposto sobre a renda retido na fonte 13,36",
+            "1. Parcela isenta dos proventos de aposentadoria, reserva remunerada, reforma e pensao (65 anos ou mais), exceto a 22.847,76",
+            "2. Parcela isenta do 13o salario de aposentadoria, reserva remunerada, reforma e pensao (65 anos ou mais). 1.903,98",
+            "1. Decimo terceiro salario 2.868,57",
+            "2. Imposto sobre a renda retido na fonte sobre 13o salario 0,00",
+          ].join("\n"),
+          "utf8",
+        ),
+        {
+          filename: "inss-anual.csv",
+          contentType: "text/csv",
+        },
+      );
+
+    expect(uploadResponse.status).toBe(201);
+
+    const reprocessResponse = await request(app)
+      .post(`/tax/documents/${uploadResponse.body.document.id}/reprocess`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(reprocessResponse.status).toBe(200);
+    expect(reprocessResponse.body.document).toMatchObject({
+      id: uploadResponse.body.document.id,
+      documentType: "income_report_inss",
+      processingStatus: "normalized",
+    });
+    expect(reprocessResponse.body.document.latestExtraction).toMatchObject({
+      extractorName: "income-report-inss",
+      classification: "income_report_inss",
+    });
+
+    const factsResult = await dbQuery(
+      `SELECT fact_type, subcategory, amount
+       FROM tax_facts
+       WHERE source_document_id = $1
+       ORDER BY id ASC`,
+      [uploadResponse.body.document.id],
+    );
+
+    expect(factsResult.rows).toEqual([
+      expect.objectContaining({
+        fact_type: "taxable_income",
+        subcategory: "inss_annual_taxable_income",
+        amount: 34287.13,
+      }),
+      expect.objectContaining({
+        fact_type: "withheld_tax",
+        subcategory: "inss_annual_withheld_tax",
+        amount: 13.36,
+      }),
+      expect.objectContaining({
+        fact_type: "exempt_income",
+        subcategory: "inss_retirement_65_plus_exempt",
+        amount: 22847.76,
+      }),
+      expect.objectContaining({
+        fact_type: "exempt_income",
+        subcategory: "inss_retirement_65_plus_thirteenth_exempt",
+        amount: 1903.98,
+      }),
+      expect.objectContaining({
+        fact_type: "exclusive_tax_income",
+        subcategory: "inss_thirteenth_salary_exclusive",
+        amount: 2868.57,
+      }),
+    ]);
+
+    const factIds = (
+      await dbQuery(
+        `SELECT id
+         FROM tax_facts
+         WHERE source_document_id = $1
+         ORDER BY id ASC`,
+        [uploadResponse.body.document.id],
+      )
+    ).rows.map((row) => Number(row.id));
+
+    const approveResponse = await request(app)
+      .post("/tax/facts/bulk-review")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        factIds,
+        action: "approve",
+      });
+
+    expect(approveResponse.status).toBe(200);
+
+    const rebuildResponse = await request(app)
+      .post("/tax/summary/2026/rebuild")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(rebuildResponse.status).toBe(200);
+    expect(rebuildResponse.body).toMatchObject({
+      annualTaxableIncome: 34287.13,
+      annualExemptIncome: 24751.74,
+      annualExclusiveIncome: 2868.57,
+      annualWithheldTax: 13.36,
+      sourceCounts: {
+        documents: 1,
+        factsPending: 0,
+        factsApproved: 5,
+      },
+    });
+  });
+
+  it("POST /tax/documents/:id/reprocess normaliza informe bancario anual itemizado", async () => {
+    const token = await registerAndLogin("tax-reprocess-bank-annual@test.dev");
+    const uploadResponse = await request(app)
+      .post("/tax/documents")
+      .set("Authorization", `Bearer ${token}`)
+      .field("taxYear", "2026")
+      .attach(
+        "file",
+        Buffer.from(
+          [
+            "Informe de Rendimentos",
+            "Ano Calendario 2025",
+            "Cliente: MARIA EDILEUSA MONSAO DA SILVA CPF: 433.427.604-00",
+            "Ficha da Declaracao: Rendimentos Sujeitos a Tributacao Exclusiva/Definitiva",
+            "Contas de deposito, pagamento e aplicacoes financeiras",
+            "Fonte Pagadora: Itau Unibanco S.A. CNPJ: 60.701.190/0001-04",
+            "3613/0042196-9 06 RDB/CDB 0,16 0,00 0,16",
+            "Total: 0,16 0,00 0,16",
+            "Ficha da Declaracao: Bens e Direitos",
+            "3613/0042196-9 06 01 CONTA CORRENTE 0,00 1,00",
+            "3613/0042196-9 04 02 RDB/CDB 0,00 1.052,16",
+            "Total: 0,00 1.053,16",
+            "Ficha da Declaracao: Dividas e Onus Reais",
+            "Credor: Itau Unibanco S.A. CNPJ: 60.701.190/0001-04",
+            "3613/0042196-9 11 CREDITO CONSIGNADO",
+            "INTERNO INSS 000002653219945 19/02/2025 0,00 3.308,88",
+            "Total: 0,00 3.308,88",
+          ].join("\n"),
+          "utf8",
+        ),
+        {
+          filename: "itau-anual.csv",
+          contentType: "text/csv",
+        },
+      );
+
+    expect(uploadResponse.status).toBe(201);
+
+    const reprocessResponse = await request(app)
+      .post(`/tax/documents/${uploadResponse.body.document.id}/reprocess`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(reprocessResponse.status).toBe(200);
+    expect(reprocessResponse.body.document).toMatchObject({
+      id: uploadResponse.body.document.id,
+      documentType: "income_report_bank",
+      processingStatus: "normalized",
+    });
+    expect(reprocessResponse.body.document.latestExtraction).toMatchObject({
+      extractorName: "income-report-bank",
+      classification: "income_report_bank",
+    });
+
+    const factsResult = await dbQuery(
+      `SELECT fact_type, subcategory, amount, reference_period
+       FROM tax_facts
+       WHERE source_document_id = $1
+       ORDER BY id ASC`,
+      [uploadResponse.body.document.id],
+    );
+
+    expect(factsResult.rows).toEqual([
+      expect.objectContaining({
+        fact_type: "exclusive_tax_income",
+        subcategory: "bank_annual_exclusive_income",
+        amount: 0.16,
+        reference_period: "2025-annual",
+      }),
+      expect.objectContaining({
+        fact_type: "asset_balance",
+        subcategory: "bank_account_balance",
+        amount: 1,
+        reference_period: "2025-12-31",
+      }),
+      expect.objectContaining({
+        fact_type: "asset_balance",
+        subcategory: "bank_investment_balance",
+        amount: 1052.16,
+        reference_period: "2025-12-31",
+      }),
+      expect.objectContaining({
+        fact_type: "debt_balance",
+        subcategory: "bank_debt_balance",
+        amount: 3308.88,
+        reference_period: "2025-12-31",
+      }),
+    ]);
+  });
+
   it("POST /tax/documents/:id/reprocess normaliza extrato de apoio sem gerar facts", async () => {
     const token = await registerAndLogin("tax-reprocess-bank-support@test.dev");
     const uploadResponse = await request(app)


### PR DESCRIPTION
## Contexto

Este PR corrige um bug no pipeline fiscal da Central do Leão em que documentos anuais válidos eram aceitos no upload, mas não geravam `tax_facts` úteis para review e summary.

O problema ocorria principalmente em dois cenários:

- o informe anual do INSS era classificado incorretamente como documento de empregador
- o informe bancário anual era processado por um parser genérico, sem itemização adequada de rendimentos, bens e dívidas

## Before / After

### Antes

- INSS anual podia cair em `income_report_employer`
- informe bancário anual podia ser lido sem produzir fatos fiscais úteis
- o summary podia permanecer zerado mesmo com documento fiscal válido enviado

### Depois

- INSS anual passa a ser classificado corretamente como `income_report_inss`
- informes bancários anuais compatíveis passam a ser extraídos com itemização fiscal
- a normalização passa a gerar `tax_facts` utilizáveis por review e summary

## Escopo

### Incluído neste PR

- ajuste do classifier para reconhecer informe anual do INSS
- extractor anual do INSS com payload fiscal estruturado
- extractor anual bancário para layouts reais validados
- normalização desses payloads em `tax_facts`
- refinamento de `dedupeKey` para suportar itemização por linha
- cobertura unitária
- cobertura de integração via API
- validação com PDFs reais

### Layouts cobertos

- INSS anual
- Itaú anual
- PicPay anual

## Impacto funcional

O INSS anual passa a gerar fatos como:

- `taxable_income`
- `withheld_tax`
- `exempt_income`
- `exclusive_tax_income`

Os informes bancários anuais passam a gerar fatos como:

- `exclusive_tax_income`
- `asset_balance`
- `debt_balance`

## Fora de escopo

Não entra neste PR:

- suporte genérico a qualquer layout bancário anual
- alteração de regra fiscal do summary
- automação de review
- correção retroativa sem reprocessamento dos documentos já enviados

## Riscos e pontos de atenção

- o diff é relativamente grande para um fix e merece revisão cuidadosa
- a lógica de `dedupeKey` é o ponto mais sensível deste pacote
- layouts anuais não cobertos explicitamente ainda podem cair no fallback genérico
- documentos antigos precisam de `reprocess` para refletirem o novo comportamento

## Validação executada

- testes unitários dos módulos fiscais
- testes de integração via API
- validação com PDFs reais dos cenários afetados
- lint da API
- suíte completa da API verde

## Checklist antes do merge

- validar manualmente os layouts cobertos no app
- confirmar `POST /tax/documents/:id/reprocess` para documentos antigos
- revisar com atenção a estratégia de dedupe por item
- executar smoke manual: upload, facts pendentes, aprovação e rebuild do summary

## Nota operacional

Após o merge, documentos já enviados antes deste fix devem ser reprocessados para regenerar extraction e `tax_facts`.

## Texto curto para o PR

> Corrige o pipeline fiscal para informes anuais do INSS e bancários, atuando em classificação, extração e normalização. O fix resolve o cenário em que o documento era aceito no upload, mas não gerava `tax_facts` úteis para review e summary. A validação inclui testes unitários, integração e PDFs reais. Os principais pontos de atenção antes do merge são `dedupeKey`, layouts não cobertos e reprocessamento de documentos antigos.