### PR TITLE
docs: add final audit for importacao inteligente epic

### DIFF
--- a/docs/audits/importacao-inteligente-mvp-auditoria-final.md
+++ b/docs/audits/importacao-inteligente-mvp-auditoria-final.md
@@ -1,0 +1,154 @@
+# Auditoria Final — Épico de Importação Inteligente + Limites + Cartão
+
+> Relatório executivo final do épico já entregue em `main`.
+> Foco: separar o que foi realmente entregue no MVP dos follow-ups legítimos de pós-MVP.
+
+---
+
+## 1. Entregue
+
+O épico está **majoritariamente entregue no MVP**.
+
+Entrou em `main`:
+
+- dedupe entre comprovante de renda e crédito bancário
+- documento importado podendo compor renda
+- sugestão confirmável para atualizar perfil e planejamento
+- preview com busca e filtros para extratos grandes
+- categorização em lote com regras reaproveitáveis
+- guard rails operacionais de importação
+- limite bancário no perfil e no `forecast`
+- cartão com limite, compras abertas, fechamento manual de fatura e pagamento da fatura como saída real de caixa
+
+Leitura correta:
+
+- a fundação do domínio foi entregue
+- o MVP já tem valor real de produto
+- o que falta agora é refino pós-MVP, não base estrutural
+
+---
+
+## 2. Gaps
+
+### 2.1 Undo incompleto dos derivados
+
+O desfazer importação ainda não fecha o ciclo inteiro.
+
+Hoje:
+
+- a sessão pode ser revertida pelo histórico
+- `transactions` da sessão são revertidas
+- mas artefatos derivados como `income_statements` ou `bills` não entram automaticamente nessa mesma reversão
+
+Esse é o gap mais sério do pacote porque cria risco de inconsistência operacional.
+
+### 2.2 Documento vira renda, mas ainda mais forte para INSS
+
+O núcleo existe e está bom, mas o trilho mais maduro hoje ainda é o de INSS.
+
+O produto ainda não está igualmente maduro para:
+
+- holerite/CLT
+- outros comprovantes de renda documental
+- generalização ampla do parser documental para “renda estruturada”
+
+### 2.3 Cartão/fatura entrou como MVP manual
+
+O modelo está correto para MVP, mas ainda curto para ciclo real mais rico.
+
+Follow-ups naturais:
+
+- parcelamento
+- ciclos mais sofisticados
+- conciliação por conta pagadora
+- regras mais ricas de fechamento
+
+### 2.4 Documentação fora do git
+
+Quando o código anda e a documentação fica só local, o produto começa a mentir no papel.
+
+Esse risco não é de runtime, mas é risco real de operação e alinhamento do time.
+
+---
+
+## 3. Riscos
+
+Os riscos reais deste épico, no estado atual, são:
+
+- sensação de conciliação completa sem existir reconciliador explícito
+- inconsistência entre sessão de importação e entidades derivadas
+- edge cases de cartão/fatura ainda abertos
+- drift entre `main` e documentação local
+
+---
+
+## 4. Entregue vs planejado
+
+### PR1 — dedupe entre comprovante de renda e extrato bancário
+
+- Status: entregue no MVP
+
+### PR2 — documento importado compõe renda
+
+- Status: entregue parcial/MVP
+
+### PR3 — sugestão para perfil e planejamento
+
+- Status: entregue no MVP
+
+### PR4 — preview com busca e filtros
+
+- Status: entregue no MVP
+
+### PR5 — categorização em lote + regras
+
+- Status: entregue no MVP
+
+### PR8 — guard rails operacionais
+
+- Status: entregue parcial/MVP
+- ressalva: undo ainda não cascata para derivados
+
+### Limite bancário
+
+- Status: entregue com recorte MVP
+
+### Cartão + ciclo de fatura
+
+- Status: entregue com recorte MVP
+
+---
+
+## 5. Backlog pós-MVP
+
+### P0
+
+- fazer o undo de importação bloquear ou reverter também `income_statements` e `bills` derivados
+
+### P1
+
+- ampliar renda documental além do trilho forte de INSS
+- criar visão explícita de conciliação entre renda documental e crédito bancário
+- evoluir cartão para parcelamento e ciclo mais realista
+- fazer polish e performance do preview/import em volume alto
+
+---
+
+## 6. Veredito
+
+O épico está **entregue no que prometia como fundação de MVP**.
+
+Não há blocker estrutural.
+
+O que existe agora é um conjunto de follow-ups legítimos para:
+
+- fechar consistência operacional
+- ampliar cobertura documental
+- sofisticar o subdomínio de cartão
+- manter a documentação alinhada ao estado real do código
+
+Próximo passo correto:
+
+1. manter esta auditoria versionada no repositório
+2. usar este documento como referência para o backlog pós-MVP
+3. não reabrir a fundação já entregue como se ela ainda estivesse pendente

--- a/docs/roadmap-execution.md
+++ b/docs/roadmap-execution.md
@@ -253,12 +253,41 @@ Reusa `transactions` sem nova infra.
 
 ---
 
-## 9. Importação Inteligente de Documentos fora da trilha fiscal (roadmap — não abre agora)
+## 9. Importação Inteligente de Documentos fora da trilha fiscal (entregue no MVP)
 
-> Observação: a trilha fiscal IRPF já abriu seu subdomínio próprio em `/tax`.
-> Esta nota vale para futuras frentes documentais fora da Central do Leão.
+> Observação: a trilha fiscal IRPF abriu seu subdomínio próprio em `/tax`.
+> Em paralelo, a frente de importação inteligente evoluiu o app financeiro principal sem misturar os dois domínios.
 
-Se essa frente for aberta no futuro, deve nascer como **subdomínio próprio**, não como extensão de `transactions`.
+### Estado atual
+
+**Importação inteligente de renda e extratos** já foi entregue em `main` no recorte MVP.
+
+PRs mergeados:
+
+1. `#298` dedupe entre comprovante de renda e extrato bancário
+2. `#299` documento importado pode compor renda estruturada
+3. `#300` sugestão confirmável para perfil e planejamento
+4. `#301` preview com busca e filtros para extratos grandes
+5. `#302` categorização em lote + regras reaproveitáveis
+6. `#303` guard rails operacionais e histórico auditável de imports
+7. `#304` limite bancário / cheque especial
+8. `#305` cartão + ciclo inicial de fatura
+
+Documentos de referência:
+
+- `docs/roadmaps/importacao-inteligente-renda-extratos.md`
+- `docs/audits/importacao-inteligente-mvp-auditoria-final.md`
+
+Leitura correta do estado:
+
+- fundação do épico: entregue
+- guard rails do MVP: entregues
+- limite bancário: entregue
+- cartão e fatura: entregues no recorte inicial
+- gaps atuais: refino, reconciliação e consistência operacional de undo
+
+Essa frente não deve voltar para o backlog como “fundação pendente”.
+Os próximos passos devem nascer como **follow-ups pós-MVP**, não como repetição da trilha já mergeada.
 
 ### Domínios prováveis
 

--- a/docs/roadmaps/importacao-inteligente-renda-extratos.md
+++ b/docs/roadmaps/importacao-inteligente-renda-extratos.md
@@ -1,0 +1,188 @@
+# Importação Inteligente de Renda e Extratos
+
+> Documento interno de execução do épico pós-IRPF.
+> Status atual: **entregue em `main` no recorte MVP**, com follow-ups pós-MVP ainda abertos.
+
+---
+
+## 1. Objetivo do épico
+
+Transformar importações bancárias e comprovantes de renda em dados financeiros utilizáveis pelo produto:
+
+- sem duplicidade entre comprovante de renda e crédito no extrato
+- sem contaminar `forecast` e perfil sem confirmação humana
+- sem reduzir `PIX` a uma categoria simplista
+- sem misturar compra em cartão com saída imediata de caixa
+
+---
+
+## 2. Estado consolidado
+
+PRs mergeados:
+
+1. `#298` dedupe entre comprovante de renda e extrato bancário
+2. `#299` documentos de renda podem compor renda estruturada
+3. `#300` sugestão assistida para perfil e planejamento
+4. `#301` busca e filtros no preview de importação
+5. `#302` categorização em lote + regras recorrentes
+6. `#303` guard rails operacionais / undo / histórico auditável
+7. `#304` limite bancário
+8. `#305` cartão + ciclo inicial de fatura
+
+Resumo executivo:
+
+- a fundação da importação inteligente foi entregue
+- o preview pesado já é revisável
+- renda documental já conversa com perfil e planejamento
+- limites e cartão já abriram o subdomínio financeiro correspondente
+- o que sobra agora é backlog pós-MVP, não base estrutural
+
+Auditoria final deste épico:
+
+- `docs/audits/importacao-inteligente-mvp-auditoria-final.md`
+
+---
+
+## 3. Base de código usada no épico
+
+Esta frente não nasceu do zero. O ponto de partida real do repositório foi:
+
+- importação bancária com preview em `ImportCsvModal`
+- fluxo de renda estruturada com `income_sources` e `income_statements`
+- planejamento mensal já apoiado em `forecast`
+- perfil salarial/beneficiário já existente
+
+Arquivos de referência:
+
+- `apps/web/src/components/ImportCsvModal.jsx`
+- `apps/web/src/components/IncomeStatementQuickModal.tsx`
+- `apps/web/src/pages/IncomeSourcesPage.tsx`
+- `apps/api/src/services/transactions-import.service.js`
+- `apps/api/src/services/income-sources.service.js`
+- `apps/api/src/services/forecast.service.js`
+- `apps/api/src/services/salary-profile.service.js`
+- `apps/api/src/services/credit-cards.service.js`
+
+---
+
+## 4. Entrega por etapa
+
+### PR1 — dedupe entre comprovante de renda e extrato bancário
+
+- Status: entregue no MVP
+- Título: `feat(import): add income import dedupe foundation`
+
+O que entrou:
+
+- fingerprint estável por item importado
+- status de preview `valid | duplicate | invalid | conflict`
+- vínculo entre crédito bancário e evento de renda estruturado
+- motivo de duplicidade visível no preview
+
+### PR2 — documentos de renda viram renda estruturada
+
+- Status: entregue parcial/MVP
+- Título: `feat(income): allow imported income documents to compose monthly income`
+
+O que entrou:
+
+- promoção de documento importado para renda estruturada
+- vínculo com transação existente quando disponível
+- lançamento de entrada quando não há transação compatível
+- preservação de bruto, descontos e líquido no histórico
+
+### PR3 — sugestão para perfil e planejamento
+
+- Status: entregue no MVP
+- Título: `feat(profile): suggest income updates from structured imports`
+
+O que entrou:
+
+- sugestão confirmável de atualização de renda principal
+- sugestão de valor líquido e dia provável
+- `forecast` usando só renda confirmada
+- fluxo `aceitar | ignorar | revisar depois`
+
+### PR4 — preview de importação com busca e filtros
+
+- Status: entregue no MVP
+- Título: `feat(import): add searchable import preview for large statements`
+
+O que entrou:
+
+- busca textual
+- filtro por status
+- filtro por descrição e categoria
+- revisão estável para extratos grandes
+
+### PR5 — categorização em lote e regras simples
+
+- Status: entregue no MVP
+- Título: `feat(import): add bulk categorization and import rules`
+
+O que entrou:
+
+- categoria em massa
+- regra simples baseada em descrição
+- reaproveitamento em imports futuros
+
+### PR8 — guard rails operacionais
+
+- Status: entregue parcial/MVP
+- Título: `feat(import): add import safety rails and rollback UX`
+
+O que entrou:
+
+- histórico auditável por sessão
+- confirmação antes do undo
+- estado revertido no histórico
+- resumo mais claro no pós-import
+
+### PR6 — limite bancário / cheque especial
+
+- Status: entregue com recorte MVP
+- Título: `feat(finance): add bank limit tracking`
+
+O que entrou:
+
+- `bank_limit_total` no perfil
+- cálculo de uso atual do limite
+- visão de risco no `forecast`
+
+### PR7 — limite de cartão e ciclo de fatura
+
+- Status: entregue com recorte MVP
+- Título: `feat(cards): add credit card limits and bill lifecycle`
+
+O que entrou:
+
+- cadastro de cartão
+- limite total / usado / disponível
+- compras abertas fora do caixa imediato
+- fechamento manual de fatura
+- pagamento da fatura como saída real de caixa
+
+---
+
+## 5. Guard rails fixados
+
+- nada de atualizar perfil automaticamente
+- nada de jogar renda documental no `forecast` sem confirmação
+- `PIX` continua meio de pagamento, não categoria
+- compra no cartão não é saída imediata de caixa
+- importação grande precisa continuar reversível e auditável
+
+---
+
+## 6. Próxima leitura correta
+
+Este épico **não está mais em construção**.
+
+O backlog correto a partir daqui é:
+
+- consistência operacional do undo
+- conciliação mais explícita entre renda documental e crédito bancário
+- ampliação do trilho documental além do caso mais forte de INSS
+- evolução do domínio de cartão para casos mais ricos
+
+Esses itens devem ser tratados como **pós-MVP**, não como reabertura da fundação já entregue.


### PR DESCRIPTION
## Contexto

Este PR fecha o risco documental do épico de importação inteligente.

O código do MVP já estava entregue em main, mas o roadmap atualizado e a auditoria final ainda estavam fora do repositório. Este slice materializa essa narrativa no git para evitar drift entre produto entregue e documentação oficial.

## O que entra

- atualização de docs/roadmap-execution.md com o estado real do épico
- docs/roadmaps/importacao-inteligente-renda-extratos.md como registro versionado da trilha entregue
- docs/audits/importacao-inteligente-mvp-auditoria-final.md com o relatório executivo final

## Escopo

Somente documentação.
Sem mudança de runtime.
Sem mudança de contrato de API.
Sem impacto funcional.

## Nota

Não rodei testes novamente porque este PR é docs-only.