### PR TITLE
feat(cards): add installment purchases to credit cards

### DIFF
--- a/apps/api/src/credit-cards.test.js
+++ b/apps/api/src/credit-cards.test.js
@@ -119,6 +119,9 @@ describe("credit cards", () => {
       status: "open",
       billId: null,
       statementMonth: null,
+      installmentGroupId: null,
+      installmentNumber: null,
+      installmentCount: null,
     });
 
     const listRes = await request(app)
@@ -144,6 +147,70 @@ describe("credit cards", () => {
     );
 
     expect(Number(txCountResult.rows[0].total)).toBe(0);
+  });
+
+  it("POST /credit-cards/:id/installments cria compra parcelada mensal sem distorcer o uso do limite", async () => {
+    const token = await registerAndLogin("credit-cards-installments@test.dev");
+
+    const createCardRes = await request(app)
+      .post("/credit-cards")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        name: "Nubank",
+        limitTotal: 2000,
+        closingDay: 10,
+        dueDay: 20,
+      });
+
+    const installmentsRes = await request(app)
+      .post(`/credit-cards/${createCardRes.body.id}/installments`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        title: "Notebook",
+        amount: 300,
+        purchaseDate: "2026-03-05",
+        installmentCount: 3,
+      });
+
+    expect(installmentsRes.status).toBe(201);
+    expect(installmentsRes.body).toMatchObject({
+      installmentCount: 3,
+      totalAmount: 300,
+    });
+    expect(installmentsRes.body.purchases).toHaveLength(3);
+    expect(installmentsRes.body.purchases[0]).toMatchObject({
+      title: "Notebook",
+      amount: 100,
+      purchaseDate: "2026-03-05",
+      installmentNumber: 1,
+      installmentCount: 3,
+    });
+    expect(installmentsRes.body.purchases[1]).toMatchObject({
+      purchaseDate: "2026-04-05",
+      installmentNumber: 2,
+      installmentCount: 3,
+    });
+    expect(installmentsRes.body.purchases[2]).toMatchObject({
+      purchaseDate: "2026-05-05",
+      installmentNumber: 3,
+      installmentCount: 3,
+    });
+
+    const listRes = await request(app)
+      .get("/credit-cards")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(listRes.status).toBe(200);
+    expect(listRes.body.items[0]).toMatchObject({
+      openPurchasesCount: 3,
+      openPurchasesTotal: 300,
+      usage: {
+        total: 2000,
+        used: 300,
+        available: 1700,
+        status: "using",
+      },
+    });
   });
 
   it("POST /credit-cards/:id/close-invoice bloqueia fechamento antes do dia configurado", async () => {
@@ -279,6 +346,75 @@ describe("credit cards", () => {
     expect(Number(txCountResult.rows[0].total)).toBe(1);
   });
 
+  it("fecha apenas a parcela elegivel do ciclo e preserva as proximas abertas", async () => {
+    const token = await registerAndLogin("credit-cards-installment-cycle@test.dev");
+
+    const createCardRes = await request(app)
+      .post("/credit-cards")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        name: "Visa",
+        limitTotal: 1200,
+        closingDay: 10,
+        dueDay: 20,
+      });
+    const cardId = createCardRes.body.id;
+
+    await request(app)
+      .post(`/credit-cards/${cardId}/installments`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        title: "Celular",
+        amount: 300,
+        purchaseDate: "2026-03-05",
+        installmentCount: 3,
+      });
+
+    const firstCloseRes = await request(app)
+      .post(`/credit-cards/${cardId}/close-invoice`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ closingDate: "2026-03-15" });
+
+    expect(firstCloseRes.status).toBe(200);
+    expect(firstCloseRes.body).toMatchObject({
+      purchasesCount: 1,
+      total: 100,
+      invoice: {
+        amount: 100,
+        referenceMonth: "2026-03",
+      },
+    });
+
+    const afterFirstCloseRes = await request(app)
+      .get("/credit-cards")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(afterFirstCloseRes.body.items[0]).toMatchObject({
+      openPurchasesCount: 2,
+      openPurchasesTotal: 200,
+      pendingInvoicesCount: 1,
+      pendingInvoicesTotal: 100,
+      usage: {
+        used: 300,
+        available: 900,
+      },
+    });
+    expect(afterFirstCloseRes.body.items[0].openPurchases).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          installmentNumber: 2,
+          installmentCount: 3,
+          purchaseDate: "2026-04-05",
+        }),
+        expect.objectContaining({
+          installmentNumber: 3,
+          installmentCount: 3,
+          purchaseDate: "2026-05-05",
+        }),
+      ]),
+    );
+  });
+
   it("DELETE /credit-cards/purchases/:purchaseId bloqueia compra que ja entrou em fatura fechada", async () => {
     const token = await registerAndLogin("credit-cards-delete-billed@test.dev");
 
@@ -311,5 +447,50 @@ describe("credit cards", () => {
       .set("Authorization", `Bearer ${token}`);
 
     expectErrorResponseWithRequestId(deleteRes, 409, "Compra ja entrou em fatura fechada e nao pode ser excluida.");
+  });
+
+  it("DELETE /credit-cards/purchases/:purchaseId exclui grupo parcelado inteiro enquanto tudo estiver aberto", async () => {
+    const token = await registerAndLogin("credit-cards-delete-installments@test.dev");
+
+    const createCardRes = await request(app)
+      .post("/credit-cards")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        name: "Inter",
+        limitTotal: 900,
+        closingDay: 8,
+        dueDay: 18,
+      });
+
+    const installmentsRes = await request(app)
+      .post(`/credit-cards/${createCardRes.body.id}/installments`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        title: "Curso",
+        amount: 180,
+        purchaseDate: "2026-03-03",
+        installmentCount: 3,
+      });
+
+    const deleteRes = await request(app)
+      .delete(`/credit-cards/purchases/${installmentsRes.body.purchases[0].id}`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(deleteRes.status).toBe(204);
+
+    const listRes = await request(app)
+      .get("/credit-cards")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(listRes.status).toBe(200);
+    expect(listRes.body.items[0]).toMatchObject({
+      openPurchasesCount: 0,
+      openPurchasesTotal: 0,
+      usage: {
+        used: 0,
+        available: 900,
+        status: "unused",
+      },
+    });
   });
 });

--- a/apps/api/src/db/migrations/042_add_installments_to_credit_card_purchases.sql
+++ b/apps/api/src/db/migrations/042_add_installments_to_credit_card_purchases.sql
@@ -1,0 +1,16 @@
+ALTER TABLE credit_card_purchases
+  ADD COLUMN IF NOT EXISTS installment_group_id TEXT;
+
+ALTER TABLE credit_card_purchases
+  ADD COLUMN IF NOT EXISTS installment_number INTEGER
+  CHECK (installment_number IS NULL OR installment_number >= 1);
+
+ALTER TABLE credit_card_purchases
+  ADD COLUMN IF NOT EXISTS installment_count INTEGER
+  CHECK (
+    installment_count IS NULL
+    OR (installment_count >= 2 AND installment_count <= 24)
+  );
+
+CREATE INDEX IF NOT EXISTS idx_credit_card_purchases_installment_group
+  ON credit_card_purchases (user_id, installment_group_id);

--- a/apps/api/src/routes/credit-cards.routes.js
+++ b/apps/api/src/routes/credit-cards.routes.js
@@ -6,6 +6,7 @@ import {
   createCreditCardForUser,
   updateCreditCardForUser,
   createCreditCardPurchaseForUser,
+  createCreditCardInstallmentsForUser,
   deleteCreditCardPurchaseForUser,
   closeCreditCardInvoiceForUser,
 } from "../services/credit-cards.service.js";
@@ -45,6 +46,19 @@ router.post("/:id/purchases", creditCardsWriteRateLimiter, async (req, res, next
   try {
     const purchase = await createCreditCardPurchaseForUser(req.user.id, req.params.id, req.body || {});
     res.status(201).json(purchase);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post("/:id/installments", creditCardsWriteRateLimiter, async (req, res, next) => {
+  try {
+    const result = await createCreditCardInstallmentsForUser(
+      req.user.id,
+      req.params.id,
+      req.body || {},
+    );
+    res.status(201).json(result);
   } catch (error) {
     next(error);
   }

--- a/apps/api/src/services/credit-cards.service.js
+++ b/apps/api/src/services/credit-cards.service.js
@@ -2,6 +2,8 @@ import { dbQuery, withDbTransaction } from "../db/index.js";
 
 const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 const CREDIT_CARD_INVOICE_BILL_TYPE = "credit_card_invoice";
+const MIN_INSTALLMENT_COUNT = 2;
+const MAX_INSTALLMENT_COUNT = 24;
 
 const createError = (status, message) => {
   const error = new Error(message);
@@ -82,6 +84,22 @@ const normalizePurchaseDate = (value) => {
   return value;
 };
 
+const normalizeInstallmentCount = (value, { required = false } = {}) => {
+  if (value === undefined || value === null || value === "") {
+    if (required) {
+      throw createError(400, "Informe entre 2 e 24 parcelas.");
+    }
+    return 1;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < MIN_INSTALLMENT_COUNT || parsed > MAX_INSTALLMENT_COUNT) {
+    throw createError(400, "Informe entre 2 e 24 parcelas.");
+  }
+
+  return parsed;
+};
+
 const normalizeOptionalText = (value, fieldName) => {
   if (value === undefined) return undefined;
   if (value === null || value === "") return null;
@@ -117,6 +135,32 @@ const clampDateDay = (year, monthIndex, day) => {
   const clampedDay = Math.min(day, lastDay);
   return `${year}-${String(monthIndex + 1).padStart(2, "0")}-${String(clampedDay).padStart(2, "0")}`;
 };
+
+const addMonthsClamped = (isoDate, n) => {
+  const [yearPart, monthPart, dayPart] = isoDate.split("-").map(Number);
+  const targetYear = yearPart + Math.floor((monthPart - 1 + n) / 12);
+  const targetMonth = ((monthPart - 1 + n) % 12) + 1;
+  const lastDay = new Date(Date.UTC(targetYear, targetMonth, 0)).getUTCDate();
+  const clampedDay = Math.min(dayPart, lastDay);
+  return [
+    targetYear,
+    String(targetMonth).padStart(2, "0"),
+    String(clampedDay).padStart(2, "0"),
+  ].join("-");
+};
+
+const splitInstallmentAmounts = (totalAmount, installmentCount) => {
+  const totalCents = Math.round(normalizeAmount(totalAmount, "Valor da compra") * 100);
+  const baseAmountCents = Math.floor(totalCents / installmentCount);
+  const remainder = totalCents % installmentCount;
+
+  return Array.from({ length: installmentCount }, (_, index) =>
+    Number(((baseAmountCents + (index < remainder ? 1 : 0)) / 100).toFixed(2)),
+  );
+};
+
+const buildInstallmentGroupId = (userId, cardId) =>
+  `cc_install_${userId}_${cardId}_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
 
 const resolveNextDueDate = (closingDate, dueDay) => {
   const [yearPart, monthPart, dayPart] = closingDate.split("-").map(Number);
@@ -154,6 +198,11 @@ const mapPurchaseRow = (row) => ({
   purchaseDate: toISODateOnly(row.purchase_date),
   status: row.status,
   statementMonth: row.statement_month || null,
+  installmentGroupId: row.installment_group_id || null,
+  installmentNumber:
+    row.installment_number != null ? Number(row.installment_number) : null,
+  installmentCount:
+    row.installment_count != null ? Number(row.installment_count) : null,
   notes: row.notes || null,
   createdAt: toISODateTime(row.created_at),
   updatedAt: toISODateTime(row.updated_at),
@@ -372,13 +421,77 @@ export const createCreditCardPurchaseForUser = async (userId, cardId, payload = 
     }
 
     const result = await client.query(
-      `INSERT INTO credit_card_purchases (user_id, credit_card_id, title, amount, purchase_date, notes)
+      `INSERT INTO credit_card_purchases (
+         user_id,
+         credit_card_id,
+         title,
+         amount,
+         purchase_date,
+         notes
+       )
        VALUES ($1, $2, $3, $4, $5, $6)
        RETURNING *`,
       [normalizedUserId, normalizedCardId, title, amount, purchaseDate, notes ?? null],
     );
 
     return mapPurchaseRow(result.rows[0]);
+  });
+};
+
+export const createCreditCardInstallmentsForUser = async (userId, cardId, payload = {}) => {
+  const normalizedUserId = normalizeUserId(userId);
+  const normalizedCardId = normalizeCardId(cardId);
+  const title = normalizeName(payload.title);
+  const totalAmount = normalizeAmount(payload.amount, "Valor da compra");
+  const purchaseDate = normalizePurchaseDate(payload.purchaseDate);
+  const notes = normalizeOptionalText(payload.notes, "Notas");
+  const installmentCount = normalizeInstallmentCount(payload.installmentCount, { required: true });
+  const installmentAmounts = splitInstallmentAmounts(totalAmount, installmentCount);
+  const installmentGroupId = buildInstallmentGroupId(normalizedUserId, normalizedCardId);
+
+  return withDbTransaction(async (client) => {
+    const card = await getCardForUserOrThrow(client, normalizedUserId, normalizedCardId);
+
+    if (!card.is_active) {
+      throw createError(409, "Cartao inativo. Reative antes de lancar compras.");
+    }
+
+    const purchases = [];
+    for (let index = 0; index < installmentCount; index += 1) {
+      const result = await client.query(
+        `INSERT INTO credit_card_purchases (
+           user_id,
+           credit_card_id,
+           title,
+           amount,
+           purchase_date,
+           notes,
+           installment_group_id,
+           installment_number,
+           installment_count
+         )
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+         RETURNING *`,
+        [
+          normalizedUserId,
+          normalizedCardId,
+          title,
+          installmentAmounts[index],
+          addMonthsClamped(purchaseDate, index),
+          notes ?? null,
+          installmentGroupId,
+          index + 1,
+          installmentCount,
+        ],
+      );
+      purchases.push(mapPurchaseRow(result.rows[0]));
+    }
+
+    return {
+      purchases,
+      installmentCount,
+      totalAmount,
+    };
   });
 };
 
@@ -399,6 +512,37 @@ export const deleteCreditCardPurchaseForUser = async (userId, purchaseId) => {
     }
 
     const purchase = result.rows[0];
+
+    if (purchase.installment_group_id) {
+      const groupResult = await client.query(
+        `SELECT id, status
+           FROM credit_card_purchases
+          WHERE user_id = $1
+            AND installment_group_id = $2
+          ORDER BY installment_number ASC, id ASC`,
+        [normalizedUserId, purchase.installment_group_id],
+      );
+
+      const hasBilledInstallment = groupResult.rows.some((row) => row.status !== "open");
+      if (hasBilledInstallment) {
+        throw createError(
+          409,
+          "Compra parcelada ja entrou em fatura fechada e nao pode ser excluida por completo.",
+        );
+      }
+
+      await client.query(
+        `DELETE FROM credit_card_purchases
+          WHERE user_id = $1
+            AND installment_group_id = $2`,
+        [normalizedUserId, purchase.installment_group_id],
+      );
+
+      return {
+        id: normalizedPurchaseId,
+        deletedCount: groupResult.rows.length,
+      };
+    }
 
     if (purchase.status !== "open") {
       throw createError(409, "Compra ja entrou em fatura fechada e nao pode ser excluida.");

--- a/apps/web/src/components/CreditCardPurchaseModal.tsx
+++ b/apps/web/src/components/CreditCardPurchaseModal.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from "react";
 import { getTodayISODate, isValidISODate, parseCurrencyInput } from "./DatabaseUtils";
 
+const MIN_INSTALLMENT_COUNT = 2;
+const MAX_INSTALLMENT_COUNT = 24;
+
 interface CreditCardPurchaseModalProps {
   isOpen: boolean;
   cardName: string;
@@ -10,6 +13,7 @@ interface CreditCardPurchaseModalProps {
     amount: number;
     purchaseDate: string;
     notes: string | null;
+    installmentCount?: number;
   }) => Promise<void> | void;
 }
 
@@ -23,6 +27,8 @@ const CreditCardPurchaseModal = ({
   const [amount, setAmount] = useState("");
   const [purchaseDate, setPurchaseDate] = useState(getTodayISODate());
   const [notes, setNotes] = useState("");
+  const [isInstallment, setIsInstallment] = useState(false);
+  const [installmentCount, setInstallmentCount] = useState(String(MIN_INSTALLMENT_COUNT));
   const [isSaving, setIsSaving] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
 
@@ -32,6 +38,8 @@ const CreditCardPurchaseModal = ({
     setAmount("");
     setPurchaseDate(getTodayISODate());
     setNotes("");
+    setIsInstallment(false);
+    setInstallmentCount(String(MIN_INSTALLMENT_COUNT));
     setIsSaving(false);
     setErrorMessage("");
   }, [isOpen]);
@@ -68,6 +76,22 @@ const CreditCardPurchaseModal = ({
       return;
     }
 
+    let normalizedInstallmentCount: number | undefined;
+    if (isInstallment) {
+      normalizedInstallmentCount = Math.max(
+        MIN_INSTALLMENT_COUNT,
+        Math.min(MAX_INSTALLMENT_COUNT, parseInt(installmentCount, 10) || MIN_INSTALLMENT_COUNT),
+      );
+      if (
+        !Number.isInteger(normalizedInstallmentCount)
+        || normalizedInstallmentCount < MIN_INSTALLMENT_COUNT
+        || normalizedInstallmentCount > MAX_INSTALLMENT_COUNT
+      ) {
+        setErrorMessage("Informe entre 2 e 24 parcelas.");
+        return;
+      }
+    }
+
     setIsSaving(true);
     try {
       await onSave({
@@ -75,6 +99,7 @@ const CreditCardPurchaseModal = ({
         amount: parsedAmount,
         purchaseDate,
         notes: notes.trim() || null,
+        installmentCount: normalizedInstallmentCount,
       });
     } catch (error) {
       const err = error as { response?: { data?: { message?: string } }; message?: string };
@@ -169,6 +194,44 @@ const CreditCardPurchaseModal = ({
             />
           </div>
 
+          <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-3">
+            <label className="flex items-center gap-2 text-sm font-medium text-cf-text-primary">
+              <input
+                type="checkbox"
+                checked={isInstallment}
+                onChange={(event) => setIsInstallment(event.target.checked)}
+                disabled={isSaving}
+              />
+              Parcelar esta compra
+            </label>
+
+            {isInstallment ? (
+              <div className="mt-3 flex flex-col gap-1.5">
+                <label
+                  htmlFor="credit-card-purchase-installment-count"
+                  className="text-sm font-medium text-cf-text-primary"
+                >
+                  Parcelas
+                </label>
+                <div className="flex items-center gap-2">
+                  <input
+                    id="credit-card-purchase-installment-count"
+                    type="number"
+                    min={MIN_INSTALLMENT_COUNT}
+                    max={MAX_INSTALLMENT_COUNT}
+                    value={installmentCount}
+                    onChange={(event) => setInstallmentCount(event.target.value)}
+                    className="w-20 rounded border border-cf-border-input bg-cf-surface px-3 py-2 text-sm text-cf-text-primary"
+                    disabled={isSaving}
+                  />
+                  <span className="text-xs text-cf-text-secondary">
+                    As parcelas futuras entram nos próximos fechamentos mensais.
+                  </span>
+                </div>
+              </div>
+            ) : null}
+          </div>
+
           {errorMessage ? (
             <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700" role="alert">
               {errorMessage}
@@ -189,7 +252,11 @@ const CreditCardPurchaseModal = ({
               className="rounded bg-brand-1 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-2 disabled:opacity-60"
               disabled={isSaving}
             >
-              {isSaving ? "Salvando..." : "Adicionar compra"}
+              {isSaving
+                ? "Salvando..."
+                : isInstallment
+                  ? `Adicionar em ${parseInt(installmentCount, 10) || MIN_INSTALLMENT_COUNT}x`
+                  : "Adicionar compra"}
             </button>
           </div>
         </form>

--- a/apps/web/src/pages/CreditCardsPage.test.tsx
+++ b/apps/web/src/pages/CreditCardsPage.test.tsx
@@ -17,6 +17,7 @@ vi.mock("../services/credit-cards.service", () => ({
     create: vi.fn(),
     update: vi.fn(),
     createPurchase: vi.fn(),
+    createInstallments: vi.fn(),
     removePurchase: vi.fn(),
     closeInvoice: vi.fn(),
   },
@@ -38,6 +39,9 @@ const buildOpenPurchase = (): CreditCardPurchase => ({
   purchaseDate: "2026-03-15",
   status: "open",
   statementMonth: null,
+  installmentGroupId: null,
+  installmentNumber: null,
+  installmentCount: null,
   notes: null,
   createdAt: "2026-03-15T10:00:00.000Z",
   updatedAt: "2026-03-15T10:00:00.000Z",
@@ -95,6 +99,39 @@ describe("CreditCardsPage", () => {
     vi.mocked(creditCardsService.create).mockResolvedValue(buildCard());
     vi.mocked(creditCardsService.update).mockResolvedValue(buildCard());
     vi.mocked(creditCardsService.createPurchase).mockResolvedValue(buildOpenPurchase());
+    vi.mocked(creditCardsService.createInstallments).mockResolvedValue({
+      purchases: [
+        {
+          ...buildOpenPurchase(),
+          id: 21,
+          amount: 60,
+          purchaseDate: "2026-03-15",
+          installmentGroupId: "grp_1",
+          installmentNumber: 1,
+          installmentCount: 3,
+        },
+        {
+          ...buildOpenPurchase(),
+          id: 22,
+          amount: 60,
+          purchaseDate: "2026-04-15",
+          installmentGroupId: "grp_1",
+          installmentNumber: 2,
+          installmentCount: 3,
+        },
+        {
+          ...buildOpenPurchase(),
+          id: 23,
+          amount: 60,
+          purchaseDate: "2026-05-15",
+          installmentGroupId: "grp_1",
+          installmentNumber: 3,
+          installmentCount: 3,
+        },
+      ],
+      installmentCount: 3,
+      totalAmount: 180,
+    });
     vi.mocked(creditCardsService.removePurchase).mockResolvedValue(undefined);
     vi.mocked(creditCardsService.closeInvoice).mockResolvedValue({
       invoice: buildInvoice(),
@@ -164,6 +201,32 @@ describe("CreditCardsPage", () => {
         expect.objectContaining({
           title: "Farmácia",
           amount: 89.9,
+        }),
+      );
+    });
+  });
+
+  it("adiciona compra parcelada no cartão", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await screen.findByText("Nubank");
+    await user.click(screen.getByRole("button", { name: "Nova compra" }));
+    await user.type(screen.getByLabelText("Descrição"), "Curso");
+    await user.type(screen.getByLabelText("Valor"), "180,00");
+    await user.click(screen.getByLabelText("Parcelar esta compra"));
+    const countInput = screen.getByRole("spinbutton", { name: "Parcelas" });
+    await user.clear(countInput);
+    await user.type(countInput, "3");
+    await user.click(screen.getByRole("button", { name: "Adicionar em 3x" }));
+
+    await waitFor(() => {
+      expect(creditCardsService.createInstallments).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({
+          title: "Curso",
+          amount: 180,
+          installmentCount: 3,
         }),
       );
     });

--- a/apps/web/src/pages/CreditCardsPage.tsx
+++ b/apps/web/src/pages/CreditCardsPage.tsx
@@ -84,12 +84,23 @@ const CreditCardsPage = ({
     amount: number;
     purchaseDate: string;
     notes: string | null;
+    installmentCount?: number;
   }) => {
     if (!purchaseCard) return;
 
     try {
-      await creditCardsService.createPurchase(purchaseCard.id, payload);
-      showSuccess("Compra adicionada ao cartão.");
+      if ((payload.installmentCount ?? 1) > 1) {
+        const result = await creditCardsService.createInstallments(purchaseCard.id, {
+          ...payload,
+          installmentCount: payload.installmentCount ?? 2,
+        });
+        showSuccess(
+          `Compra parcelada adicionada em ${result.installmentCount}x, total de ${formatCurrency(result.totalAmount)}.`,
+        );
+      } else {
+        await creditCardsService.createPurchase(purchaseCard.id, payload);
+        showSuccess("Compra adicionada ao cartão.");
+      }
       setPurchaseCard(null);
       await loadCards();
     } catch (error) {
@@ -272,6 +283,9 @@ const CreditCardsPage = ({
                                 <p className="text-sm font-medium text-cf-text-primary">{purchase.title}</p>
                                 <p className="text-xs text-cf-text-secondary">
                                   {formatDate(purchase.purchaseDate)}
+                                  {purchase.installmentCount && purchase.installmentNumber
+                                    ? ` · Parcela ${purchase.installmentNumber}/${purchase.installmentCount}`
+                                    : ""}
                                   {purchase.notes ? ` · ${purchase.notes}` : ""}
                                 </p>
                               </div>

--- a/apps/web/src/services/credit-cards.service.ts
+++ b/apps/web/src/services/credit-cards.service.ts
@@ -19,6 +19,9 @@ export interface CreditCardPurchase {
   purchaseDate: string;
   status: "open" | "billed";
   statementMonth: string | null;
+  installmentGroupId: string | null;
+  installmentNumber: number | null;
+  installmentCount: number | null;
   notes: string | null;
   createdAt: string;
   updatedAt: string;
@@ -73,6 +76,13 @@ export interface CreateCreditCardPurchasePayload {
   amount: number;
   purchaseDate: string;
   notes?: string | null;
+  installmentCount?: number;
+}
+
+export interface CreateCreditCardInstallmentsResult {
+  purchases: CreditCardPurchase[];
+  installmentCount: number;
+  totalAmount: number;
 }
 
 export interface CloseInvoiceResult {
@@ -112,6 +122,17 @@ const normalizePurchase = (payload: Record<string, unknown>): CreditCardPurchase
   purchaseDate: normalizeString(payload.purchaseDate ?? payload.purchase_date),
   status: payload.status === "billed" ? "billed" : "open",
   statementMonth: normalizeStringOrNull(payload.statementMonth ?? payload.statement_month),
+  installmentGroupId: normalizeStringOrNull(
+    payload.installmentGroupId ?? payload.installment_group_id,
+  ),
+  installmentNumber:
+    payload.installmentNumber != null || payload.installment_number != null
+      ? Number(payload.installmentNumber ?? payload.installment_number) || 0
+      : null,
+  installmentCount:
+    payload.installmentCount != null || payload.installment_count != null
+      ? Number(payload.installmentCount ?? payload.installment_count) || 0
+      : null,
   notes: normalizeStringOrNull(payload.notes),
   createdAt: normalizeString(payload.createdAt ?? payload.created_at),
   updatedAt: normalizeString(payload.updatedAt ?? payload.updated_at),
@@ -178,6 +199,25 @@ export const creditCardsService = {
   ): Promise<CreditCardPurchase> => {
     const { data } = await api.post(`/credit-cards/${cardId}/purchases`, payload);
     return normalizePurchase(data as Record<string, unknown>);
+  },
+
+  createInstallments: async (
+    cardId: number,
+    payload: CreateCreditCardPurchasePayload & { installmentCount: number },
+  ): Promise<CreateCreditCardInstallmentsResult> => {
+    const { data } = await api.post(`/credit-cards/${cardId}/installments`, payload);
+    const raw = data as {
+      purchases?: Record<string, unknown>[];
+      installmentCount?: unknown;
+      totalAmount?: unknown;
+    };
+    return {
+      purchases: Array.isArray(raw.purchases)
+        ? raw.purchases.map((item) => normalizePurchase(item))
+        : [],
+      installmentCount: Number(raw.installmentCount) || 0,
+      totalAmount: Number(raw.totalAmount) || 0,
+    };
   },
 
   removePurchase: async (purchaseId: number): Promise<void> => {


### PR DESCRIPTION
## Contexto

Este PR evolui o modulo de cartoes para um caso de uso mais real: compras parceladas sem misturar compra com pagamento da fatura.

O MVP atual ja cobria cartao, limite, compras abertas e fechamento manual de fatura. O proximo passo natural era suportar parcelamento simples com comportamento deterministico.

## O que entra

- suporte a compras parceladas no backend e no modal do cartao
- parcelas mensais deterministicas a partir da data da compra
- metadata por parcela (installment_group_id, installment_number, installment_count)
- fechamento de fatura considerando apenas a parcela elegivel do ciclo
- exclusao de compra parcelada removendo o grupo inteiro enquanto tudo estiver aberto
- exibicao de parcela X/Y na lista de compras do cartao
- migration 