### PR TITLE
feat(import): add income import dedupe foundation

### DIFF
--- a/apps/api/src/import.test.js
+++ b/apps/api/src/import.test.js
@@ -457,6 +457,7 @@ describe("transaction imports", () => {
       validRows: 2,
       invalidRows: 0,
       duplicateRows: 0,
+      conflictRows: 0,
       income: 2812.99,
       expense: 15.98,
     });
@@ -491,6 +492,7 @@ describe("transaction imports", () => {
       validRows: 2,
       invalidRows: 0,
       duplicateRows: 0,
+      conflictRows: 0,
       income: 2812.99,
       expense: 15.98,
     });
@@ -615,6 +617,7 @@ describe("transaction imports", () => {
       validRows: 2,
       invalidRows: 2,
       duplicateRows: 0,
+      conflictRows: 0,
       income: 1000,
       expense: 220.5,
     });
@@ -737,6 +740,7 @@ describe("transaction imports", () => {
       validRows: 0,
       invalidRows: 2,
       duplicateRows: 0,
+      conflictRows: 0,
       income: 0,
       expense: 0,
     });
@@ -1026,6 +1030,87 @@ describe("transaction imports", () => {
     expect(second.body.summary.duplicateRows).toBe(1);
     expect(second.body.rows[0].status).toBe("duplicate");
     expect(second.body.rows[0].normalized).toBeNull();
+  });
+
+  it("POST /transactions/import/dry-run marca conflito quando credito bancario bate com historico de renda", async () => {
+    const email = "import-income-conflict@controlfinance.dev";
+    const token = await registerAndLogin(email);
+    await makeProUser(email);
+
+    const sourceResponse = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        name: "INSS Beneficio",
+      });
+
+    expect(sourceResponse.status).toBe(201);
+
+    const statementResponse = await request(app)
+      .post(`/income-sources/${sourceResponse.body.id}/statements`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        referenceMonth: "2026-03",
+        netAmount: 1412,
+        paymentDate: "2026-03-05",
+      });
+
+    expect(statementResponse.status).toBe(201);
+
+    const csv = csvFile(
+      [
+        "date,type,value,description,notes,category",
+        "2026-03-06,Entrada,1412,CREDITO BENEFICIO INSS,,",
+      ].join("\n"),
+    );
+
+    const response = await request(app)
+      .post("/transactions/import/dry-run")
+      .set("Authorization", `Bearer ${token}`)
+      .attach("file", csv.buffer, { filename: csv.fileName, contentType: "text/csv" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.summary).toEqual({
+      totalRows: 1,
+      validRows: 0,
+      invalidRows: 0,
+      duplicateRows: 0,
+      conflictRows: 1,
+      income: 0,
+      expense: 0,
+    });
+    expect(response.body.rows[0]).toMatchObject({
+      line: 2,
+      status: "conflict",
+      normalized: null,
+      statusDetail: "INSS Beneficio ja registrado no historico de renda (2026-03, 2026-03-05).",
+      conflict: {
+        type: "income_statement",
+        statementId: statementResponse.body.statement.id,
+        sourceName: "INSS Beneficio",
+        referenceMonth: "2026-03",
+        paymentDate: "2026-03-05",
+        netAmount: 1412,
+        status: "draft",
+        postedTransactionId: null,
+      },
+    });
+
+    const commitResponse = await request(app)
+      .post("/transactions/import/commit")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ importId: response.body.importId });
+
+    expect(commitResponse.status).toBe(200);
+    expect(commitResponse.body.imported).toBe(0);
+
+    const userId = await getUserIdByEmail(email);
+    const transactionCountResult = await dbQuery(
+      `SELECT COUNT(*)::int AS count FROM transactions WHERE user_id = $1`,
+      [userId],
+    );
+
+    expect(Number(transactionCountResult.rows[0].count)).toBe(0);
   });
 
   it("POST /transactions/import/commit nao insere duplicatas mesmo se sessao foi criada antes do primeiro commit", async () => {

--- a/apps/api/src/services/transactions-import.service.js
+++ b/apps/api/src/services/transactions-import.service.js
@@ -31,6 +31,8 @@ const IMPORT_TTL_MINUTES = 30;
 const DEFAULT_IMPORT_CSV_MAX_ROWS = 2000;
 const DEFAULT_IMPORT_HISTORY_LIMIT = 20;
 const MAX_IMPORT_HISTORY_LIMIT = 100;
+const IMPORT_INCOME_STATEMENT_AMOUNT_TOLERANCE = 0.05;
+const IMPORT_INCOME_STATEMENT_DATE_TOLERANCE_DAYS = 10;
 const REQUIRED_HEADERS = ["date", "type", "value", "description"];
 const OPTIONAL_HEADERS = ["notes", "category"];
 const ALLOWED_HEADERS = new Set([...REQUIRED_HEADERS, ...OPTIONAL_HEADERS]);
@@ -68,6 +70,133 @@ const loadExistingFingerprints = async (userId, fingerprints) => {
     [userId, fingerprints],
   );
   return new Set(result.rows.map((row) => row.import_fingerprint));
+};
+
+const toMoneyNumber = (value) => {
+  const parsedValue = Number(value);
+  return Number.isFinite(parsedValue) ? Number(parsedValue.toFixed(2)) : 0;
+};
+
+const loadStructuredIncomeStatementsForUser = async (userId) => {
+  const result = await dbQuery(
+    `SELECT st.id,
+            st.reference_month,
+            st.net_amount,
+            st.payment_date,
+            st.status,
+            st.posted_transaction_id,
+            s.name AS source_name
+       FROM income_statements st
+       JOIN income_sources s
+         ON s.id = st.income_source_id
+      WHERE s.user_id = $1`,
+    [userId],
+  );
+
+  return result.rows.map((row) => ({
+    id: Number(row.id),
+    referenceMonth:
+      typeof row.reference_month === "string" && row.reference_month.trim()
+        ? row.reference_month.trim()
+        : null,
+    netAmount: toMoneyNumber(row.net_amount),
+    paymentDate: toISODateOnly(row.payment_date),
+    status: row.status === "posted" ? "posted" : "draft",
+    postedTransactionId:
+      Number.isInteger(Number(row.posted_transaction_id)) && Number(row.posted_transaction_id) > 0
+        ? Number(row.posted_transaction_id)
+        : null,
+    sourceName:
+      typeof row.source_name === "string" && row.source_name.trim()
+        ? row.source_name.trim()
+        : null,
+  }));
+};
+
+const calculateDateDiffInDays = (leftDate, rightDate) => {
+  if (!leftDate || !rightDate) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  const leftMs = new Date(`${leftDate}T00:00:00Z`).getTime();
+  const rightMs = new Date(`${rightDate}T00:00:00Z`).getTime();
+
+  if (!Number.isFinite(leftMs) || !Number.isFinite(rightMs)) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  return Math.abs(leftMs - rightMs) / (1000 * 60 * 60 * 24);
+};
+
+const buildStructuredIncomeConflictDetail = (statement) => {
+  const sourceLabel = statement.sourceName || "Historico de renda";
+  const referenceLabel = statement.referenceMonth || "sem competencia";
+  const paymentLabel = statement.paymentDate || "sem data de pagamento";
+
+  return `${sourceLabel} ja registrado no historico de renda (${referenceLabel}, ${paymentLabel}).`;
+};
+
+const findStructuredIncomeConflict = (normalizedRow, statements = []) => {
+  if (!normalizedRow || normalizedRow.type !== CATEGORY_ENTRY || statements.length === 0) {
+    return null;
+  }
+
+  const rowAmount = toMoneyNumber(normalizedRow.value);
+
+  if (rowAmount <= 0) {
+    return null;
+  }
+
+  const matches = statements
+    .map((statement) => {
+      if (!statement.paymentDate || statement.netAmount <= 0) {
+        return null;
+      }
+
+      const amountDiff = Math.abs(rowAmount - statement.netAmount);
+      const amountDiffRatio = statement.netAmount > 0 ? amountDiff / statement.netAmount : 1;
+
+      if (amountDiffRatio > IMPORT_INCOME_STATEMENT_AMOUNT_TOLERANCE) {
+        return null;
+      }
+
+      const dateDiffDays = calculateDateDiffInDays(normalizedRow.date, statement.paymentDate);
+
+      if (dateDiffDays > IMPORT_INCOME_STATEMENT_DATE_TOLERANCE_DAYS) {
+        return null;
+      }
+
+      return {
+        statement,
+        amountDiff,
+        dateDiffDays,
+      };
+    })
+    .filter(Boolean)
+    .sort((leftMatch, rightMatch) => {
+      if (leftMatch.dateDiffDays !== rightMatch.dateDiffDays) {
+        return leftMatch.dateDiffDays - rightMatch.dateDiffDays;
+      }
+
+      return leftMatch.amountDiff - rightMatch.amountDiff;
+    });
+
+  if (matches.length === 0) {
+    return null;
+  }
+
+  const bestMatch = matches[0].statement;
+
+  return {
+    type: "income_statement",
+    statementId: bestMatch.id,
+    sourceName: bestMatch.sourceName,
+    referenceMonth: bestMatch.referenceMonth,
+    paymentDate: bestMatch.paymentDate,
+    netAmount: bestMatch.netAmount,
+    status: bestMatch.status,
+    postedTransactionId: bestMatch.postedTransactionId,
+  };
 };
 
 const createError = (status, message) => {
@@ -567,6 +696,8 @@ const createSummary = (rows = []) => {
         }
       } else if (row.status === "duplicate") {
         summary.duplicateRows += 1;
+      } else if (row.status === "conflict") {
+        summary.conflictRows += 1;
       } else {
         summary.invalidRows += 1;
       }
@@ -578,6 +709,7 @@ const createSummary = (rows = []) => {
       validRows: 0,
       invalidRows: 0,
       duplicateRows: 0,
+      conflictRows: 0,
       income: 0,
       expense: 0,
     },
@@ -684,14 +816,40 @@ export const dryRunTransactionsImportForUser = async (userId, importFile) => {
   const fingerprintMap = new Map(
     validOnly.map((r) => [r.line, generateImportFingerprint(r.normalized)]),
   );
-  const existingSet = await loadExistingFingerprints(userId, [...fingerprintMap.values()]);
+  const [existingSet, structuredIncomeStatements] = await Promise.all([
+    loadExistingFingerprints(userId, [...fingerprintMap.values()]),
+    loadStructuredIncomeStatementsForUser(userId),
+  ]);
 
   const rows = validatedRows.map((row) => {
     if (row.status !== "valid" || !row.normalized) return row;
     const fp = fingerprintMap.get(row.line);
     if (existingSet.has(fp)) {
-      return { ...row, status: "duplicate", fingerprint: fp, normalized: null };
+      return {
+        ...row,
+        status: "duplicate",
+        statusDetail: "Ja existe uma transacao importada equivalente.",
+        fingerprint: fp,
+        normalized: null,
+      };
     }
+
+    const structuredIncomeConflict = findStructuredIncomeConflict(
+      row.normalized,
+      structuredIncomeStatements,
+    );
+
+    if (structuredIncomeConflict) {
+      return {
+        ...row,
+        status: "conflict",
+        statusDetail: buildStructuredIncomeConflictDetail(structuredIncomeConflict),
+        conflict: structuredIncomeConflict,
+        fingerprint: fp,
+        normalized: null,
+      };
+    }
+
     return { ...row, fingerprint: fp };
   });
 

--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -102,6 +102,10 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
     return (dryRunResult?.summary?.duplicateRows || 0) > 0;
   }, [dryRunResult]);
 
+  const hasConflicts = useMemo(() => {
+    return (dryRunResult?.summary?.conflictRows || 0) > 0;
+  }, [dryRunResult]);
+
   const documentTypeBadge = useMemo(() => {
     switch (dryRunResult?.documentType) {
       case "bank_statement":
@@ -596,7 +600,7 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
               </div>
             ) : null}
 
-            <div className="grid gap-2 sm:grid-cols-3 lg:grid-cols-6">
+            <div className="grid gap-2 sm:grid-cols-3 lg:grid-cols-7">
               <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2">
                 <p className="text-xs font-medium uppercase text-cf-text-secondary">Total</p>
                 <p className="text-sm font-semibold text-cf-text-primary">{dryRunResult.summary.totalRows}</p>
@@ -612,6 +616,10 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
               <div className={`rounded border px-3 py-2 ${hasDuplicates ? "border-red-300 bg-red-50 dark:border-red-800 dark:bg-red-950/40" : "border-cf-border bg-cf-bg-subtle"}`}>
                 <p className="text-xs font-medium uppercase text-cf-text-secondary">Duplicadas</p>
                 <p className={`text-sm font-semibold ${hasDuplicates ? "text-red-600 dark:text-red-400" : "text-cf-text-primary"}`}>{dryRunResult.summary.duplicateRows ?? 0}</p>
+              </div>
+              <div className={`rounded border px-3 py-2 ${hasConflicts ? "border-amber-300 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/40" : "border-cf-border bg-cf-bg-subtle"}`}>
+                <p className="text-xs font-medium uppercase text-cf-text-secondary">Conflitos</p>
+                <p className={`text-sm font-semibold ${hasConflicts ? "text-amber-700 dark:text-amber-400" : "text-cf-text-primary"}`}>{dryRunResult.summary.conflictRows ?? 0}</p>
               </div>
               <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2">
                 <p className="text-xs font-medium uppercase text-cf-text-secondary">Entradas</p>
@@ -713,6 +721,8 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
                                 ? "bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-400"
                                 : row.status === "duplicate"
                                   ? "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-400"
+                                  : row.status === "conflict"
+                                    ? "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400"
                                   : "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-400"
                             }`}
                           >
@@ -720,10 +730,12 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
                               ? "Valida"
                               : row.status === "duplicate"
                                 ? "Duplicada"
+                                : row.status === "conflict"
+                                  ? "Conflito"
                                 : "Invalida"}
                           </span>
-                          {row.status === "duplicate" && (
-                            <span className="ml-1.5 text-xs text-cf-text-secondary">já existe</span>
+                          {(row.status === "duplicate" || row.status === "conflict") && row.statusDetail && (
+                            <span className="ml-1.5 text-xs text-cf-text-secondary">{row.statusDetail}</span>
                           )}
                         </td>
                         <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
@@ -809,6 +821,8 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
                         <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
                           {row.errors.length > 0
                             ? row.errors.map((error) => error.message).join(" | ")
+                            : row.statusDetail
+                              ? row.statusDetail
                             : "-"}
                         </td>
                       </tr>

--- a/apps/web/src/components/ImportCsvModal.test.jsx
+++ b/apps/web/src/components/ImportCsvModal.test.jsx
@@ -35,6 +35,8 @@ const buildDryRunResponse = (overrides = {}) => ({
     totalRows: 2,
     validRows: 1,
     invalidRows: 1,
+    duplicateRows: 0,
+    conflictRows: 0,
     income: 100,
     expense: 20,
   },
@@ -103,6 +105,68 @@ describe("ImportCsvModal", () => {
 
     expect(validRowsCard).toHaveTextContent("1");
     expect(invalidRowsCard).toHaveTextContent("1");
+  });
+
+  it("renders conflict rows with visible reason and blocks import when there are no valid rows", async () => {
+    const file = new File(["date,type,value"], "import.csv", { type: "text/csv" });
+    transactionsService.dryRunImportCsv.mockResolvedValueOnce(
+      buildDryRunResponse({
+        summary: {
+          totalRows: 1,
+          validRows: 0,
+          invalidRows: 0,
+          duplicateRows: 0,
+          conflictRows: 1,
+          income: 0,
+          expense: 0,
+        },
+        rows: [
+          {
+            line: 2,
+            status: "conflict",
+            raw: {
+              date: "2026-03-06",
+              type: "Entrada",
+              value: "1412",
+              description: "CREDITO BENEFICIO INSS",
+              notes: "",
+              category: "",
+            },
+            normalized: null,
+            errors: [],
+            statusDetail:
+              "INSS Beneficio ja registrado no historico de renda (2026-03, 2026-03-05).",
+            conflict: {
+              type: "income_statement",
+              statementId: 15,
+              sourceName: "INSS Beneficio",
+              referenceMonth: "2026-03",
+              paymentDate: "2026-03-05",
+              netAmount: 1412,
+              status: "draft",
+              postedTransactionId: null,
+            },
+          },
+        ],
+      }),
+    );
+
+    render(<ImportCsvModal isOpen onClose={vi.fn()} />);
+
+    await userEvent.upload(screen.getByLabelText("Arquivo do extrato"), file);
+    await userEvent.click(screen.getByRole("button", { name: "Pré-visualizar" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Conflitos")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Conflito")).toBeInTheDocument();
+    expect(
+      screen.getAllByText(
+        "INSS Beneficio ja registrado no historico de renda (2026-03, 2026-03-05).",
+      ).length,
+    ).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "Importar" })).toBeDisabled();
   });
 
   it("commits import and calls onImported callback when Fechar is clicked", async () => {

--- a/apps/web/src/services/transactions.service.ts
+++ b/apps/web/src/services/transactions.service.ts
@@ -149,18 +149,33 @@ export interface ImportDryRunNormalizedRow {
   categoryId: number | null;
 }
 
+export interface ImportDryRunConflict {
+  type: "income_statement";
+  statementId: number;
+  sourceName: string | null;
+  referenceMonth: string | null;
+  paymentDate: string | null;
+  netAmount: number;
+  status: "draft" | "posted";
+  postedTransactionId: number | null;
+}
+
 export interface ImportDryRunRow {
   line: number;
-  status: "valid" | "invalid";
+  status: "valid" | "invalid" | "duplicate" | "conflict";
   raw: ImportDryRunRawRow;
   normalized: ImportDryRunNormalizedRow | null;
   errors: ImportDryRunError[];
+  statusDetail?: string | null;
+  conflict?: ImportDryRunConflict | null;
 }
 
 export interface ImportDryRunSummary {
   totalRows: number;
   validRows: number;
   invalidRows: number;
+  duplicateRows: number;
+  conflictRows: number;
   income: number;
   expense: number;
 }
@@ -309,6 +324,8 @@ interface ImportDryRunApiResponse {
     totalRows?: unknown;
     validRows?: unknown;
     invalidRows?: unknown;
+    duplicateRows?: unknown;
+    conflictRows?: unknown;
     income?: unknown;
     expense?: unknown;
   };
@@ -335,6 +352,17 @@ interface ImportDryRunApiResponse {
       field?: unknown;
       message?: unknown;
     }>;
+    statusDetail?: unknown;
+    conflict?: {
+      type?: unknown;
+      statementId?: unknown;
+      sourceName?: unknown;
+      referenceMonth?: unknown;
+      paymentDate?: unknown;
+      netAmount?: unknown;
+      status?: unknown;
+      postedTransactionId?: unknown;
+    } | null;
   }>;
 }
 
@@ -686,11 +714,22 @@ export const transactionsService = {
     const rows = Array.isArray(responseBody.rows)
       ? responseBody.rows.map((row) => {
           const normalizedStatus: ImportDryRunRow["status"] =
-            row?.status === "valid" ? "valid" : "invalid";
+            row?.status === "valid" ||
+            row?.status === "duplicate" ||
+            row?.status === "conflict"
+              ? row.status
+              : "invalid";
           const numericLine = Number(row?.line);
           const normalized = row?.normalized;
           const normalizedType = String(normalized?.type || "").trim();
           const numericNormalizedCategoryId = Number(normalized?.categoryId);
+          const conflict = row?.conflict;
+          const numericStatementId = Number(conflict?.statementId);
+          const numericPostedTransactionId = Number(conflict?.postedTransactionId);
+          const normalizedConflictType = String(conflict?.type || "").trim();
+          const normalizedConflictStatus = String(conflict?.status || "").trim();
+          const conflictStatus: ImportDryRunConflict["status"] =
+            normalizedConflictStatus === "posted" ? "posted" : "draft";
 
           return {
             line: Number.isInteger(numericLine) && numericLine >= 2 ? numericLine : 0,
@@ -724,6 +763,39 @@ export const transactionsService = {
                   message: String(error?.message || ""),
                 }))
               : [],
+            statusDetail:
+              typeof row?.statusDetail === "string" && row.statusDetail.trim()
+                ? row.statusDetail
+                : null,
+            conflict:
+              normalizedConflictType === "income_statement" &&
+              Number.isInteger(numericStatementId) &&
+              numericStatementId > 0
+                ? {
+                    type: "income_statement" as const,
+                    statementId: numericStatementId,
+                    sourceName:
+                      typeof conflict?.sourceName === "string" && conflict.sourceName.trim()
+                        ? conflict.sourceName
+                        : null,
+                    referenceMonth:
+                      typeof conflict?.referenceMonth === "string" &&
+                      conflict.referenceMonth.trim()
+                        ? conflict.referenceMonth
+                        : null,
+                    paymentDate:
+                      typeof conflict?.paymentDate === "string" && conflict.paymentDate.trim()
+                        ? conflict.paymentDate
+                        : null,
+                    netAmount: Number(conflict?.netAmount) || 0,
+                    status: conflictStatus,
+                    postedTransactionId:
+                      Number.isInteger(numericPostedTransactionId) &&
+                      numericPostedTransactionId > 0
+                        ? numericPostedTransactionId
+                        : null,
+                  }
+                : null,
           };
         })
       : [];
@@ -735,6 +807,8 @@ export const transactionsService = {
         totalRows: Number(responseBody.summary?.totalRows) || 0,
         validRows: Number(responseBody.summary?.validRows) || 0,
         invalidRows: Number(responseBody.summary?.invalidRows) || 0,
+        duplicateRows: Number(responseBody.summary?.duplicateRows) || 0,
+        conflictRows: Number(responseBody.summary?.conflictRows) || 0,
         income: Number(responseBody.summary?.income) || 0,
         expense: Number(responseBody.summary?.expense) || 0,
       },


### PR DESCRIPTION
## Contexto

Este PR fecha o primeiro slice do épico de importação inteligente de renda e extratos.

O foco aqui é impedir que um crédito bancário importado entre como nova renda quando ele já corresponde a um evento de renda estruturado existente no histórico, como INSS ou holerite registrado anteriormente.

## O que entra

- detecção de conflito entre linha de extrato bancário e income_statement já registrado
- novo status de preview conflict, além de alid, duplicate e invalid
- motivo visível para duplicidade e conflito no preview de importação
- bloqueio de commit para linhas em conflito, sem criar transação órfã
- regressão de API cobrindo histórico de renda versus crédito bancário equivalente
- regressão web cobrindo badge, razão visível e bloqueio de import quando só houver conflito

## Regra

- duplicate: já existe transação importada equivalente no histórico
- conflict: a linha bate com um evento de renda estruturado já registrado no histórico de renda
- apenas linhas alid entram no commit da sessão

## Fora de escopo

- promoção automática de comprovante para renda estruturada
- atualização de perfil ou forecast
- busca e filtros pesados no preview

## Validação

- 
pm -w apps/api run lint ✅
- 
pm -w apps/api test ✅ 720/720
- 
pm -w apps/web run lint ✅
- 
pm -w apps/web run typecheck ✅
- 
pm -w apps/web run test:run ✅ 297/297
- 
pm -w apps/web run build ✅

## Observação

Este PR não inclui os docs locais ainda não commitados (docs/roadmap-execution.md e docs/roadmaps/...). O slice é só runtime + testes do PR1.