### PR TITLE
feat(profile): suggest income updates from structured imports

### DIFF
--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { transactionsService } from "../services/transactions.service";
 import { profileService } from "../services/profile.service";
+import { forecastService } from "../services/forecast.service";
 import { categoriesService } from "../services/categories.service";
 import { formatCurrency } from "../utils/formatCurrency";
 import { getApiErrorMessage } from "../utils/apiError";
@@ -19,6 +20,8 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
   const [showProfileConfirm, setShowProfileConfirm] = useState(false);
   const [isApplyingProfile, setIsApplyingProfile] = useState(false);
   const [profileApplied, setProfileApplied] = useState(false);
+  const [profileSuggestionDismissed, setProfileSuggestionDismissed] = useState(false);
+  const [planningUpdateError, setPlanningUpdateError] = useState("");
   const [categories, setCategories] = useState([]);
   // categoryOverrides: Record<line, categoryId | null>
   const [categoryOverrides, setCategoryOverrides] = useState({});
@@ -53,6 +56,8 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
     setShowProfileConfirm(false);
     setIsApplyingProfile(false);
     setProfileApplied(false);
+    setProfileSuggestionDismissed(false);
+    setPlanningUpdateError("");
     setCategoryOverrides({});
     setInlineCreate(null);
     setInlineCreateName("");
@@ -211,9 +216,21 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
     if (!profilePatch) return;
     setIsApplyingProfile(true);
     setErrorMessage("");
+    setPlanningUpdateError("");
     try {
       await profileService.updateProfile(profilePatch);
+      try {
+        await forecastService.recompute();
+      } catch (forecastError) {
+        setPlanningUpdateError(
+          getApiErrorMessage(
+            forecastError,
+            "Perfil atualizado, mas nao foi possivel atualizar o planejamento agora.",
+          ),
+        );
+      }
       setProfileApplied(true);
+      setProfileSuggestionDismissed(false);
     } catch (error) {
       setErrorMessage(getApiErrorMessage(error, "Não foi possível atualizar o perfil."));
     } finally {
@@ -517,11 +534,30 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
                     <li key={line} className="text-xs text-blue-700 dark:text-blue-300">{line}</li>
                   ))}
                 </ul>
-                {suggestionCard.kind === "profile" && profilePatch && !profileApplied ? (
+                {suggestionCard.kind === "profile" && !incomeStatementCreated ? (
+                  <p className="mb-2 text-xs text-blue-700 dark:text-blue-300">
+                    Depois de usar este documento na sua renda, o app pode sugerir uma atualizacao
+                    do perfil financeiro e do planejamento.
+                  </p>
+                ) : null}
+                {suggestionCard.kind === "profile" && !incomeStatementCreated ? (
+                  <button
+                    type="button"
+                    onClick={() => setIsIncomeModalOpen(true)}
+                    className="mt-1 rounded border border-blue-400 bg-blue-100 px-3 py-1 text-xs font-semibold text-blue-700 hover:bg-blue-200 dark:border-blue-600 dark:bg-blue-900/40 dark:text-blue-300 dark:hover:bg-blue-800/40"
+                  >
+                    Usar este documento na minha renda
+                  </button>
+                ) : null}
+                {suggestionCard.kind === "profile" &&
+                incomeStatementCreated &&
+                profilePatch &&
+                !profileApplied &&
+                !profileSuggestionDismissed ? (
                   showProfileConfirm ? (
                     <div className="mt-2 rounded border border-blue-300 bg-blue-100 px-3 py-2 dark:border-blue-700 dark:bg-blue-900/40">
                       <p className="mb-2 text-xs font-semibold text-blue-800 dark:text-blue-200">
-                        Confirmar atualização do perfil?
+                        Confirmar atualização do perfil e do planejamento?
                       </p>
                       <ul className="mb-3 space-y-0.5">
                         {profilePatch.salary_monthly != null && (
@@ -550,38 +586,61 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
                           disabled={isApplyingProfile}
                           className="rounded border border-blue-300 px-3 py-1 text-xs font-semibold text-blue-700 hover:bg-blue-100 dark:border-blue-700 dark:text-blue-300 disabled:opacity-60"
                         >
-                          Cancelar
+                          Revisar depois
                         </button>
                       </div>
                     </div>
                   ) : (
-                    <button
-                      type="button"
-                      onClick={() => setShowProfileConfirm(true)}
-                      className="mt-1 rounded border border-blue-400 bg-blue-100 px-3 py-1 text-xs font-semibold text-blue-700 hover:bg-blue-200 dark:border-blue-600 dark:bg-blue-900/40 dark:text-blue-300 dark:hover:bg-blue-800/40"
-                    >
-                      Atualizar perfil com esses dados
-                    </button>
+                    <div className="mt-2 rounded border border-blue-300 bg-blue-100 px-3 py-2 dark:border-blue-700 dark:bg-blue-900/40">
+                      <p className="mb-2 text-xs font-semibold text-blue-800 dark:text-blue-200">
+                        Renda estruturada confirmada. Deseja atualizar seu perfil e o planejamento
+                        com esses dados?
+                      </p>
+                      <div className="flex flex-wrap gap-2">
+                        <button
+                          type="button"
+                          onClick={() => setShowProfileConfirm(true)}
+                          className="rounded border border-blue-400 bg-blue-600 px-3 py-1 text-xs font-semibold text-white hover:bg-blue-700 dark:border-blue-500"
+                        >
+                          Atualizar perfil e planejamento
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setProfileSuggestionDismissed(true);
+                            setShowProfileConfirm(false);
+                          }}
+                          className="rounded border border-blue-300 px-3 py-1 text-xs font-semibold text-blue-700 hover:bg-blue-100 dark:border-blue-700 dark:text-blue-300"
+                        >
+                          Ignorar
+                        </button>
+                      </div>
+                    </div>
                   )
                 ) : null}
                 {suggestionCard.kind === "profile" && profileApplied ? (
-                  <p className="mt-1 text-xs font-semibold text-green-600 dark:text-green-400">
-                    Perfil atualizado com sucesso.
-                  </p>
-                ) : null}
-                {suggestionCard.kind === "profile" && !incomeStatementCreated ? (
-                  <button
-                    type="button"
-                    onClick={() => setIsIncomeModalOpen(true)}
-                    className="mt-1 rounded border border-blue-400 bg-blue-100 px-3 py-1 text-xs font-semibold text-blue-700 hover:bg-blue-200 dark:border-blue-600 dark:bg-blue-900/40 dark:text-blue-300 dark:hover:bg-blue-800/40"
-                  >
-                    Usar este documento na minha renda
-                  </button>
+                  <div className="mt-1 space-y-1">
+                    <p className="text-xs font-semibold text-green-600 dark:text-green-400">
+                      Perfil e planejamento atualizados com sucesso.
+                    </p>
+                    {planningUpdateError ? (
+                      <p className="text-xs font-medium text-amber-700 dark:text-amber-400">
+                        {planningUpdateError}
+                      </p>
+                    ) : null}
+                  </div>
                 ) : null}
                 {suggestionCard.kind === "profile" && incomeStatementCreated ? (
-                  <p className="mt-1 text-xs font-semibold text-green-600 dark:text-green-400">
-                    Lançamento registrado no histórico de renda.
-                  </p>
+                  <div className="mt-1 space-y-1">
+                    <p className="text-xs font-semibold text-green-600 dark:text-green-400">
+                      Lancamento registrado no historico de renda.
+                    </p>
+                    {profileSuggestionDismissed && !profileApplied ? (
+                      <p className="text-xs font-medium text-cf-text-secondary">
+                        Sugestao de atualizacao ignorada por enquanto.
+                      </p>
+                    ) : null}
+                  </div>
                 ) : null}
                 {suggestionCard.kind === "bill" && !billCreated ? (
                   <button

--- a/apps/web/src/components/ImportCsvModal.test.jsx
+++ b/apps/web/src/components/ImportCsvModal.test.jsx
@@ -5,6 +5,8 @@ import ImportCsvModal from "./ImportCsvModal";
 import { transactionsService } from "../services/transactions.service";
 import { categoriesService } from "../services/categories.service";
 import { incomeSourcesService } from "../services/incomeSources.service";
+import { profileService } from "../services/profile.service";
+import { forecastService } from "../services/forecast.service";
 
 vi.mock("../services/transactions.service", () => ({
   transactionsService: {
@@ -25,6 +27,19 @@ vi.mock("../services/incomeSources.service", () => ({
   incomeSourcesService: {
     list: vi.fn(),
     createStatement: vi.fn(),
+    postStatement: vi.fn(),
+  },
+}));
+
+vi.mock("../services/profile.service", () => ({
+  profileService: {
+    updateProfile: vi.fn(),
+  },
+}));
+
+vi.mock("../services/forecast.service", () => ({
+  forecastService: {
+    recompute: vi.fn(),
   },
 }));
 
@@ -71,6 +86,32 @@ describe("ImportCsvModal", () => {
     vi.clearAllMocks();
     categoriesService.listCategories.mockResolvedValue([]);
     incomeSourcesService.list.mockResolvedValue([]);
+    incomeSourcesService.postStatement.mockResolvedValue({
+      statement: {
+        id: 11,
+        incomeSourceId: 1,
+        referenceMonth: "2026-02",
+        netAmount: 1412,
+        totalDeductions: 0,
+        grossAmount: 1800,
+        details: null,
+        paymentDate: "2026-02-25",
+        status: "posted",
+        postedTransactionId: 91,
+        createdAt: "2026-02-25T00:00:00Z",
+        updatedAt: "2026-02-25T00:00:00Z",
+      },
+      transaction: {
+        id: 91,
+        type: "Entrada",
+        value: 1412,
+        date: "2026-02-25",
+        description: "INSS Beneficio - 2026-02",
+        categoryId: null,
+      },
+    });
+    profileService.updateProfile.mockResolvedValue({});
+    forecastService.recompute.mockResolvedValue({});
   });
 
   it("does not render when isOpen is false", () => {
@@ -344,6 +385,159 @@ describe("ImportCsvModal", () => {
           screen.getByRole("dialog", { name: /Registrar no histórico de renda/i }),
         ).toBeInTheDocument();
       });
+    });
+
+    it("sugere atualizar perfil e planejamento depois de confirmar a renda estruturada", async () => {
+      const file = new File(["dummy"], "inss.pdf", { type: "application/pdf" });
+      transactionsService.dryRunImportCsv.mockResolvedValueOnce(buildInssResponse());
+      incomeSourcesService.list.mockResolvedValue([
+        {
+          id: 1,
+          name: "INSS Benefício",
+          deductions: [],
+          userId: 1,
+          categoryId: null,
+          defaultDay: null,
+          notes: null,
+          createdAt: "",
+          updatedAt: "",
+        },
+      ]);
+      incomeSourcesService.createStatement.mockResolvedValue({
+        statement: {
+          id: 11,
+          incomeSourceId: 1,
+          referenceMonth: "2026-02",
+          netAmount: 1412,
+          totalDeductions: 0,
+          grossAmount: 1800,
+          details: null,
+          paymentDate: "2026-02-25",
+          status: "draft",
+          postedTransactionId: null,
+          createdAt: "2026-02-25T00:00:00Z",
+          updatedAt: "2026-02-25T00:00:00Z",
+        },
+        deductions: [],
+      });
+
+      render(<ImportCsvModal isOpen onClose={vi.fn()} />);
+      await userEvent.upload(screen.getByLabelText("Arquivo do extrato"), file);
+      await userEvent.click(screen.getByRole("button", { name: "Pré-visualizar" }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "Usar este documento na minha renda" }),
+        ).toBeInTheDocument();
+      });
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Usar este documento na minha renda" }),
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "Registrar e lancar entrada" }),
+        ).toBeInTheDocument();
+      });
+
+      await userEvent.click(screen.getByRole("button", { name: "Registrar e lancar entrada" }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "Atualizar perfil e planejamento" }),
+        ).toBeInTheDocument();
+      });
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Atualizar perfil e planejamento" }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Confirmar" })).toBeInTheDocument();
+      });
+
+      await userEvent.click(screen.getByRole("button", { name: "Confirmar" }));
+
+      await waitFor(() => {
+        expect(profileService.updateProfile).toHaveBeenCalledWith({
+          salary_monthly: 1412,
+          payday: 25,
+        });
+      });
+      expect(forecastService.recompute).toHaveBeenCalled();
+      expect(
+        screen.getByText(/perfil e planejamento atualizados com sucesso/i),
+      ).toBeInTheDocument();
+    });
+
+    it("permite ignorar a sugestao de perfil depois de confirmar a renda", async () => {
+      const file = new File(["dummy"], "inss.pdf", { type: "application/pdf" });
+      transactionsService.dryRunImportCsv.mockResolvedValueOnce(buildInssResponse());
+      incomeSourcesService.list.mockResolvedValue([
+        {
+          id: 1,
+          name: "INSS Benefício",
+          deductions: [],
+          userId: 1,
+          categoryId: null,
+          defaultDay: null,
+          notes: null,
+          createdAt: "",
+          updatedAt: "",
+        },
+      ]);
+      incomeSourcesService.createStatement.mockResolvedValue({
+        statement: {
+          id: 11,
+          incomeSourceId: 1,
+          referenceMonth: "2026-02",
+          netAmount: 1412,
+          totalDeductions: 0,
+          grossAmount: 1800,
+          details: null,
+          paymentDate: "2026-02-25",
+          status: "draft",
+          postedTransactionId: null,
+          createdAt: "2026-02-25T00:00:00Z",
+          updatedAt: "2026-02-25T00:00:00Z",
+        },
+        deductions: [],
+      });
+
+      render(<ImportCsvModal isOpen onClose={vi.fn()} />);
+      await userEvent.upload(screen.getByLabelText("Arquivo do extrato"), file);
+      await userEvent.click(screen.getByRole("button", { name: "Pré-visualizar" }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "Usar este documento na minha renda" }),
+        ).toBeInTheDocument();
+      });
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Usar este documento na minha renda" }),
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "Registrar e lancar entrada" }),
+        ).toBeInTheDocument();
+      });
+
+      await userEvent.click(screen.getByRole("button", { name: "Registrar e lancar entrada" }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "Atualizar perfil e planejamento" }),
+        ).toBeInTheDocument();
+      });
+
+      await userEvent.click(screen.getByRole("button", { name: "Ignorar" }));
+
+      expect(profileService.updateProfile).not.toHaveBeenCalled();
+      expect(forecastService.recompute).not.toHaveBeenCalled();
+      expect(screen.getByText(/sugestao de atualizacao ignorada por enquanto/i)).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Contexto

Este PR continua a trilha de importacao inteligente de renda depois da composicao do documento na renda mensal.

Depois que o comprovante importado vira renda estruturada, o app passa a sugerir uma atualizacao assistida do perfil financeiro e do planejamento, sem alterar nada automaticamente.

## O que entra

- sugestao de perfil e planejamento so aparece depois de confirmar a renda estruturada
- CTA para Atualizar perfil e planejamento
- fluxo de confirmacao com Confirmar e Revisar depois
- opcao Ignorar para dispensar a sugestao naquele momento
- ao confirmar, o web atualiza o perfil e tenta recomputar o forecast
- feedback explicito para sucesso completo ou falha apenas na atualizacao do planejamento

## Regra

- o perfil nao muda sozinho
- a sugestao nasce da renda estruturada, nao do documento cru
- ignorar nao apaga a renda estruturada; so dispensa a sugestao de perfil naquele fluxo
- se o recompute do forecast falhar, o perfil ainda pode ser salvo

## Validacao

- 
pm -w apps/web run lint ✅
- 
pm -w apps/web run typecheck ✅
- 
pm -w apps/web run test:run -- src/components/ImportCsvModal.test.jsx src/components/IncomeStatementQuickModal.test.tsx ✅
- 
pm -w apps/web run test:run ✅ 300/300
- 
pm -w apps/web run build ✅

## Escopo

Somente web.
Sem mudanca de API neste slice.
