### PR TITLE
feat(tax): block fiscal document upload on taxpayer cpf mismatch

### DIFF
--- a/apps/api/src/ops-tax-reprocess.test.js
+++ b/apps/api/src/ops-tax-reprocess.test.js
@@ -121,15 +121,15 @@ describe("ops tax legacy reprocess", () => {
     const token = await registerAndLogin(email);
     const userId = await getUserIdByEmail(email);
 
+    const uploadResponse = await uploadInssAnnualDocument(token, "inss-legacy-dry-run.csv");
+
+    expect(uploadResponse.status).toBe(201);
+
     await dbQuery(
       `INSERT INTO user_profiles (user_id, taxpayer_cpf)
        VALUES ($1, '52998224725')`,
       [userId],
     );
-
-    const uploadResponse = await uploadInssAnnualDocument(token, "inss-legacy-dry-run.csv");
-
-    expect(uploadResponse.status).toBe(201);
 
     const response = await request(app)
       .post("/ops/tax-documents/reprocess-legacy")

--- a/apps/api/src/services/tax-classification.service.js
+++ b/apps/api/src/services/tax-classification.service.js
@@ -56,15 +56,14 @@ const extractTaxDocumentText = async ({ buffer, originalFileName }) => {
   };
 };
 
-export const classifyStoredTaxDocument = async (documentRecord) => {
-  const buffer = await readStoredTaxDocumentBuffer(documentRecord.storage_key);
+export const classifyTaxDocumentBuffer = async ({ buffer, originalFileName }) => {
   const textResult = await extractTaxDocumentText({
     buffer,
-    originalFileName: documentRecord.original_file_name,
+    originalFileName,
   });
   const classification = classifyTaxDocument({
     text: textResult.text,
-    originalFileName: documentRecord.original_file_name,
+    originalFileName,
   });
 
   return {
@@ -82,4 +81,13 @@ export const classifyStoredTaxDocument = async (documentRecord) => {
     },
     warnings: [...classification.warnings, ...textResult.warnings],
   };
+};
+
+export const classifyStoredTaxDocument = async (documentRecord) => {
+  const buffer = await readStoredTaxDocumentBuffer(documentRecord.storage_key);
+
+  return classifyTaxDocumentBuffer({
+    buffer,
+    originalFileName: documentRecord.original_file_name,
+  });
 };

--- a/apps/api/src/services/tax-documents.service.js
+++ b/apps/api/src/services/tax-documents.service.js
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { dbQuery, withDbTransaction } from "../db/index.js";
+import { runTaxExtractorForDocument } from "../domain/tax/tax-document-extractors.js";
 import {
   createTaxError,
   normalizeOptionalDocumentProcessingStatus,
@@ -9,12 +10,14 @@ import {
   toISOStringOrNull,
 } from "../domain/tax/tax.validation.js";
 import { logWarn } from "../observability/logger.js";
+import { classifyTaxDocumentBuffer } from "./tax-classification.service.js";
 import {
   deleteStoredTaxDocument,
   saveTaxDocumentBuffer,
 } from "./tax-document-storage.service.js";
 
 const DUPLICATE_TAX_DOCUMENT_ERROR_CODE = "23505";
+const TAX_DOCUMENT_TAXPAYER_CPF_MISMATCH_CODE = "TAX_DOCUMENT_TAXPAYER_CPF_MISMATCH";
 
 const mapTaxDocument = (row) => ({
   id: Number(row.id),
@@ -80,6 +83,18 @@ const normalizeOptionalText = (value, { maxLength, fieldName }) => {
   return normalizedValue;
 };
 
+const normalizeDocumentNumber = (value) => String(value || "").replace(/\D/g, "");
+
+const formatCpf = (value) => {
+  const digits = normalizeDocumentNumber(value);
+
+  if (digits.length !== 11) {
+    return digits;
+  }
+
+  return `${digits.slice(0, 3)}.${digits.slice(3, 6)}.${digits.slice(6, 9)}-${digits.slice(9)}`;
+};
+
 const TAX_DOCUMENT_SELECT_COLUMNS = `
   id,
   tax_year,
@@ -105,6 +120,72 @@ const findTaxDocumentRowByIdForUser = async (client, userId, documentId) => {
   );
 
   return result.rows[0] || null;
+};
+
+const getUserTaxpayerCpf = async (userId) => {
+  const result = await dbQuery(
+    `SELECT taxpayer_cpf
+     FROM user_profiles
+     WHERE user_id = $1
+     LIMIT 1`,
+    [userId],
+  );
+
+  return normalizeDocumentNumber(result.rows[0]?.taxpayer_cpf);
+};
+
+const resolveExtractorOwnerDocument = (extractorResult) => {
+  const payload =
+    extractorResult?.payload && typeof extractorResult.payload === "object"
+      ? extractorResult.payload
+      : null;
+
+  if (!payload) {
+    return "";
+  }
+
+  return normalizeDocumentNumber(
+    payload.beneficiaryDocument ||
+      payload.customerDocument ||
+      payload.studentDocument ||
+      payload.ownerDocument ||
+      "",
+  );
+};
+
+const buildTaxpayerMismatchMessage = ({ taxpayerCpf, ownerDocument }) =>
+  `Conflito de CPF divergente. Documento no CPF ${formatCpf(ownerDocument)} e perfil fiscal no CPF ${formatCpf(taxpayerCpf)}.`;
+
+const ensureTaxDocumentMatchesUserTaxpayerCpf = async ({ userId, file }) => {
+  const taxpayerCpf = await getUserTaxpayerCpf(userId);
+
+  if (!taxpayerCpf) {
+    return;
+  }
+
+  const classification = await classifyTaxDocumentBuffer({
+    buffer: file.buffer,
+    originalFileName: file.originalname,
+  });
+  const extractorResult = runTaxExtractorForDocument({
+    documentType: classification.documentType,
+    text: classification.text,
+    classification,
+  });
+  const ownerDocument = resolveExtractorOwnerDocument(extractorResult);
+
+  if (!ownerDocument || ownerDocument === taxpayerCpf) {
+    return;
+  }
+
+  throw createTaxError(
+    409,
+    buildTaxpayerMismatchMessage({
+      taxpayerCpf,
+      ownerDocument,
+    }),
+    TAX_DOCUMENT_TAXPAYER_CPF_MISMATCH_CODE,
+  );
 };
 
 export const listTaxDocumentsByUser = async (userId, query = {}) => {
@@ -195,6 +276,11 @@ export const createTaxDocumentForUser = async (userId, payload = {}, file) => {
   if (existingDocumentResult.rows[0]) {
     throw createTaxError(409, "Documento ja enviado anteriormente.", "TAX_DOCUMENT_DUPLICATE");
   }
+
+  await ensureTaxDocumentMatchesUserTaxpayerCpf({
+    userId: normalizedUserId,
+    file,
+  });
 
   let storedDocument = null;
 

--- a/apps/api/src/tax.test.js
+++ b/apps/api/src/tax.test.js
@@ -303,6 +303,111 @@ describe("Tax API foundation", () => {
     });
   });
 
+  it("POST /tax/documents bloqueia upload quando o CPF do documento diverge do titular cadastrado", async () => {
+    const email = "tax-upload-cpf-mismatch@test.dev";
+    const token = await registerAndLogin(email);
+    const userResult = await dbQuery(
+      `SELECT id
+       FROM users
+       WHERE email = $1`,
+      [email],
+    );
+    const userId = Number(userResult.rows[0].id);
+
+    await dbQuery(
+      `INSERT INTO user_profiles (user_id, taxpayer_cpf)
+       VALUES ($1, '52998224725')`,
+      [userId],
+    );
+
+    const response = await request(app)
+      .post("/tax/documents")
+      .set("Authorization", `Bearer ${token}`)
+      .field("taxYear", "2026")
+      .attach(
+        "file",
+        Buffer.from(
+          [
+            "Ministerio da Economia Comprovante de Rendimentos Pagos e de",
+            "Imposto sobre a Renda Retido na Fonte",
+            "Exercicio de 2026 Ano-calendario de 2025",
+            "16.727.230/0001-97 Fundo do Regime Geral de Previdencia Social",
+            "214.679.738-07 AMARO VALERIO DA SILVA JUNIOR 1776829899",
+            "3533-PROVENTOS DE APOSENT., RESERVA, REFORMA OU PENSAO PAGOS PELA PREV. SOCIAL",
+            "1. Total dos rendimentos (inclusive ferias) 34.287,13",
+            "5. Imposto sobre a renda retido na fonte 13,36",
+          ].join("\n"),
+          "utf8",
+        ),
+        {
+          filename: "inss-mismatch.csv",
+          contentType: "text/csv",
+        },
+      );
+
+    expect(response.status).toBe(409);
+    expect(response.body).toMatchObject({
+      code: "TAX_DOCUMENT_TAXPAYER_CPF_MISMATCH",
+      message:
+        "Conflito de CPF divergente. Documento no CPF 214.679.738-07 e perfil fiscal no CPF 529.982.247-25.",
+    });
+
+    const persistedDocumentCount = await dbQuery(
+      `SELECT COUNT(*) AS total
+       FROM tax_documents
+       WHERE user_id = $1`,
+      [userId],
+    );
+
+    expect(Number(persistedDocumentCount.rows[0].total)).toBe(0);
+  });
+
+  it("POST /tax/documents permite upload quando o CPF do documento bate com o titular cadastrado", async () => {
+    const email = "tax-upload-cpf-match@test.dev";
+    const token = await registerAndLogin(email);
+    const userResult = await dbQuery(
+      `SELECT id
+       FROM users
+       WHERE email = $1`,
+      [email],
+    );
+    const userId = Number(userResult.rows[0].id);
+
+    await dbQuery(
+      `INSERT INTO user_profiles (user_id, taxpayer_cpf)
+       VALUES ($1, '43342760400')`,
+      [userId],
+    );
+
+    const response = await request(app)
+      .post("/tax/documents")
+      .set("Authorization", `Bearer ${token}`)
+      .field("taxYear", "2026")
+      .attach(
+        "file",
+        Buffer.from(
+          [
+            "Ministerio da Economia Comprovante de Rendimentos Pagos e de",
+            "Imposto sobre a Renda Retido na Fonte",
+            "Exercicio de 2026 Ano-calendario de 2025",
+            "16.727.230/0001-97 Fundo do Regime Geral de Previdencia Social",
+            "433.427.604-00 MARIA EDLEUSA MONSAO DA SILVA 1776829899",
+            "3533-PROVENTOS DE APOSENT., RESERVA, REFORMA OU PENSAO PAGOS PELA PREV. SOCIAL",
+            "1. Total dos rendimentos (inclusive ferias) 34.287,13",
+            "5. Imposto sobre a renda retido na fonte 13,36",
+          ].join("\n"),
+          "utf8",
+        ),
+        {
+          filename: "inss-match.csv",
+          contentType: "text/csv",
+        },
+      );
+
+    expect(response.status).toBe(201);
+    expect(response.body.document.originalFileName).toBe("inss-match.csv");
+  });
+
   it("POST /tax/documents permite mesmo arquivo para usuarios diferentes", async () => {
     const tokenA = await registerAndLogin("tax-upload-user-a@test.dev");
     const tokenB = await registerAndLogin("tax-upload-user-b@test.dev");
@@ -1585,12 +1690,6 @@ describe("Tax API foundation", () => {
     );
     const userId = Number(userResult.rows[0].id);
 
-    await dbQuery(
-      `INSERT INTO user_profiles (user_id, taxpayer_cpf)
-       VALUES ($1, '52998224725')`,
-      [userId],
-    );
-
     const uploadResponse = await request(app)
       .post("/tax/documents")
       .set("Authorization", `Bearer ${token}`)
@@ -1620,6 +1719,12 @@ describe("Tax API foundation", () => {
       );
 
     expect(uploadResponse.status).toBe(201);
+
+    await dbQuery(
+      `INSERT INTO user_profiles (user_id, taxpayer_cpf)
+       VALUES ($1, '52998224725')`,
+      [userId],
+    );
 
     const reprocessResponse = await request(app)
       .post(`/tax/documents/${uploadResponse.body.document.id}/reprocess`)

--- a/apps/web/src/pages/TaxPage.test.tsx
+++ b/apps/web/src/pages/TaxPage.test.tsx
@@ -493,6 +493,39 @@ describe("TaxPage", () => {
     expect(taxService.rebuildSummary).not.toHaveBeenCalled();
   });
 
+  it("bloqueia upload quando a API retorna conflito de CPF divergente", async () => {
+    const user = userEvent.setup();
+    const uploadedFile = new File(["conteudo fiscal"], "picpay.pdf", {
+      type: "application/pdf",
+    });
+
+    vi.mocked(taxService.uploadDocument).mockRejectedValueOnce({
+      response: {
+        status: 409,
+        data: {
+          message:
+            "Conflito de CPF divergente. Documento no CPF 214.679.738-07 e perfil fiscal no CPF 529.982.247-25.",
+          code: "TAX_DOCUMENT_TAXPAYER_CPF_MISMATCH",
+        },
+      },
+    });
+
+    renderPage();
+
+    await screen.findByRole("button", { name: "Enviar documento" });
+    await user.click(screen.getByRole("button", { name: "Enviar documento" }));
+    await user.upload(screen.getByLabelText("Arquivo fiscal"), uploadedFile);
+    await user.click(screen.getByRole("button", { name: "Enviar e processar" }));
+
+    expect(
+      await screen.findByText(
+        "Conflito de CPF divergente. Documento no CPF 214.679.738-07 e perfil fiscal no CPF 529.982.247-25.",
+      ),
+    ).toBeInTheDocument();
+    expect(taxService.reprocessDocument).not.toHaveBeenCalled();
+    expect(taxService.rebuildSummary).not.toHaveBeenCalled();
+  });
+
   it("permite tentar novamente um documento com falha e rebuilda o resumo", async () => {
     const user = userEvent.setup();
 


### PR DESCRIPTION
## Contexto

Este PR endurece o fluxo de upload fiscal: documentos com CPF divergente do `taxpayer_cpf` do perfil passam a ser barrados já na entrada.

Antes, o documento podia subir e só ficava fora do cálculo oficial depois.
Agora, o backend classifica/extrai em memória antes de persistir e responde conflito explícito quando o CPF do arquivo não corresponde ao CPF do titular.

## O que entra

- helper de classificação em memória
- bloqueio no upload antes de criar `tax_document`
- erro `409` com code `TAX_DOCUMENT_TAXPAYER_CPF_MISMATCH`
- teste de API para mismatch
- teste de API para match
- teste web cobrindo a mensagem de conflito de CPF divergente

## Regra

- se o CPF extraído do documento divergir do `taxpayer_cpf` do perfil, o upload é bloqueado
- se o CPF bater, o upload segue normalmente
- documentos legados já existentes continuam visíveis e fora do oficial, sem mudança retroativa de comportamento

## Nota de teste

O teste de mismatch usa um layout anual do INSS para manter o classifier determinístico no cenário de conflito, sem depender da heurística do layout bancário.

## Validação

- `npm -w apps/api run lint` ✅
- `npm -w apps/api test` ✅
- `npm -w apps/web run lint` ✅
- `npm -w apps/web run typecheck` ✅
- `npm -w apps/web run test:run -- src/pages/TaxPage.test.tsx` ✅
