### PR TITLE
feat(finance): add bank limit tracking

### DIFF
--- a/apps/api/src/db/migrations/039_add_bank_limit_total_to_user_profiles.sql
+++ b/apps/api/src/db/migrations/039_add_bank_limit_total_to_user_profiles.sql
@@ -1,0 +1,6 @@
+ALTER TABLE user_profiles
+ADD COLUMN IF NOT EXISTS bank_limit_total NUMERIC(12, 2);
+
+ALTER TABLE user_profiles
+ADD CONSTRAINT chk_user_profiles_bank_limit_total
+CHECK (bank_limit_total IS NULL OR bank_limit_total >= 0);

--- a/apps/api/src/forecast.test.js
+++ b/apps/api/src/forecast.test.js
@@ -281,6 +281,62 @@ describe("computeForecast — flip detection (deterministic)", () => {
     expect(result.projectedBalance).toBe(0);
   });
 
+  it("calcula uso projetado do limite bancario quando a projeção entra no cheque especial", async () => {
+    await registerAndLogin("fc-bank-limit-using@test.dev");
+    const userId = await getUserIdByEmail("fc-bank-limit-using@test.dev");
+
+    await dbQuery(
+      `INSERT INTO user_profiles (user_id, bank_limit_total)
+       VALUES ($1, 1000)`,
+      [userId],
+    );
+
+    await dbQuery(
+      `INSERT INTO transactions (user_id, type, value, date)
+       VALUES ($1, 'Saida', 500, $2)`,
+      [userId, FIXED_MONTH_START],
+    );
+
+    const result = await computeForecast(userId, { now: FIXED_NOW });
+
+    expect(result.adjustedProjectedBalance).toBeLessThan(0);
+    expect(result.bankLimit).toMatchObject({
+      total: 1000,
+      status: "using",
+      exceededBy: 0,
+    });
+    expect(result.bankLimit.used).toBeGreaterThan(0);
+    expect(result.bankLimit.remaining).toBeLessThan(1000);
+  });
+
+  it("marca limite bancario como excedido quando a projeção passa do cheque especial", async () => {
+    await registerAndLogin("fc-bank-limit-exceeded@test.dev");
+    const userId = await getUserIdByEmail("fc-bank-limit-exceeded@test.dev");
+
+    await dbQuery(
+      `INSERT INTO user_profiles (user_id, bank_limit_total)
+       VALUES ($1, 1000)`,
+      [userId],
+    );
+
+    await dbQuery(
+      `INSERT INTO transactions (user_id, type, value, date)
+       VALUES ($1, 'Saida', 900, $2)`,
+      [userId, FIXED_MONTH_START],
+    );
+
+    const result = await computeForecast(userId, { now: FIXED_NOW });
+
+    expect(result.bankLimit).toMatchObject({
+      total: 1000,
+      used: 1000,
+      remaining: 0,
+      status: "exceeded",
+    });
+    expect(result.bankLimit.exceededBy).toBeGreaterThan(0);
+    expect(result.bankLimit.alertTriggered).toBe(true);
+  });
+
   it("getLatestForecast retorna null antes do primeiro compute", async () => {
     await registerAndLogin("fc-get-null-svc@test.dev");
     const userId = await getUserIdByEmail("fc-get-null-svc@test.dev");
@@ -413,6 +469,13 @@ describe("forecast — bills integration", () => {
 
   it("GET /forecasts/current enriquece com bills em tempo real", async () => {
     const token = await registerAndLogin("fc-bills-realtime@test.dev");
+    const userId = await getUserIdByEmail("fc-bills-realtime@test.dev");
+
+    await dbQuery(
+      `INSERT INTO user_profiles (user_id, salary_monthly, payday, bank_limit_total)
+       VALUES ($1, 100, 31, 800)`,
+      [userId],
+    );
 
     // Recompute without bills — stored projectedBalance has no bills
     await request(app)
@@ -423,7 +486,7 @@ describe("forecast — bills integration", () => {
     await request(app)
       .post("/bills")
       .set("Authorization", `Bearer ${token}`)
-      .send({ title: "Agua", amount: 80, dueDate: CURRENT_MONTH_END });
+      .send({ title: "Agua", amount: 180, dueDate: CURRENT_MONTH_END });
 
     // GET /current should reflect the fresh bill even without recompute
     const res = await request(app)
@@ -431,11 +494,16 @@ describe("forecast — bills integration", () => {
       .set("Authorization", `Bearer ${token}`);
 
     expect(res.status).toBe(200);
-    expect(res.body.billsPendingTotal).toBe(80);
+    expect(res.body.billsPendingTotal).toBe(180);
     expect(res.body.billsPendingCount).toBe(1);
     expect(res.body.adjustedProjectedBalance).toBe(
-      Number((res.body.projectedBalance - 80).toFixed(2)),
+      Number((res.body.projectedBalance - 180).toFixed(2)),
     );
+    expect(res.body.bankLimit).toMatchObject({
+      total: 800,
+      used: 80,
+      status: "using",
+    });
   });
 
   it("recompute com multiplas bills soma corretamente", async () => {

--- a/apps/api/src/me.test.js
+++ b/apps/api/src/me.test.js
@@ -132,8 +132,8 @@ describe("GET /me", () => {
     const userId = userResult.rows[0].id;
 
     await dbQuery(
-      `INSERT INTO user_profiles (user_id, display_name, salary_monthly, payday, avatar_url, taxpayer_cpf)
-       VALUES ($1, 'Joao Silva', 5000.00, 5, 'https://example.com/avatar.jpg', '52998224725')`,
+      `INSERT INTO user_profiles (user_id, display_name, salary_monthly, bank_limit_total, payday, avatar_url, taxpayer_cpf)
+       VALUES ($1, 'Joao Silva', 5000.00, 1500.00, 5, 'https://example.com/avatar.jpg', '52998224725')`,
       [userId],
     );
 
@@ -145,6 +145,7 @@ describe("GET /me", () => {
     expect(response.body.profile).toMatchObject({
       displayName: "Joao Silva",
       salaryMonthly: 5000,
+      bankLimitTotal: 1500,
       payday: 5,
       avatarUrl: "https://example.com/avatar.jpg",
       taxpayerCpf: "52998224725",
@@ -188,6 +189,7 @@ describe("PATCH /me/profile", () => {
       .send({
         display_name: "Maria Santos",
         salary_monthly: 7500,
+        bank_limit_total: 1200,
         payday: 10,
         avatar_url: "https://example.com/maria.jpg",
         taxpayer_cpf: "529.982.247-25",
@@ -197,6 +199,7 @@ describe("PATCH /me/profile", () => {
     expect(response.body).toMatchObject({
       displayName: "Maria Santos",
       salaryMonthly: 7500,
+      bankLimitTotal: 1200,
       payday: 10,
       avatarUrl: "https://example.com/maria.jpg",
       taxpayerCpf: "52998224725",
@@ -300,6 +303,17 @@ describe("PATCH /me/profile", () => {
       .send({ salary_monthly: -100 });
 
     expectErrorResponseWithRequestId(response, 400, "salary_monthly nao pode ser negativo.");
+  });
+
+  it("retorna 400 para bank_limit_total negativo", async () => {
+    const token = await registerAndLogin("patch-bank-limit-neg@test.dev");
+
+    const response = await request(app)
+      .patch("/me/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ bank_limit_total: -10 });
+
+    expectErrorResponseWithRequestId(response, 400, "bank_limit_total nao pode ser negativo.");
   });
 
   it("retorna 400 para avatar_url sem https://", async () => {
@@ -440,5 +454,24 @@ describe("PATCH /me/profile", () => {
     const beforeTs = new Date(before.rows[0].trial_ends_at).getTime();
     const afterTs = new Date(after.rows[0].trial_ends_at).getTime();
     expect(afterTs).toBe(beforeTs);
+  });
+
+  it("persiste bank_limit_total e retorna no round-trip GET /me", async () => {
+    const token = await registerAndLogin("patch-bank-limit-roundtrip@test.dev");
+
+    const patchResponse = await request(app)
+      .patch("/me/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ bank_limit_total: 890.55 });
+
+    expect(patchResponse.status).toBe(200);
+    expect(patchResponse.body.bankLimitTotal).toBe(890.55);
+
+    const getResponse = await request(app)
+      .get("/me")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(getResponse.status).toBe(200);
+    expect(getResponse.body.profile.bankLimitTotal).toBe(890.55);
   });
 });

--- a/apps/api/src/services/forecast.service.js
+++ b/apps/api/src/services/forecast.service.js
@@ -59,6 +59,38 @@ const rowToForecast = (row) => ({
   generatedAt: row.generated_at,
 });
 
+const buildBankLimitProjection = (bankLimitTotal, adjustedProjectedBalance) => {
+  if (bankLimitTotal == null) return null;
+
+  const total = Number(bankLimitTotal);
+  if (!Number.isFinite(total) || total <= 0) return null;
+
+  const projectedDeficit = adjustedProjectedBalance < 0
+    ? Math.abs(Number(adjustedProjectedBalance))
+    : 0;
+  const used = Number(Math.min(projectedDeficit, total).toFixed(2));
+  const remaining = Number(Math.max(total - used, 0).toFixed(2));
+  const exceededBy = Number(Math.max(projectedDeficit - total, 0).toFixed(2));
+  const usagePct = total > 0 ? Number(((used / total) * 100).toFixed(2)) : 0;
+
+  let status = "unused";
+  if (exceededBy > 0) {
+    status = "exceeded";
+  } else if (used > 0) {
+    status = "using";
+  }
+
+  return {
+    total: Number(total.toFixed(2)),
+    used,
+    remaining,
+    exceededBy,
+    usagePct,
+    status,
+    alertTriggered: status === "exceeded" || usagePct >= 80,
+  };
+};
+
 /**
  * Computes (or recomputes) the forecast for the given user and month,
  * persists it, and returns the result.
@@ -77,13 +109,15 @@ export const computeForecast = async (userId, { now = new Date() } = {}) => {
 
   // 1. Profile (salary + payday)
   const profileResult = await dbQuery(
-    `SELECT salary_monthly, payday FROM user_profiles WHERE user_id = $1 LIMIT 1`,
+    `SELECT salary_monthly, payday, bank_limit_total FROM user_profiles WHERE user_id = $1 LIMIT 1`,
     [uid],
   );
   const profile = profileResult.rows[0] ?? null;
   const salaryMonthly =
     profile?.salary_monthly != null ? Number(profile.salary_monthly) : null;
   const payday = profile?.payday != null ? Number(profile.payday) : null;
+  const bankLimitTotal =
+    profile?.bank_limit_total != null ? Number(profile.bank_limit_total) : null;
 
   // 2. This-month totals
   const monthlyResult = await dbQuery(
@@ -218,6 +252,7 @@ export const computeForecast = async (userId, { now = new Date() } = {}) => {
     billsPendingTotal: Number(billsTotal.toFixed(2)),
     billsPendingCount: billsCount,
     adjustedProjectedBalance,
+    bankLimit: buildBankLimitProjection(bankLimitTotal, adjustedProjectedBalance),
   };
 };
 
@@ -241,5 +276,17 @@ export const getLatestForecast = async (userId, { now = new Date() } = {}) => {
   forecast.billsPendingTotal = Number(billsTotal.toFixed(2));
   forecast.billsPendingCount = billsCount;
   forecast.adjustedProjectedBalance = Number((forecast.projectedBalance - billsTotal).toFixed(2));
+  const profileResult = await dbQuery(
+    `SELECT bank_limit_total FROM user_profiles WHERE user_id = $1 LIMIT 1`,
+    [uid],
+  );
+  const bankLimitTotal =
+    profileResult.rows[0]?.bank_limit_total != null
+      ? Number(profileResult.rows[0].bank_limit_total)
+      : null;
+  forecast.bankLimit = buildBankLimitProjection(
+    bankLimitTotal,
+    forecast.adjustedProjectedBalance,
+  );
   return forecast;
 };

--- a/apps/api/src/services/profile.service.js
+++ b/apps/api/src/services/profile.service.js
@@ -36,6 +36,15 @@ const normalizeSalaryMonthly = (value) => {
   return n;
 };
 
+const normalizeBankLimitTotal = (value) => {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  const n = Number(value);
+  if (!Number.isFinite(n)) throw createError(400, "bank_limit_total deve ser um numero.");
+  if (n < 0) throw createError(400, "bank_limit_total nao pode ser negativo.");
+  return n;
+};
+
 const normalizePayday = (value) => {
   if (value === undefined) return undefined;
   if (value === null) return null;
@@ -150,6 +159,10 @@ const rowToProfile = (row) => ({
     row.salary_monthly !== null && row.salary_monthly !== undefined
       ? Number(row.salary_monthly)
       : null,
+  bankLimitTotal:
+    row.bank_limit_total !== null && row.bank_limit_total !== undefined
+      ? Number(row.bank_limit_total)
+      : null,
   payday: row.payday !== null && row.payday !== undefined ? Number(row.payday) : null,
   avatarUrl: row.avatar_url ?? null,
   taxpayerCpf: row.taxpayer_cpf ?? null,
@@ -193,7 +206,7 @@ export const getMyProfile = async (userId) => {
 
   const [profileResult, identitiesResult] = await Promise.all([
     dbQuery(
-      `SELECT display_name, salary_monthly, payday, avatar_url, taxpayer_cpf, ai_tone, ai_insight_frequency
+      `SELECT display_name, salary_monthly, bank_limit_total, payday, avatar_url, taxpayer_cpf, ai_tone, ai_insight_frequency
        FROM user_profiles WHERE user_id = $1 LIMIT 1`,
       [normalizedUserId],
     ),
@@ -226,6 +239,9 @@ export const updateMyProfile = async (userId, payload = {}) => {
 
   const salaryMonthly = normalizeSalaryMonthly(payload.salary_monthly);
   if (salaryMonthly !== undefined) updates.salary_monthly = salaryMonthly;
+
+  const bankLimitTotal = normalizeBankLimitTotal(payload.bank_limit_total);
+  if (bankLimitTotal !== undefined) updates.bank_limit_total = bankLimitTotal;
 
   const normalizedPayday = normalizePayday(payload.payday);
   if (normalizedPayday !== undefined) updates.payday = normalizedPayday;
@@ -285,7 +301,7 @@ export const updateMyProfile = async (userId, payload = {}) => {
   }
 
   const result = await dbQuery(
-    `SELECT display_name, salary_monthly, payday, avatar_url, taxpayer_cpf, ai_tone, ai_insight_frequency
+    `SELECT display_name, salary_monthly, bank_limit_total, payday, avatar_url, taxpayer_cpf, ai_tone, ai_insight_frequency
      FROM user_profiles WHERE user_id = $1 LIMIT 1`,
     [normalizedUserId],
   );

--- a/apps/web/src/components/ForecastCard.test.tsx
+++ b/apps/web/src/components/ForecastCard.test.tsx
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import ForecastCard from "./ForecastCard";
+import { DiscreetModeProvider } from "../context/DiscreetModeContext";
+import type { Forecast } from "../services/forecast.service";
+
+vi.mock("../services/forecast.service", () => ({
+  forecastService: {
+    getCurrent: vi.fn(),
+    recompute: vi.fn(),
+  },
+}));
+
+vi.mock("../services/profile.service", () => ({
+  profileService: {
+    getMe: vi.fn(),
+  },
+}));
+
+const { forecastService } = await import("../services/forecast.service");
+const { profileService } = await import("../services/profile.service");
+
+const buildForecast = (overrides: Partial<Forecast> = {}): Forecast => ({
+  month: "2026-03",
+  projectedBalance: 100,
+  adjustedProjectedBalance: -220,
+  spendingToDate: 900,
+  dailyAvgSpending: 30,
+  daysRemaining: 7,
+  flipDetected: false,
+  flipDirection: null,
+  engineVersion: "v2",
+  incomeExpected: 1200,
+  billsPendingTotal: 0,
+  billsPendingCount: 0,
+  bankLimit: {
+    total: 1000,
+    used: 220,
+    remaining: 780,
+    exceededBy: 0,
+    usagePct: 22,
+    status: "using",
+    alertTriggered: false,
+  },
+  ...overrides,
+});
+
+const buildMe = () => ({
+  id: 1,
+  name: "Jr",
+  email: "jr@example.com",
+  hasPassword: true,
+  linkedProviders: [],
+  trialEndsAt: null,
+  trialExpired: false,
+  profile: {
+    displayName: "Jr",
+    salaryMonthly: 5000,
+    bankLimitTotal: 1000,
+    payday: 5,
+    avatarUrl: null,
+    taxpayerCpf: null,
+  },
+});
+
+const renderCard = () =>
+  render(
+    <DiscreetModeProvider>
+      <ForecastCard />
+    </DiscreetModeProvider>,
+  );
+
+describe("ForecastCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(profileService.getMe).mockResolvedValue(buildMe());
+    vi.mocked(forecastService.getCurrent).mockResolvedValue(buildForecast());
+    vi.mocked(forecastService.recompute).mockResolvedValue(buildForecast());
+  });
+
+  it("renderiza painel de limite bancario quando o forecast inclui uso projetado", async () => {
+    renderCard();
+
+    await waitFor(() => expect(screen.getByText("Limite bancário")).toBeInTheDocument());
+    expect(screen.getByText(/A projeção usa/)).toBeInTheDocument();
+    expect(screen.getByText(/disponível/)).toBeInTheDocument();
+    expect(screen.getByText(/22% do limite/)).toBeInTheDocument();
+  });
+
+  it("destaca quando a projeção ultrapassa o limite bancario", async () => {
+    vi.mocked(forecastService.getCurrent).mockResolvedValue(
+      buildForecast({
+        adjustedProjectedBalance: -1400,
+        bankLimit: {
+          total: 1000,
+          used: 1000,
+          remaining: 0,
+          exceededBy: 400,
+          usagePct: 100,
+          status: "exceeded",
+          alertTriggered: true,
+        },
+      }),
+    );
+
+    renderCard();
+
+    await waitFor(() =>
+      expect(screen.getByText(/A projeção ultrapassa o limite/)).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/100% do limite/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/ForecastCard.tsx
+++ b/apps/web/src/components/ForecastCard.tsx
@@ -46,6 +46,48 @@ const FlipBanner = ({ direction }: { direction: "pos_to_neg" | "neg_to_pos" }) =
   );
 };
 
+const BankLimitPanel = ({ forecast, money }: { forecast: Forecast; money: (value: unknown) => string }) => {
+  const bankLimit = forecast.bankLimit;
+  if (!bankLimit) return null;
+
+  const statusTone =
+    bankLimit.status === "exceeded"
+      ? "border-red-200 bg-red-50 text-red-700"
+      : bankLimit.alertTriggered
+        ? "border-amber-200 bg-amber-50 text-amber-700"
+        : "border-cf-border bg-cf-bg-subtle text-cf-text-secondary";
+
+  const headline =
+    bankLimit.status === "exceeded"
+      ? `A projeção ultrapassa o limite em ${money(bankLimit.exceededBy)}.`
+      : bankLimit.status === "using"
+        ? `A projeção usa ${money(bankLimit.used)} do limite da conta.`
+        : "A projeção do mês não entra no limite da conta.";
+
+  return (
+    <div className={`mt-3 rounded border px-3 py-2.5 ${statusTone}`}>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-medium uppercase">Limite bancário</p>
+          <p className="mt-1 text-sm font-semibold">{headline}</p>
+          <p className="mt-0.5 text-xs">
+            Total {money(bankLimit.total)} · disponível {money(bankLimit.remaining)}
+          </p>
+        </div>
+        <div className="text-right">
+          <p className="text-xs font-medium uppercase">Uso projetado</p>
+          <p className="mt-1 text-base font-semibold">
+            {money(bankLimit.used)}
+          </p>
+          <p className="mt-0.5 text-xs">
+            {bankLimit.usagePct.toFixed(0)}% do limite
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
 const ForecastCard = ({
   onOpenProfileSettings,
   trialExpired = false,
@@ -279,6 +321,8 @@ const ForecastCard = ({
           {forecast.flipDetected && forecast.flipDirection ? (
             <FlipBanner direction={forecast.flipDirection} />
           ) : null}
+
+          <BankLimitPanel forecast={forecast} money={money} />
         </>
       ) : null}
     </div>

--- a/apps/web/src/pages/ProfileSettings.test.tsx
+++ b/apps/web/src/pages/ProfileSettings.test.tsx
@@ -23,6 +23,7 @@ const buildMe = (overrides = {}) => ({
   profile: {
     displayName: "Jr Valerio",
     salaryMonthly: 5000,
+    bankLimitTotal: null,
     payday: 5,
     avatarUrl: null,
     taxpayerCpf: null,
@@ -49,6 +50,7 @@ describe("ProfileSettings — Dados da conta", () => {
     vi.mocked(profileService.updateProfile).mockResolvedValue({
       displayName: "Jr Valerio",
       salaryMonthly: 5000,
+      bankLimitTotal: null,
       payday: 5,
       avatarUrl: null,
       taxpayerCpf: null,
@@ -113,6 +115,7 @@ describe("ProfileSettings — Dados da conta", () => {
         profile: {
           displayName: "Jr Valerio",
           salaryMonthly: 5000,
+          bankLimitTotal: null,
           payday: 5,
           avatarUrl: null,
           taxpayerCpf: "52998224725",
@@ -133,6 +136,38 @@ describe("ProfileSettings — Dados da conta", () => {
     await waitFor(() =>
       expect(profileService.updateProfile).toHaveBeenCalledWith(
         expect.objectContaining({ taxpayer_cpf: "529.982.247-25" }),
+      ),
+    );
+  });
+
+  it("loads and submits bank limit with the profile", async () => {
+    const user = userEvent.setup();
+    vi.mocked(profileService.getMe).mockResolvedValue(
+      buildMe({
+        profile: {
+          displayName: "Jr Valerio",
+          salaryMonthly: 5000,
+          bankLimitTotal: 850,
+          payday: 5,
+          avatarUrl: null,
+          taxpayerCpf: null,
+        },
+      }),
+    );
+
+    renderPage();
+    await waitFor(() => expect(screen.getByLabelText("Limite bancário (R$)")).toBeInTheDocument());
+
+    const bankLimitInput = screen.getByLabelText("Limite bancário (R$)");
+    expect(bankLimitInput).toHaveValue(850);
+
+    await user.clear(bankLimitInput);
+    await user.type(bankLimitInput, "1200");
+    await user.click(screen.getByRole("button", { name: "Salvar perfil" }));
+
+    await waitFor(() =>
+      expect(profileService.updateProfile).toHaveBeenCalledWith(
+        expect.objectContaining({ bank_limit_total: 1200 }),
       ),
     );
   });
@@ -178,6 +213,7 @@ describe("ProfileSettings — Preferências (Copiloto)", () => {
     vi.mocked(profileService.updateProfile).mockResolvedValue({
       displayName: "Jr Valerio",
       salaryMonthly: 5000,
+      bankLimitTotal: null,
       payday: 5,
       avatarUrl: null,
       taxpayerCpf: null,

--- a/apps/web/src/pages/ProfileSettings.tsx
+++ b/apps/web/src/pages/ProfileSettings.tsx
@@ -79,6 +79,7 @@ const ProfileSettings = ({
   const [email, setEmail] = useState("");
   const [displayName, setDisplayName] = useState("");
   const [salaryMonthly, setSalaryMonthly] = useState("");
+  const [bankLimitTotal, setBankLimitTotal] = useState("");
   const [payday, setPayday] = useState("");
   const [avatarUrl, setAvatarUrl] = useState("");
   const [taxpayerCpf, setTaxpayerCpf] = useState("");
@@ -118,6 +119,11 @@ const ProfileSettings = ({
       setSalaryMonthly(
         p?.salaryMonthly !== null && p?.salaryMonthly !== undefined
           ? String(p.salaryMonthly)
+          : "",
+      );
+      setBankLimitTotal(
+        p?.bankLimitTotal !== null && p?.bankLimitTotal !== undefined
+          ? String(p.bankLimitTotal)
           : "",
       );
       setPayday(
@@ -161,12 +167,14 @@ const ProfileSettings = ({
     setSaveSuccess(false);
 
     const salaryNum = salaryMonthly.trim() ? Number(salaryMonthly) : null;
+    const bankLimitNum = bankLimitTotal.trim() ? Number(bankLimitTotal) : null;
     const paydayNum = payday.trim() ? Number(payday) : null;
 
     try {
       await profileService.updateProfile({
         display_name: displayName.trim() || null,
         salary_monthly: salaryNum,
+        bank_limit_total: bankLimitNum,
         payday: paydayNum,
         avatar_url: avatarUrl.trim() || null,
         taxpayer_cpf: taxpayerCpf.trim() || null,
@@ -353,7 +361,7 @@ const ProfileSettings = ({
                 </div>
 
                 {/* Salary + Payday */}
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
                   <div>
                     <label
                       htmlFor="salary_monthly"
@@ -371,6 +379,27 @@ const ProfileSettings = ({
                       placeholder="0,00"
                       className="mt-1 w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
                     />
+                  </div>
+                  <div>
+                    <label
+                      htmlFor="bank_limit_total"
+                      className="block text-sm font-semibold text-cf-text-primary"
+                    >
+                      Limite bancário (R$)
+                    </label>
+                    <input
+                      id="bank_limit_total"
+                      type="number"
+                      min="0"
+                      step="0.01"
+                      value={bankLimitTotal}
+                      onChange={(e) => setBankLimitTotal(e.target.value)}
+                      placeholder="Cheque especial"
+                      className="mt-1 w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
+                    />
+                    <p className="mt-0.5 text-xs text-cf-text-secondary">
+                      Usado para mostrar quanto da projeção do mês entraria no limite da conta.
+                    </p>
                   </div>
                   <div>
                     <label

--- a/apps/web/src/services/forecast.service.ts
+++ b/apps/web/src/services/forecast.service.ts
@@ -1,5 +1,15 @@
 import { api } from "./api";
 
+export interface ForecastBankLimit {
+  total: number;
+  used: number;
+  remaining: number;
+  exceededBy: number;
+  usagePct: number;
+  status: "unused" | "using" | "exceeded";
+  alertTriggered: boolean;
+}
+
 export interface Forecast {
   month: string;
   projectedBalance: number;
@@ -13,6 +23,7 @@ export interface Forecast {
   billsPendingTotal: number;
   billsPendingCount: number;
   adjustedProjectedBalance: number;
+  bankLimit?: ForecastBankLimit | null;
 }
 
 export const forecastService = {

--- a/apps/web/src/services/profile.service.ts
+++ b/apps/web/src/services/profile.service.ts
@@ -3,6 +3,7 @@ import { api } from "./api";
 export interface UserProfile {
   displayName: string | null;
   salaryMonthly: number | null;
+  bankLimitTotal?: number | null;
   payday: number | null;
   avatarUrl: string | null;
   taxpayerCpf?: string | null;
@@ -24,6 +25,7 @@ export interface MeResponse {
 export interface ProfileUpdatePayload {
   display_name?: string | null;
   salary_monthly?: number | null;
+  bank_limit_total?: number | null;
   payday?: number | null;
   avatar_url?: string | null;
   taxpayer_cpf?: string | null;


### PR DESCRIPTION
## Contexto

Este PR adiciona o MVP de limite bancario / cheque especial ao app.

O foco e permitir que o usuario cadastre o limite da conta no perfil e veja, no forecast do dashboard, quanto da projecao ajustada do mes entraria no limite da conta.

## O que entra

- migration com `bank_limit_total` em `user_profiles`
- round-trip de `bank_limit_total` em `GET /me` e `PATCH /me/profile`
- projecao `bankLimit` no contrato de forecast
- painel de `Limite bancario` no `ForecastCard`
- testes de API para perfil e forecast
- testes web para perfil e card de forecast

## Regra

- limite bancario configurado no perfil nao altera o saldo nem cria novo dominio financeiro
- ele apenas mostra, com base na `adjustedProjectedBalance`, se a projecao:
  - nao usa o limite
  - usa parte do limite
  - ultrapassa o limite

## Validacao

- `npm -w apps/api run lint` ✅
- `npm -w apps/api test` ✅ `726/726`
- `npm -w apps/web run lint` ✅
- `npm -w apps/web run typecheck` ✅
- `npm -w apps/web run test:run` ✅ `311/311`
- `npm -w apps/web run build` ✅

## Escopo

Somente limite bancario / cheque especial.
Sem dominio de cartao/fatura neste PR.
