### PR TITLE
feat(import): add operational guard rails for import history

### DIFF
--- a/apps/api/src/import.test.js
+++ b/apps/api/src/import.test.js
@@ -179,9 +179,13 @@ describe("transaction imports", () => {
         olderImportId,
         userAId,
         JSON.stringify({
+          fileName: "older.csv",
+          documentType: "bank_statement",
           summary: {
             totalRows: 4,
             validRows: 3,
+            duplicateRows: 1,
+            conflictRows: 0,
             invalidRows: 1,
             income: 1000,
             expense: 150.5,
@@ -193,9 +197,13 @@ describe("transaction imports", () => {
         newerImportId,
         userAId,
         JSON.stringify({
+          fileName: "newer.ofx",
+          documentType: "bank_statement",
           summary: {
             totalRows: 2,
             validRows: 2,
+            duplicateRows: 0,
+            conflictRows: 0,
             invalidRows: 0,
             income: 700,
             expense: 220.25,
@@ -219,6 +227,24 @@ describe("transaction imports", () => {
         "2026-04-01T11:30:00.000Z",
         null,
       ],
+    );
+
+    await dbQuery(
+      `
+        INSERT INTO transactions (
+          user_id,
+          type,
+          value,
+          date,
+          description,
+          import_session_id,
+          imported_at
+        )
+        VALUES
+          ($1, 'Entrada', 500, '2026-04-01', 'Importada A', $2, NOW()),
+          ($1, 'Entrada', 200, '2026-04-01', 'Importada B', $2, NOW())
+      `,
+      [userAId, newerImportId],
     );
 
     const response = await request(app)
@@ -245,9 +271,14 @@ describe("transaction imports", () => {
       createdAt: "2026-04-01T10:00:00.000Z",
       expiresAt: "2026-04-01T10:30:00.000Z",
       committedAt: "2026-04-01T10:10:00.000Z",
+      fileName: "newer.ofx",
+      documentType: "bank_statement",
+      canUndo: true,
       summary: {
         totalRows: 2,
         validRows: 2,
+        duplicateRows: 0,
+        conflictRows: 0,
         invalidRows: 0,
         income: 700,
         expense: 220.25,
@@ -259,9 +290,14 @@ describe("transaction imports", () => {
       createdAt: "2026-04-01T09:00:00.000Z",
       expiresAt: "2026-04-01T09:30:00.000Z",
       committedAt: null,
+      fileName: "older.csv",
+      documentType: "bank_statement",
+      canUndo: false,
       summary: {
         totalRows: 4,
         validRows: 3,
+        duplicateRows: 1,
+        conflictRows: 0,
         invalidRows: 1,
         income: 1000,
         expense: 150.5,
@@ -1398,6 +1434,19 @@ describe("transaction imports", () => {
     expect(undoResponse.body.importSessionId).toBe(sessionId);
     expect(undoResponse.body.deletedCount).toBe(2);
     expect(undoResponse.body.success).toBe(true);
+
+    const historyResponse = await request(app)
+      .get("/transactions/imports")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(historyResponse.status).toBe(200);
+    expect(historyResponse.body.items[0]).toMatchObject({
+      id: sessionId,
+      canUndo: false,
+      summary: {
+        imported: 0,
+      },
+    });
 
     // Transacoes devem estar soft-deleted (GET retorna zero)
     const listResponse = await request(app)

--- a/apps/api/src/services/transactions-import.service.js
+++ b/apps/api/src/services/transactions-import.service.js
@@ -884,10 +884,26 @@ export const listTransactionsImportSessionsByUser = async (userId, filters = {})
   const pagination = normalizeImportHistoryPagination(filters);
   const result = await dbQuery(
     `
-      SELECT id, created_at, expires_at, committed_at, payload_json
-      FROM transaction_import_sessions
-      WHERE user_id = $1
-      ORDER BY created_at DESC
+      SELECT s.id,
+             s.created_at,
+             s.expires_at,
+             s.committed_at,
+             s.payload_json,
+             COALESCE(tx.active_imported_count, 0) AS active_imported_count
+      FROM transaction_import_sessions s
+      LEFT JOIN (
+        SELECT import_session_id,
+               user_id,
+               COUNT(*)::int AS active_imported_count
+        FROM transactions
+        WHERE deleted_at IS NULL
+          AND import_session_id IS NOT NULL
+        GROUP BY import_session_id, user_id
+      ) tx
+        ON tx.import_session_id = s.id
+       AND tx.user_id = s.user_id
+      WHERE s.user_id = $1
+      ORDER BY s.created_at DESC
       LIMIT $2 OFFSET $3
     `,
     [userId, pagination.limit, pagination.offset],
@@ -896,17 +912,28 @@ export const listTransactionsImportSessionsByUser = async (userId, filters = {})
   const items = result.rows.map((row) => {
     const payload = parsePayloadJson(row.payload_json);
     const summary = payload.summary || {};
-    const validRows = normalizeSummaryInteger(summary.validRows, 0);
-    const imported = row.committed_at ? validRows : 0;
+    const imported = normalizeSummaryInteger(row.active_imported_count, 0);
+    const committedAt = toIsoDateString(row.committed_at);
 
     return {
       id: String(row.id),
       createdAt: toIsoDateString(row.created_at),
       expiresAt: toIsoDateString(row.expires_at),
-      committedAt: toIsoDateString(row.committed_at),
+      committedAt,
+      fileName:
+        typeof payload.fileName === "string" && payload.fileName.trim()
+          ? payload.fileName.trim()
+          : null,
+      documentType:
+        typeof payload.documentType === "string" && payload.documentType.trim()
+          ? payload.documentType.trim()
+          : null,
+      canUndo: Boolean(committedAt) && imported > 0,
       summary: {
         totalRows: normalizeSummaryInteger(summary.totalRows, 0),
-        validRows,
+        validRows: normalizeSummaryInteger(summary.validRows, 0),
+        duplicateRows: normalizeSummaryInteger(summary.duplicateRows, 0),
+        conflictRows: normalizeSummaryInteger(summary.conflictRows, 0),
         invalidRows: normalizeSummaryInteger(summary.invalidRows, 0),
         income: normalizeSummaryNumber(summary.income, 0),
         expense: normalizeSummaryNumber(summary.expense, 0),

--- a/apps/web/src/components/ImportCsvModal.d.ts
+++ b/apps/web/src/components/ImportCsvModal.d.ts
@@ -1,7 +1,8 @@
 interface ImportCsvModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onImported?: () => Promise<void> | void;
+  onImported?: (result?: unknown) => Promise<void> | void;
+  onOpenHistory?: (result?: unknown) => Promise<void> | void;
 }
 
 declare function ImportCsvModal(props: ImportCsvModalProps): JSX.Element;

--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -8,8 +8,9 @@ import { formatCurrency } from "../utils/formatCurrency";
 import { getApiErrorMessage } from "../utils/apiError";
 import BillModal from "./BillModal";
 import IncomeStatementQuickModal from "./IncomeStatementQuickModal";
+import ConfirmDialog from "./ConfirmDialog";
 
-const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
+const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory = undefined }) => {
   const fileInputRef = useRef(null);
   const [selectedFile, setSelectedFile] = useState(null);
   const [isDryRunning, setIsDryRunning] = useState(false);
@@ -32,6 +33,7 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
   // post-commit state
   const [lastCommitResult, setLastCommitResult] = useState(null);
   const [isUndoing, setIsUndoing] = useState(false);
+  const [showUndoConfirm, setShowUndoConfirm] = useState(false);
   // bill bridge
   const [isBillModalOpen, setIsBillModalOpen] = useState(false);
   const [billCreated, setBillCreated] = useState(false);
@@ -71,6 +73,7 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
     setInlineCreateName("");
     setLastCommitResult(null);
     setIsUndoing(false);
+    setShowUndoConfirm(false);
     setIsBillModalOpen(false);
     setBillCreated(false);
     setIsIncomeModalOpen(false);
@@ -558,10 +561,24 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
     else onClose();
   };
 
+  const handleOpenHistoryAfterCommit = async () => {
+    if (onImported) {
+      await onImported(lastCommitResult);
+    }
+
+    if (onOpenHistory) {
+      await onOpenHistory(lastCommitResult);
+      return;
+    }
+
+    onClose();
+  };
+
   const handleUndo = async () => {
     if (!lastCommitResult?.importSessionId) return;
     setIsUndoing(true);
     setErrorMessage("");
+    setShowUndoConfirm(false);
     try {
       await transactionsService.deleteImportSession(lastCommitResult.importSessionId);
       if (onImported) await onImported(null);
@@ -635,6 +652,8 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
               setCategoryOverrides({});
               setInlineCreate(null);
               setInlineCreateName("");
+              setLastCommitResult(null);
+              setShowUndoConfirm(false);
             }}
             className="block w-full text-sm text-cf-text-primary file:mr-3 file:rounded file:border file:border-cf-border file:bg-cf-bg-subtle file:px-3 file:py-1 file:text-sm file:font-semibold file:text-cf-text-primary hover:file:bg-cf-border"
           />
@@ -653,6 +672,20 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
                 ? "1 lançamento importado."
                 : `${lastCommitResult.imported} lançamentos importados.`}
             </p>
+            <div className="mb-3 grid gap-2 sm:grid-cols-3">
+              <div className="rounded border border-green-200 bg-white px-3 py-2 text-xs text-green-800 dark:border-green-900 dark:bg-green-950/30 dark:text-green-300">
+                <p className="font-semibold uppercase">Entradas</p>
+                <p>{formatCurrency(lastCommitResult.summary?.income || 0)}</p>
+              </div>
+              <div className="rounded border border-green-200 bg-white px-3 py-2 text-xs text-green-800 dark:border-green-900 dark:bg-green-950/30 dark:text-green-300">
+                <p className="font-semibold uppercase">Saídas</p>
+                <p>{formatCurrency(lastCommitResult.summary?.expense || 0)}</p>
+              </div>
+              <div className="rounded border border-green-200 bg-white px-3 py-2 text-xs text-green-800 dark:border-green-900 dark:bg-green-950/30 dark:text-green-300">
+                <p className="font-semibold uppercase">Saldo</p>
+                <p>{formatCurrency(lastCommitResult.summary?.balance || 0)}</p>
+              </div>
+            </div>
             <div className="flex flex-wrap items-center gap-2">
               <button
                 type="button"
@@ -664,7 +697,15 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
               </button>
               <button
                 type="button"
-                onClick={handleUndo}
+                onClick={handleOpenHistoryAfterCommit}
+                disabled={isUndoing}
+                className="rounded border border-cf-border bg-white px-3 py-1.5 text-sm font-semibold text-cf-text-primary hover:bg-cf-bg-subtle disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                Ver histórico
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowUndoConfirm(true)}
                 disabled={isUndoing}
                 className="rounded border border-red-300 bg-red-50 px-3 py-1.5 text-sm font-semibold text-red-600 hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-red-700 dark:bg-red-950/40 dark:text-red-400"
               >
@@ -1277,6 +1318,15 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined }) => {
           setIncomeStatementCreated(true);
         }}
       />
+
+      <ConfirmDialog
+        isOpen={showUndoConfirm}
+        title="Desfazer esta importação?"
+        description="Os lançamentos criados nesta sessão serão removidos e o histórico continuará disponível como registro revertido."
+        confirmLabel="Desfazer importação"
+        onConfirm={() => void handleUndo()}
+        onCancel={() => setShowUndoConfirm(false)}
+      />
     </div>
   );
 };
@@ -1285,6 +1335,7 @@ ImportCsvModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   onImported: PropTypes.func,
+  onOpenHistory: PropTypes.func,
 };
 
 export default ImportCsvModal;

--- a/apps/web/src/components/ImportCsvModal.test.jsx
+++ b/apps/web/src/components/ImportCsvModal.test.jsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ImportCsvModal from "./ImportCsvModal";
 import { transactionsService } from "../services/transactions.service";
@@ -248,6 +248,103 @@ describe("ImportCsvModal", () => {
 
     await waitFor(() => {
       expect(onImported).toHaveBeenCalled();
+    });
+  });
+
+  it("abre o histórico depois do commit sem perder o refresh do app", async () => {
+    const onImported = vi.fn();
+    const onOpenHistory = vi.fn();
+    const file = new File(["date,type,value"], "import.csv", { type: "text/csv" });
+
+    transactionsService.dryRunImportCsv.mockResolvedValueOnce(buildDryRunResponse());
+    transactionsService.commitImportCsv.mockResolvedValueOnce({
+      imported: 1,
+      importSessionId: "import-session-1",
+      summary: { income: 100, expense: 20, balance: 80 },
+    });
+
+    render(
+      <ImportCsvModal
+        isOpen
+        onClose={vi.fn()}
+        onImported={onImported}
+        onOpenHistory={onOpenHistory}
+      />,
+    );
+
+    await userEvent.upload(screen.getByLabelText("Arquivo do extrato"), file);
+    await userEvent.click(screen.getByRole("button", { name: "Pré-visualizar" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Importar" })).not.toBeDisabled();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Importar" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Ver histórico" })).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Ver histórico" }));
+
+    await waitFor(() => {
+      expect(onImported).toHaveBeenCalledWith(
+        expect.objectContaining({
+          importSessionId: "import-session-1",
+        }),
+      );
+      expect(onOpenHistory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          importSessionId: "import-session-1",
+        }),
+      );
+    });
+  });
+
+  it("pede confirmação antes de desfazer a importação", async () => {
+    const onImported = vi.fn();
+    const file = new File(["date,type,value"], "import.csv", { type: "text/csv" });
+
+    transactionsService.dryRunImportCsv.mockResolvedValueOnce(buildDryRunResponse());
+    transactionsService.commitImportCsv.mockResolvedValueOnce({
+      imported: 1,
+      importSessionId: "import-session-1",
+      summary: { income: 100, expense: 20, balance: 80 },
+    });
+    transactionsService.deleteImportSession.mockResolvedValueOnce({
+      importSessionId: "import-session-1",
+      deletedCount: 1,
+      success: true,
+    });
+
+    render(<ImportCsvModal isOpen onClose={vi.fn()} onImported={onImported} />);
+
+    await userEvent.upload(screen.getByLabelText("Arquivo do extrato"), file);
+    await userEvent.click(screen.getByRole("button", { name: "Pré-visualizar" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Importar" })).not.toBeDisabled();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Importar" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Desfazer importação" })).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Desfazer importação" }));
+
+    expect(transactionsService.deleteImportSession).not.toHaveBeenCalled();
+    const confirmDialog = screen.getByRole("dialog", { name: "Desfazer esta importação?" });
+    expect(confirmDialog).toBeInTheDocument();
+
+    await userEvent.click(
+      within(confirmDialog).getByRole("button", { name: "Desfazer importação" }),
+    );
+
+    await waitFor(() => {
+      expect(transactionsService.deleteImportSession).toHaveBeenCalledWith("import-session-1");
+      expect(onImported).toHaveBeenCalledWith(null);
     });
   });
 

--- a/apps/web/src/components/ImportHistoryModal.d.ts
+++ b/apps/web/src/components/ImportHistoryModal.d.ts
@@ -1,0 +1,8 @@
+interface ImportHistoryModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onImportSessionReverted?: (sessionId?: string) => Promise<void> | void;
+}
+
+declare function ImportHistoryModal(props: ImportHistoryModalProps): JSX.Element;
+export default ImportHistoryModal;

--- a/apps/web/src/components/ImportHistoryModal.jsx
+++ b/apps/web/src/components/ImportHistoryModal.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { transactionsService } from "../services/transactions.service";
 import { formatCurrency } from "../utils/formatCurrency";
 import { getApiErrorMessage } from "../utils/apiError";
+import ConfirmDialog from "./ConfirmDialog";
 
 const DEFAULT_LIMIT = 20;
 
@@ -23,8 +24,11 @@ const formatDateTime = (value) => {
 const resolveImportStatus = (item) => {
   if (item.committedAt) {
     return {
-      label: "Committed",
-      className: "bg-green-100 text-green-700",
+      label: item.summary.imported > 0 ? "Committed" : "Reverted",
+      className:
+        item.summary.imported > 0
+          ? "bg-green-100 text-green-700"
+          : "bg-slate-100 text-slate-700",
     };
   }
 
@@ -43,13 +47,31 @@ const resolveImportStatus = (item) => {
   };
 };
 
-const ImportHistoryModal = ({ isOpen, onClose }) => {
+const formatDocumentType = (value) => {
+  switch (String(value || "").trim()) {
+    case "bank_statement":
+      return "Extrato bancário";
+    case "income_statement_inss":
+      return "Comprovante INSS";
+    case "utility_bill_energy":
+      return "Conta de energia";
+    case "utility_bill_water":
+      return "Conta de água";
+    default:
+      return "Importação";
+  }
+};
+
+const ImportHistoryModal = ({ isOpen, onClose, onImportSessionReverted = undefined }) => {
   const closeButtonRef = useRef(null);
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
+  const [successMessage, setSuccessMessage] = useState("");
   const [items, setItems] = useState([]);
   const [limit, setLimit] = useState(DEFAULT_LIMIT);
   const [offset, setOffset] = useState(0);
+  const [undoingSessionId, setUndoingSessionId] = useState(null);
+  const [pendingUndoItem, setPendingUndoItem] = useState(null);
 
   const loadImportHistory = useCallback(async (nextOffset = 0, nextLimit = DEFAULT_LIMIT) => {
     setIsLoading(true);
@@ -78,9 +100,12 @@ const ImportHistoryModal = ({ isOpen, onClose }) => {
 
     setIsLoading(false);
     setErrorMessage("");
+    setSuccessMessage("");
     setItems([]);
     setLimit(DEFAULT_LIMIT);
     setOffset(0);
+    setUndoingSessionId(null);
+    setPendingUndoItem(null);
   }, [isOpen]);
 
   useEffect(() => {
@@ -142,6 +167,32 @@ const ImportHistoryModal = ({ isOpen, onClose }) => {
     }
   };
 
+  const handleConfirmUndo = useCallback(async () => {
+    if (!pendingUndoItem?.id) {
+      return;
+    }
+
+    setUndoingSessionId(pendingUndoItem.id);
+    setErrorMessage("");
+    setSuccessMessage("");
+
+    try {
+      await transactionsService.deleteImportSession(pendingUndoItem.id);
+
+      if (onImportSessionReverted) {
+        await onImportSessionReverted(pendingUndoItem.id);
+      }
+
+      await loadImportHistory(offset, limit);
+      setSuccessMessage("Importação desfeita com sucesso.");
+      setPendingUndoItem(null);
+    } catch (error) {
+      setErrorMessage(getApiErrorMessage(error, "Não foi possível desfazer a importação."));
+    } finally {
+      setUndoingSessionId(null);
+    }
+  }, [limit, loadImportHistory, offset, onImportSessionReverted, pendingUndoItem]);
+
   if (!isOpen) {
     return null;
   }
@@ -186,6 +237,12 @@ const ImportHistoryModal = ({ isOpen, onClose }) => {
           </div>
         ) : null}
 
+        {successMessage ? (
+          <div className="mb-3 rounded border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">
+            {successMessage}
+          </div>
+        ) : null}
+
         {isLoading ? (
           <div className="rounded border border-cf-border bg-cf-surface px-3 py-3 text-sm text-cf-text-secondary">
             Carregando histórico...
@@ -208,13 +265,11 @@ const ImportHistoryModal = ({ isOpen, onClose }) => {
                 <thead className="bg-cf-bg-subtle">
                   <tr>
                     <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Data</th>
+                    <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Arquivo</th>
                     <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Status</th>
-                    <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
-                      Válidas / Inválidas
-                    </th>
-                    <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Importadas</th>
-                    <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Entradas</th>
-                    <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Saídas</th>
+                    <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Resumo</th>
+                    <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Valores</th>
+                    <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Ações</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -223,22 +278,47 @@ const ImportHistoryModal = ({ isOpen, onClose }) => {
                       <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
                         {formatDateTime(item.createdAt)}
                       </td>
+                      <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
+                        <p className="font-semibold text-cf-text-primary">
+                          {item.fileName || "Arquivo não informado"}
+                        </p>
+                        <p className="text-[11px] text-cf-text-secondary">
+                          {formatDocumentType(item.documentType)}
+                        </p>
+                      </td>
                       <td className="border-b border-cf-border px-2 py-2">
                         <span className={`rounded px-2 py-0.5 font-semibold ${item.status.className}`}>
                           {item.status.label}
                         </span>
                       </td>
                       <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
-                        {item.summary.validRows} / {item.summary.invalidRows}
+                        <div className="space-y-1 text-[11px]">
+                          <p>Válidas: {item.summary.validRows}</p>
+                          <p>Duplicadas: {item.summary.duplicateRows}</p>
+                          <p>Conflitos: {item.summary.conflictRows}</p>
+                          <p>Inválidas: {item.summary.invalidRows}</p>
+                          <p>Importadas: {item.summary.imported}</p>
+                        </div>
                       </td>
                       <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
-                        {item.summary.imported}
+                        <div className="space-y-1 text-[11px]">
+                          <p>Entradas: {formatCurrency(item.summary.income)}</p>
+                          <p>Saídas: {formatCurrency(item.summary.expense)}</p>
+                        </div>
                       </td>
-                      <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
-                        {formatCurrency(item.summary.income)}
-                      </td>
-                      <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
-                        {formatCurrency(item.summary.expense)}
+                      <td className="border-b border-cf-border px-2 py-2">
+                        {item.canUndo ? (
+                          <button
+                            type="button"
+                            onClick={() => setPendingUndoItem(item)}
+                            disabled={undoingSessionId === item.id}
+                            className="rounded border border-red-300 bg-red-50 px-2 py-1 text-xs font-semibold text-red-600 hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-60"
+                          >
+                            {undoingSessionId === item.id ? "Desfazendo..." : "Desfazer"}
+                          </button>
+                        ) : (
+                          <span className="text-[11px] text-cf-text-secondary">Sem ação</span>
+                        )}
                       </td>
                     </tr>
                   ))}
@@ -276,6 +356,15 @@ const ImportHistoryModal = ({ isOpen, onClose }) => {
           </button>
         </div>
       </div>
+
+      <ConfirmDialog
+        isOpen={Boolean(pendingUndoItem)}
+        title="Desfazer importação?"
+        description="Os lançamentos ativos desta sessão serão removidos e o histórico ficará marcado como revertido."
+        confirmLabel="Desfazer importação"
+        onConfirm={() => void handleConfirmUndo()}
+        onCancel={() => setPendingUndoItem(null)}
+      />
     </div>
   );
 };
@@ -283,6 +372,7 @@ const ImportHistoryModal = ({ isOpen, onClose }) => {
 ImportHistoryModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
+  onImportSessionReverted: PropTypes.func,
 };
 
 export default ImportHistoryModal;

--- a/apps/web/src/components/ImportHistoryModal.test.jsx
+++ b/apps/web/src/components/ImportHistoryModal.test.jsx
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ImportHistoryModal from "./ImportHistoryModal";
+import { transactionsService } from "../services/transactions.service";
+
+vi.mock("../services/transactions.service", () => ({
+  transactionsService: {
+    getImportHistory: vi.fn(),
+    deleteImportSession: vi.fn(),
+  },
+}));
+
+const buildHistoryResponse = (overrides = {}) => ({
+  items: [],
+  pagination: {
+    limit: 20,
+    offset: 0,
+  },
+  ...overrides,
+});
+
+describe("ImportHistoryModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("exibe sessoes revertidas com resumo detalhado", async () => {
+    transactionsService.getImportHistory.mockResolvedValueOnce(
+      buildHistoryResponse({
+        items: [
+          {
+            id: "import-1",
+            createdAt: "2026-04-01T10:00:00.000Z",
+            expiresAt: "2026-04-01T10:30:00.000Z",
+            committedAt: "2026-04-01T10:10:00.000Z",
+            fileName: "itau-90-dias.ofx",
+            documentType: "bank_statement",
+            canUndo: false,
+            summary: {
+              totalRows: 5,
+              validRows: 3,
+              duplicateRows: 1,
+              conflictRows: 1,
+              invalidRows: 1,
+              income: 200,
+              expense: 50,
+              imported: 0,
+            },
+          },
+        ],
+      }),
+    );
+
+    render(<ImportHistoryModal isOpen onClose={vi.fn()} />);
+
+    expect(await screen.findByText("Reverted")).toBeInTheDocument();
+    expect(screen.getByText("itau-90-dias.ofx")).toBeInTheDocument();
+    expect(screen.getByText("Extrato bancário")).toBeInTheDocument();
+    expect(screen.getByText("Duplicadas: 1")).toBeInTheDocument();
+    expect(screen.getByText("Conflitos: 1")).toBeInTheDocument();
+    expect(screen.getByText("Sem ação")).toBeInTheDocument();
+  });
+
+  it("confirma e desfaz a sessao com refresh do histórico", async () => {
+    const onImportSessionReverted = vi.fn();
+
+    transactionsService.getImportHistory
+      .mockResolvedValueOnce(
+        buildHistoryResponse({
+          items: [
+            {
+              id: "import-undo",
+              createdAt: "2026-04-01T10:00:00.000Z",
+              expiresAt: "2026-04-01T10:30:00.000Z",
+              committedAt: "2026-04-01T10:10:00.000Z",
+              fileName: "inss.pdf",
+              documentType: "income_statement_inss",
+              canUndo: true,
+              summary: {
+                totalRows: 2,
+                validRows: 2,
+                duplicateRows: 0,
+                conflictRows: 0,
+                invalidRows: 0,
+                income: 1412,
+                expense: 0,
+                imported: 2,
+              },
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(
+        buildHistoryResponse({
+          items: [
+            {
+              id: "import-undo",
+              createdAt: "2026-04-01T10:00:00.000Z",
+              expiresAt: "2026-04-01T10:30:00.000Z",
+              committedAt: "2026-04-01T10:10:00.000Z",
+              fileName: "inss.pdf",
+              documentType: "income_statement_inss",
+              canUndo: false,
+              summary: {
+                totalRows: 2,
+                validRows: 2,
+                duplicateRows: 0,
+                conflictRows: 0,
+                invalidRows: 0,
+                income: 1412,
+                expense: 0,
+                imported: 0,
+              },
+            },
+          ],
+        }),
+      );
+    transactionsService.deleteImportSession.mockResolvedValueOnce({
+      importSessionId: "import-undo",
+      deletedCount: 2,
+      success: true,
+    });
+
+    render(
+      <ImportHistoryModal
+        isOpen
+        onClose={vi.fn()}
+        onImportSessionReverted={onImportSessionReverted}
+      />,
+    );
+
+    expect(await screen.findByText("Committed")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Desfazer" }));
+
+    const confirmDialog = screen.getByRole("dialog", { name: "Desfazer importação?" });
+    await userEvent.click(
+      within(confirmDialog).getByRole("button", { name: "Desfazer importação" }),
+    );
+
+    await waitFor(() => {
+      expect(transactionsService.deleteImportSession).toHaveBeenCalledWith("import-undo");
+      expect(onImportSessionReverted).toHaveBeenCalledWith("import-undo");
+    });
+
+    expect(await screen.findByText("Importação desfeita com sucesso.")).toBeInTheDocument();
+    expect(screen.getByText("Reverted")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -1502,6 +1502,20 @@ const App = ({
     setImportModalOpen(false);
   }, [loadMonthlyBudgets, loadMonthlySummary, loadTransactions]);
 
+  const handleOpenImportHistoryAfterImport = useCallback(async () => {
+    await loadTransactions();
+    await loadMonthlySummary();
+    await loadMonthlyBudgets();
+    setImportModalOpen(false);
+    setImportHistoryModalOpen(true);
+  }, [loadMonthlyBudgets, loadMonthlySummary, loadTransactions]);
+
+  const handleImportSessionReverted = useCallback(async () => {
+    await loadTransactions();
+    await loadMonthlySummary();
+    await loadMonthlyBudgets();
+  }, [loadMonthlyBudgets, loadMonthlySummary, loadTransactions]);
+
   const handleViewBudgetTransactions = (budget: MonthlyBudget) => {
     const monthRange = getMonthRange(selectedSummaryMonth);
     setSelectedTransactionCategoryId(String(budget.categoryId));
@@ -2922,11 +2936,13 @@ const App = ({
         isOpen={isImportModalOpen}
         onClose={() => setImportModalOpen(false)}
         onImported={handleImportCommitted}
+        onOpenHistory={handleOpenImportHistoryAfterImport}
       />
 
       <ImportHistoryModal
         isOpen={isImportHistoryModalOpen}
         onClose={() => setImportHistoryModalOpen(false)}
+        onImportSessionReverted={handleImportSessionReverted}
       />
     </div>
   );

--- a/apps/web/src/services/transactions.service.ts
+++ b/apps/web/src/services/transactions.service.ts
@@ -210,6 +210,8 @@ export interface ImportCommitResult {
 export interface ImportHistorySummary {
   totalRows: number;
   validRows: number;
+  duplicateRows: number;
+  conflictRows: number;
   invalidRows: number;
   income: number;
   expense: number;
@@ -221,6 +223,9 @@ export interface ImportHistoryItem {
   createdAt: string;
   expiresAt: string;
   committedAt: string | null;
+  fileName: string | null;
+  documentType: string | null;
+  canUndo: boolean;
   summary: ImportHistorySummary;
 }
 
@@ -400,9 +405,14 @@ interface ImportHistoryApiResponse {
     createdAt?: unknown;
     expiresAt?: unknown;
     committedAt?: unknown;
+    fileName?: unknown;
+    documentType?: unknown;
+    canUndo?: unknown;
     summary?: {
       totalRows?: unknown;
       validRows?: unknown;
+      duplicateRows?: unknown;
+      conflictRows?: unknown;
       invalidRows?: unknown;
       income?: unknown;
       expense?: unknown;
@@ -948,9 +958,20 @@ export const transactionsService = {
             typeof item?.committedAt === "string" && item.committedAt.trim()
               ? item.committedAt
               : null,
+          fileName:
+            typeof item?.fileName === "string" && item.fileName.trim()
+              ? item.fileName.trim()
+              : null,
+          documentType:
+            typeof item?.documentType === "string" && item.documentType.trim()
+              ? item.documentType.trim()
+              : null,
+          canUndo: Boolean(item?.canUndo),
           summary: {
             totalRows: Number(item?.summary?.totalRows) || 0,
             validRows: Number(item?.summary?.validRows) || 0,
+            duplicateRows: Number(item?.summary?.duplicateRows) || 0,
+            conflictRows: Number(item?.summary?.conflictRows) || 0,
             invalidRows: Number(item?.summary?.invalidRows) || 0,
             income: Number(item?.summary?.income) || 0,
             expense: Number(item?.summary?.expense) || 0,


### PR DESCRIPTION
## Contexto

Este PR fecha o slice de guard rails operacionais da trilha de importação inteligente.

O foco aqui é deixar o fluxo de histórico e rollback mais seguro e mais honesto para uso real, sem mexer no runtime fiscal nem incluir mudanças de docs/env fora do escopo.

## O que entra

- histórico de imports com estado real por sessão (`Committed`, `Reverted`, `Pending`, `Expired`)
- contagem viva de itens importados ativos no backend
- resumo mais rico por sessão (`valid`, `duplicate`, `conflict`, `invalid`, `imported`)
- `fileName`, `documentType` e `canUndo` expostos no contrato do histórico
- ação de desfazer diretamente no histórico com confirmação explícita
- confirmação antes de desfazer a última importação no modal de importação
- resumo pós-commit mais informativo no modal
- atalho `Ver histórico` após commit
- refresh do dashboard quando uma sessão é revertida

## Regra / comportamento

- sessões já commitadas continuam visíveis no histórico mesmo após undo
- uma sessão revertida não some: passa a aparecer como `Reverted`
- `summary.imported` reflete apenas transações ativas ainda vinculadas à sessão
- `canUndo` só fica habilitado quando ainda há lançamentos ativos para desfazer
- o undo exige confirmação explícita antes de remover os lançamentos

## Backend

- `GET /transactions/imports` agora retorna contagem viva de importados por sessão
- o shape do histórico foi ampliado com `fileName`, `documentType`, `canUndo`, `duplicateRows` e `conflictRows`
- o cálculo de importados ativos foi refeito com agregação compatível com a suíte em memória

## Frontend

- `ImportHistoryModal` ganhou resumo detalhado, status `Reverted` e ação de undo com confirmação
- `ImportCsvModal` ganhou confirmação antes do undo e resumo pós-importação mais útil
- `App` agora refresha transações, resumo e budgets quando o undo acontece via histórico

## Validação

- `npm -w apps/api run lint` ✅
- `npm -w apps/api test` ✅ `722/722`
- `npm -w apps/web run lint` ✅
- `npm -w apps/web run typecheck` ✅
- `npm -w apps/web run test:run` ✅ `308/308`
- `npm -w apps/web run build` ✅

## Escopo

Somente guard rails operacionais do fluxo de importação.
Sem mudança de docs de roadmap.
Sem incluir `apps/api/.env` local.
