### PR TITLE
feat(tax): add legacy fiscal document batch reprocess endpoint

### DIFF
--- a/apps/api/src/ops-tax-reprocess.test.js
+++ b/apps/api/src/ops-tax-reprocess.test.js
@@ -1,0 +1,345 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import app from "./app.js";
+import { clearDbClientForTests, dbQuery } from "./db/index.js";
+import { resetLoginProtectionState } from "./middlewares/login-protection.middleware.js";
+import {
+  resetImportRateLimiterState,
+  resetWriteRateLimiterState,
+} from "./middlewares/rate-limit.middleware.js";
+import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
+import {
+  expectErrorResponseWithRequestId,
+  getUserIdByEmail,
+  registerAndLogin,
+  setupTestDb,
+} from "./test-helpers.js";
+
+const OPS_TOKEN_TEST = "ops-token-test";
+const TEST_TAX_STORAGE_DIR = path.join(
+  os.tmpdir(),
+  "control-finance-tax-legacy-reprocess-tests",
+);
+
+const INSS_ANNUAL_CONTENT = [
+  "Ministerio da Economia Comprovante de Rendimentos Pagos e de",
+  "Imposto sobre a Renda Retido na Fonte",
+  "Exercicio de 2026 Ano-calendario de 2025",
+  "16.727.230/0001-97 Fundo do Regime Geral de Previdencia Social",
+  "433.427.604-00 MARIA EDLEUSA MONSAO DA SILVA 1776829899",
+  "3533-PROVENTOS DE APOSENT., RESERVA, REFORMA OU PENSAO PAGOS PELA PREV. SOCIAL",
+  "1. Total dos rendimentos (inclusive ferias) 34.287,13",
+  "5. Imposto sobre a renda retido na fonte 13,36",
+  "1. Parcela isenta dos proventos de aposentadoria, reserva remunerada, reforma e pensao (65 anos ou mais), exceto a 22.847,76",
+  "2. Parcela isenta do 13o salario de aposentadoria, reserva remunerada, reforma e pensao (65 anos ou mais). 1.903,98",
+  "1. Decimo terceiro salario 2.868,57",
+].join("\n");
+
+let previousNodeEnv;
+let previousOpsToken;
+let previousTaxStorageDir;
+
+const removeTaxStorageDir = async () => {
+  await fs.rm(TEST_TAX_STORAGE_DIR, {
+    recursive: true,
+    force: true,
+  });
+};
+
+const resetState = async () => {
+  resetLoginProtectionState();
+  resetImportRateLimiterState();
+  resetWriteRateLimiterState();
+  resetHttpMetricsForTests();
+  await removeTaxStorageDir();
+  await dbQuery("DELETE FROM tax_reviews");
+  await dbQuery("DELETE FROM tax_facts");
+  await dbQuery("DELETE FROM tax_document_extractions");
+  await dbQuery("DELETE FROM tax_documents");
+  await dbQuery("DELETE FROM tax_rule_sets");
+  await dbQuery("DELETE FROM tax_summaries");
+  await dbQuery("DELETE FROM user_profiles");
+  await dbQuery("DELETE FROM user_identities");
+  await dbQuery("DELETE FROM users");
+};
+
+const uploadInssAnnualDocument = async (token, filename = "inss-anual.csv") =>
+  request(app)
+    .post("/tax/documents")
+    .set("Authorization", `Bearer ${token}`)
+    .field("taxYear", "2026")
+    .attach("file", Buffer.from(INSS_ANNUAL_CONTENT, "utf8"), {
+      filename,
+      contentType: "text/csv",
+    });
+
+describe("ops tax legacy reprocess", () => {
+  beforeAll(async () => {
+    previousNodeEnv = process.env.NODE_ENV;
+    previousOpsToken = process.env.OPS_TOKEN;
+    previousTaxStorageDir = process.env.TAX_DOCUMENTS_STORAGE_DIR;
+    process.env.NODE_ENV = "test";
+    process.env.OPS_TOKEN = OPS_TOKEN_TEST;
+    process.env.TAX_DOCUMENTS_STORAGE_DIR = TEST_TAX_STORAGE_DIR;
+    await setupTestDb();
+  });
+
+  afterAll(async () => {
+    process.env.NODE_ENV = previousNodeEnv;
+    process.env.OPS_TOKEN = previousOpsToken;
+
+    if (typeof previousTaxStorageDir === "undefined") {
+      delete process.env.TAX_DOCUMENTS_STORAGE_DIR;
+    } else {
+      process.env.TAX_DOCUMENTS_STORAGE_DIR = previousTaxStorageDir;
+    }
+
+    await removeTaxStorageDir();
+    await clearDbClientForTests();
+  });
+
+  beforeEach(async () => {
+    process.env.NODE_ENV = "test";
+    process.env.OPS_TOKEN = OPS_TOKEN_TEST;
+    process.env.TAX_DOCUMENTS_STORAGE_DIR = TEST_TAX_STORAGE_DIR;
+    await resetState();
+  });
+
+  it("POST /ops/tax-documents/reprocess-legacy retorna 401 sem x-ops-token", async () => {
+    const response = await request(app)
+      .post("/ops/tax-documents/reprocess-legacy")
+      .send({ dryRun: true });
+
+    expectErrorResponseWithRequestId(response, 401, "Ops token ausente ou invalido.");
+  });
+
+  it("dry-run reprocessa em memoria, nao persiste e reporta exclusao por CPF divergente", async () => {
+    const email = "ops-tax-reprocess-dry-run@test.dev";
+    const token = await registerAndLogin(email);
+    const userId = await getUserIdByEmail(email);
+
+    await dbQuery(
+      `INSERT INTO user_profiles (user_id, taxpayer_cpf)
+       VALUES ($1, '52998224725')`,
+      [userId],
+    );
+
+    const uploadResponse = await uploadInssAnnualDocument(token, "inss-legacy-dry-run.csv");
+
+    expect(uploadResponse.status).toBe(201);
+
+    const response = await request(app)
+      .post("/ops/tax-documents/reprocess-legacy")
+      .set("x-ops-token", OPS_TOKEN_TEST)
+      .send({
+        dryRun: true,
+        userId,
+        taxYear: 2026,
+        limit: 10,
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      dryRun: true,
+      processed: 1,
+      succeeded: 1,
+      failed: 0,
+      updatedExtractions: 0,
+      updatedTaxFacts: 0,
+      totalFactsGenerated: 5,
+      excludedByCpfMismatch: 5,
+      summariesRebuilt: 0,
+      nextAfterDocumentId: uploadResponse.body.document.id,
+    });
+    expect(response.body.items).toEqual([
+      expect.objectContaining({
+        documentId: uploadResponse.body.document.id,
+        userId,
+        taxYear: 2026,
+        documentTypeBefore: "unknown",
+        documentTypeAfter: "income_report_inss",
+        statusBefore: "uploaded",
+        statusAfter: "normalized",
+        factsGenerated: 5,
+        officialEligibleFacts: 0,
+        excludedByCpfMismatch: 5,
+        dryRun: true,
+      }),
+    ]);
+
+    const extractionCountResult = await dbQuery(
+      `SELECT COUNT(*) AS total
+       FROM tax_document_extractions`,
+    );
+    const factsCountResult = await dbQuery(
+      `SELECT COUNT(*) AS total
+       FROM tax_facts`,
+    );
+    const summariesCountResult = await dbQuery(
+      `SELECT COUNT(*) AS total
+       FROM tax_summaries`,
+    );
+    const documentStatusResult = await dbQuery(
+      `SELECT processing_status
+       FROM tax_documents
+       WHERE id = $1`,
+      [uploadResponse.body.document.id],
+    );
+
+    expect(Number(extractionCountResult.rows[0].total)).toBe(0);
+    expect(Number(factsCountResult.rows[0].total)).toBe(0);
+    expect(Number(summariesCountResult.rows[0].total)).toBe(0);
+    expect(documentStatusResult.rows[0].processing_status).toBe("uploaded");
+  });
+
+  it("apply reprocessa legado, preserva aprovacao e rebuilda o summary", async () => {
+    const email = "ops-tax-reprocess-apply@test.dev";
+    const token = await registerAndLogin(email);
+    const userId = await getUserIdByEmail(email);
+
+    await dbQuery(
+      `INSERT INTO user_profiles (user_id, taxpayer_cpf)
+       VALUES ($1, '43342760400')`,
+      [userId],
+    );
+
+    const uploadResponse = await uploadInssAnnualDocument(token, "inss-legacy-apply.csv");
+
+    expect(uploadResponse.status).toBe(201);
+
+    const reprocessResponse = await request(app)
+      .post(`/tax/documents/${uploadResponse.body.document.id}/reprocess`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(reprocessResponse.status).toBe(200);
+
+    const factIdsResult = await dbQuery(
+      `SELECT id
+       FROM tax_facts
+       WHERE source_document_id = $1
+       ORDER BY id ASC`,
+      [uploadResponse.body.document.id],
+    );
+    const factIds = factIdsResult.rows.map((row) => Number(row.id));
+
+    const approveResponse = await request(app)
+      .post("/tax/facts/bulk-review")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        factIds,
+        action: "approve",
+      });
+
+    expect(approveResponse.status).toBe(200);
+
+    const initialSummaryResponse = await request(app)
+      .post("/tax/summary/2026/rebuild")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(initialSummaryResponse.status).toBe(200);
+    expect(initialSummaryResponse.body).toMatchObject({
+      snapshotVersion: 1,
+      annualTaxableIncome: 34287.13,
+      annualExemptIncome: 24751.74,
+      annualExclusiveIncome: 2868.57,
+      annualWithheldTax: 13.36,
+      sourceCounts: {
+        documents: 1,
+        factsPending: 0,
+        factsApproved: 5,
+      },
+    });
+
+    const response = await request(app)
+      .post("/ops/tax-documents/reprocess-legacy")
+      .set("x-ops-token", OPS_TOKEN_TEST)
+      .send({
+        dryRun: false,
+        userId,
+        taxYear: 2026,
+        limit: 10,
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      dryRun: false,
+      processed: 1,
+      succeeded: 1,
+      failed: 0,
+      updatedExtractions: 1,
+      updatedTaxFacts: 1,
+      totalFactsGenerated: 5,
+      excludedByCpfMismatch: 0,
+      summariesRebuilt: 1,
+      nextAfterDocumentId: uploadResponse.body.document.id,
+    });
+    expect(response.body.items).toEqual([
+      expect.objectContaining({
+        documentId: uploadResponse.body.document.id,
+        userId,
+        taxYear: 2026,
+        documentTypeBefore: "income_report_inss",
+        documentTypeAfter: "income_report_inss",
+        statusBefore: "normalized",
+        statusAfter: "normalized",
+        factsGenerated: 5,
+        officialEligibleFacts: 5,
+        excludedByCpfMismatch: 0,
+        dryRun: false,
+      }),
+    ]);
+
+    const reviewCountsResult = await dbQuery(
+      `SELECT review_status, COUNT(*) AS total
+       FROM tax_facts
+       WHERE source_document_id = $1
+       GROUP BY review_status
+       ORDER BY review_status ASC`,
+      [uploadResponse.body.document.id],
+    );
+    const extractionsCountResult = await dbQuery(
+      `SELECT COUNT(*) AS total
+       FROM tax_document_extractions
+       WHERE document_id = $1`,
+      [uploadResponse.body.document.id],
+    );
+    const summariesCountResult = await dbQuery(
+      `SELECT COUNT(*) AS total
+       FROM tax_summaries
+       WHERE user_id = $1
+         AND tax_year = 2026`,
+      [userId],
+    );
+
+    expect(reviewCountsResult.rows).toEqual([
+      {
+        review_status: "approved",
+        total: 5,
+      },
+    ]);
+    expect(Number(extractionsCountResult.rows[0].total)).toBe(2);
+    expect(Number(summariesCountResult.rows[0].total)).toBe(2);
+
+    const summaryResponse = await request(app)
+      .get("/tax/summary/2026")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(summaryResponse.status).toBe(200);
+    expect(summaryResponse.body).toMatchObject({
+      status: "generated",
+      snapshotVersion: 2,
+      annualTaxableIncome: 34287.13,
+      annualExemptIncome: 24751.74,
+      annualExclusiveIncome: 2868.57,
+      annualWithheldTax: 13.36,
+      sourceCounts: {
+        documents: 1,
+        factsPending: 0,
+        factsApproved: 5,
+      },
+    });
+  });
+});

--- a/apps/api/src/routes/ops.routes.js
+++ b/apps/api/src/routes/ops.routes.js
@@ -1,6 +1,7 @@
 import { timingSafeEqual } from "node:crypto";
 import { Router } from "express";
 import { forcePlanForEmail } from "../services/ops-force-plan.service.js";
+import { reprocessLegacyTaxDocuments } from "../services/tax-legacy-reprocess.service.js";
 
 const router = Router();
 
@@ -74,5 +75,19 @@ router.post("/force-plan", async (req, res, next) => {
   }
 });
 
-export default router;
+router.post("/tax-documents/reprocess-legacy", async (req, res, next) => {
+  try {
+    const result = await reprocessLegacyTaxDocuments({
+      dryRun: req.body?.dryRun,
+      limit: req.body?.limit,
+      userId: req.body?.userId,
+      taxYear: req.body?.taxYear,
+      afterDocumentId: req.body?.afterDocumentId,
+    });
+    res.status(200).json(result);
+  } catch (error) {
+    next(error);
+  }
+});
 
+export default router;

--- a/apps/api/src/services/tax-extraction.service.js
+++ b/apps/api/src/services/tax-extraction.service.js
@@ -3,7 +3,10 @@ import { runTaxExtractorForDocument } from "../domain/tax/tax-document-extractor
 import { createTaxError, normalizeTaxUserId } from "../domain/tax/tax.validation.js";
 import { classifyStoredTaxDocument } from "./tax-classification.service.js";
 import { getTaxDocumentByIdForUser } from "./tax-documents.service.js";
-import { normalizeProcessedTaxDocument } from "./tax-normalization.service.js";
+import {
+  buildNormalizedFactsFromExtraction,
+  normalizeProcessedTaxDocument,
+} from "./tax-normalization.service.js";
 
 const CLASSIFIER_ONLY_EXTRACTOR_NAME = "classifier-only";
 const CLASSIFIER_ONLY_EXTRACTOR_VERSION = "1.0.0";
@@ -56,6 +59,28 @@ const mapPersistedExtraction = (row) => ({
       : Number(row.confidence_score),
   rawJson: row.raw_json && typeof row.raw_json === "object" ? row.raw_json : {},
   warnings: Array.isArray(row.warnings_json) ? row.warnings_json : [],
+});
+
+const buildExtractionPreview = ({
+  classification,
+  extractorResult,
+  warnings,
+}) => ({
+  id: null,
+  extractorName: extractorResult?.extractorName || CLASSIFIER_ONLY_EXTRACTOR_NAME,
+  extractorVersion:
+    extractorResult?.extractorVersion || CLASSIFIER_ONLY_EXTRACTOR_VERSION,
+  classification: classification.documentType,
+  confidenceScore: classification.confidenceScore,
+  rawJson: extractorResult
+    ? {
+        classification: classification.classificationPayload,
+        extraction: extractorResult.payload,
+      }
+    : {
+        classification: classification.classificationPayload,
+      },
+  warnings,
 });
 
 const persistSuccessfulProcessing = async ({
@@ -157,6 +182,64 @@ const persistFailedProcessing = async ({
   );
 };
 
+const buildTaxDocumentProcessingPreview = async ({
+  userId,
+  document,
+}) => {
+  const classification = await classifyStoredTaxDocument(document);
+  const extractorResult = runTaxExtractorForDocument({
+    documentType: classification.documentType,
+    text: classification.text,
+    classification,
+  });
+  const warnings = [...classification.warnings, ...(extractorResult?.warnings || [])];
+  const extractionPreview = buildExtractionPreview({
+    classification,
+    extractorResult,
+    warnings,
+  });
+  const normalizedFacts = buildNormalizedFactsFromExtraction({
+    userId,
+    document: {
+      id: Number(document.id),
+      taxYear: Number(document.tax_year),
+      documentType: classification.documentType,
+    },
+    extraction: extractionPreview,
+  });
+
+  return {
+    classification,
+    extractorResult,
+    warnings,
+    extractionPreview,
+    normalizedFacts,
+  };
+};
+
+export const previewTaxDocumentProcessingByIdForUser = async (userId, documentId) => {
+  const normalizedUserId = normalizeTaxUserId(userId);
+  const normalizedDocumentId = normalizeDocumentId(documentId);
+  const document = await getProcessableTaxDocumentByIdForUser(
+    normalizedUserId,
+    normalizedDocumentId,
+  );
+
+  if (!document) {
+    throw createTaxError(404, "Documento fiscal nao encontrado.");
+  }
+
+  const preview = await buildTaxDocumentProcessingPreview({
+    userId: normalizedUserId,
+    document,
+  });
+
+  return {
+    document,
+    ...preview,
+  };
+};
+
 export const processTaxDocumentByIdForUser = async (userId, documentId) => {
   const normalizedUserId = normalizeTaxUserId(userId);
   const normalizedDocumentId = normalizeDocumentId(documentId);
@@ -170,28 +253,26 @@ export const processTaxDocumentByIdForUser = async (userId, documentId) => {
   }
 
   try {
-    const classification = await classifyStoredTaxDocument(document);
-    const extractorResult = runTaxExtractorForDocument({
-      documentType: classification.documentType,
-      text: classification.text,
-      classification,
+    const preview = await buildTaxDocumentProcessingPreview({
+      userId: normalizedUserId,
+      document,
     });
-    const warnings = [...classification.warnings, ...(extractorResult?.warnings || [])];
     const persistedExtraction = await persistSuccessfulProcessing({
       userId: normalizedUserId,
       documentId: normalizedDocumentId,
-      classification,
-      extractorResult,
-      warnings,
+      classification: preview.classification,
+      extractorResult: preview.extractorResult,
+      warnings: preview.warnings,
     });
     await normalizeProcessedTaxDocument({
       userId: normalizedUserId,
       document: {
         id: normalizedDocumentId,
         taxYear: Number(document.tax_year),
-        documentType: classification.documentType,
+        documentType: preview.classification.documentType,
       },
       extraction: persistedExtraction,
+      precomputedFacts: preview.normalizedFacts,
     });
 
     return getTaxDocumentByIdForUser(normalizedUserId, normalizedDocumentId);

--- a/apps/api/src/services/tax-legacy-reprocess.service.js
+++ b/apps/api/src/services/tax-legacy-reprocess.service.js
@@ -1,0 +1,287 @@
+import { dbQuery } from "../db/index.js";
+import { createTaxError, normalizeTaxUserId, normalizeTaxYear } from "../domain/tax/tax.validation.js";
+import { logInfo, logWarn } from "../observability/logger.js";
+import {
+  previewTaxDocumentProcessingByIdForUser,
+  processTaxDocumentByIdForUser,
+} from "./tax-extraction.service.js";
+import { rebuildTaxSummaryByYear } from "./tax-summary.service.js";
+
+const DEFAULT_BATCH_LIMIT = 50;
+const MAX_BATCH_LIMIT = 200;
+
+const normalizeBoolean = (value, fallback = false) => {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+
+    if (["true", "1", "yes", "y"].includes(normalized)) {
+      return true;
+    }
+
+    if (["false", "0", "no", "n"].includes(normalized)) {
+      return false;
+    }
+  }
+
+  return fallback;
+};
+
+const normalizeOptionalPositiveInteger = (value, fieldName, { max = Number.MAX_SAFE_INTEGER } = {}) => {
+  if (typeof value === "undefined" || value === null || value === "") {
+    return undefined;
+  }
+
+  const parsedValue = Number(value);
+
+  if (!Number.isInteger(parsedValue) || parsedValue <= 0 || parsedValue > max) {
+    throw createTaxError(400, `${fieldName} invalido.`);
+  }
+
+  return parsedValue;
+};
+
+const normalizeBatchLimit = (value) =>
+  normalizeOptionalPositiveInteger(value, "limit", { max: MAX_BATCH_LIMIT }) || DEFAULT_BATCH_LIMIT;
+
+const normalizeDocumentNumber = (value) => String(value || "").replace(/\D/g, "");
+
+const resolveFactOwnerDocument = (fact) => {
+  const metadata = fact?.metadataJson || fact?.metadata_json || {};
+
+  return normalizeDocumentNumber(
+    metadata.beneficiaryDocument ||
+      metadata.customerDocument ||
+      metadata.studentDocument ||
+      metadata.ownerDocument,
+  );
+};
+
+const isFactEligibleForOfficialCalc = (fact, taxpayerCpf) => {
+  const normalizedTaxpayerCpf = normalizeDocumentNumber(taxpayerCpf);
+
+  if (!normalizedTaxpayerCpf) {
+    return true;
+  }
+
+  const ownerDocument = resolveFactOwnerDocument(fact);
+
+  if (!ownerDocument) {
+    return true;
+  }
+
+  return ownerDocument === normalizedTaxpayerCpf;
+};
+
+const getUserTaxpayerCpf = async (userId, cache) => {
+  if (cache.has(userId)) {
+    return cache.get(userId);
+  }
+
+  const result = await dbQuery(
+    `SELECT taxpayer_cpf
+     FROM user_profiles
+     WHERE user_id = $1
+     LIMIT 1`,
+    [userId],
+  );
+  const taxpayerCpf = normalizeDocumentNumber(result.rows[0]?.taxpayer_cpf);
+  cache.set(userId, taxpayerCpf);
+  return taxpayerCpf;
+};
+
+const listEligibleTaxDocuments = async ({
+  limit,
+  userId,
+  taxYear,
+  afterDocumentId,
+}) => {
+  const whereClauses = ["1 = 1"];
+  const params = [];
+
+  if (userId) {
+    params.push(userId);
+    whereClauses.push(`user_id = $${params.length}`);
+  }
+
+  if (taxYear) {
+    params.push(taxYear);
+    whereClauses.push(`tax_year = $${params.length}`);
+  }
+
+  if (afterDocumentId) {
+    params.push(afterDocumentId);
+    whereClauses.push(`id > $${params.length}`);
+  }
+
+  params.push(limit);
+
+  const result = await dbQuery(
+    `SELECT
+       id,
+       user_id,
+       tax_year,
+       original_file_name,
+       document_type,
+       processing_status
+     FROM tax_documents
+     WHERE ${whereClauses.join(" AND ")}
+     ORDER BY id ASC
+     LIMIT $${params.length}`,
+    params,
+  );
+
+  return result.rows.map((row) => ({
+    id: Number(row.id),
+    userId: Number(row.user_id),
+    taxYear: Number(row.tax_year),
+    originalFileName: row.original_file_name,
+    documentType: row.document_type,
+    processingStatus: row.processing_status,
+  }));
+};
+
+export const reprocessLegacyTaxDocuments = async (payload = {}) => {
+  const dryRun = normalizeBoolean(payload.dryRun, false);
+  const userId = normalizeOptionalPositiveInteger(payload.userId, "userId")
+    ? normalizeTaxUserId(payload.userId)
+    : undefined;
+  const taxYear =
+    typeof payload.taxYear === "undefined" || payload.taxYear === null || payload.taxYear === ""
+      ? undefined
+      : normalizeTaxYear(payload.taxYear);
+  const limit = normalizeBatchLimit(payload.limit);
+  const afterDocumentId = normalizeOptionalPositiveInteger(payload.afterDocumentId, "afterDocumentId");
+
+  const documents = await listEligibleTaxDocuments({
+    limit,
+    userId,
+    taxYear,
+    afterDocumentId,
+  });
+  const taxpayerCpfCache = new Map();
+  const summaryKeysToRebuild = new Set();
+  const items = [];
+  let succeeded = 0;
+  let failed = 0;
+  let updatedExtractions = 0;
+  let updatedTaxFacts = 0;
+  let totalFactsGenerated = 0;
+  let excludedByCpfMismatch = 0;
+
+  for (const document of documents) {
+    try {
+      const taxpayerCpf = await getUserTaxpayerCpf(document.userId, taxpayerCpfCache);
+      const preview = await previewTaxDocumentProcessingByIdForUser(document.userId, document.id);
+      const eligibleFactsCount = preview.normalizedFacts.filter((fact) =>
+        isFactEligibleForOfficialCalc(fact, taxpayerCpf)
+      ).length;
+      const excludedFactsCount = Math.max(preview.normalizedFacts.length - eligibleFactsCount, 0);
+
+      const item = {
+        documentId: document.id,
+        userId: document.userId,
+        taxYear: document.taxYear,
+        originalFileName: document.originalFileName,
+        documentTypeBefore: document.documentType,
+        documentTypeAfter: preview.classification.documentType,
+        statusBefore: document.processingStatus,
+        statusAfter: "normalized",
+        factsGenerated: preview.normalizedFacts.length,
+        officialEligibleFacts: eligibleFactsCount,
+        excludedByCpfMismatch: excludedFactsCount,
+        dryRun,
+      };
+
+      if (!dryRun) {
+        await processTaxDocumentByIdForUser(document.userId, document.id);
+        summaryKeysToRebuild.add(`${document.userId}:${document.taxYear}`);
+        updatedExtractions += 1;
+        updatedTaxFacts += 1;
+      }
+
+      succeeded += 1;
+      totalFactsGenerated += preview.normalizedFacts.length;
+      excludedByCpfMismatch += excludedFactsCount;
+      items.push(item);
+
+      logInfo({
+        event: "tax.legacy_reprocess.document_processed",
+        dryRun,
+        documentId: document.id,
+        userId: document.userId,
+        taxYear: document.taxYear,
+        statusBefore: document.processingStatus,
+        statusAfter: item.statusAfter,
+        documentTypeBefore: document.documentType,
+        documentTypeAfter: preview.classification.documentType,
+        factsGenerated: preview.normalizedFacts.length,
+        officialEligibleFacts: eligibleFactsCount,
+        excludedByCpfMismatch: excludedFactsCount,
+      });
+    } catch (error) {
+      failed += 1;
+      items.push({
+        documentId: document.id,
+        userId: document.userId,
+        taxYear: document.taxYear,
+        originalFileName: document.originalFileName,
+        documentTypeBefore: document.documentType,
+        statusBefore: document.processingStatus,
+        statusAfter: "failed",
+        factsGenerated: 0,
+        officialEligibleFacts: 0,
+        excludedByCpfMismatch: 0,
+        dryRun,
+        error: error?.message || "Falha ao reprocessar documento fiscal.",
+      });
+
+      logWarn({
+        event: "tax.legacy_reprocess.document_failed",
+        dryRun,
+        documentId: document.id,
+        userId: document.userId,
+        taxYear: document.taxYear,
+        statusBefore: document.processingStatus,
+        error: error?.message || "unknown_tax_legacy_reprocess_error",
+      });
+    }
+  }
+
+  let summariesRebuilt = 0;
+
+  if (!dryRun) {
+    for (const summaryKey of summaryKeysToRebuild) {
+      const [summaryUserId, summaryTaxYear] = summaryKey.split(":").map(Number);
+
+      try {
+        await rebuildTaxSummaryByYear(summaryUserId, summaryTaxYear);
+        summariesRebuilt += 1;
+      } catch (error) {
+        logWarn({
+          event: "tax.legacy_reprocess.summary_rebuild_failed",
+          userId: summaryUserId,
+          taxYear: summaryTaxYear,
+          error: error?.message || "unknown_tax_summary_rebuild_error",
+        });
+      }
+    }
+  }
+
+  return {
+    dryRun,
+    processed: documents.length,
+    succeeded,
+    failed,
+    updatedExtractions,
+    updatedTaxFacts,
+    totalFactsGenerated,
+    excludedByCpfMismatch,
+    summariesRebuilt,
+    nextAfterDocumentId: documents.length > 0 ? documents[documents.length - 1].id : null,
+    items,
+  };
+};

--- a/apps/api/src/services/tax-normalization.service.js
+++ b/apps/api/src/services/tax-normalization.service.js
@@ -7,6 +7,17 @@ const DUPLICATE_FACT_CONFLICT_CODE = "TAX_FACT_DUPLICATE";
 const buildDuplicateConflictMessage = () =>
   "Fato potencialmente duplicado com outro documento fiscal do usuario.";
 
+const buildFactIdentityKey = (fact) =>
+  [
+    String(fact.dedupeKey || fact.dedupe_key || ""),
+    String(fact.dedupeStrength || fact.dedupe_strength || ""),
+    String(fact.factType || fact.fact_type || ""),
+    String(fact.subcategory || ""),
+    Number(fact.amount || 0).toFixed(2),
+    String(fact.referencePeriod || fact.reference_period || ""),
+    String(fact.conflictCode || fact.conflict_code || ""),
+  ].join("|");
+
 const buildExistingStrongFactsQuery = (dedupeKeys) => {
   const placeholders = dedupeKeys.map((_, index) => `$${index + 2}`).join(", ");
 
@@ -88,10 +99,35 @@ const buildConflictFact = (fact, existingStrongFact) => ({
   },
 });
 
+const applyPreviousReviewState = (fact, previousFactsByIdentity) => {
+  const previousFact = previousFactsByIdentity.get(buildFactIdentityKey(fact));
+
+  if (!previousFact) {
+    return fact;
+  }
+
+  return {
+    ...fact,
+    reviewStatus: previousFact.review_status,
+  };
+};
+
+export const buildNormalizedFactsFromExtraction = ({
+  userId,
+  document,
+  extraction,
+}) =>
+  normalizeTaxExtractionToFacts({
+    userId,
+    document,
+    extraction,
+  });
+
 export const normalizeProcessedTaxDocument = async ({
   userId,
   document,
   extraction,
+  precomputedFacts = null,
 }) => {
   const normalizedUserId = normalizeTaxUserId(userId);
 
@@ -99,16 +135,39 @@ export const normalizeProcessedTaxDocument = async ({
     throw createTaxError(400, "Documento fiscal invalido para normalizacao.");
   }
 
-  const normalizedFacts = normalizeTaxExtractionToFacts({
-    userId: normalizedUserId,
-    document,
-    extraction,
-  });
+  const normalizedFacts = Array.isArray(precomputedFacts)
+    ? precomputedFacts
+    : buildNormalizedFactsFromExtraction({
+        userId: normalizedUserId,
+        document,
+        extraction,
+      });
   const dedupeKeys = [...new Set(normalizedFacts.map((fact) => fact.dedupeKey).filter(Boolean))];
 
   await withDbTransaction(async (client) => {
-    // Enquanto ainda nao existe review queue, reprocessar um documento deve recriar
-    // integralmente os fatos dele sem acumular duplicatas do mesmo source_document_id.
+    const existingDocumentFactsResult = await client.query(
+      `SELECT
+         fact_type,
+         subcategory,
+         amount,
+         reference_period,
+         dedupe_key,
+         dedupe_strength,
+         review_status,
+         conflict_code
+       FROM tax_facts
+       WHERE user_id = $1
+         AND source_document_id = $2`,
+      [normalizedUserId, document.id],
+    );
+    const previousFactsByIdentity = existingDocumentFactsResult.rows.reduce((accumulator, row) => {
+      accumulator.set(buildFactIdentityKey(row), row);
+      return accumulator;
+    }, new Map());
+
+    // Reprocessar um documento recria integralmente os fatos do mesmo
+    // source_document_id, preservando o review_status quando a identidade
+    // logica do fato continua a mesma no pipeline novo.
     await client.query(
       `DELETE FROM tax_facts
        WHERE user_id = $1
@@ -135,11 +194,17 @@ export const normalizeProcessedTaxDocument = async ({
       const existingStrongFact = existingStrongFactsByKey.get(fact.dedupeKey);
 
       if (existingStrongFact) {
-        await insertTaxFact(client, buildConflictFact(fact, existingStrongFact));
+        await insertTaxFact(
+          client,
+          applyPreviousReviewState(
+            buildConflictFact(fact, existingStrongFact),
+            previousFactsByIdentity,
+          ),
+        );
         continue;
       }
 
-      await insertTaxFact(client, fact);
+      await insertTaxFact(client, applyPreviousReviewState(fact, previousFactsByIdentity));
     }
 
     await client.query(


### PR DESCRIPTION
## Contexto

Este PR adiciona um batch seguro de reprocessamento para documentos fiscais legados da Central do Leão.

O objetivo é reaplicar o pipeline fiscal mais recente sobre documentos já enviados, regenerando `extraction`, `tax_facts` e `summary` sem exigir reprocess manual documento por documento.

Este endpoint é estritamente operacional, voltado a manutenção corretiva de base legada, sem exposição para fluxo comum de produto.

O batch foi desenhado para corrigir base legada sem perder governança fiscal:
- documentos continuam visíveis
- fatos com CPF divergente continuam auditáveis
- apenas o cálculo oficial, summary e export excluem fatos incompatíveis com o `taxpayer_cpf` do perfil

## O que entra

- endpoint protegido `POST /ops/tax-documents/reprocess-legacy`
- serviço batch com suporte a:
  - `dryRun`
  - `apply`
  - `limit`
  - `userId`
  - `taxYear`
  - `afterDocumentId`
- preview real do pipeline fiscal no `dryRun`
- reprocess idempotente por documento
- rebuild de `summary` por `userId + taxYear` afetado
- preservação de `review_status` quando a identidade lógica do fato não muda

## Decisão importante

Ao reprocessar um documento, os `tax_facts` daquele `source_document_id` são recriados, mas o `review_status` é preservado quando o fato novo continua logicamente igual ao anterior.

Isso evita que um batch técnico derrube fatos já aprovados/corrigidos e zere indevidamente o cálculo oficial.

O reprocess por documento é idempotente: rodadas repetidas não duplicam `tax_facts` nem corrompem `summary`.

## Contrato do endpoint

### `POST /ops/tax-documents/reprocess-legacy`

Header obrigatório:
- `x-ops-token`

Body:
```json
{
  "dryRun": true,
  "limit": 50,
  "userId": 123,
  "taxYear": 2026,
  "afterDocumentId": 1000
}
```

### Semântica

* `dryRun: true`

  * executa classificação, extração e normalização em memória
  * não persiste `tax_document_extractions`
  * não persiste `tax_facts`
  * não rebuilda `summary`

* `dryRun: false`

  * persiste extraction/facts novos
  * reaplica exclusão do oficial por CPF divergente
  * rebuilda `summary` dos pares `userId + taxYear` afetados

### Resposta

```json
{
  "dryRun": true,
  "processed": 48,
  "succeeded": 45,
  "failed": 3,
  "updatedExtractions": 45,
  "updatedTaxFacts": 45,
  "totalFactsGenerated": 120,
  "excludedByCpfMismatch": 12,
  "summariesRebuilt": 8,
  "nextAfterDocumentId": 1048,
  "items": []
}
```

## Impacto funcional

* reprocess antigo deixa de depender de ação manual documento por documento
* documentos com CPF divergente continuam visíveis, mas fora do oficial
* fatos já aprovados não são resetados desnecessariamente quando o pipeline novo mantém a mesma identidade lógica
* `summary` e export oficial passam a refletir a base regenerada

## Fora de escopo

Não entra neste PR:

* job agendado
* fila assíncrona
* UI administrativa
* reprocess global automático em background

## Riscos e pontos de atenção

* o endpoint é operacional e deve ser usado com lote controlado
* rebuild síncrono de `summary` está correto agora, mas pode virar candidato a job assíncrono se o volume crescer
* fatos cuja identidade lógica mudar de verdade podem voltar para fluxo normal de review, o que é comportamento esperado

## Validação executada

* `npm -w apps/api run lint` ✅
* `npm -w apps/api test` ✅
* suíte completa da API verde: `710/710`

## Testes cobertos

* `dryRun` não persiste extraction/facts/summary
* `apply` reprocessa legado e preserva aprovação
* `apply` rebuilda `summary`
* exclusão por CPF divergente continua refletida no batch
* proteção por `x-ops-token`

## Rollout recomendado

1. rodar `dryRun` com recorte pequeno
2. validar contagens e exclusões por CPF divergente
3. rodar `apply` em lotes controlados
4. monitorar erros por documento e `summariesRebuilt`

## Nota operacional

O batch não oculta documentos divergentes. Ele apenas exclui do cálculo oficial, `summary` e export os fatos incompatíveis com o `taxpayer_cpf` configurado.
