### PR TITLE
feat(tax): add taxpayer CPF guardrails to fiscal calculation

### DIFF
--- a/apps/api/src/db/migrations/037_add_taxpayer_cpf_to_user_profiles.sql
+++ b/apps/api/src/db/migrations/037_add_taxpayer_cpf_to_user_profiles.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user_profiles
+  ADD COLUMN IF NOT EXISTS taxpayer_cpf VARCHAR(11);

--- a/apps/api/src/domain/tax/tax-document-extractors.js
+++ b/apps/api/src/domain/tax/tax-document-extractors.js
@@ -234,6 +234,72 @@ const parseCustomerInfo = (lineEntries) => {
   };
 };
 
+const extractMoneyValuesFromLine = (value) => {
+  const matches = String(value || "").match(/\d[\d.]*,\d{2}/g) || [];
+
+  return matches
+    .map((match) => parseSignedAmount(match))
+    .filter((amount) => amount !== null);
+};
+
+const isMoneyOnlyLine = (value) => /^\d[\d.]*,\d{2}$/.test(String(value || "").trim());
+
+const extractAmountFromMatchingLineEntries = (lineEntries, matcher) => {
+  for (let index = 0; index < lineEntries.length; index += 1) {
+    const entry = lineEntries[index];
+
+    if (!matcher.test(entry.normalized)) {
+      continue;
+    }
+
+    const sameLineAmounts = extractMoneyValuesFromLine(entry.raw);
+
+    if (sameLineAmounts.length > 0) {
+      return Math.abs(sameLineAmounts[sameLineAmounts.length - 1]);
+    }
+
+    const previousRaw = lineEntries[index - 1]?.raw;
+    const nextRaw = lineEntries[index + 1]?.raw;
+    const nextLineAmounts = extractMoneyValuesFromLine(nextRaw);
+
+    if (nextLineAmounts.length > 0) {
+      return Math.abs(nextLineAmounts[nextLineAmounts.length - 1]);
+    }
+
+    if (isMoneyOnlyLine(previousRaw)) {
+      return Math.abs(parseSignedAmount(previousRaw));
+    }
+
+    if (isMoneyOnlyLine(nextRaw)) {
+      return Math.abs(parseSignedAmount(nextRaw));
+    }
+  }
+
+  return null;
+};
+
+const findNextRawLineByMatcher = (lineEntries, startIndex, matcher) => {
+  for (let index = Math.max(startIndex, 0); index < lineEntries.length; index += 1) {
+    if (matcher.test(lineEntries[index].normalized)) {
+      return lineEntries[index].raw;
+    }
+  }
+
+  return null;
+};
+
+const findNextValueAfterLabel = (lineEntries, startIndex, matcher) => {
+  const labelIndex = lineEntries.findIndex(
+    (entry, index) => index >= Math.max(startIndex, 0) && matcher.test(entry.normalized),
+  );
+
+  if (labelIndex < 0) {
+    return null;
+  }
+
+  return lineEntries[labelIndex + 1]?.raw?.trim() || null;
+};
+
 const extractAnnualInssIncomeReport = (text) => {
   const normalizedText = normalizeText(text);
   const collapsedText = normalizedText.replace(/\s+/g, " ");
@@ -246,6 +312,9 @@ const extractAnnualInssIncomeReport = (text) => {
   }
 
   const lineEntries = getLineEntries(text);
+  const beneficiarySectionIndex = lineEntries.findIndex((entry) =>
+    entry.normalized.includes("2 - pessoa fisica beneficiaria"),
+  );
   const payerLine = lineEntries.find((entry) =>
     /\d{2}\.?\d{3}\.?\d{3}\/?\d{4}-?\d{2}/.test(entry.raw),
   );
@@ -261,6 +330,40 @@ const extractAnnualInssIncomeReport = (text) => {
     /(\d{3}\.?\d{3}\.?\d{3}-?\d{2})\s+(.+?)\s+(\d{8,})$/,
   );
   const natureMatch = natureLine?.raw.match(/^(\d{4})[-–](.+)$/);
+  const payerDocumentFallback = findNextValueAfterLabel(
+    lineEntries,
+    0,
+    /^cnpj\/cpf:$/i,
+  );
+  const payerNameFallback = findNextValueAfterLabel(
+    lineEntries,
+    0,
+    /^nome da empresa\/nome completo:$/i,
+  );
+  const beneficiaryDocumentFallback = findNextValueAfterLabel(
+    lineEntries,
+    beneficiarySectionIndex,
+    /^cpf:$/i,
+  );
+  const beneficiaryNameFallback = findNextValueAfterLabel(
+    lineEntries,
+    beneficiarySectionIndex,
+    /^nome completo:$/i,
+  );
+  const benefitNumberFallback = findNextValueAfterLabel(
+    lineEntries,
+    beneficiarySectionIndex,
+    /^numero do beneficio:$/i,
+  );
+  const incomeNatureFallback = findNextValueAfterLabel(
+    lineEntries,
+    beneficiarySectionIndex,
+    /^natureza do rendimento:$/i,
+  );
+  const incomeNatureFallbackMatch = incomeNatureFallback?.match(/^(\d{4})\s*[-–]\s*(.+)$/);
+  const extractAnnualInssAmount = (patterns, lineMatcher) =>
+    extractAmountByPatterns(normalizedText, patterns) ??
+    extractAmountFromMatchingLineEntries(lineEntries, lineMatcher);
 
   return {
     extractorName: "income-report-inss",
@@ -268,40 +371,70 @@ const extractAnnualInssIncomeReport = (text) => {
     payload: {
       reportProfile: "annual",
       reportYear: extractCalendarYear(text),
-      payerName: payerMatch?.[2]?.trim() || "INSS",
-      payerDocument: payerMatch?.[1]?.trim() || null,
-      beneficiaryName: beneficiaryMatch?.[2]?.trim() || null,
-      beneficiaryDocument: beneficiaryMatch?.[1]?.trim() || null,
-      benefitNumber: beneficiaryMatch?.[3]?.trim() || null,
-      incomeNatureCode: natureMatch?.[1]?.trim() || null,
-      incomeNatureDescription: natureMatch?.[2]?.trim() || null,
-      taxableIncome: extractAmountByPatterns(normalizedText, [
+      payerName: payerMatch?.[2]?.trim() || payerNameFallback || "INSS",
+      payerDocument: payerMatch?.[1]?.trim() || payerDocumentFallback || null,
+      beneficiaryName: beneficiaryMatch?.[2]?.trim() || beneficiaryNameFallback || null,
+      beneficiaryDocument:
+        beneficiaryMatch?.[1]?.trim() || beneficiaryDocumentFallback || null,
+      benefitNumber: beneficiaryMatch?.[3]?.trim() || benefitNumberFallback || null,
+      incomeNatureCode:
+        natureMatch?.[1]?.trim() || incomeNatureFallbackMatch?.[1]?.trim() || null,
+      incomeNatureDescription:
+        natureMatch?.[2]?.trim() || incomeNatureFallbackMatch?.[2]?.trim() || null,
+      taxableIncome: extractAnnualInssAmount(
+        [
         /1\.\s*total dos rendimentos \(inclusive ferias\)\s+([\d.]*,\d{2})/i,
-      ]),
-      officialSocialSecurity: extractAmountByPatterns(normalizedText, [
+      ],
+        /1\s*-\s*total de rendimentos \(inclusive ferias\)$/i,
+      ),
+      officialSocialSecurity: extractAnnualInssAmount(
+        [
         /2\.\s*contribuicao previdenciaria oficial\s+([\d.]*,\d{2})/i,
-      ]),
-      privatePensionOrFapi: extractAmountByPatterns(normalizedText, [
+      ],
+        /2\s*-\s*contribuicao previdenciaria oficial$/i,
+      ),
+      privatePensionOrFapi: extractAnnualInssAmount(
+        [
         /3\.\s*contribuicoes a entidades de previdencia complementar.*?\s+([\d.]*,\d{2})/i,
-      ]),
-      alimony: extractAmountByPatterns(normalizedText, [
+      ],
+        /3\s*-\s*contribuic(?:ao|oes).+fapi\)$/i,
+      ),
+      alimony: extractAnnualInssAmount(
+        [
         /4\.\s*pensao alimenticia.*?\s+([\d.]*,\d{2})/i,
-      ]),
-      withheldTax: extractAmountByPatterns(normalizedText, [
+      ],
+        /4\s*-\s*pensao alimenticia/i,
+      ),
+      withheldTax: extractAnnualInssAmount(
+        [
         /5\.\s*imposto sobre a renda retido na fonte\s+([\d.]*,\d{2})/i,
-      ]),
-      retirement65PlusExempt: extractAmountByPatterns(normalizedText, [
+      ],
+        /5\s*-\s*imposto retido na fonte$/i,
+      ),
+      retirement65PlusExempt: extractAnnualInssAmount(
+        [
         /1\.\s*parcela isenta dos proventos de aposentadoria.*?\s+([\d.]*,\d{2})/i,
-      ]),
-      retirement65PlusThirteenthExempt: extractAmountByPatterns(normalizedText, [
+      ],
+        /1\s*-\s*parcela isenta dos proventos de aposentadoria/i,
+      ),
+      retirement65PlusThirteenthExempt: extractAnnualInssAmount(
+        [
         /2\.\s*parcela isenta do 13o salario.*?\s+([\d.]*,\d{2})/i,
-      ]),
-      thirteenthSalary: extractAmountByPatterns(normalizedText, [
+      ],
+        /2\.\s*parcela isenta do 13o salario/i,
+      ),
+      thirteenthSalary: extractAnnualInssAmount(
+        [
         /1\.\s*decimo terceiro salario\s+([\d.]*,\d{2})/i,
-      ]),
-      thirteenthWithheldTax: extractAmountByPatterns(normalizedText, [
+      ],
+        /1\s*-\s*decimo terceiro salario$/i,
+      ),
+      thirteenthWithheldTax: extractAnnualInssAmount(
+        [
         /2\.\s*imposto sobre a renda retido na fonte sobre 13o salario\s+([\d.]*,\d{2})/i,
-      ]),
+      ],
+        /2\s*-\s*imposto sobre a renda retida? na fonte sobre o 13o salario$/i,
+      ),
       annualSimplifiedDiscount: extractAmountByPatterns(normalizedText, [
         /desconto simplificado.*?valor anual r\$\s*([\d.]*,\d{2})/i,
       ]),

--- a/apps/api/src/domain/tax/tax-document-extractors.js
+++ b/apps/api/src/domain/tax/tax-document-extractors.js
@@ -278,16 +278,6 @@ const extractAmountFromMatchingLineEntries = (lineEntries, matcher) => {
   return null;
 };
 
-const findNextRawLineByMatcher = (lineEntries, startIndex, matcher) => {
-  for (let index = Math.max(startIndex, 0); index < lineEntries.length; index += 1) {
-    if (matcher.test(lineEntries[index].normalized)) {
-      return lineEntries[index].raw;
-    }
-  }
-
-  return null;
-};
-
 const findNextValueAfterLabel = (lineEntries, startIndex, matcher) => {
   const labelIndex = lineEntries.findIndex(
     (entry, index) => index >= Math.max(startIndex, 0) && matcher.test(entry.normalized),

--- a/apps/api/src/domain/tax/tax-document-extractors.test.js
+++ b/apps/api/src/domain/tax/tax-document-extractors.test.js
@@ -82,6 +82,65 @@ describe("tax document extractors", () => {
     expect(result.payload.thirteenthSalary).toBe(2868.57);
   });
 
+  it("extrai payload anual do INSS no layout com valores antes do rotulo", () => {
+    const result = runTaxExtractorForDocument({
+      documentType: "income_report_inss",
+      text: [
+        "Ministerio da Fazenda - Secretaria da Receita",
+        "Federal do Brasil - Imposto sobre a Renda da",
+        "Pessoa Fisica - Exercicio 2026",
+        "Comprovante de Rendimentos Pagos e de",
+        "Imposto sobre a Renda Retido na Fonte",
+        "Ano-Calendario 2025",
+        "1 - Fonte Pagadora Pessoa Fisica ou Juridica",
+        "CNPJ/CPF:",
+        "16.727.230/0001-97",
+        "Nome da Empresa/Nome Completo:",
+        "Fundo do Regime Geral de Previdencia Social - FRGPS",
+        "2 - Pessoa Fisica Beneficiaria dos Rendimentos",
+        "CPF:",
+        "433.427.604-00",
+        "Nome Completo:",
+        "MARIA EDLEUSA MONSAO DA SILVA",
+        "Numero do Beneficio:",
+        "177.682.989-9",
+        "Natureza do Rendimento:",
+        "3533 - Proventos de Aposentadoria, Reserva, Reforma ou Pensao Pagos pela Previdencia",
+        "3 - Rendimentos Tributaveis, Deducoes e Imposto Retido na Fonte: Valores em Reais",
+        "0,00  3 - Contribuicao a Previdencia Privada e ao Fundo de Aposentadoria Programada Individual (FAPI)",
+        "0,00  2 - Contribuicao Previdenciaria Oficial",
+        "34287,13  1 - Total de Rendimentos (inclusive ferias)",
+        "13,36  5 - Imposto Retido na Fonte",
+        "0,00  4 - Pensao Alimenticia (Informar o beneficiario no quadro 7)",
+        "4 - Rendimentos Isentos e Nao Tributaveis",
+        "22847,76",
+        "1 - Parcela Isenta dos Proventos de Aposentadoria, Reserva, Reforma e Pensao (65 anos ou mais),",
+        "exceto a parcela isenta do 13o (decimo terceiro) salario.",
+        "2. Parcela isenta do 13o salario de aposentadoria, reserva remunerada, reforma e pensao (65 anos",
+        "ou mais). 1903,98",
+        "5 - Rendimentos Sujeitos a Tributacao Exclusiva (rendimento liquido)",
+        "0,00  2 - Imposto sobre a renda retida na fonte sobre o 13o salario",
+        "2868,57  1 - Decimo Terceiro Salario",
+        "7 - Informacoes Complementares",
+        "1- Desconto Simplificado (MP n. 1.171/2023) - Valor anual R$ 7.074,40. Valor de 13o R$ 607,20",
+      ].join("\n"),
+    });
+
+    expect(result.extractorName).toBe("income-report-inss");
+    expect(result.payload.reportProfile).toBe("annual");
+    expect(result.payload.reportYear).toBe(2025);
+    expect(result.payload.payerDocument).toBe("16.727.230/0001-97");
+    expect(result.payload.beneficiaryDocument).toBe("433.427.604-00");
+    expect(result.payload.benefitNumber).toBe("177.682.989-9");
+    expect(result.payload.incomeNatureCode).toBe("3533");
+    expect(result.payload.taxableIncome).toBe(34287.13);
+    expect(result.payload.withheldTax).toBe(13.36);
+    expect(result.payload.retirement65PlusExempt).toBe(22847.76);
+    expect(result.payload.retirement65PlusThirteenthExempt).toBe(1903.98);
+    expect(result.payload.thirteenthSalary).toBe(2868.57);
+    expect(result.payload.thirteenthWithheldTax).toBe(0);
+  });
+
   it("extrai sugestao estruturada do INSS", () => {
     const result = runTaxExtractorForDocument({
       documentType: "income_report_inss",

--- a/apps/api/src/domain/tax/tax-obligation.calculator.js
+++ b/apps/api/src/domain/tax/tax-obligation.calculator.js
@@ -72,6 +72,8 @@ export const calculateTaxObligation = ({
   const annualTaxableIncome = normalizeMoney(totals.annualTaxableIncome);
   const annualExemptIncome = normalizeMoney(totals.annualExemptIncome);
   const annualExclusiveIncome = normalizeMoney(totals.annualExclusiveIncome);
+  const annualWithheldTax = normalizeMoney(totals.annualWithheldTax);
+  const totalLegalDeductions = normalizeMoney(totals.totalLegalDeductions);
   const annualCombinedExemptAndExclusiveIncome = normalizeMoney(
     annualExemptIncome + annualExclusiveIncome,
   );
@@ -117,6 +119,8 @@ export const calculateTaxObligation = ({
       annualTaxableIncome,
       annualExemptIncome,
       annualExclusiveIncome,
+      annualWithheldTax,
+      totalLegalDeductions,
       annualCombinedExemptAndExclusiveIncome,
       totalAssetBalance,
     },

--- a/apps/api/src/me.test.js
+++ b/apps/api/src/me.test.js
@@ -132,8 +132,8 @@ describe("GET /me", () => {
     const userId = userResult.rows[0].id;
 
     await dbQuery(
-      `INSERT INTO user_profiles (user_id, display_name, salary_monthly, payday, avatar_url)
-       VALUES ($1, 'Joao Silva', 5000.00, 5, 'https://example.com/avatar.jpg')`,
+      `INSERT INTO user_profiles (user_id, display_name, salary_monthly, payday, avatar_url, taxpayer_cpf)
+       VALUES ($1, 'Joao Silva', 5000.00, 5, 'https://example.com/avatar.jpg', '52998224725')`,
       [userId],
     );
 
@@ -147,6 +147,7 @@ describe("GET /me", () => {
       salaryMonthly: 5000,
       payday: 5,
       avatarUrl: "https://example.com/avatar.jpg",
+      taxpayerCpf: "52998224725",
     });
   });
 });
@@ -189,6 +190,7 @@ describe("PATCH /me/profile", () => {
         salary_monthly: 7500,
         payday: 10,
         avatar_url: "https://example.com/maria.jpg",
+        taxpayer_cpf: "529.982.247-25",
       });
 
     expect(response.status).toBe(200);
@@ -197,7 +199,38 @@ describe("PATCH /me/profile", () => {
       salaryMonthly: 7500,
       payday: 10,
       avatarUrl: "https://example.com/maria.jpg",
+      taxpayerCpf: "52998224725",
     });
+  });
+
+  it("retorna 400 para taxpayer_cpf invalido", async () => {
+    const token = await registerAndLogin("patch-taxpayer-cpf-bad@test.dev");
+
+    const response = await request(app)
+      .patch("/me/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ taxpayer_cpf: "111.111.111-11" });
+
+    expectErrorResponseWithRequestId(response, 400, "taxpayer_cpf invalido.");
+  });
+
+  it("persiste taxpayer_cpf e retorna no round-trip GET /me", async () => {
+    const token = await registerAndLogin("patch-taxpayer-cpf-roundtrip@test.dev");
+
+    const patchResponse = await request(app)
+      .patch("/me/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ taxpayer_cpf: "529.982.247-25" });
+
+    expect(patchResponse.status).toBe(200);
+    expect(patchResponse.body.taxpayerCpf).toBe("52998224725");
+
+    const getResponse = await request(app)
+      .get("/me")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(getResponse.status).toBe(200);
+    expect(getResponse.body.profile.taxpayerCpf).toBe("52998224725");
   });
 
   it("atualiza parcialmente — so o campo enviado muda", async () => {

--- a/apps/api/src/services/profile.service.js
+++ b/apps/api/src/services/profile.service.js
@@ -61,6 +61,67 @@ const normalizeAvatarUrl = (value) => {
   return trimmed;
 };
 
+const isValidCpf = (digits) => {
+  if (!/^\d{11}$/.test(digits)) {
+    return false;
+  }
+
+  if (/^(\d)\1{10}$/.test(digits)) {
+    return false;
+  }
+
+  let sum = 0;
+
+  for (let index = 0; index < 9; index += 1) {
+    sum += Number(digits[index]) * (10 - index);
+  }
+
+  let remainder = (sum * 10) % 11;
+
+  if (remainder === 10) {
+    remainder = 0;
+  }
+
+  if (remainder !== Number(digits[9])) {
+    return false;
+  }
+
+  sum = 0;
+
+  for (let index = 0; index < 10; index += 1) {
+    sum += Number(digits[index]) * (11 - index);
+  }
+
+  remainder = (sum * 10) % 11;
+
+  if (remainder === 10) {
+    remainder = 0;
+  }
+
+  return remainder === Number(digits[10]);
+};
+
+const normalizeTaxpayerCpf = (value) => {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+
+  if (typeof value !== "string" && typeof value !== "number") {
+    throw createError(400, "taxpayer_cpf deve ser texto.");
+  }
+
+  const digits = String(value).replace(/\D/g, "");
+
+  if (!digits) {
+    return null;
+  }
+
+  if (!isValidCpf(digits)) {
+    throw createError(400, "taxpayer_cpf invalido.");
+  }
+
+  return digits;
+};
+
 const AI_TONE_VALID = ["pragmatic", "motivator", "sarcastic"];
 const AI_INSIGHT_FREQUENCY_VALID = ["always", "risk_only"];
 
@@ -91,6 +152,7 @@ const rowToProfile = (row) => ({
       : null,
   payday: row.payday !== null && row.payday !== undefined ? Number(row.payday) : null,
   avatarUrl: row.avatar_url ?? null,
+  taxpayerCpf: row.taxpayer_cpf ?? null,
   aiTone: AI_TONE_VALID.includes(row.ai_tone) ? row.ai_tone : "pragmatic",
   aiInsightFrequency: AI_INSIGHT_FREQUENCY_VALID.includes(row.ai_insight_frequency)
     ? row.ai_insight_frequency
@@ -131,7 +193,7 @@ export const getMyProfile = async (userId) => {
 
   const [profileResult, identitiesResult] = await Promise.all([
     dbQuery(
-      `SELECT display_name, salary_monthly, payday, avatar_url, ai_tone, ai_insight_frequency
+      `SELECT display_name, salary_monthly, payday, avatar_url, taxpayer_cpf, ai_tone, ai_insight_frequency
        FROM user_profiles WHERE user_id = $1 LIMIT 1`,
       [normalizedUserId],
     ),
@@ -170,6 +232,9 @@ export const updateMyProfile = async (userId, payload = {}) => {
 
   const avatarUrl = normalizeAvatarUrl(payload.avatar_url);
   if (avatarUrl !== undefined) updates.avatar_url = avatarUrl;
+
+  const taxpayerCpf = normalizeTaxpayerCpf(payload.taxpayer_cpf);
+  if (taxpayerCpf !== undefined) updates.taxpayer_cpf = taxpayerCpf;
 
   const aiTone = normalizeAiTone(payload.ai_tone);
   if (aiTone !== undefined) updates.ai_tone = aiTone;
@@ -220,7 +285,7 @@ export const updateMyProfile = async (userId, payload = {}) => {
   }
 
   const result = await dbQuery(
-    `SELECT display_name, salary_monthly, payday, avatar_url, ai_tone, ai_insight_frequency
+    `SELECT display_name, salary_monthly, payday, avatar_url, taxpayer_cpf, ai_tone, ai_insight_frequency
      FROM user_profiles WHERE user_id = $1 LIMIT 1`,
     [normalizedUserId],
   );

--- a/apps/api/src/services/tax-export.service.js
+++ b/apps/api/src/services/tax-export.service.js
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { dbQuery } from "../db/index.js";
 import { createTaxError, normalizeTaxUserId, normalizeTaxYear, toISOStringOrNull } from "../domain/tax/tax.validation.js";
+import { getReviewedTaxFactsSelectionByUserAndYear } from "./tax-obligation.service.js";
 
 const TAX_EXPORT_ENGINE_VERSION = "irpf-mvp-v1";
 
@@ -36,30 +37,7 @@ const getLatestStoredSummaryRow = async (userId, taxYear) => {
   return result.rows[0] || null;
 };
 
-const listExportableTaxFactsByUserAndYear = async (userId, taxYear) => {
-  const result = await dbQuery(
-    `SELECT
-       id,
-       tax_year,
-       source_document_id,
-       fact_type,
-       category,
-       subcategory,
-       payer_name,
-       payer_document,
-       reference_period,
-       currency,
-       amount,
-       review_status
-     FROM tax_facts
-     WHERE user_id = $1
-       AND tax_year = $2
-       AND review_status IN ('approved', 'corrected')
-     ORDER BY id ASC`,
-    [userId, taxYear],
-  );
-
-  return result.rows.map((row) => ({
+const mapFactRowToExportPayload = (row) => ({
     factId: Number(row.id),
     taxYear: Number(row.tax_year),
     sourceDocumentId:
@@ -75,8 +53,7 @@ const listExportableTaxFactsByUserAndYear = async (userId, taxYear) => {
     amount: Number(row.amount),
     currency: row.currency,
     reviewStatus: row.review_status,
-  }));
-};
+  });
 
 const escapeCsvValue = (value) => {
   const normalizedValue = value == null ? "" : String(value);
@@ -148,7 +125,10 @@ export const exportTaxDossierByYear = async (userId, taxYearValue, formatValue) 
     );
   }
 
-  const facts = await listExportableTaxFactsByUserAndYear(normalizedUserId, taxYear);
+  const factSelection = await getReviewedTaxFactsSelectionByUserAndYear(normalizedUserId, taxYear);
+  const facts = [...factSelection.includedFacts]
+    .sort((leftFact, rightFact) => Number(leftFact.id) - Number(rightFact.id))
+    .map(mapFactRowToExportPayload);
   const summary = {
     taxYear,
     exerciseYear: taxYear,

--- a/apps/api/src/services/tax-obligation.service.js
+++ b/apps/api/src/services/tax-obligation.service.js
@@ -5,6 +5,40 @@ import { requireActiveTaxRuleConfigByYear } from "./tax-rules.service.js";
 
 const REVIEWED_FACT_STATUSES_SQL = "'approved', 'corrected'";
 
+const normalizeJsonObject = (value) => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+
+  return value;
+};
+
+const normalizeDocumentNumber = (value) => String(value || "").replace(/\D/g, "");
+
+const resolveFactOwnerDocument = (fact) => {
+  const metadata = normalizeJsonObject(fact?.metadata_json);
+
+  return normalizeDocumentNumber(
+    metadata.beneficiaryDocument ||
+      metadata.customerDocument ||
+      metadata.studentDocument ||
+      metadata.ownerDocument ||
+      "",
+  );
+};
+
+const getUserTaxpayerDocument = async (userId) => {
+  const result = await dbQuery(
+    `SELECT taxpayer_cpf
+     FROM user_profiles
+     WHERE user_id = $1
+     LIMIT 1`,
+    [userId],
+  );
+
+  return normalizeDocumentNumber(result.rows[0]?.taxpayer_cpf || "");
+};
+
 export const listReviewedTaxFactsByUserAndYear = async (userId, taxYearValue) => {
   const normalizedUserId = normalizeTaxUserId(userId);
   const taxYear = normalizeTaxYear(taxYearValue);
@@ -32,12 +66,52 @@ export const listReviewedTaxFactsByUserAndYear = async (userId, taxYearValue) =>
   return result.rows;
 };
 
+export const getReviewedTaxFactsSelectionByUserAndYear = async (userId, taxYearValue) => {
+  const normalizedUserId = normalizeTaxUserId(userId);
+  const taxYear = normalizeTaxYear(taxYearValue);
+  const [reviewedFacts, taxpayerDocument] = await Promise.all([
+    listReviewedTaxFactsByUserAndYear(normalizedUserId, taxYear),
+    getUserTaxpayerDocument(normalizedUserId),
+  ]);
+
+  if (!taxpayerDocument) {
+    return {
+      taxpayerDocument: null,
+      includedFacts: reviewedFacts,
+      excludedFacts: [],
+    };
+  }
+
+  const includedFacts = [];
+  const excludedFacts = [];
+
+  for (const fact of reviewedFacts) {
+    const ownerDocument = resolveFactOwnerDocument(fact);
+
+    if (!ownerDocument || ownerDocument === taxpayerDocument) {
+      includedFacts.push(fact);
+      continue;
+    }
+
+    excludedFacts.push({
+      ...fact,
+      owner_document: ownerDocument,
+    });
+  }
+
+  return {
+    taxpayerDocument,
+    includedFacts,
+    excludedFacts,
+  };
+};
+
 export const getTaxObligationByYear = async (userId, taxYearValue) => {
   const normalizedUserId = normalizeTaxUserId(userId);
   const taxYear = normalizeTaxYear(taxYearValue);
   const activeRuleConfig = await requireActiveTaxRuleConfigByYear(taxYear);
-  const reviewedFacts = await listReviewedTaxFactsByUserAndYear(normalizedUserId, taxYear);
-  const totals = summarizeReviewedTaxFacts(reviewedFacts);
+  const factSelection = await getReviewedTaxFactsSelectionByUserAndYear(normalizedUserId, taxYear);
+  const totals = summarizeReviewedTaxFacts(factSelection.includedFacts);
   const obligation = calculateTaxObligation({
     totals,
     obligationRules: activeRuleConfig.ruleSets.obligation?.rules,
@@ -52,5 +126,7 @@ export const getTaxObligationByYear = async (userId, taxYearValue) => {
     thresholds: obligation.thresholds,
     totals: obligation.totals,
     approvedFactsCount: totals.approvedFactsCount,
+    taxpayerCpfConfigured: Boolean(factSelection.taxpayerDocument),
+    excludedFactsCount: factSelection.excludedFacts.length,
   };
 };

--- a/apps/api/src/services/tax-summary.service.js
+++ b/apps/api/src/services/tax-summary.service.js
@@ -5,10 +5,11 @@ import {
   calculateSimplifiedDiscount,
 } from "../domain/tax/tax-rules.engine.js";
 import { normalizeTaxUserId, normalizeTaxYear, toISOStringOrNull } from "../domain/tax/tax.validation.js";
-import { listReviewedTaxFactsByUserAndYear } from "./tax-obligation.service.js";
+import { getReviewedTaxFactsSelectionByUserAndYear } from "./tax-obligation.service.js";
 import { requireActiveTaxRuleConfigByYear } from "./tax-rules.service.js";
 
 const DUPLICATE_FACT_CONFLICT_CODE = "TAX_FACT_DUPLICATE";
+const TAXPAYER_CPF_MISMATCH_WARNING_CODE = "TAXPAYER_CPF_MISMATCH_EXCLUDED";
 
 const buildDefaultSummaryPayload = () => ({
   mustDeclare: null,
@@ -68,7 +69,7 @@ const getSourceCountsByUserAndYear = async (userId, taxYear) => {
   };
 };
 
-const buildSummaryWarnings = ({ reviewedFacts, sourceCounts }) => {
+const buildSummaryWarnings = ({ reviewedFacts, sourceCounts, excludedFactsCount }) => {
   const warnings = [];
 
   if (sourceCounts.factsPending > 0) {
@@ -86,11 +87,22 @@ const buildSummaryWarnings = ({ reviewedFacts, sourceCounts }) => {
     });
   }
 
+  if (Number(excludedFactsCount || 0) > 0) {
+    warnings.push({
+      code: TAXPAYER_CPF_MISMATCH_WARNING_CODE,
+      message:
+        Number(excludedFactsCount) === 1
+          ? "Ha 1 fato revisado com CPF divergente do titular cadastrado e ele ficou fora do resumo anual."
+          : `Ha ${Number(excludedFactsCount)} fatos revisados com CPF divergente do titular cadastrado e eles ficaram fora do resumo anual.`,
+    });
+  }
+
   return warnings;
 };
 
 const buildCalculatedSummaryPayload = ({
   reviewedFacts,
+  excludedFactsCount,
   sourceCounts,
   activeRuleConfig,
 }) => {
@@ -145,6 +157,7 @@ const buildCalculatedSummaryPayload = ({
     warnings: buildSummaryWarnings({
       reviewedFacts,
       sourceCounts,
+      excludedFactsCount,
     }),
   };
 };
@@ -190,9 +203,10 @@ export const rebuildTaxSummaryByYear = async (userId, taxYearValue) => {
   const taxYear = normalizeTaxYear(taxYearValue);
   const activeRuleConfig = await requireActiveTaxRuleConfigByYear(taxYear);
   const sourceCounts = await getSourceCountsByUserAndYear(normalizedUserId, taxYear);
-  const reviewedFacts = await listReviewedTaxFactsByUserAndYear(normalizedUserId, taxYear);
+  const factSelection = await getReviewedTaxFactsSelectionByUserAndYear(normalizedUserId, taxYear);
   const summaryPayload = buildCalculatedSummaryPayload({
-    reviewedFacts,
+    reviewedFacts: factSelection.includedFacts,
+    excludedFactsCount: factSelection.excludedFacts.length,
     sourceCounts,
     activeRuleConfig,
   });

--- a/apps/api/src/tax.test.js
+++ b/apps/api/src/tax.test.js
@@ -1574,6 +1574,127 @@ describe("Tax API foundation", () => {
     expect(afterApprovalResponse.body.approvedFactsCount).toBe(3);
   });
 
+  it("exclui do calculo oficial fatos revisados com CPF divergente do titular cadastrado", async () => {
+    const email = "tax-obligation-taxpayer-filter@test.dev";
+    const token = await registerAndLogin(email);
+    const userResult = await dbQuery(
+      `SELECT id
+       FROM users
+       WHERE email = $1`,
+      [email],
+    );
+    const userId = Number(userResult.rows[0].id);
+
+    await dbQuery(
+      `INSERT INTO user_profiles (user_id, taxpayer_cpf)
+       VALUES ($1, '52998224725')`,
+      [userId],
+    );
+
+    const uploadResponse = await request(app)
+      .post("/tax/documents")
+      .set("Authorization", `Bearer ${token}`)
+      .field("taxYear", "2026")
+      .attach(
+        "file",
+        Buffer.from(
+          [
+            "Ministerio da Economia Comprovante de Rendimentos Pagos e de",
+            "Imposto sobre a Renda Retido na Fonte",
+            "Exercicio de 2026 Ano-calendario de 2025",
+            "16.727.230/0001-97 Fundo do Regime Geral de Previdencia Social",
+            "433.427.604-00 MARIA EDLEUSA MONSAO DA SILVA 1776829899",
+            "3533-PROVENTOS DE APOSENT., RESERVA, REFORMA OU PENSAO PAGOS PELA PREV. SOCIAL",
+            "1. Total dos rendimentos (inclusive ferias) 34.287,13",
+            "5. Imposto sobre a renda retido na fonte 13,36",
+            "1. Parcela isenta dos proventos de aposentadoria, reserva remunerada, reforma e pensao (65 anos ou mais), exceto a 22.847,76",
+            "2. Parcela isenta do 13o salario de aposentadoria, reserva remunerada, reforma e pensao (65 anos ou mais). 1.903,98",
+            "1. Decimo terceiro salario 2.868,57",
+          ].join("\n"),
+          "utf8",
+        ),
+        {
+          filename: "inss-taxpayer-mismatch.csv",
+          contentType: "text/csv",
+        },
+      );
+
+    expect(uploadResponse.status).toBe(201);
+
+    const reprocessResponse = await request(app)
+      .post(`/tax/documents/${uploadResponse.body.document.id}/reprocess`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(reprocessResponse.status).toBe(200);
+
+    const factsResult = await dbQuery(
+      `SELECT id
+       FROM tax_facts
+       WHERE source_document_id = $1
+       ORDER BY id ASC`,
+      [uploadResponse.body.document.id],
+    );
+    const factIds = factsResult.rows.map((row) => Number(row.id));
+
+    const bulkApproveResponse = await request(app)
+      .post("/tax/facts/bulk-review")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        factIds,
+        action: "approve",
+      });
+
+    expect(bulkApproveResponse.status).toBe(200);
+
+    const obligationResponse = await request(app)
+      .get("/tax/obligation/2026")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(obligationResponse.status).toBe(200);
+    expect(obligationResponse.body).toMatchObject({
+      mustDeclare: false,
+      approvedFactsCount: 0,
+      taxpayerCpfConfigured: true,
+      excludedFactsCount: 5,
+      totals: {
+        annualTaxableIncome: 0,
+        annualExemptIncome: 0,
+        annualExclusiveIncome: 0,
+        annualWithheldTax: 0,
+        totalLegalDeductions: 0,
+      },
+    });
+
+    const rebuildResponse = await request(app)
+      .post("/tax/summary/2026/rebuild")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(rebuildResponse.status).toBe(200);
+    expect(rebuildResponse.body).toMatchObject({
+      annualTaxableIncome: 0,
+      annualExemptIncome: 0,
+      annualExclusiveIncome: 0,
+      annualWithheldTax: 0,
+      warnings: [
+        {
+          code: "TAXPAYER_CPF_MISMATCH_EXCLUDED",
+          message:
+            "Ha 5 fatos revisados com CPF divergente do titular cadastrado e eles ficaram fora do resumo anual.",
+        },
+      ],
+    });
+
+    const exportResponse = await request(app)
+      .get("/tax/export/2026?format=json")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(exportResponse.status).toBe(200);
+    const exportPayload = JSON.parse(exportResponse.text);
+    expect(exportPayload.manifest.factsIncluded).toBe(0);
+    expect(exportPayload.summary.annualTaxableIncome).toBe(0);
+    expect(exportPayload.facts).toEqual([]);
+  });
+
   it("GET /tax/summary/:taxYear retorna esqueleto da trilha fiscal antes da primeira geracao", async () => {
     const token = await registerAndLogin("tax-summary@test.dev");
     const response = await request(app)

--- a/apps/web/src/pages/ProfileSettings.test.tsx
+++ b/apps/web/src/pages/ProfileSettings.test.tsx
@@ -25,6 +25,7 @@ const buildMe = (overrides = {}) => ({
     salaryMonthly: 5000,
     payday: 5,
     avatarUrl: null,
+    taxpayerCpf: null,
   },
   ...overrides,
 });
@@ -50,6 +51,7 @@ describe("ProfileSettings — Dados da conta", () => {
       salaryMonthly: 5000,
       payday: 5,
       avatarUrl: null,
+      taxpayerCpf: null,
     });
   });
 
@@ -103,6 +105,37 @@ describe("ProfileSettings — Dados da conta", () => {
       expect.objectContaining({ display_name: "Novo Nome" }),
     );
   });
+
+  it("loads and submits taxpayer CPF with the profile", async () => {
+    const user = userEvent.setup();
+    vi.mocked(profileService.getMe).mockResolvedValue(
+      buildMe({
+        profile: {
+          displayName: "Jr Valerio",
+          salaryMonthly: 5000,
+          payday: 5,
+          avatarUrl: null,
+          taxpayerCpf: "52998224725",
+        },
+      }),
+    );
+
+    renderPage();
+    await waitFor(() => expect(screen.getByLabelText("CPF do titular (IRPF)")).toBeInTheDocument());
+
+    const cpfInput = screen.getByLabelText("CPF do titular (IRPF)");
+    expect(cpfInput).toHaveValue("52998224725");
+
+    await user.clear(cpfInput);
+    await user.type(cpfInput, "529.982.247-25");
+    await user.click(screen.getByRole("button", { name: "Salvar perfil" }));
+
+    await waitFor(() =>
+      expect(profileService.updateProfile).toHaveBeenCalledWith(
+        expect.objectContaining({ taxpayer_cpf: "529.982.247-25" }),
+      ),
+    );
+  });
 });
 
 describe("ProfileSettings — Preferências (Modo Discreto)", () => {
@@ -147,6 +180,7 @@ describe("ProfileSettings — Preferências (Copiloto)", () => {
       salaryMonthly: 5000,
       payday: 5,
       avatarUrl: null,
+      taxpayerCpf: null,
       aiTone: "pragmatic",
       aiInsightFrequency: "always",
     });
@@ -203,6 +237,7 @@ describe("ProfileSettings — Preferências (Copiloto)", () => {
           salaryMonthly: 5000,
           payday: 5,
           avatarUrl: null,
+          taxpayerCpf: null,
           aiTone: "sarcastic",
           aiInsightFrequency: "risk_only",
         },

--- a/apps/web/src/pages/ProfileSettings.tsx
+++ b/apps/web/src/pages/ProfileSettings.tsx
@@ -81,6 +81,7 @@ const ProfileSettings = ({
   const [salaryMonthly, setSalaryMonthly] = useState("");
   const [payday, setPayday] = useState("");
   const [avatarUrl, setAvatarUrl] = useState("");
+  const [taxpayerCpf, setTaxpayerCpf] = useState("");
 
   // Auth info (read-only display)
   const [hasPassword, setHasPassword] = useState<boolean | null>(null);
@@ -123,6 +124,7 @@ const ProfileSettings = ({
         p?.payday !== null && p?.payday !== undefined ? String(p.payday) : "",
       );
       setAvatarUrl(p?.avatarUrl ?? "");
+      setTaxpayerCpf(p?.taxpayerCpf ?? "");
       setAiTone(p?.aiTone ?? "pragmatic");
       setAiInsightFrequency(p?.aiInsightFrequency ?? "always");
     } catch (error) {
@@ -167,6 +169,7 @@ const ProfileSettings = ({
         salary_monthly: salaryNum,
         payday: paydayNum,
         avatar_url: avatarUrl.trim() || null,
+        taxpayer_cpf: taxpayerCpf.trim() || null,
       });
       setSaveSuccess(true);
       successTimerRef.current = setTimeout(() => setSaveSuccess(false), 4000);
@@ -303,6 +306,28 @@ const ProfileSettings = ({
                     placeholder="Como você quer ser chamado"
                     className="mt-1 w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
                   />
+                </div>
+
+                <div>
+                  <label
+                    htmlFor="taxpayer_cpf"
+                    className="block text-sm font-semibold text-cf-text-primary"
+                  >
+                    CPF do titular (IRPF)
+                  </label>
+                  <input
+                    id="taxpayer_cpf"
+                    type="text"
+                    inputMode="numeric"
+                    value={taxpayerCpf}
+                    onChange={(e) => setTaxpayerCpf(e.target.value)}
+                    maxLength={14}
+                    placeholder="000.000.000-00"
+                    className="mt-1 w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
+                  />
+                  <p className="mt-0.5 text-xs text-cf-text-secondary">
+                    Usado pela Central do Leão para conferir se os informes pertencem ao mesmo titular e evitar mistura de receitas.
+                  </p>
                 </div>
 
                 {/* Email (read-only) */}

--- a/apps/web/src/pages/TaxPage.test.tsx
+++ b/apps/web/src/pages/TaxPage.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import TaxPage from "./TaxPage";
+import { profileService } from "../services/profile.service";
 import {
   taxService,
   type TaxDocument,
@@ -25,6 +26,12 @@ vi.mock("../services/tax.service", () => ({
     listFacts: vi.fn(),
     reviewFact: vi.fn(),
     bulkApproveFacts: vi.fn(),
+  },
+}));
+
+vi.mock("../services/profile.service", () => ({
+  profileService: {
+    getMe: vi.fn(),
   },
 }));
 
@@ -75,6 +82,8 @@ const buildObligation = (overrides: Partial<TaxObligation> = {}): TaxObligation 
     annualTaxableIncome: 54321,
     annualExemptIncome: 0,
     annualExclusiveIncome: 5000,
+    annualWithheldTax: 4321.09,
+    totalLegalDeductions: 0,
     annualCombinedExemptAndExclusiveIncome: 5000,
     totalAssetBalance: 0,
   },
@@ -184,6 +193,20 @@ describe("TaxPage", () => {
     vi.mocked(taxService.rebuildSummary).mockResolvedValue(buildSummary({ snapshotVersion: 2 }));
     vi.mocked(taxService.bulkApproveFacts).mockResolvedValue({ updatedCount: 1 });
     vi.mocked(taxService.reviewFact).mockResolvedValue(buildFact({ reviewStatus: "approved" }));
+    vi.mocked(profileService.getMe).mockResolvedValue({
+      id: 1,
+      name: "Jr",
+      email: "jr@example.com",
+      trialEndsAt: null,
+      trialExpired: false,
+      profile: {
+        displayName: "Jr",
+        salaryMonthly: null,
+        payday: null,
+        avatarUrl: null,
+        taxpayerCpf: "52998224725",
+      },
+    });
   });
 
   it("renderiza resumo, gatilhos e fila de revisão", async () => {
@@ -199,6 +222,70 @@ describe("TaxPage", () => {
     expect(screen.getByText("Documentos do exercício")).toBeInTheDocument();
     expect(screen.getByText("empregador.pdf")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Aprovar todos pendentes" })).toBeInTheDocument();
+  });
+
+  it("explica de forma didatica quando o usuario esta sem obrigatoriedade", async () => {
+    vi.mocked(taxService.getSummary).mockResolvedValue(
+      buildSummary({
+        status: "not_generated",
+        snapshotVersion: null,
+        annualTaxableIncome: 0,
+        annualExemptIncome: 0,
+        annualExclusiveIncome: 0,
+        annualWithheldTax: 0,
+      }),
+    );
+    vi.mocked(taxService.getObligation).mockResolvedValue(
+      buildObligation({
+        mustDeclare: false,
+        reasons: [],
+        totals: {
+          annualTaxableIncome: 34287.13,
+          annualExemptIncome: 24751.74,
+          annualExclusiveIncome: 2868.57,
+          annualWithheldTax: 13.36,
+          totalLegalDeductions: 0,
+          annualCombinedExemptAndExclusiveIncome: 27620.31,
+          totalAssetBalance: 0,
+        },
+        approvedFactsCount: 5,
+      }),
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Sem obrigatoriedade hoje")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/você está sem obrigatoriedade objetiva/i)).toBeInTheDocument();
+    expect(screen.getByText("Rendimentos Isentos")).toBeInTheDocument();
+    expect(screen.getByText("R$ 24.751,74")).toBeInTheDocument();
+    expect(screen.getByText("R$ 13,36")).toBeInTheDocument();
+  });
+
+  it("sinaliza fato pendente com CPF divergente do titular cadastrado", async () => {
+    vi.mocked(taxService.listFacts).mockResolvedValue({
+      items: [
+        buildFact({
+          metadata: {
+            beneficiaryDocument: "11111111111",
+          },
+        }),
+      ],
+      page: 1,
+      pageSize: 25,
+      total: 1,
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("CPF divergente")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/Titular do informe: 111.111.111-11/)).toBeInTheDocument();
+    expect(screen.getByText(/fica fora do cálculo oficial do IRPF/i)).toBeInTheDocument();
   });
 
   it("aprovar todos pendentes chama bulkApproveFacts e recarrega os dados", async () => {

--- a/apps/web/src/pages/TaxPage.tsx
+++ b/apps/web/src/pages/TaxPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 import TaxUploadModal, { type TaxUploadStage } from "../components/TaxUploadModal";
+import { profileService } from "../services/profile.service";
 import {
   taxService,
   type TaxDocument,
@@ -68,10 +69,14 @@ const EMPTY_OBLIGATION: TaxObligation = {
     annualTaxableIncome: 0,
     annualExemptIncome: 0,
     annualExclusiveIncome: 0,
+    annualWithheldTax: 0,
+    totalLegalDeductions: 0,
     annualCombinedExemptAndExclusiveIncome: 0,
     totalAssetBalance: 0,
   },
   approvedFactsCount: 0,
+  taxpayerCpfConfigured: false,
+  excludedFactsCount: 0,
 };
 
 const EMPTY_DOCUMENTS_PAGE: TaxDocumentsListResult = {
@@ -154,6 +159,29 @@ const formatDateTime = (value: string | null) => {
   });
 };
 
+const normalizeDocumentNumber = (value: unknown) => String(value || "").replace(/\D/g, "");
+
+const formatCpf = (value: string | null) => {
+  const digits = normalizeDocumentNumber(value);
+
+  if (digits.length !== 11) {
+    return value || "CPF não informado";
+  }
+
+  return `${digits.slice(0, 3)}.${digits.slice(3, 6)}.${digits.slice(6, 9)}-${digits.slice(9)}`;
+};
+
+const resolveFactOwnerDocument = (fact: TaxFact) => {
+  const metadata = fact.metadata || {};
+
+  return normalizeDocumentNumber(
+    metadata.beneficiaryDocument ||
+      metadata.customerDocument ||
+      metadata.studentDocument ||
+      metadata.ownerDocument,
+  );
+};
+
 const FactSummaryCard = ({
   title,
   value,
@@ -193,6 +221,7 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
     pageSize: DEFAULT_FACTS_PAGE_SIZE,
     total: 0,
   });
+  const [taxpayerCpf, setTaxpayerCpf] = useState<string | null>(null);
   const [isLoadingPage, setIsLoadingPage] = useState(true);
   const [isRebuildingSummary, setIsRebuildingSummary] = useState(false);
   const [exportingFormat, setExportingFormat] = useState<"json" | "csv" | null>(null);
@@ -222,7 +251,7 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
     setIsLoadingPage(true);
     setPageError("");
 
-    const [summaryResult, obligationResult, documentsResult, factsResult] = await Promise.allSettled([
+    const [summaryResult, obligationResult, documentsResult, factsResult, profileResult] = await Promise.allSettled([
       taxService.getSummary(taxYear),
       taxService.getObligation(taxYear),
       taxService.listDocuments({
@@ -234,6 +263,7 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
         reviewStatus: "pending",
         pageSize: DEFAULT_FACTS_PAGE_SIZE,
       }),
+      profileService.getMe(),
     ]);
 
     const nextErrors: string[] = [];
@@ -288,6 +318,12 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
       nextErrors.push(
         getApiErrorMessage(documentsResult.reason, "Não foi possível carregar os documentos do exercício."),
       );
+    }
+
+    if (profileResult.status === "fulfilled") {
+      setTaxpayerCpf(profileResult.value.profile?.taxpayerCpf ?? null);
+    } else {
+      setTaxpayerCpf(null);
     }
 
     setPageError(nextErrors[0] || "");
@@ -570,6 +606,47 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
 
   const headerCalendarYear = summary.calendarYear || obligation.calendarYear || taxYear - 1;
   const methodLabel = summary.bestMethod ? METHOD_LABELS[summary.bestMethod] : "Ainda não definido";
+  const liveTaxableIncome = obligation.totals.annualTaxableIncome;
+  const liveExemptIncome = obligation.totals.annualExemptIncome;
+  const liveExclusiveIncome = obligation.totals.annualExclusiveIncome;
+  const liveWithheldTax = obligation.totals.annualWithheldTax;
+  const liveLegalDeductions = obligation.totals.totalLegalDeductions;
+  const displayAnnualTaxableIncome =
+    summary.status === "generated" ? summary.annualTaxableIncome : liveTaxableIncome;
+  const displayAnnualExemptIncome =
+    summary.status === "generated" ? summary.annualExemptIncome : liveExemptIncome;
+  const displayAnnualExclusiveIncome =
+    summary.status === "generated" ? summary.annualExclusiveIncome : liveExclusiveIncome;
+  const displayAnnualWithheldTax =
+    summary.status === "generated" ? summary.annualWithheldTax : liveWithheldTax;
+  const displayLegalDeductions =
+    summary.status === "generated" ? summary.totalLegalDeductions : liveLegalDeductions;
+  const excludedApprovedFactsCount = Math.max(
+    summary.sourceCounts.factsApproved - obligation.approvedFactsCount,
+    0,
+  );
+  const factWarnings = [...summary.warnings];
+
+  if (!factWarnings.some((warning) => warning.code === "TAXPAYER_CPF_MISMATCH_EXCLUDED") &&
+      excludedApprovedFactsCount > 0) {
+    factWarnings.push({
+      code: "TAXPAYER_CPF_MISMATCH_EXCLUDED",
+      message:
+        excludedApprovedFactsCount === 1
+          ? "Há 1 fato aprovado com CPF diferente do titular cadastrado e ele ficou fora do cálculo oficial."
+          : `Há ${excludedApprovedFactsCount} fatos aprovados com CPF diferente do titular cadastrado e eles ficaram fora do cálculo oficial.`,
+    });
+  }
+
+  if (!factWarnings.some((warning) => warning.code === "TAXPAYER_CPF_NOT_CONFIGURED") && !taxpayerCpf) {
+    factWarnings.push({
+      code: "TAXPAYER_CPF_NOT_CONFIGURED",
+      message:
+        "Cadastre o CPF do titular em Configurações para a Central do Leão conseguir conferir a titularidade dos informes automaticamente.",
+    });
+  }
+
+  const showNoObligationInfo = !obligation.mustDeclare;
 
   return (
     <div className="min-h-screen bg-cf-bg-page px-4 py-6 sm:px-6">
@@ -661,22 +738,22 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
         <div className="grid gap-4 lg:grid-cols-4">
           <FactSummaryCard
             title="Obrigatoriedade"
-            value={obligation.mustDeclare ? "Obrigatório declarar" : "Sem gatilho objetivo"}
+            value={obligation.mustDeclare ? "Obrigatório declarar" : "Sem obrigatoriedade hoje"}
             helper={
               obligation.mustDeclare
                 ? `${obligation.reasons.length} motivo(s) ativo(s) com base em fatos revisados`
-                : "Só fatos approved/corrected entram aqui"
+                : "Mesmo isento, o espelho do exercício continua disponível"
             }
           />
           <FactSummaryCard
             title="Rendimentos Tributáveis"
-            value={formatCurrency(obligation.totals.annualTaxableIncome)}
+            value={formatCurrency(displayAnnualTaxableIncome)}
             helper="Base considerada para o gatilho principal"
           />
           <FactSummaryCard
             title="IRRF Acumulado"
-            value={formatCurrency(summary.annualWithheldTax)}
-            helper="Valor separado do imposto pela tabela"
+            value={formatCurrency(displayAnnualWithheldTax)}
+            helper="Valor separado do imposto pela tabela, mesmo abaixo do limite"
           />
           <FactSummaryCard
             title="Método Sugerido"
@@ -688,6 +765,15 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
             }
           />
         </div>
+
+        {showNoObligationInfo ? (
+          <section className="mt-4 rounded border border-sky-200 bg-sky-50 p-5">
+            <h2 className="text-lg font-bold text-sky-900">Sua situação hoje</h2>
+            <p className="mt-2 text-sm text-sky-900">
+              Pelos fatos revisados até agora, você está sem obrigatoriedade objetiva no exercício {taxYear}. Ainda assim, a Central do Leão continua mostrando seu espelho fiscal com valores tributáveis, isentos, exclusivos e IRRF para conferência.
+            </p>
+          </section>
+        ) : null}
 
         <div className="mt-4 grid gap-4 lg:grid-cols-[1.4fr_1fr]">
           <section className="rounded border border-cf-border bg-cf-surface p-5">
@@ -710,13 +796,18 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
                 helper="Sem compensar IRRF"
               />
               <FactSummaryCard
+                title="Rendimentos Isentos"
+                value={formatCurrency(displayAnnualExemptIncome)}
+                helper="Ex.: aposentadoria 65+, parcelas isentas e afins"
+              />
+              <FactSummaryCard
                 title="Exclusivos na Fonte"
-                value={formatCurrency(summary.annualExclusiveIncome)}
+                value={formatCurrency(displayAnnualExclusiveIncome)}
                 helper="Ex.: 13º e aplicações"
               />
               <FactSummaryCard
                 title="Deduções Legais"
-                value={formatCurrency(summary.totalLegalDeductions)}
+                value={formatCurrency(displayLegalDeductions)}
                 helper="Médicas e instrução já revisadas"
               />
               <FactSummaryCard
@@ -730,9 +821,13 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
                 helper="Arquivos vinculados ao exercício"
               />
               <FactSummaryCard
-                title="Fatos Aprovados"
-                value={String(summary.sourceCounts.factsApproved)}
-                helper="Base que entra em obrigação e summary"
+                title="Fatos no Cálculo"
+                value={String(obligation.approvedFactsCount)}
+                helper={
+                  excludedApprovedFactsCount > 0
+                    ? `${excludedApprovedFactsCount} aprovado(s) ficaram fora por CPF divergente`
+                    : "Base que entra em obrigação e summary"
+                }
               />
             </div>
           </section>
@@ -768,7 +863,7 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
               <p className="text-xs font-semibold uppercase text-cf-text-secondary">Motivos ativos</p>
               {obligation.reasons.length === 0 ? (
                 <p className="mt-2 text-sm text-cf-text-secondary">
-                  Ainda não há gatilho objetivo com base nos fatos revisados.
+                  Pelos fatos revisados até agora, você continua abaixo dos limites objetivos do exercício.
                 </p>
               ) : (
                 <ul className="mt-2 space-y-2">
@@ -783,11 +878,11 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
           </section>
         </div>
 
-        {summary.warnings.length > 0 ? (
+        {factWarnings.length > 0 ? (
           <section className="mt-4 rounded border border-amber-200 bg-amber-50 p-5">
-            <h2 className="text-lg font-bold text-amber-900">Warnings fiscais</h2>
+            <h2 className="text-lg font-bold text-amber-900">Alertas e observações fiscais</h2>
             <div className="mt-3 space-y-2">
-              {summary.warnings.map((warning) => (
+              {factWarnings.map((warning) => (
                 <div
                   key={warning.code}
                   className="rounded border border-amber-200 bg-white/60 px-3 py-2 text-sm text-amber-900"
@@ -947,84 +1042,109 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
               </p>
             ) : (
               factsPage.items.map((fact) => (
-                <div key={fact.id} className="rounded border border-cf-border bg-cf-bg-subtle p-4">
-                  <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-                    <div className="min-w-0 flex-1">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <span className="rounded-full border border-cf-border bg-cf-surface px-2 py-0.5 text-xs font-semibold text-cf-text-secondary">
-                          {FACT_TYPE_LABELS[fact.factType] || fact.factType}
-                        </span>
-                        <span className="text-xs text-cf-text-secondary">#{fact.id}</span>
-                        {fact.conflictCode ? (
-                          <span className="rounded-full border border-amber-300 bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-800">
-                            {fact.conflictCode}
-                          </span>
-                        ) : null}
-                      </div>
-                      <p className="mt-2 text-lg font-bold text-cf-text-primary">
-                        {formatCurrency(fact.amount)}
-                      </p>
-                      <p className="mt-1 text-sm text-cf-text-primary">
-                        {fact.payerName || "Fonte pagadora não identificada"}
-                      </p>
-                      <div className="mt-2 flex flex-wrap gap-3 text-xs text-cf-text-secondary">
-                        {fact.subcategory ? <span>Subcategoria: {fact.subcategory}</span> : null}
-                        {fact.referencePeriod ? <span>Período: {fact.referencePeriod}</span> : null}
-                        {fact.sourceDocument?.originalFileName ? (
-                          <span>Documento: {fact.sourceDocument.originalFileName}</span>
-                        ) : null}
-                      </div>
-                      {fact.conflictMessage ? (
-                        <p className="mt-2 text-xs text-amber-800">{fact.conflictMessage}</p>
-                      ) : null}
-                    </div>
+                (() => {
+                  const ownerDocument = resolveFactOwnerDocument(fact);
+                  const hasTaxpayerCpf = Boolean(taxpayerCpf);
+                  const hasOwnerDocument = Boolean(ownerDocument);
+                  const ownershipMismatch =
+                    hasTaxpayerCpf &&
+                    hasOwnerDocument &&
+                    normalizeDocumentNumber(taxpayerCpf) !== ownerDocument;
 
-                    <div className="flex flex-wrap gap-2">
-                      <button
-                        type="button"
-                        onClick={() =>
-                          void reviewFact(
-                            fact.id,
-                            {
-                              action: "approve",
-                              note: "Aprovado pela Central do Leão.",
-                            },
-                            "Fato fiscal aprovado.",
-                          )
-                        }
-                        disabled={processingFactId === fact.id}
-                        className="rounded border border-green-300 px-3 py-2 text-sm font-semibold text-green-700 hover:bg-green-50 disabled:cursor-not-allowed disabled:opacity-60"
-                      >
-                        Aprovar
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => handleOpenCorrection(fact)}
-                        disabled={processingFactId === fact.id}
-                        className="rounded border border-amber-300 px-3 py-2 text-sm font-semibold text-amber-800 hover:bg-amber-50 disabled:cursor-not-allowed disabled:opacity-60"
-                      >
-                        Corrigir
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() =>
-                          void reviewFact(
-                            fact.id,
-                            {
-                              action: "reject",
-                              note: "Rejeitado pela Central do Leão.",
-                            },
-                            "Fato fiscal rejeitado.",
-                          )
-                        }
-                        disabled={processingFactId === fact.id}
-                        className="rounded border border-red-300 px-3 py-2 text-sm font-semibold text-red-700 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
-                      >
-                        Rejeitar
-                      </button>
+                  return (
+                    <div key={fact.id} className="rounded border border-cf-border bg-cf-bg-subtle p-4">
+                      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                        <div className="min-w-0 flex-1">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span className="rounded-full border border-cf-border bg-cf-surface px-2 py-0.5 text-xs font-semibold text-cf-text-secondary">
+                              {FACT_TYPE_LABELS[fact.factType] || fact.factType}
+                            </span>
+                            <span className="text-xs text-cf-text-secondary">#{fact.id}</span>
+                            {fact.conflictCode ? (
+                              <span className="rounded-full border border-amber-300 bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-800">
+                                {fact.conflictCode}
+                              </span>
+                            ) : null}
+                            {ownershipMismatch ? (
+                              <span className="rounded-full border border-red-300 bg-red-100 px-2 py-0.5 text-xs font-semibold text-red-800">
+                                CPF divergente
+                              </span>
+                            ) : null}
+                          </div>
+                          <p className="mt-2 text-lg font-bold text-cf-text-primary">
+                            {formatCurrency(fact.amount)}
+                          </p>
+                          <p className="mt-1 text-sm text-cf-text-primary">
+                            {fact.payerName || "Fonte pagadora não identificada"}
+                          </p>
+                          <div className="mt-2 flex flex-wrap gap-3 text-xs text-cf-text-secondary">
+                            {fact.subcategory ? <span>Subcategoria: {fact.subcategory}</span> : null}
+                            {fact.referencePeriod ? <span>Período: {fact.referencePeriod}</span> : null}
+                            {fact.sourceDocument?.originalFileName ? (
+                              <span>Documento: {fact.sourceDocument.originalFileName}</span>
+                            ) : null}
+                            {hasOwnerDocument ? (
+                              <span>Titular do informe: {formatCpf(ownerDocument)}</span>
+                            ) : null}
+                          </div>
+                          {ownershipMismatch ? (
+                            <p className="mt-2 text-xs text-red-800">
+                              Este fato pertence a um CPF diferente do titular cadastrado ({formatCpf(taxpayerCpf)}). Mesmo aprovado, ele fica fora do cálculo oficial do IRPF até ser corrigido ou rejeitado.
+                            </p>
+                          ) : null}
+                          {fact.conflictMessage ? (
+                            <p className="mt-2 text-xs text-amber-800">{fact.conflictMessage}</p>
+                          ) : null}
+                        </div>
+
+                        <div className="flex flex-wrap gap-2">
+                          <button
+                            type="button"
+                            onClick={() =>
+                              void reviewFact(
+                                fact.id,
+                                {
+                                  action: "approve",
+                                  note: "Aprovado pela Central do Leão.",
+                                },
+                                "Fato fiscal aprovado.",
+                              )
+                            }
+                            disabled={processingFactId === fact.id}
+                            className="rounded border border-green-300 px-3 py-2 text-sm font-semibold text-green-700 hover:bg-green-50 disabled:cursor-not-allowed disabled:opacity-60"
+                          >
+                            Aprovar
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleOpenCorrection(fact)}
+                            disabled={processingFactId === fact.id}
+                            className="rounded border border-amber-300 px-3 py-2 text-sm font-semibold text-amber-800 hover:bg-amber-50 disabled:cursor-not-allowed disabled:opacity-60"
+                          >
+                            Corrigir
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() =>
+                              void reviewFact(
+                                fact.id,
+                                {
+                                  action: "reject",
+                                  note: "Rejeitado pela Central do Leão.",
+                                },
+                                "Fato fiscal rejeitado.",
+                              )
+                            }
+                            disabled={processingFactId === fact.id}
+                            className="rounded border border-red-300 px-3 py-2 text-sm font-semibold text-red-700 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+                          >
+                            Rejeitar
+                          </button>
+                        </div>
+                      </div>
                     </div>
-                  </div>
-                </div>
+                  );
+                })()
               ))
             )}
           </div>

--- a/apps/web/src/services/profile.service.ts
+++ b/apps/web/src/services/profile.service.ts
@@ -5,6 +5,7 @@ export interface UserProfile {
   salaryMonthly: number | null;
   payday: number | null;
   avatarUrl: string | null;
+  taxpayerCpf?: string | null;
   aiTone?: string;
   aiInsightFrequency?: string;
 }
@@ -25,6 +26,7 @@ export interface ProfileUpdatePayload {
   salary_monthly?: number | null;
   payday?: number | null;
   avatar_url?: string | null;
+  taxpayer_cpf?: string | null;
   ai_tone?: string;
   ai_insight_frequency?: string;
 }

--- a/apps/web/src/services/tax.service.ts
+++ b/apps/web/src/services/tax.service.ts
@@ -100,10 +100,14 @@ export interface TaxObligation {
     annualTaxableIncome: number;
     annualExemptIncome: number;
     annualExclusiveIncome: number;
+    annualWithheldTax: number;
+    totalLegalDeductions: number;
     annualCombinedExemptAndExclusiveIncome: number;
     totalAssetBalance: number;
   };
   approvedFactsCount: number;
+  taxpayerCpfConfigured?: boolean;
+  excludedFactsCount?: number;
 }
 
 export interface TaxFact {
@@ -385,12 +389,16 @@ const normalizeObligation = (value: unknown): TaxObligation => {
       annualTaxableIncome: normalizeNumber(totals.annualTaxableIncome),
       annualExemptIncome: normalizeNumber(totals.annualExemptIncome),
       annualExclusiveIncome: normalizeNumber(totals.annualExclusiveIncome),
+      annualWithheldTax: normalizeNumber(totals.annualWithheldTax),
+      totalLegalDeductions: normalizeNumber(totals.totalLegalDeductions),
       annualCombinedExemptAndExclusiveIncome: normalizeNumber(
         totals.annualCombinedExemptAndExclusiveIncome,
       ),
       totalAssetBalance: normalizeNumber(totals.totalAssetBalance),
     },
     approvedFactsCount: normalizeNumber(raw.approvedFactsCount),
+    taxpayerCpfConfigured: Boolean(raw.taxpayerCpfConfigured),
+    excludedFactsCount: normalizeNumber(raw.excludedFactsCount),
   };
 };
 


### PR DESCRIPTION
## Contexto

Este PR corrige dois problemas práticos da Central do Leão:

- fatos fiscais de outro titular podiam entrar no cálculo oficial do IRPF quando o usuário ainda não tinha uma trava de titularidade
- o layout real do `extrato-ir.pdf` era aceito, mas não virava `tax_facts` úteis no pipeline anual do INSS

Também melhora a UX do módulo para o caso de usuário sem obrigatoriedade objetiva no exercício, mantendo o espelho fiscal visível de forma mais didática.

## Before / After

### Antes

- a Central do Leão podia misturar fatos revisados de CPFs diferentes no cálculo oficial
- o perfil não tinha `CPF do titular (IRPF)` para conferir titularidade
- `extrato-ir.pdf` classificava como INSS, mas zerava na normalização
- abaixo do teto, a tela ficava pouco didática sobre valores já importados e situação de obrigatoriedade

### Depois

- o perfil passa a aceitar `taxpayer_cpf`
- fatos revisados com CPF divergente continuam visíveis, mas ficam fora do cálculo oficial, summary e export
- `extrato-ir.pdf` passa a gerar os 5 fatos anuais esperados do INSS
- a tela fiscal passa a explicar melhor a situação do usuário, inclusive quando ele segue sem obrigatoriedade objetiva

## Escopo

### Incluído neste PR

- migration para `user_profiles.taxpayer_cpf`
- validação e persistência de `taxpayer_cpf` no backend
- campo de `CPF do titular (IRPF)` nas configurações do perfil
- filtro de titularidade no cálculo oficial (`obligation`, `summary` e `export`)
- warnings e UX didática no dashboard fiscal
- suporte ao layout real do `extrato-ir.pdf` no extractor anual do INSS
- cobertura unitária, integração e web tests para os fluxos novos

### Fora de escopo

- suporte genérico a qualquer layout bancário anual
- mudança de regra tributária do IRPF
- automação de review sem confirmação humana
- correção retroativa automática sem `reprocess`

## Layouts e cenários cobertos

- `shareFile.pdf` -> INSS anual com 5 fatos
- `extrato-ir.pdf` -> INSS anual com 5 fatos
- `shareFile (1).pdf` -> informe bancário anual itemizado
- `Informe de Rendimentos 2025 - PicPay.pdf` -> informe bancário anual com facts úteis

## Bordas ainda conhecidas

Os seguintes arquivos continuam fora do trilho útil de fatos fiscais anuais e permanecem como layouts não cobertos neste PR:

- `ComprovanteSantander-1774467437284.pdf`
- `Informe de Crédito 2025 - Original e PicPay Bank.pdf`

## Validação executada

- API: `npm run lint`
- API: `npx vitest run` -> `707/707`
- Web: `npm run lint`
- Web: `npm run typecheck`
- Web: `npm run test:run` -> `294/294`
- Web: `npm run build`
- conferência manual do pipeline com PDFs reais do INSS e informes bancários citados acima

## Nota operacional

Após o merge, documentos já enviados antes deste ajuste precisam de `reprocess` para regenerar `extraction` e `tax_facts` com o pipeline novo.

## Texto curto

> Corrige a mistura de titularidade no cálculo oficial via CPF do titular, melhora a UX fiscal da Central do Leão e fecha o gap do layout real do `extrato-ir.pdf` no extractor anual do INSS. A validação está forte em API e web. Após o merge, documentos antigos precisam de `reprocess`, e ainda há layouts conhecidos fora da cobertura útil de fatos anuais.
