### PR TITLE
feat(income): add explicit reconciliation between statements and bank credits

### DIFF
--- a/apps/api/src/income-sources.test.js
+++ b/apps/api/src/income-sources.test.js
@@ -695,6 +695,126 @@ describe("income-sources", () => {
     expectErrorResponseWithRequestId(res, 409, "Extrato ja foi lancado.");
   });
 
+  it("GET /income-sources/:id/statements retorna candidato de conciliacao para credito importado compativel", async () => {
+    const email = "inss-reconcile-candidate@test.dev";
+    const token = await registerAndLogin(email);
+
+    const srcRes = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Pensao INSS" });
+    const sourceId = srcRes.body.id;
+
+    await request(app)
+      .post(`/income-sources/${sourceId}/statements`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        referenceMonth: "2026-02",
+        netAmount: 1412,
+        paymentDate: "2026-02-25",
+        sourceImportSessionId: "income-doc-session-1",
+      });
+
+    await dbQuery(
+      `INSERT INTO transactions (
+         user_id, type, value, date, description, import_session_id, import_document_type
+       )
+       VALUES ((SELECT id FROM users WHERE email = $1), $2, $3, $4, $5, $6, $7)`,
+      [email, "Entrada", 1412, "2026-02-25", "Credito INSS", "bank-session-1", "bank_statement"],
+    );
+
+    const res = await request(app)
+      .get(`/income-sources/${sourceId}/statements`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.statements[0]).toMatchObject({
+      referenceMonth: "2026-02",
+      reconciliation: {
+        status: "candidate",
+        candidates: [
+          expect.objectContaining({
+            description: "Credito INSS",
+            importSessionId: "bank-session-1",
+          }),
+        ],
+      },
+    });
+  });
+
+  it("GET /income-sources/:id/statements distingue conciliado de lancamento manual", async () => {
+    const email = "inss-reconcile-linked@test.dev";
+    const token = await registerAndLogin(email);
+
+    const srcRes = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Pensao INSS" });
+    const sourceId = srcRes.body.id;
+
+    const importedStatementRes = await request(app)
+      .post(`/income-sources/${sourceId}/statements`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        referenceMonth: "2026-02",
+        netAmount: 1412,
+        paymentDate: "2026-02-25",
+      });
+
+    const manualStatementRes = await request(app)
+      .post(`/income-sources/${sourceId}/statements`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        referenceMonth: "2026-03",
+        netAmount: 1500,
+        paymentDate: "2026-03-25",
+      });
+
+    const { rows: importedTxRows } = await dbQuery(
+      `INSERT INTO transactions (
+         user_id, type, value, date, description, import_session_id, import_document_type
+       )
+       VALUES ((SELECT id FROM users WHERE email = $1), $2, $3, $4, $5, $6, $7)
+       RETURNING id`,
+      [email, "Entrada", 1412, "2026-02-25", "Credito INSS", "bank-session-2", "bank_statement"],
+    );
+
+    const { rows: manualTxRows } = await dbQuery(
+      `INSERT INTO transactions (user_id, type, value, date, description)
+       VALUES ((SELECT id FROM users WHERE email = $1), $2, $3, $4, $5)
+       RETURNING id`,
+      [email, "Entrada", 1500, "2026-03-25", "Entrada manual"],
+    );
+
+    await request(app)
+      .post(`/income-sources/statements/${importedStatementRes.body.statement.id}/link-transaction`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionId: Number(importedTxRows[0].id) });
+
+    await request(app)
+      .post(`/income-sources/statements/${manualStatementRes.body.statement.id}/link-transaction`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionId: Number(manualTxRows[0].id) });
+
+    const res = await request(app)
+      .get(`/income-sources/${sourceId}/statements`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.statements).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          referenceMonth: "2026-02",
+          reconciliation: expect.objectContaining({ status: "reconciled" }),
+        }),
+        expect.objectContaining({
+          referenceMonth: "2026-03",
+          reconciliation: expect.objectContaining({ status: "manual_entry" }),
+        }),
+      ]),
+    );
+  });
+
   // ─── Link statement to transaction ───────────────────────────────────────────
 
   const setupStatementAndTransaction = async (email, opts = {}) => {

--- a/apps/api/src/services/income-sources.service.js
+++ b/apps/api/src/services/income-sources.service.js
@@ -232,6 +232,230 @@ const mapTransactionRow = (row) => ({
   categoryId: row.category_id != null ? Number(row.category_id) : null,
 });
 
+const mapReconciliationTransactionRow = (row) => ({
+  id: Number(row.id),
+  type: String(row.type),
+  value: toMoney(row.value),
+  date: toISODate(row.date),
+  description: row.description != null ? String(row.description) : null,
+  importSessionId: row.import_session_id != null ? String(row.import_session_id) : null,
+  importDocumentType:
+    row.import_document_type != null ? String(row.import_document_type) : null,
+  deletedAt: row.deleted_at != null ? toISODateTime(row.deleted_at) : null,
+});
+
+const mapStatementWithReconciliationRow = (row, reconciliation = null) => ({
+  ...mapStatementRow(row),
+  reconciliation,
+});
+
+const addDaysToISODate = (value, days) => {
+  const date = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) return value;
+  date.setUTCDate(date.getUTCDate() + days);
+  return toISODate(date);
+};
+
+const getImportedTransactionWindowForStatements = (statementRows = []) => {
+  const paymentDates = statementRows
+    .map((row) => (row.payment_date != null ? toISODate(row.payment_date) : null))
+    .filter(Boolean);
+
+  if (paymentDates.length === 0) {
+    return null;
+  }
+
+  const sortedDates = [...paymentDates].sort();
+  return {
+    from: addDaysToISODate(sortedDates[0], -LINK_DATE_TOLERANCE_DAYS),
+    to: addDaysToISODate(sortedDates[sortedDates.length - 1], LINK_DATE_TOLERANCE_DAYS),
+  };
+};
+
+const buildStatementCandidateMatch = (statementRow, transactionRow) => {
+  if (!statementRow || !transactionRow || statementRow.payment_date == null) {
+    return null;
+  }
+
+  const paymentDate = toISODate(statementRow.payment_date);
+  const transactionDate = toISODate(transactionRow.date);
+  const dateDiffDays = Math.abs(
+    new Date(`${paymentDate}T00:00:00Z`).getTime() -
+      new Date(`${transactionDate}T00:00:00Z`).getTime(),
+  ) / (1000 * 60 * 60 * 24);
+
+  if (dateDiffDays > LINK_DATE_TOLERANCE_DAYS) {
+    return null;
+  }
+
+  const statementAmount = toMoney(statementRow.net_amount);
+  const transactionAmount = toMoney(transactionRow.value);
+
+  if (statementAmount <= 0) {
+    return null;
+  }
+
+  const amountDiff = Math.abs(statementAmount - transactionAmount);
+  const amountDiffRatio = amountDiff / statementAmount;
+
+  if (amountDiffRatio > LINK_AMOUNT_TOLERANCE) {
+    return null;
+  }
+
+  return {
+    transaction: transactionRow,
+    dateDiffDays,
+    amountDiff,
+  };
+};
+
+const buildStatementReconciliation = ({
+  statementRow,
+  linkedTransactionRow,
+  importedTransactionRows = [],
+}) => {
+  const linkedTransaction = linkedTransactionRow
+    ? mapReconciliationTransactionRow(linkedTransactionRow)
+    : null;
+
+  const candidates = statementRow.payment_date != null
+    ? importedTransactionRows
+        .filter((transactionRow) => Number(transactionRow.id) !== Number(statementRow.posted_transaction_id))
+        .map((transactionRow) => buildStatementCandidateMatch(statementRow, transactionRow))
+        .filter(Boolean)
+        .sort((leftMatch, rightMatch) => {
+          if (leftMatch.dateDiffDays !== rightMatch.dateDiffDays) {
+            return leftMatch.dateDiffDays - rightMatch.dateDiffDays;
+          }
+          return leftMatch.amountDiff - rightMatch.amountDiff;
+        })
+        .map((match) => mapReconciliationTransactionRow(match.transaction))
+    : [];
+
+  if (linkedTransactionRow) {
+    if (linkedTransactionRow.deleted_at != null) {
+      return {
+        status: "pending",
+        summary: "A entrada vinculada foi removida. Revise a conciliacao deste extrato.",
+        linkedTransaction,
+        candidates,
+      };
+    }
+
+    if (linkedTransaction.importSessionId) {
+      return {
+        status: "reconciled",
+        summary: "Credito bancario conciliado com este extrato.",
+        linkedTransaction,
+        candidates: [],
+      };
+    }
+
+    return {
+      status: "manual_entry",
+      summary: "Extrato lancado como entrada manual no app.",
+      linkedTransaction,
+      candidates: [],
+    };
+  }
+
+  if (statementRow.payment_date == null) {
+    return {
+      status: "pending",
+      summary: "Defina a data de pagamento para buscar credito bancario compativel.",
+      linkedTransaction: null,
+      candidates: [],
+    };
+  }
+
+  if (candidates.length === 1) {
+    return {
+      status: "candidate",
+      summary: "1 credito bancario compativel encontrado para conciliacao.",
+      linkedTransaction: null,
+      candidates,
+    };
+  }
+
+  if (candidates.length > 1) {
+    return {
+      status: "conflict",
+      summary: `${candidates.length} creditos bancarios compativeis encontrados para conciliacao.`,
+      linkedTransaction: null,
+      candidates,
+    };
+  }
+
+  return {
+    status: "pending",
+    summary: "Nenhum credito bancario compativel encontrado ate agora.",
+    linkedTransaction: null,
+    candidates: [],
+  };
+};
+
+const decorateStatementsWithReconciliation = async (userId, statementRows = []) => {
+  if (!Array.isArray(statementRows) || statementRows.length === 0) {
+    return [];
+  }
+
+  const linkedTransactionIds = [...new Set(
+    statementRows
+      .map((row) => Number(row.posted_transaction_id))
+      .filter((value) => Number.isInteger(value) && value > 0),
+  )];
+
+  const transactionWindow = getImportedTransactionWindowForStatements(
+    statementRows.filter((row) => row.posted_transaction_id == null),
+  );
+  const linkedTransactionPlaceholders = linkedTransactionIds
+    .map((_, index) => `$${index + 2}`)
+    .join(", ");
+
+  const [linkedTransactionsResult, importedTransactionsResult] = await Promise.all([
+    linkedTransactionIds.length > 0
+      ? dbQuery(
+          `SELECT id, type, value, date, description, import_session_id, import_document_type, deleted_at
+             FROM transactions
+            WHERE user_id = $1
+              AND id IN (${linkedTransactionPlaceholders})`,
+          [userId, ...linkedTransactionIds],
+        )
+      : Promise.resolve({ rows: [] }),
+    transactionWindow
+      ? dbQuery(
+          `SELECT id, type, value, date, description, import_session_id, import_document_type, deleted_at
+             FROM transactions
+            WHERE user_id = $1
+              AND deleted_at IS NULL
+              AND type = $2
+              AND import_session_id IS NOT NULL
+              AND date BETWEEN $3 AND $4
+            ORDER BY date DESC, id DESC`,
+          [userId, TRANSACTION_TYPE_ENTRY, transactionWindow.from, transactionWindow.to],
+        )
+      : Promise.resolve({ rows: [] }),
+  ]);
+
+  const linkedTransactionsById = new Map(
+    linkedTransactionsResult.rows.map((row) => [Number(row.id), row]),
+  );
+
+  return statementRows.map((row) =>
+    mapStatementWithReconciliationRow(
+      row,
+      buildStatementReconciliation({
+        statementRow: row,
+        linkedTransactionRow:
+          row.posted_transaction_id != null
+            ? linkedTransactionsById.get(Number(row.posted_transaction_id)) ?? null
+            : null,
+        importedTransactionRows: importedTransactionsResult.rows,
+      }),
+    ),
+  );
+};
+
 // ─── Income Sources ────────────────────────────────────────────────────────────
 
 export const createIncomeSourceForUser = async (userId, payload) => {
@@ -530,8 +754,10 @@ export const getStatementWithDeductions = async (userId, statementId) => {
     ),
   ]);
 
+  const [statementWithReconciliation] = await decorateStatementsWithReconciliation(uid, stmtRows);
+
   return {
-    statement: mapStatementRow(stmtRows[0]),
+    statement: statementWithReconciliation,
     deductions: dedRows.map(mapStatementDeductionRow),
   };
 };
@@ -751,5 +977,5 @@ export const listStatementsForSource = async (userId, sourceId) => {
     [sid],
   );
 
-  return rows.map(mapStatementRow);
+  return decorateStatementsWithReconciliation(uid, rows);
 };

--- a/apps/web/src/components/IncomeStatementQuickModal.test.tsx
+++ b/apps/web/src/components/IncomeStatementQuickModal.test.tsx
@@ -43,6 +43,7 @@ const mockStatement = {
   status: "draft" as const,
   postedTransactionId: null,
   sourceImportSessionId: null,
+  reconciliation: null,
   createdAt: "2026-02-25T00:00:00Z",
   updatedAt: "2026-02-25T00:00:00Z",
 };

--- a/apps/web/src/pages/IncomeSourcesPage.test.tsx
+++ b/apps/web/src/pages/IncomeSourcesPage.test.tsx
@@ -6,6 +6,7 @@ import IncomeSourcesPage from "./IncomeSourcesPage";
 import {
   incomeSourcesService,
   type IncomeDeduction,
+  type IncomeStatement,
   type IncomeSourceWithDeductions,
   type IncomeStatementWithDeductions,
   type PostStatementResult,
@@ -26,6 +27,7 @@ vi.mock("../services/incomeSources.service", () => ({
     createStatement: vi.fn(),
     updateStatement: vi.fn(),
     postStatement: vi.fn(),
+    linkTransaction: vi.fn(),
     listStatements: vi.fn(),
   },
 }));
@@ -76,6 +78,7 @@ const buildStatementResult = (): IncomeStatementWithDeductions => ({
     status: "draft",
     postedTransactionId: null,
     sourceImportSessionId: null,
+    reconciliation: null,
     createdAt: "2026-02-23T00:00:00.000Z",
     updatedAt: "2026-02-23T00:00:00.000Z",
   },
@@ -97,6 +100,7 @@ const buildPostResult = (): PostStatementResult => ({
     status: "posted",
     postedTransactionId: 99,
     sourceImportSessionId: null,
+    reconciliation: null,
     createdAt: "2026-02-23T00:00:00.000Z",
     updatedAt: "2026-02-23T00:00:00.000Z",
   },
@@ -108,6 +112,40 @@ const buildPostResult = (): PostStatementResult => ({
     description: "Pensao INSS – 2026-02",
     categoryId: null,
   },
+});
+
+const buildListedStatement = (overrides: Partial<IncomeStatement> = {}): IncomeStatement => ({
+  id: 10,
+  incomeSourceId: 1,
+  referenceMonth: "2026-02",
+  netAmount: 2803.52,
+  totalDeductions: 300,
+  grossAmount: null,
+  details: null,
+  paymentDate: "2026-02-23",
+  status: "draft",
+  postedTransactionId: null,
+  sourceImportSessionId: "import-session-1",
+  reconciliation: {
+    status: "candidate",
+    summary: "1 credito bancario compativel encontrado para conciliacao.",
+    linkedTransaction: null,
+    candidates: [
+      {
+        id: 501,
+        type: "Entrada",
+        value: 2803.52,
+        date: "2026-02-23",
+        description: "Credito INSS",
+        importSessionId: "bank-import-1",
+        importDocumentType: "bank_statement",
+        deletedAt: null,
+      },
+    ],
+  },
+  createdAt: "2026-02-23T00:00:00.000Z",
+  updatedAt: "2026-02-23T00:00:00.000Z",
+  ...overrides,
 });
 
 // ─── Render helper ────────────────────────────────────────────────────────────
@@ -125,6 +163,7 @@ describe("IncomeSourcesPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(incomeSourcesService.list).mockResolvedValue([buildSource()]);
+    vi.mocked(incomeSourcesService.listStatements).mockResolvedValue([]);
     vi.mocked(categoriesService.listCategories).mockResolvedValue([]);
   });
 
@@ -213,6 +252,46 @@ describe("IncomeSourcesPage", () => {
 
     await waitFor(() => {
       expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+  });
+
+  it("exibe conciliacao explicita e permite vincular credito bancario compativel", async () => {
+    const user = userEvent.setup();
+    vi.mocked(incomeSourcesService.listStatements).mockResolvedValueOnce([
+      buildListedStatement(),
+    ]).mockResolvedValue([]);
+    vi.mocked(incomeSourcesService.linkTransaction).mockResolvedValue(
+      buildListedStatement({
+        postedTransactionId: 501,
+        status: "posted",
+        reconciliation: {
+          status: "reconciled",
+          summary: "Credito bancario conciliado com este extrato.",
+          linkedTransaction: {
+            id: 501,
+            type: "Entrada",
+            value: 2803.52,
+            date: "2026-02-23",
+            description: "Credito INSS",
+            importSessionId: "bank-import-1",
+            importDocumentType: "bank_statement",
+            deletedAt: null,
+          },
+          candidates: [],
+        },
+      }),
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/1 credito bancario compativel encontrado/i)).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /vincular crédito de 2026-02-23/i }));
+
+    await waitFor(() => {
+      expect(incomeSourcesService.linkTransaction).toHaveBeenCalledWith(10, 501);
     });
   });
 

--- a/apps/web/src/pages/IncomeSourcesPage.tsx
+++ b/apps/web/src/pages/IncomeSourcesPage.tsx
@@ -6,7 +6,9 @@ import { categoriesService } from "../services/categories.service";
 import {
   incomeSourcesService,
   type IncomeDeduction,
+  type IncomeStatementReconciliation,
   type IncomeSourceWithDeductions,
+  type IncomeStatement,
   type PostStatementResult,
 } from "../services/incomeSources.service";
 import { formatCurrency } from "../utils/formatCurrency";
@@ -21,14 +23,47 @@ interface IncomeSourcesPageProps {
   onBack?: () => void;
 }
 
+const getReconciliationBadge = (status: IncomeStatementReconciliation["status"]) => {
+  switch (status) {
+    case "reconciled":
+      return {
+        label: "Conciliado",
+        className: "border-green-200 bg-green-50 text-green-700",
+      };
+    case "manual_entry":
+      return {
+        label: "Lancado no app",
+        className: "border-blue-200 bg-blue-50 text-blue-700",
+      };
+    case "candidate":
+      return {
+        label: "Conciliar",
+        className: "border-amber-200 bg-amber-50 text-amber-700",
+      };
+    case "conflict":
+      return {
+        label: "Conflito",
+        className: "border-red-200 bg-red-50 text-red-700",
+      };
+    default:
+      return {
+        label: "Pendente",
+        className: "border-cf-border bg-cf-bg-subtle text-cf-text-secondary",
+      };
+  }
+};
+
 const IncomeSourcesPage = ({
   onBack = undefined,
 }: IncomeSourcesPageProps): JSX.Element => {
   const [sources, setSources] = useState<IncomeSourceWithDeductions[]>([]);
+  const [statementsBySource, setStatementsBySource] = useState<Record<number, IncomeStatement[]>>({});
   const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingStatements, setIsLoadingStatements] = useState(false);
   const [pageError, setPageError] = useState("");
   const [successMessage, setSuccessMessage] = useState("");
   const [categories, setCategories] = useState<CategoryOption[]>([]);
+  const [linkingStatementId, setLinkingStatementId] = useState<number | null>(null);
 
   // Source modal state
   const [isSourceModalOpen, setIsSourceModalOpen] = useState(false);
@@ -53,18 +88,51 @@ const IncomeSourcesPage = ({
 
   // ─── Data loading ─────────────────────────────────────────────────────────────
 
-  const loadSources = useCallback(async () => {
+  const loadStatementsForSources = useCallback(async (sourceList: IncomeSourceWithDeductions[]) => {
+    if (sourceList.length === 0) {
+      setStatementsBySource({});
+      return;
+    }
+
+    setIsLoadingStatements(true);
+    try {
+      const statementLists = await Promise.all(
+        sourceList.map(async (source) => ({
+          sourceId: source.id,
+          statements: await incomeSourcesService.listStatements(source.id),
+        })),
+      );
+
+      setStatementsBySource(
+        statementLists.reduce<Record<number, IncomeStatement[]>>((acc, item) => {
+          acc[item.sourceId] = item.statements;
+          return acc;
+        }, {}),
+      );
+    } catch (error) {
+      setStatementsBySource({});
+      setPageError((current) =>
+        current || getApiErrorMessage(error, "Não foi possível carregar o histórico de renda."),
+      );
+    } finally {
+      setIsLoadingStatements(false);
+    }
+  }, []);
+
+  const reloadIncomeData = useCallback(async () => {
     setIsLoading(true);
     try {
       const data = await incomeSourcesService.list();
       setSources(data);
+      await loadStatementsForSources(data);
     } catch (error) {
       setSources([]);
+      setStatementsBySource({});
       setPageError(getApiErrorMessage(error, "Não foi possível carregar as fontes de renda."));
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [loadStatementsForSources]);
 
   const loadCategories = useCallback(async () => {
     try {
@@ -76,9 +144,9 @@ const IncomeSourcesPage = ({
   }, []);
 
   useEffect(() => {
-    void loadSources();
+    void reloadIncomeData();
     void loadCategories();
-  }, [loadSources, loadCategories]);
+  }, [reloadIncomeData, loadCategories]);
 
   // ─── Success helper ────────────────────────────────────────────────────────────
 
@@ -108,7 +176,7 @@ const IncomeSourcesPage = ({
   const handleSourceSaved = () => {
     closeSourceModal();
     showSuccess(editingSource ? "Fonte atualizada." : "Fonte criada.");
-    void loadSources();
+    void reloadIncomeData();
   };
 
   // ─── Deduction modal ──────────────────────────────────────────────────────────
@@ -131,7 +199,7 @@ const IncomeSourcesPage = ({
   const handleDeductionSaved = () => {
     closeDeductionModal();
     showSuccess(deductionContext?.deduction ? "Desconto atualizado." : "Desconto adicionado.");
-    void loadSources();
+    void reloadIncomeData();
   };
 
   // ─── Delete deduction ─────────────────────────────────────────────────────────
@@ -142,7 +210,7 @@ const IncomeSourcesPage = ({
     try {
       await incomeSourcesService.removeDeduction(deductionId);
       showSuccess("Desconto removido.");
-      void loadSources();
+      void reloadIncomeData();
     } catch (error) {
       setPageError(getApiErrorMessage(error, "Não foi possível remover o desconto."));
     }
@@ -156,7 +224,7 @@ const IncomeSourcesPage = ({
     try {
       await incomeSourcesService.remove(sourceId);
       showSuccess("Fonte removida.");
-      void loadSources();
+      void reloadIncomeData();
     } catch (error) {
       setPageError(getApiErrorMessage(error, "Não foi possível remover a fonte."));
     }
@@ -177,7 +245,7 @@ const IncomeSourcesPage = ({
   const handleDraftSaved = () => {
     closeStatementModal();
     showSuccess("Rascunho salvo.");
-    void loadSources();
+    void reloadIncomeData();
   };
 
   const handlePosted = (result: PostStatementResult) => {
@@ -185,7 +253,21 @@ const IncomeSourcesPage = ({
     showSuccess(
       `Entrada lancada: ${formatCurrency(result.transaction.value)} — ${result.transaction.description ?? ""}`,
     );
-    void loadSources();
+    void reloadIncomeData();
+  };
+
+  const handleLinkCandidate = async (statementId: number, transactionId: number) => {
+    setLinkingStatementId(statementId);
+    setPageError("");
+    try {
+      await incomeSourcesService.linkTransaction(statementId, transactionId);
+      showSuccess("Credito bancario conciliado com sucesso.");
+      await reloadIncomeData();
+    } catch (error) {
+      setPageError(getApiErrorMessage(error, "Não foi possível conciliar o crédito bancário."));
+    } finally {
+      setLinkingStatementId(null);
+    }
   };
 
   // ─── Render ────────────────────────────────────────────────────────────────────
@@ -375,6 +457,97 @@ const IncomeSourcesPage = ({
                   ) : (
                     <p className="mt-1 text-xs text-cf-text-secondary">
                       Nenhum desconto cadastrado.
+                    </p>
+                  )}
+                </div>
+
+                <div className="mt-4">
+                  <div className="flex items-center justify-between">
+                    <p className="text-xs font-semibold uppercase text-cf-text-secondary">
+                      Extratos recentes ({(statementsBySource[source.id] ?? []).length})
+                    </p>
+                    {isLoadingStatements ? (
+                      <span className="text-xs text-cf-text-secondary">Atualizando...</span>
+                    ) : null}
+                  </div>
+
+                  {(statementsBySource[source.id] ?? []).length > 0 ? (
+                    <div className="mt-2 space-y-2">
+                      {(statementsBySource[source.id] ?? []).slice(0, 3).map((statement) => {
+                        const reconciliation = statement.reconciliation;
+                        const badge = getReconciliationBadge(reconciliation?.status ?? "pending");
+
+                        return (
+                          <div
+                            key={statement.id}
+                            className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-3"
+                          >
+                            <div className="flex flex-wrap items-start justify-between gap-2">
+                              <div>
+                                <p className="text-sm font-semibold text-cf-text-primary">
+                                  Competência {statement.referenceMonth}
+                                </p>
+                                <p className="text-xs text-cf-text-secondary">
+                                  Líquido {formatCurrency(statement.netAmount)}
+                                  {statement.paymentDate ? ` · Pago em ${statement.paymentDate}` : ""}
+                                </p>
+                              </div>
+                              <span
+                                className={`rounded border px-2 py-0.5 text-xs font-semibold ${badge.className}`}
+                              >
+                                {badge.label}
+                              </span>
+                            </div>
+
+                            {reconciliation ? (
+                              <div className="mt-2 space-y-2">
+                                <p className="text-xs text-cf-text-secondary">
+                                  {reconciliation.summary}
+                                </p>
+
+                                {reconciliation.linkedTransaction ? (
+                                  <div className="rounded border border-cf-border bg-cf-surface px-2 py-2 text-xs text-cf-text-secondary">
+                                    <p className="font-medium text-cf-text-primary">
+                                      {reconciliation.linkedTransaction.importSessionId
+                                        ? "Crédito conciliado"
+                                        : "Entrada vinculada"}
+                                    </p>
+                                    <p>
+                                      {formatCurrency(reconciliation.linkedTransaction.value)} em{" "}
+                                      {reconciliation.linkedTransaction.date}
+                                      {reconciliation.linkedTransaction.description
+                                        ? ` · ${reconciliation.linkedTransaction.description}`
+                                        : ""}
+                                    </p>
+                                  </div>
+                                ) : null}
+
+                                {(reconciliation.status === "candidate" ||
+                                  reconciliation.status === "conflict") &&
+                                reconciliation.candidates.length > 0 ? (
+                                  <div className="space-y-1">
+                                    {reconciliation.candidates.slice(0, 3).map((candidate) => (
+                                      <button
+                                        key={candidate.id}
+                                        type="button"
+                                        onClick={() => void handleLinkCandidate(statement.id, candidate.id)}
+                                        disabled={linkingStatementId === statement.id}
+                                        className="w-full rounded border border-brand-1 px-2 py-1.5 text-left text-xs font-semibold text-brand-1 hover:bg-brand-1/10 disabled:cursor-not-allowed disabled:opacity-60"
+                                      >
+                                        Vincular crédito de {candidate.date} · {formatCurrency(candidate.value)}
+                                      </button>
+                                    ))}
+                                  </div>
+                                ) : null}
+                              </div>
+                            ) : null}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  ) : (
+                    <p className="mt-1 text-xs text-cf-text-secondary">
+                      Nenhum extrato registrado para esta fonte ainda.
                     </p>
                   )}
                 </div>

--- a/apps/web/src/services/incomeSources.service.ts
+++ b/apps/web/src/services/incomeSources.service.ts
@@ -44,8 +44,27 @@ export interface IncomeStatement {
   status: "draft" | "posted";
   postedTransactionId: number | null;
   sourceImportSessionId: string | null;
+  reconciliation: IncomeStatementReconciliation | null;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface IncomeStatementReconciliationTransaction {
+  id: number;
+  type: string;
+  value: number;
+  date: string;
+  description: string | null;
+  importSessionId: string | null;
+  importDocumentType: string | null;
+  deletedAt: string | null;
+}
+
+export interface IncomeStatementReconciliation {
+  status: "reconciled" | "manual_entry" | "candidate" | "conflict" | "pending";
+  summary: string;
+  linkedTransaction: IncomeStatementReconciliationTransaction | null;
+  candidates: IncomeStatementReconciliationTransaction[];
 }
 
 export interface IncomeSourceWithDeductions extends IncomeSource {
@@ -140,8 +159,27 @@ interface RawStatement {
   status?: unknown;
   postedTransactionId?: unknown;
   sourceImportSessionId?: unknown;
+  reconciliation?: unknown;
   createdAt?: unknown;
   updatedAt?: unknown;
+}
+
+interface RawStatementReconciliationTransaction {
+  id?: unknown;
+  type?: unknown;
+  value?: unknown;
+  date?: unknown;
+  description?: unknown;
+  importSessionId?: unknown;
+  importDocumentType?: unknown;
+  deletedAt?: unknown;
+}
+
+interface RawStatementReconciliation {
+  status?: unknown;
+  summary?: unknown;
+  linkedTransaction?: unknown;
+  candidates?: unknown;
 }
 
 // ─── Normalization ─────────────────────────────────────────────────────────────
@@ -196,9 +234,56 @@ const normalizeStatement = (raw: RawStatement): IncomeStatement => ({
   status: raw.status === "posted" ? "posted" : "draft",
   postedTransactionId: normalizeIntOrNull(raw.postedTransactionId),
   sourceImportSessionId: normalizeStringOrNull(raw.sourceImportSessionId),
+  reconciliation: normalizeStatementReconciliation(raw.reconciliation),
   createdAt: normalizeISOString(raw.createdAt),
   updatedAt: normalizeISOString(raw.updatedAt),
 });
+
+const normalizeStatementReconciliationTransaction = (
+  raw: RawStatementReconciliationTransaction,
+): IncomeStatementReconciliationTransaction => ({
+  id: Number(raw.id) || 0,
+  type: typeof raw.type === "string" ? raw.type : "",
+  value: Number(raw.value) || 0,
+  date: normalizeISOString(raw.date),
+  description: normalizeStringOrNull(raw.description),
+  importSessionId: normalizeStringOrNull(raw.importSessionId),
+  importDocumentType: normalizeStringOrNull(raw.importDocumentType),
+  deletedAt: normalizeStringOrNull(raw.deletedAt),
+});
+
+const normalizeStatementReconciliation = (
+  raw: unknown,
+): IncomeStatementReconciliation | null => {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return null;
+  }
+
+  const parsed = raw as RawStatementReconciliation;
+  const normalizedStatus = String(parsed.status || "").trim();
+
+  return {
+    status:
+      normalizedStatus === "reconciled" ||
+      normalizedStatus === "manual_entry" ||
+      normalizedStatus === "candidate" ||
+      normalizedStatus === "conflict"
+        ? (normalizedStatus as IncomeStatementReconciliation["status"])
+        : "pending",
+    summary: typeof parsed.summary === "string" ? parsed.summary : "",
+    linkedTransaction:
+      parsed.linkedTransaction && typeof parsed.linkedTransaction === "object"
+        ? normalizeStatementReconciliationTransaction(
+            parsed.linkedTransaction as RawStatementReconciliationTransaction,
+          )
+        : null,
+    candidates: Array.isArray(parsed.candidates)
+      ? (parsed.candidates as RawStatementReconciliationTransaction[]).map(
+          normalizeStatementReconciliationTransaction,
+        )
+      : [],
+  };
+};
 
 const normalizeSource = (raw: RawSource): IncomeSourceWithDeductions => {
   const deductions = Array.isArray(raw.deductions)


### PR DESCRIPTION
## Contexto

Este PR torna explicita a conciliacao entre extratos de renda e creditos bancarios importados.

Hoje o produto ja evita duplicidade e permite promover documento para renda, mas a ligacao entre extrato documental e credito do banco ainda ficava implicita. O objetivo aqui e expor esse estado com clareza para o usuario.

## O que entra

- reconciliacao explicita nos statements de renda
- status econciled, manual_entry, candidate, conflict e pending
- retorno de credito vinculado e candidatos compativeis na API
- UI na pagina de fontes de renda mostrando resumo, badge e acoes de vinculacao
- acao direta para vincular credito bancario compativel
- testes de API e web cobrindo candidato, conciliado e lancamento manual

## Regra

- statement com credito importado vinculado aparece como conciliado
- statement com entrada manual vinculada aparece como lancado no app
- statement sem vinculo passa a mostrar candidato, conflito ou pendencia conforme credito bancario compativel
- a conciliacao continua deterministica, baseada em valor, data e origem importada

## Validação

- 
pm -w apps/api run lint ✅
- 
pm -w apps/api test ✅ 739/739
- 
pm -w apps/web run lint ✅
- 
pm -w apps/web run typecheck ✅
- 
pm -w apps/web run test:run ✅ 318/318
- 
pm -w apps/web run build ✅

## Fora de escopo

- reconciliador financeiro completo
- cascata de undo para derivados
- expansao documental alem do trilho atual mais forte
