### PR TITLE
fix(import): cascade undo for safe derived artifacts

### DIFF
--- a/apps/api/src/import.test.js
+++ b/apps/api/src/import.test.js
@@ -1459,8 +1459,8 @@ describe("transaction imports", () => {
     expect(listResponse.body.data).toHaveLength(0);
   });
 
-  it("GET /transactions/imports marca sessao como nao desfeita quando ha renda derivada vinculada", async () => {
-    const email = "import-history-income-block@controlfinance.dev";
+  it("GET /transactions/imports mantem canUndo quando a sessao so tem renda derivada revertivel", async () => {
+    const email = "import-history-income-undoable@controlfinance.dev";
     const token = await registerAndLogin(email);
     await makeProUser(email);
 
@@ -1504,14 +1504,78 @@ describe("transaction imports", () => {
     expect(historyResponse.status).toBe(200);
     expect(historyResponse.body.items[0]).toMatchObject({
       id: sessionId,
+      canUndo: true,
+      undoBlockedReason: null,
+    });
+  });
+
+  it("GET /transactions/imports marca sessao como nao desfeita quando ha renda derivada bloqueante", async () => {
+    const email = "import-history-income-block@controlfinance.dev";
+    const token = await registerAndLogin(email);
+    await makeProUser(email);
+
+    const csv = csvFile("date,type,value,description\n2026-03-01,Entrada,1412,Credito INSS");
+
+    const dryRunResponse = await request(app)
+      .post("/transactions/import/dry-run")
+      .set("Authorization", `Bearer ${token}`)
+      .attach("file", csv.buffer, { filename: csv.fileName, contentType: "text/csv" });
+
+    const commitResponse = await request(app)
+      .post("/transactions/import/commit")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ importId: dryRunResponse.body.importId });
+
+    const sessionId = commitResponse.body.importSessionId;
+
+    const sourceResponse = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "INSS Beneficio" });
+
+    expect(sourceResponse.status).toBe(201);
+
+    const statementResponse = await request(app)
+      .post(`/income-sources/${sourceResponse.body.id}/statements`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        referenceMonth: "2026-03",
+        netAmount: 1412,
+        paymentDate: "2026-03-05",
+        sourceImportSessionId: sessionId,
+      });
+
+    expect(statementResponse.status).toBe(201);
+
+    const { rows: manualTxRows } = await dbQuery(
+      `INSERT INTO transactions (user_id, type, value, date, description)
+       VALUES ((SELECT id FROM users WHERE email = $1), $2, $3, $4, $5)
+       RETURNING id`,
+      [email, "Entrada", 1412, "2026-03-05", "Credito manual conciliado"],
+    );
+
+    const linkResponse = await request(app)
+      .post(`/income-sources/statements/${statementResponse.body.statement.id}/link-transaction`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionId: Number(manualTxRows[0].id) });
+
+    expect(linkResponse.status).toBe(200);
+
+    const historyResponse = await request(app)
+      .get("/transactions/imports")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(historyResponse.status).toBe(200);
+    expect(historyResponse.body.items[0]).toMatchObject({
+      id: sessionId,
       canUndo: false,
       undoBlockedReason:
         "Nao e possivel desfazer esta importacao porque existem derivados ativos vinculados a ela: 1 lancamento no historico de renda.",
     });
   });
 
-  it("DELETE /transactions/imports/:sessionId bloqueia undo quando existe bill derivada da sessao", async () => {
-    const email = "import-undo-bill-block@controlfinance.dev";
+  it("DELETE /transactions/imports/:sessionId remove bill pendente derivada da sessao", async () => {
+    const email = "import-undo-bill-cascade@controlfinance.dev";
     const token = await registerAndLogin(email);
     await makeProUser(email);
 
@@ -1545,21 +1609,109 @@ describe("transaction imports", () => {
       .delete(`/transactions/imports/${sessionId}`)
       .set("Authorization", `Bearer ${token}`);
 
-    expectErrorResponseWithRequestId(
-      undoResponse,
-      409,
-      "Nao e possivel desfazer esta importacao porque existem derivados ativos vinculados a ela: 1 conta derivada.",
-    );
+    expect(undoResponse.status).toBe(200);
+    expect(undoResponse.body).toMatchObject({
+      importSessionId: sessionId,
+      deletedCount: 1,
+      success: true,
+      deletedDerived: {
+        incomeStatements: 0,
+        bills: 1,
+      },
+    });
 
     const listResponse = await request(app)
       .get("/transactions")
       .set("Authorization", `Bearer ${token}`);
 
     expect(listResponse.status).toBe(200);
-    expect(listResponse.body.data).toHaveLength(1);
+    expect(listResponse.body.data).toHaveLength(0);
+
+    const billsResponse = await request(app)
+      .get("/bills")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(billsResponse.status).toBe(200);
+    expect(billsResponse.body.pagination.total).toBe(0);
   });
 
-  it("DELETE /transactions/imports/:sessionId bloqueia undo quando existe renda derivada da sessao", async () => {
+  it("DELETE /transactions/imports/:sessionId remove income statement da propria sessao quando ainda e seguro", async () => {
+    const email = "import-undo-income-cascade@controlfinance.dev";
+    const token = await registerAndLogin(email);
+    await makeProUser(email);
+
+    const csv = csvFile("date,type,value,description\n2026-03-01,Entrada,1412,Credito INSS");
+
+    const dryRunResponse = await request(app)
+      .post("/transactions/import/dry-run")
+      .set("Authorization", `Bearer ${token}`)
+      .attach("file", csv.buffer, { filename: csv.fileName, contentType: "text/csv" });
+
+    const commitResponse = await request(app)
+      .post("/transactions/import/commit")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ importId: dryRunResponse.body.importId });
+
+    const sessionId = commitResponse.body.importSessionId;
+    const importedTransactionId = Number(commitResponse.body.createdTransactions[0].id);
+
+    const sourceResponse = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "INSS Beneficio" });
+
+    expect(sourceResponse.status).toBe(201);
+
+    const statementResponse = await request(app)
+      .post(`/income-sources/${sourceResponse.body.id}/statements`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        referenceMonth: "2026-03",
+        netAmount: 1412,
+        paymentDate: "2026-03-05",
+        sourceImportSessionId: sessionId,
+      });
+
+    expect(statementResponse.status).toBe(201);
+
+    const linkResponse = await request(app)
+      .post(`/income-sources/statements/${statementResponse.body.statement.id}/link-transaction`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionId: importedTransactionId });
+
+    expect(linkResponse.status).toBe(200);
+
+    const undoResponse = await request(app)
+      .delete(`/transactions/imports/${sessionId}`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(undoResponse.status).toBe(200);
+    expect(undoResponse.body).toMatchObject({
+      importSessionId: sessionId,
+      deletedCount: 1,
+      success: true,
+      deletedDerived: {
+        incomeStatements: 1,
+        bills: 0,
+      },
+    });
+
+    const listResponse = await request(app)
+      .get("/transactions")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.data).toHaveLength(0);
+
+    const statementsResponse = await request(app)
+      .get(`/income-sources/${sourceResponse.body.id}/statements`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(statementsResponse.status).toBe(200);
+    expect(statementsResponse.body.statements).toHaveLength(0);
+  });
+
+  it("DELETE /transactions/imports/:sessionId bloqueia undo quando existe renda derivada conciliada fora da sessao", async () => {
     const email = "import-undo-income-block@controlfinance.dev";
     const token = await registerAndLogin(email);
     await makeProUser(email);
@@ -1597,6 +1749,20 @@ describe("transaction imports", () => {
 
     expect(statementResponse.status).toBe(201);
 
+    const { rows: manualTxRows } = await dbQuery(
+      `INSERT INTO transactions (user_id, type, value, date, description)
+       VALUES ((SELECT id FROM users WHERE email = $1), $2, $3, $4, $5)
+       RETURNING id`,
+      [email, "Entrada", 1412, "2026-03-05", "Credito manual conciliado"],
+    );
+
+    const linkResponse = await request(app)
+      .post(`/income-sources/statements/${statementResponse.body.statement.id}/link-transaction`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionId: Number(manualTxRows[0].id) });
+
+    expect(linkResponse.status).toBe(200);
+
     const undoResponse = await request(app)
       .delete(`/transactions/imports/${sessionId}`)
       .set("Authorization", `Bearer ${token}`);
@@ -1612,7 +1778,63 @@ describe("transaction imports", () => {
       .set("Authorization", `Bearer ${token}`);
 
     expect(listResponse.status).toBe(200);
-    expect(listResponse.body.data).toHaveLength(1);
+    expect(listResponse.body.data).toHaveLength(2);
+  });
+
+  it("DELETE /transactions/imports/:sessionId bloqueia undo quando existe bill derivada ja paga", async () => {
+    const email = "import-undo-bill-block@controlfinance.dev";
+    const token = await registerAndLogin(email);
+    await makeProUser(email);
+
+    const csv = csvFile("date,type,value,description\n2026-03-01,Saida,120,Conta de luz");
+
+    const dryRunResponse = await request(app)
+      .post("/transactions/import/dry-run")
+      .set("Authorization", `Bearer ${token}`)
+      .attach("file", csv.buffer, { filename: csv.fileName, contentType: "text/csv" });
+
+    const commitResponse = await request(app)
+      .post("/transactions/import/commit")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ importId: dryRunResponse.body.importId });
+
+    const sessionId = commitResponse.body.importSessionId;
+
+    const billResponse = await request(app)
+      .post("/bills")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        title: "Conta de luz",
+        amount: 120,
+        dueDate: "2026-03-10",
+        sourceImportSessionId: sessionId,
+      });
+
+    expect(billResponse.status).toBe(201);
+
+    const markPaidResponse = await request(app)
+      .patch(`/bills/${billResponse.body.id}/mark-paid`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ paidAt: "2026-03-09T10:00:00.000Z" });
+
+    expect(markPaidResponse.status).toBe(200);
+
+    const undoResponse = await request(app)
+      .delete(`/transactions/imports/${sessionId}`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expectErrorResponseWithRequestId(
+      undoResponse,
+      409,
+      "Nao e possivel desfazer esta importacao porque existem derivados ativos vinculados a ela: 1 conta derivada.",
+    );
+
+    const listResponse = await request(app)
+      .get("/transactions")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.data).toHaveLength(2);
   });
 
   it("DELETE /transactions/imports/:sessionId retorna 404 para sessao de outro usuario", async () => {

--- a/apps/api/src/services/transactions-import.service.js
+++ b/apps/api/src/services/transactions-import.service.js
@@ -329,24 +329,24 @@ const parsePayloadJson = (payloadJson) => {
 };
 
 const buildUndoBlockedReason = ({
-  derivedIncomeStatements = 0,
-  derivedBills = 0,
+  blockingIncomeStatements = 0,
+  blockingBills = 0,
 } = {}) => {
   const blockers = [];
 
-  if (derivedIncomeStatements > 0) {
+  if (blockingIncomeStatements > 0) {
     blockers.push(
-      `${derivedIncomeStatements} ${
-        derivedIncomeStatements === 1
+      `${blockingIncomeStatements} ${
+        blockingIncomeStatements === 1
           ? "lancamento no historico de renda"
           : "lancamentos no historico de renda"
       }`,
     );
   }
 
-  if (derivedBills > 0) {
+  if (blockingBills > 0) {
     blockers.push(
-      `${derivedBills} ${derivedBills === 1 ? "conta derivada" : "contas derivadas"}`,
+      `${blockingBills} ${blockingBills === 1 ? "conta derivada" : "contas derivadas"}`,
     );
   }
 
@@ -355,6 +355,114 @@ const buildUndoBlockedReason = ({
   }
 
   return `Nao e possivel desfazer esta importacao porque existem derivados ativos vinculados a ela: ${blockers.join(" e ")}.`;
+};
+
+const buildDeleteByIdsQuery = (tableName, ids = []) => {
+  if (!Array.isArray(ids) || ids.length === 0) {
+    return null;
+  }
+
+  const placeholders = ids.map((_, index) => `$${index + 1}`).join(", ");
+
+  return {
+    sql: `DELETE FROM ${tableName} WHERE id IN (${placeholders})`,
+    params: ids,
+  };
+};
+
+const evaluateImportSessionUndoPlan = async (
+  executeQuery,
+  userId,
+  sessionId,
+  {
+    activeDerivedIncomeStatements = undefined,
+    activeDerivedBills = undefined,
+  } = {},
+) => {
+  const plan = {
+    deletableIncomeStatementIds: [],
+    blockingIncomeStatements: 0,
+    deletableBillIds: [],
+    blockingBills: 0,
+  };
+
+  const shouldInspectIncomeStatements =
+    typeof activeDerivedIncomeStatements === "undefined" || activeDerivedIncomeStatements > 0;
+  const shouldInspectBills =
+    typeof activeDerivedBills === "undefined" || activeDerivedBills > 0;
+
+  if (shouldInspectIncomeStatements) {
+    const incomeStatementsResult = await executeQuery(
+      `SELECT st.id,
+              st.status,
+              st.posted_transaction_id,
+              tx.import_session_id AS posted_transaction_import_session_id
+         FROM income_statements st
+         JOIN income_sources src
+           ON src.id = st.income_source_id
+         LEFT JOIN transactions tx
+           ON tx.id = st.posted_transaction_id
+        WHERE src.user_id = $1
+          AND st.source_import_session_id = $2`,
+      [userId, sessionId],
+    );
+
+    incomeStatementsResult.rows.forEach((row) => {
+      const postedTransactionId =
+        row.posted_transaction_id != null ? Number(row.posted_transaction_id) : null;
+      const postedTransactionImportSessionId =
+        row.posted_transaction_import_session_id != null
+          ? String(row.posted_transaction_import_session_id)
+          : null;
+
+      if (postedTransactionId == null && row.status === "draft") {
+        plan.deletableIncomeStatementIds.push(Number(row.id));
+        return;
+      }
+
+      if (postedTransactionId != null && postedTransactionImportSessionId === sessionId) {
+        plan.deletableIncomeStatementIds.push(Number(row.id));
+        return;
+      }
+
+      plan.blockingIncomeStatements += 1;
+    });
+  }
+
+  if (shouldInspectBills) {
+    const billsResult = await executeQuery(
+      `SELECT b.id,
+              b.status,
+              b.credit_card_id,
+              COUNT(p.id)::int AS purchase_count
+         FROM bills b
+         LEFT JOIN credit_card_purchases p
+           ON p.bill_id = b.id
+        WHERE b.user_id = $1
+          AND b.source_import_session_id = $2
+        GROUP BY b.id, b.status, b.credit_card_id`,
+      [userId, sessionId],
+    );
+
+    billsResult.rows.forEach((row) => {
+      const purchaseCount = Number(row.purchase_count || 0);
+
+      if (row.status === "pending" && row.credit_card_id == null && purchaseCount === 0) {
+        plan.deletableBillIds.push(Number(row.id));
+        return;
+      }
+
+      plan.blockingBills += 1;
+    });
+  }
+
+  return {
+    ...plan,
+    undoBlockedReason: buildUndoBlockedReason({
+      blockingIncomeStatements: plan.blockingIncomeStatements,
+      blockingBills: plan.blockingBills,
+    }),
+  };
 };
 
 const ensureValidCsvHeaders = (headerRow) => {
@@ -974,7 +1082,7 @@ export const listTransactionsImportSessionsByUser = async (userId, filters = {})
     [userId, pagination.limit, pagination.offset],
   );
 
-  const items = result.rows.map((row) => {
+  const items = await Promise.all(result.rows.map(async (row) => {
     const payload = parsePayloadJson(row.payload_json);
     const summary = payload.summary || {};
     const imported = normalizeSummaryInteger(row.active_imported_count, 0);
@@ -984,10 +1092,18 @@ export const listTransactionsImportSessionsByUser = async (userId, filters = {})
       0,
     );
     const derivedBills = normalizeSummaryInteger(row.active_bills_count, 0);
-    const undoBlockedReason = buildUndoBlockedReason({
-      derivedIncomeStatements,
-      derivedBills,
-    });
+    const undoPlan =
+      derivedIncomeStatements > 0 || derivedBills > 0
+        ? await evaluateImportSessionUndoPlan(
+            dbQuery,
+            userId,
+            String(row.id),
+            {
+              activeDerivedIncomeStatements: derivedIncomeStatements,
+              activeDerivedBills: derivedBills,
+            },
+          )
+        : { undoBlockedReason: null };
 
     return {
       id: String(row.id),
@@ -1002,8 +1118,8 @@ export const listTransactionsImportSessionsByUser = async (userId, filters = {})
         typeof payload.documentType === "string" && payload.documentType.trim()
           ? payload.documentType.trim()
           : null,
-      canUndo: Boolean(committedAt) && imported > 0 && !undoBlockedReason,
-      undoBlockedReason,
+      canUndo: Boolean(committedAt) && imported > 0 && !undoPlan.undoBlockedReason,
+      undoBlockedReason: undoPlan.undoBlockedReason,
       summary: {
         totalRows: normalizeSummaryInteger(summary.totalRows, 0),
         validRows: normalizeSummaryInteger(summary.validRows, 0),
@@ -1015,7 +1131,7 @@ export const listTransactionsImportSessionsByUser = async (userId, filters = {})
         imported,
       },
     };
-  });
+  }));
 
   return {
     items,
@@ -1248,13 +1364,34 @@ export const deleteImportSessionForUser = async (userId, sessionId) => {
       0,
     );
     const derivedBills = normalizeSummaryInteger(billsResult.rows[0]?.count, 0);
-    const undoBlockedReason = buildUndoBlockedReason({
-      derivedIncomeStatements,
-      derivedBills,
-    });
+    const undoPlan = await evaluateImportSessionUndoPlan(
+      (sql, params) => transactionClient.query(sql, params),
+      userId,
+      normalizedSessionId,
+      {
+        activeDerivedIncomeStatements: derivedIncomeStatements,
+        activeDerivedBills: derivedBills,
+      },
+    );
 
-    if (undoBlockedReason) {
-      throw createError(409, undoBlockedReason);
+    if (undoPlan.undoBlockedReason) {
+      throw createError(409, undoPlan.undoBlockedReason);
+    }
+
+    const deleteIncomeStatementsQuery = buildDeleteByIdsQuery(
+      "income_statements",
+      undoPlan.deletableIncomeStatementIds,
+    );
+    if (deleteIncomeStatementsQuery) {
+      await transactionClient.query(
+        deleteIncomeStatementsQuery.sql,
+        deleteIncomeStatementsQuery.params,
+      );
+    }
+
+    const deleteBillsQuery = buildDeleteByIdsQuery("bills", undoPlan.deletableBillIds);
+    if (deleteBillsQuery) {
+      await transactionClient.query(deleteBillsQuery.sql, deleteBillsQuery.params);
     }
 
     const deleteResult = await transactionClient.query(
@@ -1263,10 +1400,22 @@ export const deleteImportSessionForUser = async (userId, sessionId) => {
       [userId, normalizedSessionId],
     );
 
-    return { deletedCount: Number(deleteResult.rowCount || 0) };
+    return {
+      deletedCount: Number(deleteResult.rowCount || 0),
+      deletedDerivedIncomeStatements: undoPlan.deletableIncomeStatementIds.length,
+      deletedDerivedBills: undoPlan.deletableBillIds.length,
+    };
   });
 
-  return { importSessionId: normalizedSessionId, deletedCount: result.deletedCount, success: true };
+  return {
+    importSessionId: normalizedSessionId,
+    deletedCount: result.deletedCount,
+    success: true,
+    deletedDerived: {
+      incomeStatements: result.deletedDerivedIncomeStatements,
+      bills: result.deletedDerivedBills,
+    },
+  };
 };
 
 export const bulkDeleteTransactionsForUser = async (userId, transactionIds) => {


### PR DESCRIPTION
## Contexto

Este PR fecha o P0 pós-MVP do undo de importação com cascata segura para derivados.

Antes, o undo da sessão removia apenas as 	ransactions, o que podia deixar artefatos derivados ativos e quebrar a consistência entre histórico, estado persistido e operação real.

## O que entra

- planner de undo por sessão em 	ransactions-import.service.js
- cascata segura para income_statements revertíveis
- cascata segura para ills revertíveis
- bloqueio explícito quando existem derivados evoluídos fora do fluxo seguro
- cobertura de API em import.test.js para cenários revertíveis e bloqueantes

## Regra

- derivado seguro: remove em cascata
- derivado evoluído: bloqueia o undo com motivo explícito
- histórico e estado persistido precisam contar a mesma história

## Cenários cobertos

- GET /transactions/imports mantém canUndo quando a sessão só tem derivados revertíveis
- GET /transactions/imports marca canUndo=false quando existe derivado bloqueante
- DELETE /transactions/imports/:sessionId remove ill pendente derivada da sessão
- DELETE /transactions/imports/:sessionId remove income_statement da própria sessão quando ainda é seguro
- DELETE /transactions/imports/:sessionId bloqueia quando existe income_statement conciliado fora da sessão
- DELETE /transactions/imports/:sessionId bloqueia quando existe ill já paga

## Validação

- 
pm -w apps/api run lint ✅
- 
pm -w apps/api test -- src/import.test.js ✅
- 
pm -w apps/api test ✅ 749/749
