### PR TITLE
feat(import): add bulk categorization and import rules

### DIFF
--- a/apps/api/src/db/migrations/038_create_transaction_import_category_rules.sql
+++ b/apps/api/src/db/migrations/038_create_transaction_import_category_rules.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS transaction_import_category_rules (
+  id BIGSERIAL PRIMARY KEY,
+  user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  category_id BIGINT NOT NULL REFERENCES categories(id) ON DELETE CASCADE,
+  match_text TEXT NOT NULL,
+  normalized_match_text TEXT NOT NULL,
+  transaction_type TEXT NOT NULL DEFAULT '',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_transaction_import_category_rules_transaction_type
+    CHECK (transaction_type IN ('', 'Entrada', 'Saida'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_transaction_import_category_rules_user_match_type_unique
+  ON transaction_import_category_rules (user_id, normalized_match_text, transaction_type);
+
+CREATE INDEX IF NOT EXISTS idx_transaction_import_category_rules_user_created_at_desc
+  ON transaction_import_category_rules (user_id, created_at DESC);

--- a/apps/api/src/domain/imports/transaction-import-rules.js
+++ b/apps/api/src/domain/imports/transaction-import-rules.js
@@ -1,0 +1,75 @@
+import { normalizeCategoryNameKey } from "../../services/categories-normalization.js";
+
+const normalizeRuleText = (value) =>
+  String(value || "")
+    .trim()
+    .replace(/\s+/g, " ");
+
+const normalizeSearchableText = (rawRow) =>
+  normalizeCategoryNameKey(`${rawRow?.description || ""} ${rawRow?.notes || ""}`);
+
+const pickBestMatchingRule = (rawRow, rules = []) => {
+  const rowType = String(rawRow?.type || "").trim();
+  const searchableText = normalizeSearchableText(rawRow);
+
+  if (!searchableText) {
+    return null;
+  }
+
+  return rules
+    .filter((rule) => {
+      if (!rule?.normalizedMatchText) {
+        return false;
+      }
+
+      if (rule.transactionType && rule.transactionType !== rowType) {
+        return false;
+      }
+
+      return searchableText.includes(rule.normalizedMatchText);
+    })
+    .sort((leftRule, rightRule) => {
+      const patternLengthDelta =
+        String(rightRule.normalizedMatchText || "").length -
+        String(leftRule.normalizedMatchText || "").length;
+
+      if (patternLengthDelta !== 0) {
+        return patternLengthDelta;
+      }
+
+      return Number(rightRule.id || 0) - Number(leftRule.id || 0);
+    })[0] || null;
+};
+
+export const applyTransactionImportCategoryRules = (rows = [], rules = []) =>
+  rows.map((row) => {
+    if (!row?.raw || row.raw.category) {
+      return row;
+    }
+
+    const matchingRule = pickBestMatchingRule(row.raw, rules);
+
+    if (!matchingRule?.categoryName) {
+      return row;
+    }
+
+    return {
+      ...row,
+      raw: {
+        ...row.raw,
+        category: matchingRule.categoryName,
+      },
+    };
+  });
+
+export const normalizeTransactionImportRuleMatchText = (value) => {
+  const normalizedValue = normalizeRuleText(value);
+
+  if (normalizedValue.length < 2) {
+    const error = new Error("Regra invalida. Informe ao menos 2 caracteres.");
+    error.status = 400;
+    throw error;
+  }
+
+  return normalizedValue;
+};

--- a/apps/api/src/import.test.js
+++ b/apps/api/src/import.test.js
@@ -580,6 +580,98 @@ describe("transaction imports", () => {
     expect(response.body.rows[1].normalized.categoryId).toBe(transportCategory.body.id);
   });
 
+  it("POST/GET/DELETE /transactions/import/rules cria, lista e remove regras do usuario", async () => {
+    const token = await registerAndLogin("import-rules@controlfinance.dev");
+    await makeProUser("import-rules@controlfinance.dev");
+
+    const categoryResponse = await request(app)
+      .post("/categories")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Moradia" });
+
+    expect(categoryResponse.status).toBe(201);
+
+    const createResponse = await request(app)
+      .post("/transactions/import/rules")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        matchText: "neoenergia",
+        categoryId: categoryResponse.body.id,
+        transactionType: "Saida",
+      });
+
+    expect(createResponse.status).toBe(201);
+    expect(createResponse.body).toMatchObject({
+      matchText: "neoenergia",
+      categoryId: categoryResponse.body.id,
+      categoryName: "Moradia",
+      transactionType: "Saida",
+    });
+
+    const listResponse = await request(app)
+      .get("/transactions/import/rules")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.items).toEqual([
+      expect.objectContaining({
+        id: createResponse.body.id,
+        matchText: "neoenergia",
+        categoryName: "Moradia",
+        transactionType: "Saida",
+      }),
+    ]);
+
+    const deleteResponse = await request(app)
+      .delete(`/transactions/import/rules/${createResponse.body.id}`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(deleteResponse.status).toBe(200);
+    expect(deleteResponse.body).toEqual({
+      id: createResponse.body.id,
+      success: true,
+    });
+  });
+
+  it("POST /transactions/import/dry-run aplica regra salva antes da heuristica padrao", async () => {
+    const token = await registerAndLogin("import-rules-dry-run@controlfinance.dev");
+    await makeProUser("import-rules-dry-run@controlfinance.dev");
+
+    const categoryResponse = await request(app)
+      .post("/categories")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Saude" });
+
+    expect(categoryResponse.status).toBe(201);
+
+    const createRuleResponse = await request(app)
+      .post("/transactions/import/rules")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        matchText: "farmacia",
+        categoryId: categoryResponse.body.id,
+        transactionType: "Saida",
+      });
+
+    expect(createRuleResponse.status).toBe(201);
+
+    const csv = csvFile(
+      [
+        "date,type,value,description,notes,category",
+        "2026-03-02,Saida,89.9,PIX FARMACIA CENTRAL,,",
+      ].join("\n"),
+    );
+
+    const response = await request(app)
+      .post("/transactions/import/dry-run")
+      .set("Authorization", `Bearer ${token}`)
+      .attach("file", csv.buffer, { filename: csv.fileName, contentType: "text/csv" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.rows[0].raw.category).toBe("Saude");
+    expect(response.body.rows[0].normalized.categoryId).toBe(categoryResponse.body.id);
+  });
+
   it("POST /transactions/import/dry-run valida linhas e persiste sessao", async () => {
     const token = await registerAndLogin("import-sessao@controlfinance.dev");
     await makeProUser("import-sessao@controlfinance.dev");

--- a/apps/api/src/routes/transactions.routes.js
+++ b/apps/api/src/routes/transactions.routes.js
@@ -32,6 +32,11 @@ import {
   getTransactionsImportMetricsByUser,
   listTransactionsImportSessionsByUser,
 } from "../services/transactions-import.service.js";
+import {
+  deleteTransactionImportCategoryRuleForUser,
+  listTransactionImportCategoryRulesByUser,
+  upsertTransactionImportCategoryRuleForUser,
+} from "../services/transactions-import-rules.service.js";
 
 const router = Router();
 const IMPORT_MAX_FILE_SIZE_BYTES = Number(
@@ -433,6 +438,37 @@ router.post("/import/commit", importRateLimiter, requireFeature("csv_import"), a
       message: error?.message || "Unexpected error.",
     });
 
+    next(error);
+  }
+});
+
+router.get("/import/rules", requireFeature("csv_import"), async (req, res, next) => {
+  try {
+    const items = await listTransactionImportCategoryRulesByUser(req.user.id);
+    res.status(200).json({ items });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post("/import/rules", transactionsWriteRateLimiter, requireFeature("csv_import"), async (req, res, next) => {
+  try {
+    const rule = await upsertTransactionImportCategoryRuleForUser(req.user.id, {
+      matchText: req.body?.matchText,
+      categoryId: req.body?.categoryId,
+      transactionType: req.body?.transactionType,
+    });
+    res.status(201).json(rule);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.delete("/import/rules/:ruleId", transactionsWriteRateLimiter, requireFeature("csv_import"), async (req, res, next) => {
+  try {
+    const result = await deleteTransactionImportCategoryRuleForUser(req.user.id, req.params.ruleId);
+    res.status(200).json(result);
+  } catch (error) {
     next(error);
   }
 });

--- a/apps/api/src/services/transactions-import-rules.service.js
+++ b/apps/api/src/services/transactions-import-rules.service.js
@@ -1,0 +1,223 @@
+import { dbQuery } from "../db/index.js";
+import { normalizeCategoryNameKey } from "./categories-normalization.js";
+import { normalizeTransactionImportRuleMatchText } from "../domain/imports/transaction-import-rules.js";
+
+const createError = (status, message) => {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+};
+
+const normalizeUserId = (value) => {
+  const parsedValue = Number(value);
+
+  if (!Number.isInteger(parsedValue) || parsedValue <= 0) {
+    throw createError(400, "Usuario invalido.");
+  }
+
+  return parsedValue;
+};
+
+const normalizeRuleId = (value) => {
+  const parsedValue = Number(value);
+
+  if (!Number.isInteger(parsedValue) || parsedValue <= 0) {
+    throw createError(400, "Regra invalida.");
+  }
+
+  return parsedValue;
+};
+
+const normalizeCategoryId = (value) => {
+  const parsedValue = Number(value);
+
+  if (!Number.isInteger(parsedValue) || parsedValue <= 0) {
+    throw createError(400, "Categoria invalida.");
+  }
+
+  return parsedValue;
+};
+
+const normalizeTransactionType = (value) => {
+  if (typeof value === "undefined" || value === null || value === "") {
+    return "";
+  }
+
+  const normalizedValue = String(value).trim();
+
+  if (normalizedValue !== "Entrada" && normalizedValue !== "Saida") {
+    throw createError(400, "Tipo invalido para a regra.");
+  }
+
+  return normalizedValue;
+};
+
+const mapRuleRow = (row) => ({
+  id: Number(row.id),
+  matchText: row.match_text,
+  normalizedMatchText: row.normalized_match_text,
+  transactionType: row.transaction_type || "",
+  categoryId: Number(row.category_id),
+  categoryName: row.category_name,
+  createdAt:
+    typeof row.created_at === "string"
+      ? row.created_at
+      : new Date(row.created_at).toISOString(),
+  updatedAt:
+    typeof row.updated_at === "string"
+      ? row.updated_at
+      : new Date(row.updated_at).toISOString(),
+});
+
+const assertCategoryBelongsToUser = async (userId, categoryId) => {
+  const result = await dbQuery(
+    `SELECT id
+       FROM categories
+      WHERE id = $1
+        AND user_id = $2
+        AND deleted_at IS NULL
+      LIMIT 1`,
+    [categoryId, userId],
+  );
+
+  if (!result.rows[0]) {
+    throw createError(404, "Categoria nao encontrada.");
+  }
+};
+
+export const listTransactionImportCategoryRulesByUser = async (userId) => {
+  const normalizedUserId = normalizeUserId(userId);
+  const result = await dbQuery(
+    `SELECT r.id,
+            r.match_text,
+            r.normalized_match_text,
+            r.transaction_type,
+            r.category_id,
+            r.created_at,
+            r.updated_at,
+            c.name AS category_name
+       FROM transaction_import_category_rules r
+       JOIN categories c
+         ON c.id = r.category_id
+        AND c.user_id = r.user_id
+        AND c.deleted_at IS NULL
+      WHERE r.user_id = $1
+      ORDER BY r.created_at DESC, r.id DESC`,
+    [normalizedUserId],
+  );
+
+  return result.rows.map(mapRuleRow);
+};
+
+export const loadActiveTransactionImportCategoryRulesByUser = async (userId) => {
+  const normalizedUserId = normalizeUserId(userId);
+  const result = await dbQuery(
+    `SELECT r.id,
+            r.match_text,
+            r.normalized_match_text,
+            r.transaction_type,
+            r.category_id,
+            c.name AS category_name
+       FROM transaction_import_category_rules r
+       JOIN categories c
+         ON c.id = r.category_id
+        AND c.user_id = r.user_id
+        AND c.deleted_at IS NULL
+      WHERE r.user_id = $1
+      ORDER BY r.id DESC`,
+    [normalizedUserId],
+  );
+
+  return result.rows
+    .map((row) => ({
+      id: Number(row.id),
+      matchText: row.match_text,
+      normalizedMatchText: row.normalized_match_text,
+      transactionType: row.transaction_type || "",
+      categoryId: Number(row.category_id),
+      categoryName: row.category_name,
+    }))
+    .sort((leftRule, rightRule) => {
+      const patternLengthDelta =
+        String(rightRule.normalizedMatchText || "").length -
+        String(leftRule.normalizedMatchText || "").length;
+
+      if (patternLengthDelta !== 0) {
+        return patternLengthDelta;
+      }
+
+      return Number(rightRule.id || 0) - Number(leftRule.id || 0);
+    });
+};
+
+export const upsertTransactionImportCategoryRuleForUser = async (userId, payload = {}) => {
+  const normalizedUserId = normalizeUserId(userId);
+  const categoryId = normalizeCategoryId(payload.categoryId);
+  const matchText = normalizeTransactionImportRuleMatchText(payload.matchText);
+  const transactionType = normalizeTransactionType(payload.transactionType);
+  const normalizedMatchText = normalizeCategoryNameKey(matchText);
+
+  await assertCategoryBelongsToUser(normalizedUserId, categoryId);
+
+  const result = await dbQuery(
+    `INSERT INTO transaction_import_category_rules (
+       user_id,
+       category_id,
+       match_text,
+       normalized_match_text,
+       transaction_type,
+       created_at,
+       updated_at
+     )
+     VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
+     ON CONFLICT (user_id, normalized_match_text, transaction_type)
+     DO UPDATE
+       SET category_id = EXCLUDED.category_id,
+           match_text = EXCLUDED.match_text,
+           updated_at = NOW()
+     RETURNING id,
+               match_text,
+               normalized_match_text,
+               transaction_type,
+               category_id,
+               created_at,
+               updated_at`,
+    [normalizedUserId, categoryId, matchText, normalizedMatchText, transactionType],
+  );
+
+  const savedRule = result.rows[0];
+  const categoryResult = await dbQuery(
+    `SELECT name
+       FROM categories
+      WHERE id = $1
+        AND user_id = $2
+      LIMIT 1`,
+    [categoryId, normalizedUserId],
+  );
+
+  return mapRuleRow({
+    ...savedRule,
+    category_name: categoryResult.rows[0]?.name || null,
+  });
+};
+
+export const deleteTransactionImportCategoryRuleForUser = async (userId, ruleId) => {
+  const normalizedUserId = normalizeUserId(userId);
+  const normalizedRuleId = normalizeRuleId(ruleId);
+  const result = await dbQuery(
+    `DELETE FROM transaction_import_category_rules
+      WHERE id = $1
+        AND user_id = $2
+      RETURNING id`,
+    [normalizedRuleId, normalizedUserId],
+  );
+
+  if (!result.rows[0]) {
+    throw createError(404, "Regra nao encontrada.");
+  }
+
+  return {
+    id: normalizedRuleId,
+    success: true,
+  };
+};

--- a/apps/api/src/services/transactions-import.service.js
+++ b/apps/api/src/services/transactions-import.service.js
@@ -20,8 +20,10 @@ import {
   extractWaterBillSuggestion,
 } from "../domain/imports/statement-import.js";
 import { detectDocumentType } from "../domain/imports/document-classifier.js";
+import { applyTransactionImportCategoryRules } from "../domain/imports/transaction-import-rules.js";
 import { applySmartClassification } from "../domain/imports/transaction-classifier.js";
 import { normalizeCategoryNameKey } from "./categories-normalization.js";
+import { loadActiveTransactionImportCategoryRulesByUser } from "./transactions-import-rules.service.js";
 
 const CATEGORY_ENTRY = TRANSACTION_TYPE_ENTRY;
 const CATEGORY_EXIT = TRANSACTION_TYPE_EXIT;
@@ -795,11 +797,13 @@ const assertSessionReadyForCommit = (session, userId) => {
 
 export const dryRunTransactionsImportForUser = async (userId, importFile) => {
   const { rows: parsedRows, documentType, suggestion } = await parseImportFileRows(importFile);
-  const [categoryMap, categories] = await Promise.all([
+  const [categoryMap, categories, importRules] = await Promise.all([
     loadCategoryMapForUser(userId),
     loadCategoriesForUser(userId),
+    loadActiveTransactionImportCategoryRulesByUser(userId),
   ]);
-  const classifiedRows = applySmartClassification(parsedRows, categories);
+  const rowsWithRuleSuggestions = applyTransactionImportCategoryRules(parsedRows, importRules);
+  const classifiedRows = applySmartClassification(rowsWithRuleSuggestions, categories);
   const validatedRows = classifiedRows.map((row) => {
     const normalizedRow = normalizeCsvRow(row.raw, categoryMap);
     return {

--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -45,6 +45,10 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
   const [previewStatusFilter, setPreviewStatusFilter] = useState("all");
   const [previewTypeFilter, setPreviewTypeFilter] = useState("all");
   const [previewCategoryFilter, setPreviewCategoryFilter] = useState("all");
+  const [importRules, setImportRules] = useState([]);
+  const [isSavingImportRule, setIsSavingImportRule] = useState(false);
+  const [deletingImportRuleId, setDeletingImportRuleId] = useState(null);
+  const [ruleFeedback, setRuleFeedback] = useState(null);
 
   useEffect(() => {
     if (isOpen) {
@@ -77,6 +81,10 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
     setPreviewStatusFilter("all");
     setPreviewTypeFilter("all");
     setPreviewCategoryFilter("all");
+    setImportRules([]);
+    setIsSavingImportRule(false);
+    setDeletingImportRuleId(null);
+    setRuleFeedback(null);
   }, [isOpen]);
 
   useEffect(() => {
@@ -105,6 +113,7 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
   useEffect(() => {
     if (!isOpen) return;
     categoriesService.listCategories().then(setCategories).catch(() => {});
+    transactionsService.listImportCategoryRules().then(setImportRules).catch(() => {});
   }, [isOpen]);
 
   const hasValidRows = useMemo(() => {
@@ -320,6 +329,40 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
     [filteredPreviewRows],
   );
 
+  const selectedPreviewRows = useMemo(
+    () =>
+      (dryRunResult?.rows ?? []).filter(
+        (row) => row.status === "valid" && selectedPreviewLines.has(row.line),
+      ),
+    [dryRunResult, selectedPreviewLines],
+  );
+
+  const importRuleMatchText = useMemo(() => {
+    const searchTerm = previewSearch.trim();
+
+    if (searchTerm.length >= 2) {
+      return searchTerm;
+    }
+
+    if (selectedPreviewRows.length === 1) {
+      return String(selectedPreviewRows[0]?.raw?.description || "").trim();
+    }
+
+    return "";
+  }, [previewSearch, selectedPreviewRows]);
+
+  const importRuleTransactionType = useMemo(() => {
+    if (previewTypeFilter === "Entrada" || previewTypeFilter === "Saida") {
+      return previewTypeFilter;
+    }
+
+    const selectedTypes = [...new Set(selectedPreviewRows.map((row) => row.raw.type).filter(Boolean))];
+    return selectedTypes.length === 1 ? selectedTypes[0] : null;
+  }, [previewTypeFilter, selectedPreviewRows]);
+
+  const canSaveImportRule =
+    batchCategoryId !== "" && importRuleMatchText.length >= 2 && selectedPreviewRows.length > 0;
+
   const allVisibleValidSelected = useMemo(
     () =>
       validPreviewLines.length > 0 && validPreviewLines.every((line) => selectedPreviewLines.has(line)),
@@ -346,17 +389,87 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
     });
   };
 
+  const applyBatchCategorySelection = useCallback(
+    (lines = [...selectedPreviewLines], categoryValue = batchCategoryId) => {
+      if (!Array.isArray(lines) || lines.length === 0) return;
+      const val = categoryValue === "" ? null : Number(categoryValue);
+      setCategoryOverrides((prev) => {
+        const next = { ...prev };
+        lines.forEach((line) => {
+          next[line] = val;
+        });
+        return next;
+      });
+      setSelectedPreviewLines(new Set());
+      setBatchCategoryId("");
+    },
+    [batchCategoryId, selectedPreviewLines],
+  );
+
   const handleApplyBatchCategory = () => {
-    if (selectedPreviewLines.size === 0) return;
-    const val = batchCategoryId === "" ? null : Number(batchCategoryId);
-    setCategoryOverrides((prev) => {
-      const next = { ...prev };
-      selectedPreviewLines.forEach((line) => { next[line] = val; });
-      return next;
-    });
-    setSelectedPreviewLines(new Set());
-    setBatchCategoryId("");
+    applyBatchCategorySelection([...selectedPreviewLines], batchCategoryId);
   };
+
+  const handleApplyBatchCategoryAndSaveRule = useCallback(async () => {
+    const selectedLines = [...selectedPreviewLines];
+
+    if (!canSaveImportRule || selectedLines.length === 0) {
+      return;
+    }
+
+    const categoryId = Number(batchCategoryId);
+    applyBatchCategorySelection(selectedLines, batchCategoryId);
+    setRuleFeedback(null);
+    setIsSavingImportRule(true);
+
+    try {
+      const savedRule = await transactionsService.createImportCategoryRule({
+        matchText: importRuleMatchText,
+        categoryId,
+        transactionType: importRuleTransactionType || undefined,
+      });
+      setImportRules((prev) => [savedRule, ...prev.filter((rule) => rule.id !== savedRule.id)]);
+      setRuleFeedback({
+        type: "success",
+        message: `Regra salva para "${savedRule.matchText}".`,
+      });
+    } catch (error) {
+      setRuleFeedback({
+        type: "error",
+        message: getApiErrorMessage(error, "Nao foi possivel salvar a regra."),
+      });
+    } finally {
+      setIsSavingImportRule(false);
+    }
+  }, [
+    applyBatchCategorySelection,
+    batchCategoryId,
+    canSaveImportRule,
+    importRuleMatchText,
+    importRuleTransactionType,
+    selectedPreviewLines,
+  ]);
+
+  const handleDeleteImportRule = useCallback(async (ruleId) => {
+    setDeletingImportRuleId(ruleId);
+    setRuleFeedback(null);
+
+    try {
+      await transactionsService.deleteImportCategoryRule(ruleId);
+      setImportRules((prev) => prev.filter((rule) => rule.id !== ruleId));
+      setRuleFeedback({
+        type: "success",
+        message: "Regra removida com sucesso.",
+      });
+    } catch (error) {
+      setRuleFeedback({
+        type: "error",
+        message: getApiErrorMessage(error, "Nao foi possivel remover a regra."),
+      });
+    } finally {
+      setDeletingImportRuleId(null);
+    }
+  }, []);
 
   const handleInlineCreateCategory = useCallback(
     async (line, rowType) => {
@@ -378,6 +491,11 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
     },
     [inlineCreateName],
   );
+
+  const selectedRuleCategory = categories.find((category) => Number(category.id) === Number(batchCategoryId));
+  const importRuleHelpText = importRuleMatchText
+    ? `A regra usara "${importRuleMatchText}"${importRuleTransactionType ? ` em ${importRuleTransactionType.toLowerCase()}` : ""}.`
+    : "Use a busca atual ou selecione uma unica linha para salvar uma regra reutilizavel.";
 
   const handleDryRun = async () => {
     if (!selectedFile) {
@@ -873,6 +991,61 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
                     </p>
                   </div>
                 </div>
+                {importRules.length > 0 ? (
+                  <div className="rounded border border-cf-border bg-cf-surface px-3 py-3">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div>
+                        <p className="text-xs font-semibold uppercase text-cf-text-secondary">
+                          Regras salvas
+                        </p>
+                        <p className="text-xs text-cf-text-secondary">
+                          Reaplicadas automaticamente nos próximos imports.
+                        </p>
+                      </div>
+                      <span className="text-xs text-cf-text-secondary">
+                        {importRules.length} {importRules.length === 1 ? "regra ativa" : "regras ativas"}
+                      </span>
+                    </div>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      {importRules.map((rule) => (
+                        <div
+                          key={rule.id}
+                          className="flex items-start gap-2 rounded border border-cf-border bg-cf-bg-subtle px-2 py-2"
+                        >
+                          <div>
+                            <p className="text-xs font-semibold text-cf-text-primary">
+                              {rule.categoryName}
+                            </p>
+                            <p className="text-xs text-cf-text-secondary">
+                              Contem &quot;{rule.matchText}&quot;
+                              {rule.transactionType ? ` · ${rule.transactionType}` : ""}
+                            </p>
+                          </div>
+                          <button
+                            type="button"
+                            onClick={() => handleDeleteImportRule(rule.id)}
+                            disabled={deletingImportRuleId === rule.id}
+                            aria-label={`Remover regra ${rule.matchText}`}
+                            className="rounded border border-cf-border px-2 py-0.5 text-xs text-cf-text-secondary hover:bg-cf-surface disabled:opacity-60"
+                          >
+                            Remover
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
+                {ruleFeedback ? (
+                  <div
+                    className={`rounded border px-3 py-2 text-xs ${
+                      ruleFeedback.type === "error"
+                        ? "border-red-300 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-300"
+                        : "border-green-300 bg-green-50 text-green-700 dark:border-green-800 dark:bg-green-950/40 dark:text-green-300"
+                    }`}
+                  >
+                    {ruleFeedback.message}
+                  </div>
+                ) : null}
                 {selectedPreviewLines.size > 0 && (
                   <div className="mb-1 flex flex-wrap items-center gap-2 rounded border border-brand-1/40 bg-brand-1/5 px-3 py-2">
                     <span className="text-xs font-medium text-cf-text-primary">
@@ -898,11 +1071,23 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
                     </button>
                     <button
                       type="button"
+                      onClick={handleApplyBatchCategoryAndSaveRule}
+                      disabled={!canSaveImportRule || isSavingImportRule}
+                      className="rounded border border-cf-border px-2 py-0.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-surface disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {isSavingImportRule ? "Salvando regra..." : "Aplicar e salvar regra"}
+                    </button>
+                    <button
+                      type="button"
                       onClick={() => setSelectedPreviewLines(new Set())}
                       className="rounded border border-cf-border px-2 py-0.5 text-xs text-cf-text-secondary hover:bg-cf-bg-subtle"
                     >
                       Cancelar
                     </button>
+                    <div className="basis-full text-[11px] text-cf-text-secondary">
+                      {importRuleHelpText}
+                      {selectedRuleCategory ? ` Categoria alvo: ${selectedRuleCategory.name}.` : ""}
+                    </div>
                   </div>
                 )}
                 <div className="max-h-80 overflow-auto rounded border border-cf-border">

--- a/apps/web/src/components/ImportCsvModal.test.jsx
+++ b/apps/web/src/components/ImportCsvModal.test.jsx
@@ -13,6 +13,9 @@ vi.mock("../services/transactions.service", () => ({
     dryRunImportCsv: vi.fn(),
     commitImportCsv: vi.fn(),
     deleteImportSession: vi.fn(),
+    listImportCategoryRules: vi.fn(),
+    createImportCategoryRule: vi.fn(),
+    deleteImportCategoryRule: vi.fn(),
   },
 }));
 
@@ -85,6 +88,7 @@ describe("ImportCsvModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     categoriesService.listCategories.mockResolvedValue([]);
+    transactionsService.listImportCategoryRules.mockResolvedValue([]);
     incomeSourcesService.list.mockResolvedValue([]);
     incomeSourcesService.postStatement.mockResolvedValue({
       statement: {
@@ -494,6 +498,115 @@ describe("ImportCsvModal", () => {
       },
       10000,
     );
+  });
+
+  describe("import category rules", () => {
+    it("salva regra a partir da busca atual e da categoria em lote", async () => {
+      const file = new File(["date,type,value"], "import.csv", { type: "text/csv" });
+      categoriesService.listCategories.mockResolvedValue([
+        { id: 7, name: "Saude" },
+      ]);
+      transactionsService.createImportCategoryRule.mockResolvedValue({
+        id: 91,
+        matchText: "farmacia",
+        transactionType: "Entrada",
+        categoryId: 7,
+        categoryName: "Saude",
+        createdAt: "2026-03-26T10:00:00Z",
+        updatedAt: "2026-03-26T10:00:00Z",
+      });
+      transactionsService.dryRunImportCsv.mockResolvedValueOnce(
+        buildDryRunResponse({
+          rows: [
+            {
+              line: 2,
+              status: "valid",
+              raw: {
+                date: "2026-02-21",
+                type: "Entrada",
+                value: "100",
+                description: "PIX FARMACIA CENTRAL",
+                notes: "",
+                category: "",
+              },
+              normalized: {
+                date: "2026-02-21",
+                type: "Entrada",
+                value: 100,
+                description: "PIX FARMACIA CENTRAL",
+                notes: "",
+                categoryId: null,
+              },
+              errors: [],
+            },
+          ],
+        }),
+      );
+
+      render(<ImportCsvModal isOpen onClose={vi.fn()} />);
+
+      await userEvent.upload(screen.getByLabelText("Arquivo do extrato"), file);
+      await userEvent.click(screen.getByRole("button", { name: "Pré-visualizar" }));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/buscar na pré-visualização/i)).toBeInTheDocument();
+      });
+
+      await userEvent.type(screen.getByLabelText(/buscar na pré-visualização/i), "farmacia");
+      await userEvent.click(screen.getByLabelText(/selecionar todas as linhas válidas/i));
+      await userEvent.selectOptions(screen.getByLabelText(/categoria para aplicar em lote/i), "7");
+      await userEvent.click(screen.getByRole("button", { name: /aplicar e salvar regra/i }));
+
+      await waitFor(() => {
+        expect(transactionsService.createImportCategoryRule).toHaveBeenCalledWith({
+          matchText: "farmacia",
+          categoryId: 7,
+          transactionType: "Entrada",
+        });
+      });
+
+      expect(screen.getByText(/regra salva para "farmacia"/i)).toBeInTheDocument();
+      expect(screen.getAllByText("Saude")[0]).toBeInTheDocument();
+      expect(screen.getByText(/contem "farmacia" · entrada/i)).toBeInTheDocument();
+    });
+
+    it("lista e remove regras salvas de importação", async () => {
+      const file = new File(["date,type,value"], "import.csv", { type: "text/csv" });
+      transactionsService.listImportCategoryRules.mockResolvedValue([
+        {
+          id: 15,
+          matchText: "neoenergia",
+          transactionType: "Saida",
+          categoryId: 3,
+          categoryName: "Moradia",
+          createdAt: "2026-03-26T10:00:00Z",
+          updatedAt: "2026-03-26T10:00:00Z",
+        },
+      ]);
+      transactionsService.deleteImportCategoryRule.mockResolvedValue({
+        id: 15,
+        success: true,
+      });
+
+      render(<ImportCsvModal isOpen onClose={vi.fn()} />);
+
+      transactionsService.dryRunImportCsv.mockResolvedValueOnce(buildDryRunResponse());
+      await userEvent.upload(screen.getByLabelText("Arquivo do extrato"), file);
+      await userEvent.click(screen.getByRole("button", { name: "Pré-visualizar" }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Moradia")).toBeInTheDocument();
+      });
+
+      await userEvent.click(screen.getByRole("button", { name: /remover regra neoenergia/i }));
+
+      await waitFor(() => {
+        expect(transactionsService.deleteImportCategoryRule).toHaveBeenCalledWith(15);
+      });
+
+      expect(screen.queryByText("Moradia")).not.toBeInTheDocument();
+      expect(screen.getByText(/regra removida com sucesso/i)).toBeInTheDocument();
+    });
   });
 
   describe("income statement bridge", () => {

--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -104,6 +104,9 @@ vi.mock("../services/transactions.service", () => ({
     getImportHistory: vi.fn(),
     dryRunImportCsv: vi.fn(),
     commitImportCsv: vi.fn(),
+    listImportCategoryRules: vi.fn(),
+    createImportCategoryRule: vi.fn(),
+    deleteImportCategoryRule: vi.fn(),
     deleteImportSession: vi.fn(),
     bulkDeleteTransactions: vi.fn(),
     create: vi.fn(),
@@ -291,6 +294,9 @@ describe("App", () => {
         balance: 100,
       },
     });
+    transactionsService.listImportCategoryRules.mockResolvedValue([]);
+    transactionsService.createImportCategoryRule.mockResolvedValue({});
+    transactionsService.deleteImportCategoryRule.mockResolvedValue({ success: true });
     transactionsService.update.mockResolvedValue({});
     transactionsService.restore.mockResolvedValue({});
     transactionsService.bulkDeleteTransactions.mockResolvedValue({ deletedCount: 0, success: true });

--- a/apps/web/src/services/transactions.service.ts
+++ b/apps/web/src/services/transactions.service.ts
@@ -239,6 +239,16 @@ export interface ImportHistoryOptions {
   offset?: number;
 }
 
+export interface ImportCategoryRule {
+  id: number;
+  matchText: string;
+  transactionType: TransactionType | null;
+  categoryId: number;
+  categoryName: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 interface TransactionsApiResponse {
   data?: unknown;
   meta?: {
@@ -813,6 +823,67 @@ export const transactionsService = {
         expense: Number(responseBody.summary?.expense) || 0,
       },
       rows,
+    };
+  },
+  listImportCategoryRules: async (): Promise<ImportCategoryRule[]> => {
+    const { data } = await api.get("/transactions/import/rules");
+    const items = Array.isArray((data as { items?: unknown[] })?.items)
+      ? ((data as { items?: unknown[] }).items as unknown[])
+      : [];
+
+    return items.map((item) => {
+      const transactionType = String((item as { transactionType?: unknown })?.transactionType || "")
+        .trim();
+
+      return {
+        id: Number((item as { id?: unknown })?.id) || 0,
+        matchText: String((item as { matchText?: unknown })?.matchText || ""),
+        transactionType:
+          transactionType === "Entrada" || transactionType === "Saida"
+            ? (transactionType as TransactionType)
+            : null,
+        categoryId: Number((item as { categoryId?: unknown })?.categoryId) || 0,
+        categoryName: String((item as { categoryName?: unknown })?.categoryName || ""),
+        createdAt: String((item as { createdAt?: unknown })?.createdAt || ""),
+        updatedAt: String((item as { updatedAt?: unknown })?.updatedAt || ""),
+      };
+    });
+  },
+  createImportCategoryRule: async (payload: {
+    matchText: string;
+    categoryId: number;
+    transactionType?: TransactionType;
+  }): Promise<ImportCategoryRule> => {
+    const { data } = await api.post("/transactions/import/rules", payload);
+    const response = data as {
+      id?: unknown;
+      matchText?: unknown;
+      transactionType?: unknown;
+      categoryId?: unknown;
+      categoryName?: unknown;
+      createdAt?: unknown;
+      updatedAt?: unknown;
+    };
+    const transactionType = String(response.transactionType || "").trim();
+
+    return {
+      id: Number(response.id) || 0,
+      matchText: String(response.matchText || ""),
+      transactionType:
+        transactionType === "Entrada" || transactionType === "Saida"
+          ? (transactionType as TransactionType)
+          : null,
+      categoryId: Number(response.categoryId) || 0,
+      categoryName: String(response.categoryName || ""),
+      createdAt: String(response.createdAt || ""),
+      updatedAt: String(response.updatedAt || ""),
+    };
+  },
+  deleteImportCategoryRule: async (ruleId: number): Promise<{ id: number; success: boolean }> => {
+    const { data } = await api.delete(`/transactions/import/rules/${ruleId}`);
+    return {
+      id: Number((data as { id?: unknown })?.id) || 0,
+      success: Boolean((data as { success?: unknown })?.success),
     };
   },
   commitImportCsv: async (


### PR DESCRIPTION
## Contexto
Este PR fecha a etapa de produtividade operacional do preview de importação com regras reutilizáveis de categorização.

## O que entra
- regras salvas por descrição para imports recorrentes
- aplicação automática das regras antes da heurística padrão
- endpoints para listar, criar e remover regras do usuário
- UI no preview para aplicar categoria em lote e salvar a regra
- listagem e remoção de regras salvas no modal de importação

## Validação
- 
pm -w apps/api run lint ✅
- 
pm -w apps/api run test ✅ 722/722
- 
pm -w apps/web run lint ✅
- 
pm -w apps/web run typecheck ✅
- 
pm -w apps/web run test:run ✅ 304/304
- 
pm -w apps/web run build ✅

## Escopo
Somente importação e categorização recorrente.
Sem mudança em docs do roadmap e sem versionar .env local.