### PR TITLE
feat(import): improve large statement preview performance

### DIFF
--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { transactionsService } from "../services/transactions.service";
 import { profileService } from "../services/profile.service";
@@ -9,6 +9,8 @@ import { getApiErrorMessage } from "../utils/apiError";
 import BillModal from "./BillModal";
 import IncomeStatementQuickModal from "./IncomeStatementQuickModal";
 import ConfirmDialog from "./ConfirmDialog";
+
+const PREVIEW_PAGE_SIZE = 100;
 
 const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory = undefined }) => {
   const fileInputRef = useRef(null);
@@ -47,10 +49,12 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory
   const [previewStatusFilter, setPreviewStatusFilter] = useState("all");
   const [previewTypeFilter, setPreviewTypeFilter] = useState("all");
   const [previewCategoryFilter, setPreviewCategoryFilter] = useState("all");
+  const [previewVisibleCount, setPreviewVisibleCount] = useState(PREVIEW_PAGE_SIZE);
   const [importRules, setImportRules] = useState([]);
   const [isSavingImportRule, setIsSavingImportRule] = useState(false);
   const [deletingImportRuleId, setDeletingImportRuleId] = useState(null);
   const [ruleFeedback, setRuleFeedback] = useState(null);
+  const deferredPreviewSearch = useDeferredValue(previewSearch);
 
   useEffect(() => {
     if (isOpen) {
@@ -84,6 +88,7 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory
     setPreviewStatusFilter("all");
     setPreviewTypeFilter("all");
     setPreviewCategoryFilter("all");
+    setPreviewVisibleCount(PREVIEW_PAGE_SIZE);
     setImportRules([]);
     setIsSavingImportRule(false);
     setDeletingImportRuleId(null);
@@ -289,7 +294,7 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory
 
   const filteredPreviewRows = useMemo(() => {
     const rows = dryRunResult?.rows ?? [];
-    const normalizedSearch = previewSearch.trim().toLowerCase();
+    const normalizedSearch = deferredPreviewSearch.trim().toLowerCase();
 
     return rows.filter((row) => {
       if (previewStatusFilter !== "all" && row.status !== previewStatusFilter) {
@@ -330,17 +335,28 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory
       return searchableFields.includes(normalizedSearch);
     });
   }, [
+    deferredPreviewSearch,
     dryRunResult,
     previewCategoryFilter,
-    previewSearch,
     previewStatusFilter,
     previewTypeFilter,
     resolvePreviewCategoryMeta,
   ]);
 
+  useEffect(() => {
+    setPreviewVisibleCount(PREVIEW_PAGE_SIZE);
+  }, [dryRunResult, deferredPreviewSearch, previewCategoryFilter, previewStatusFilter, previewTypeFilter]);
+
+  const renderedPreviewRows = useMemo(
+    () => filteredPreviewRows.slice(0, previewVisibleCount),
+    [filteredPreviewRows, previewVisibleCount],
+  );
+
+  const hasHiddenPreviewRows = renderedPreviewRows.length < filteredPreviewRows.length;
+
   const validPreviewLines = useMemo(
-    () => filteredPreviewRows.filter((r) => r.status === "valid").map((r) => r.line),
-    [filteredPreviewRows],
+    () => renderedPreviewRows.filter((r) => r.status === "valid").map((r) => r.line),
+    [renderedPreviewRows],
   );
 
   const selectedPreviewRows = useMemo(
@@ -382,6 +398,16 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory
       validPreviewLines.length > 0 && validPreviewLines.every((line) => selectedPreviewLines.has(line)),
     [selectedPreviewLines, validPreviewLines],
   );
+
+  const handleShowMorePreviewRows = () => {
+    setPreviewVisibleCount((current) =>
+      Math.min(current + PREVIEW_PAGE_SIZE, filteredPreviewRows.length),
+    );
+  };
+
+  const handleShowAllPreviewRows = () => {
+    setPreviewVisibleCount(filteredPreviewRows.length);
+  };
 
   const togglePreviewLine = (line) => {
     setSelectedPreviewLines((prev) => {
@@ -1038,9 +1064,16 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory
                     </select>
                   </div>
                   <div className="sm:col-span-2 xl:col-span-5">
-                    <p className="text-xs text-cf-text-secondary">
-                      {filteredPreviewRows.length} de {dryRunResult.rows.length} linhas visíveis nesta revisão.
-                    </p>
+                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                      <p className="text-xs text-cf-text-secondary">
+                        {filteredPreviewRows.length} de {dryRunResult.rows.length} linhas visíveis nesta revisão.
+                      </p>
+                      {hasHiddenPreviewRows ? (
+                        <p className="text-xs text-cf-text-secondary">
+                          Mostrando {renderedPreviewRows.length} agora para manter a revisão leve.
+                        </p>
+                      ) : null}
+                    </div>
                   </div>
                 </div>
                 {importRules.length > 0 ? (
@@ -1148,76 +1181,102 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory
                       Nenhuma linha encontrada para os filtros atuais.
                     </div>
                   ) : (
-                    <table className="min-w-full border-collapse text-left text-xs">
-                      <thead className="bg-cf-bg-subtle">
-                        <tr>
-                          <th className="border-b border-cf-border px-2 py-2">
-                            <input
-                              type="checkbox"
-                              aria-label="Selecionar todas as linhas válidas"
-                              checked={allVisibleValidSelected}
-                              onChange={toggleSelectAllPreview}
-                              className="h-3.5 w-3.5 cursor-pointer accent-brand-1"
-                            />
-                          </th>
-                          <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Linha</th>
-                          <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Status</th>
-                          <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Descricao</th>
-                          <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Valor</th>
-                          <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Data</th>
-                          <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Categoria</th>
-                          <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Erros</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                    {filteredPreviewRows.map((row) => (
-                      <tr key={`import-row-${row.line}`} className="align-top">
-                        <td className="border-b border-cf-border px-2 py-2">
-                          {row.status === "valid" ? (
-                            <input
-                              type="checkbox"
-                              aria-label={`Selecionar linha ${row.line}`}
-                              checked={selectedPreviewLines.has(row.line)}
-                              onChange={() => togglePreviewLine(row.line)}
-                              className="h-3.5 w-3.5 cursor-pointer accent-brand-1"
-                            />
-                          ) : null}
-                        </td>
-                        <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">{row.line}</td>
-                        <td className="border-b border-cf-border px-2 py-2">
-                          <span
-                            className={`rounded px-2 py-0.5 font-semibold ${
-                              row.status === "valid"
-                                ? "bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-400"
+                    <>
+                      {hasHiddenPreviewRows ? (
+                        <div className="border-b border-cf-border bg-cf-bg-subtle px-3 py-2">
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <p className="text-xs text-cf-text-secondary">
+                              Mostrando {renderedPreviewRows.length} de {filteredPreviewRows.length} linhas filtradas.
+                            </p>
+                            <div className="flex flex-wrap items-center gap-2">
+                              <button
+                                type="button"
+                                onClick={handleShowMorePreviewRows}
+                                className="rounded border border-cf-border px-2 py-1 text-xs font-medium text-cf-text-primary hover:bg-cf-surface"
+                              >
+                                Mostrar mais {Math.min(PREVIEW_PAGE_SIZE, filteredPreviewRows.length - renderedPreviewRows.length)}
+                              </button>
+                              <button
+                                type="button"
+                                onClick={handleShowAllPreviewRows}
+                                className="rounded border border-cf-border px-2 py-1 text-xs text-cf-text-secondary hover:bg-cf-surface"
+                              >
+                                Mostrar todas
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      ) : null}
+                      <table className="min-w-full border-collapse text-left text-xs">
+                        <thead className="bg-cf-bg-subtle">
+                          <tr>
+                            <th className="border-b border-cf-border px-2 py-2">
+                              <input
+                                type="checkbox"
+                                aria-label="Selecionar todas as linhas válidas"
+                                checked={allVisibleValidSelected}
+                                onChange={toggleSelectAllPreview}
+                                className="h-3.5 w-3.5 cursor-pointer accent-brand-1"
+                              />
+                            </th>
+                            <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Linha</th>
+                            <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Status</th>
+                            <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Descricao</th>
+                            <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Valor</th>
+                            <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Data</th>
+                            <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Categoria</th>
+                            <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Erros</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                    {renderedPreviewRows.map((row) => (
+                        <tr key={`import-row-${row.line}`} className="align-top">
+                          <td className="border-b border-cf-border px-2 py-2">
+                            {row.status === "valid" ? (
+                              <input
+                                type="checkbox"
+                                aria-label={`Selecionar linha ${row.line}`}
+                                checked={selectedPreviewLines.has(row.line)}
+                                onChange={() => togglePreviewLine(row.line)}
+                                className="h-3.5 w-3.5 cursor-pointer accent-brand-1"
+                              />
+                            ) : null}
+                          </td>
+                          <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">{row.line}</td>
+                          <td className="border-b border-cf-border px-2 py-2">
+                            <span
+                              className={`rounded px-2 py-0.5 font-semibold ${
+                                row.status === "valid"
+                                  ? "bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-400"
+                                  : row.status === "duplicate"
+                                    ? "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-400"
+                                    : row.status === "conflict"
+                                      ? "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400"
+                                    : "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-400"
+                              }`}
+                            >
+                              {row.status === "valid"
+                                ? "Valida"
                                 : row.status === "duplicate"
-                                  ? "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-400"
+                                  ? "Duplicada"
                                   : row.status === "conflict"
-                                    ? "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400"
-                                  : "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-400"
-                            }`}
-                          >
-                            {row.status === "valid"
-                              ? "Valida"
-                              : row.status === "duplicate"
-                                ? "Duplicada"
-                                : row.status === "conflict"
-                                  ? "Conflito"
-                                : "Invalida"}
-                          </span>
-                          {(row.status === "duplicate" || row.status === "conflict") && row.statusDetail && (
-                            <span className="ml-1.5 text-xs text-cf-text-secondary">{row.statusDetail}</span>
-                          )}
-                        </td>
-                        <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
-                          {row.raw.description || "-"}
-                        </td>
-                        <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
-                          {row.raw.value || "-"}
-                        </td>
-                        <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">{row.raw.date || "-"}</td>
-                        <td className="border-b border-cf-border px-2 py-2">
-                          {row.status === "valid" ? (
-                            <div className="space-y-1">
+                                    ? "Conflito"
+                                  : "Invalida"}
+                            </span>
+                            {(row.status === "duplicate" || row.status === "conflict") && row.statusDetail && (
+                              <span className="ml-1.5 text-xs text-cf-text-secondary">{row.statusDetail}</span>
+                            )}
+                          </td>
+                          <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
+                            {row.raw.description || "-"}
+                          </td>
+                          <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
+                            {row.raw.value || "-"}
+                          </td>
+                          <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">{row.raw.date || "-"}</td>
+                          <td className="border-b border-cf-border px-2 py-2">
+                            {row.status === "valid" ? (
+                              <div className="space-y-1">
                               <div className="flex items-center gap-1">
                                 <select
                                   aria-label={`Categoria da linha ${row.line}`}
@@ -1299,6 +1358,7 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory
                     ))}
                       </tbody>
                     </table>
+                  </>
                   )}
                 </div>
               </>

--- a/apps/web/src/components/ImportCsvModal.test.jsx
+++ b/apps/web/src/components/ImportCsvModal.test.jsx
@@ -582,15 +582,29 @@ describe("ImportCsvModal", () => {
 
         await waitFor(() => {
           expect(screen.getByText(/320 de 320 linhas visíveis/i)).toBeInTheDocument();
+          expect(screen.getByText(/mostrando 100 agora para manter a revisão leve/i)).toBeInTheDocument();
+          expect(screen.getByText(/mostrando 100 de 320 linhas filtradas/i)).toBeInTheDocument();
         });
+
+        expect(screen.queryByText("PIX TRANSFERENCIA 102")).not.toBeInTheDocument();
+
+        await userEvent.click(screen.getByRole("button", { name: /mostrar mais 100/i }));
+
+        await waitFor(() => {
+          expect(screen.getByText(/mostrando 200 de 320 linhas filtradas/i)).toBeInTheDocument();
+        });
+
+        expect(screen.getByText("PIX TRANSFERENCIA 102")).toBeInTheDocument();
 
         fireEvent.change(screen.getByLabelText(/buscar na pré-visualização/i), {
           target: { value: "farmacia especial" },
         });
 
-        expect(screen.getByText("PIX FARMACIA ESPECIAL")).toBeInTheDocument();
-        expect(screen.queryByText("PIX TRANSFERENCIA 002")).not.toBeInTheDocument();
-        expect(screen.getByText(/1 de 320 linhas visíveis/i)).toBeInTheDocument();
+        await waitFor(() => {
+          expect(screen.getByText("PIX FARMACIA ESPECIAL")).toBeInTheDocument();
+          expect(screen.queryByText("PIX TRANSFERENCIA 002")).not.toBeInTheDocument();
+          expect(screen.getByText(/1 de 320 linhas visíveis/i)).toBeInTheDocument();
+        });
       },
       20000,
     );


### PR DESCRIPTION
## Contexto

Este PR melhora a revisão de imports grandes no modal de pré-visualização sem mudar o domínio de importação.

O preview já tinha busca e filtros, mas ainda renderizava todas as linhas filtradas de uma vez. Em extratos grandes, isso deixava a revisão mais pesada do que precisava.

## O que entra

- busca com `useDeferredValue` no preview
- render inicial limitado a 100 linhas filtradas
- ações de `Mostrar mais` e `Mostrar todas`
- seleção em lote restrita ao subconjunto efetivamente renderizado
- testes cobrindo preview grande com expansão e busca pontual

## Escopo

Somente performance/polish do preview web.
Sem mudança de contrato de API.
Sem mudança de regra de importação.

## Validação

- `npm -w apps/web run lint` ✅
- `npm -w apps/web run typecheck` ✅
- `npm -w apps/web run test:run` ✅
- `npm -w apps/web run build` ✅
