### PR TITLE
docs(import): refresh post-mvp roadmap state

### DIFF
--- a/docs/audits/importacao-inteligente-mvp-auditoria-final.md
+++ b/docs/audits/importacao-inteligente-mvp-auditoria-final.md
@@ -20,6 +20,14 @@ Entrou em `main`:
 - limite bancário no perfil e no `forecast`
 - cartão com limite, compras abertas, fechamento manual de fatura e pagamento da fatura como saída real de caixa
 
+Follow-ups pós-MVP já entregues depois da auditoria inicial:
+
+- `#309` conciliação explícita entre renda documental e crédito bancário
+- `#310` parcelamento simples no cartão
+- `#311` bridge documental para holerite/CLT
+- `#312` polish e performance do preview grande
+- `#313` undo de importação com cascata segura para derivados
+
 Leitura correta:
 
 - a fundação do domínio foi entregue
@@ -30,31 +38,29 @@ Leitura correta:
 
 ## 2. Gaps
 
-### 2.1 Undo incompleto dos derivados
+### 2.1 Undo com cascata segura foi fechado
 
-O desfazer importação ainda não fecha o ciclo inteiro.
+O principal gap operacional do MVP foi resolvido em `#313`.
 
-Hoje:
+Agora:
 
-- a sessão pode ser revertida pelo histórico
 - `transactions` da sessão são revertidas
-- mas artefatos derivados como `income_statements` ou `bills` não entram automaticamente nessa mesma reversão
+- `income_statements` revertíveis entram na cascata
+- `bills` revertíveis entram na cascata
+- derivados evoluídos passam a bloquear o undo com motivo explícito
 
-Esse é o gap mais sério do pacote porque cria risco de inconsistência operacional.
+O risco residual aqui deixou de ser fundacional e passou a ser de edge cases futuros, não de contrato quebrado.
 
-### 2.2 Documento vira renda, mas ainda mais forte para INSS
-
-O núcleo existe e está bom, mas o trilho mais maduro hoje ainda é o de INSS.
+### 2.2 Documento vira renda, mas ainda mais forte para INSS/CLT
+O núcleo existe e está bom, e o trilho já avançou para holerite/CLT.
 
 O produto ainda não está igualmente maduro para:
 
-- holerite/CLT
 - outros comprovantes de renda documental
 - generalização ampla do parser documental para “renda estruturada”
 
-### 2.3 Cartão/fatura entrou como MVP manual
-
-O modelo está correto para MVP, mas ainda curto para ciclo real mais rico.
+### 2.3 Cartão/fatura entrou como MVP funcional, mas ainda parcial para ciclo real
+O modelo já saiu do “manual puro” e ganhou parcelamento simples, mas ainda está curto para ciclo real mais rico.
 
 Follow-ups naturais:
 
@@ -63,11 +69,13 @@ Follow-ups naturais:
 - conciliação por conta pagadora
 - regras mais ricas de fechamento
 
-### 2.4 Documentação fora do git
+### 2.4 UX de reconciliação ainda pode ficar mais explícita
 
-Quando o código anda e a documentação fica só local, o produto começa a mentir no papel.
+O vínculo entre renda documental e crédito bancário já existe, mas ainda há espaço para:
 
-Esse risco não é de runtime, mas é risco real de operação e alinhamento do time.
+- painéis mais claros de conciliado vs pendente vs conflitante
+- ações de revisão mais fluidas
+- comunicação ainda mais explícita para o usuário
 
 ---
 
@@ -75,10 +83,9 @@ Esse risco não é de runtime, mas é risco real de operação e alinhamento do 
 
 Os riscos reais deste épico, no estado atual, são:
 
-- sensação de conciliação completa sem existir reconciliador explícito
-- inconsistência entre sessão de importação e entidades derivadas
+- sensação de conciliação completa em cenários ambíguos
 - edge cases de cartão/fatura ainda abertos
-- drift entre `main` e documentação local
+- cobertura documental ainda mais forte em INSS/CLT do que em outros comprovantes
 
 ---
 
@@ -106,8 +113,8 @@ Os riscos reais deste épico, no estado atual, são:
 
 ### PR8 — guard rails operacionais
 
-- Status: entregue parcial/MVP
-- ressalva: undo ainda não cascata para derivados
+- Status: entregue e consolidado com `#313`
+- ressalva: próximos riscos ficam em edge cases, não mais no contrato base
 
 ### Limite bancário
 
@@ -121,16 +128,16 @@ Os riscos reais deste épico, no estado atual, são:
 
 ## 5. Backlog pós-MVP
 
-### P0
-
-- fazer o undo de importação bloquear ou reverter também `income_statements` e `bills` derivados
-
 ### P1
 
-- ampliar renda documental além do trilho forte de INSS
-- criar visão explícita de conciliação entre renda documental e crédito bancário
-- evoluir cartão para parcelamento e ciclo mais realista
-- fazer polish e performance do preview/import em volume alto
+- ampliar renda documental além do trilho já forte em INSS/CLT
+- evoluir cartão para ciclo mais realista além do parcelamento simples
+- enriquecer a UX de reconciliação entre renda documental e crédito bancário
+
+### P2
+
+- automações assistidas extras sem perder determinismo
+- polish contínuo de preview/import orientado por uso real
 
 ---
 
@@ -142,10 +149,9 @@ Não há blocker estrutural.
 
 O que existe agora é um conjunto de follow-ups legítimos para:
 
-- fechar consistência operacional
 - ampliar cobertura documental
 - sofisticar o subdomínio de cartão
-- manter a documentação alinhada ao estado real do código
+- refinar a experiência de reconciliação
 
 Próximo passo correto:
 

--- a/docs/roadmap-execution.md
+++ b/docs/roadmap-execution.md
@@ -272,6 +272,11 @@ PRs mergeados:
 6. `#303` guard rails operacionais e histórico auditável de imports
 7. `#304` limite bancário / cheque especial
 8. `#305` cartão + ciclo inicial de fatura
+9. `#309` conciliação explícita entre renda documental e crédito bancário
+10. `#310` parcelamento simples no cartão
+11. `#311` bridge documental para holerite/CLT
+12. `#312` polish e performance do preview grande
+13. `#313` undo com cascata segura para derivados
 
 Documentos de referência:
 
@@ -285,7 +290,8 @@ Leitura correta do estado:
 - guard rails do MVP: entregues
 - limite bancário: entregue
 - cartão e fatura: entregues no recorte inicial
-- gaps atuais: refino, reconciliação e consistência operacional de undo
+- follow-ups pós-MVP já entregues: reconciliação explícita, parcelamento simples, bridge de holerite/CLT, polish grande de preview e undo seguro
+- gaps atuais: evolução de cartão para casos mais ricos, expansão documental além de INSS/CLT e UX mais explícita de reconciliação
 
 Essa frente não deve voltar para o backlog como “fundação pendente”.
 Os próximos passos devem nascer como **follow-ups pós-MVP**, não como repetição da trilha já mergeada.

--- a/docs/roadmaps/importacao-inteligente-pos-mvp-backlog.md
+++ b/docs/roadmaps/importacao-inteligente-pos-mvp-backlog.md
@@ -27,68 +27,32 @@ Documentos de referência:
 - `docs/roadmaps/importacao-inteligente-renda-extratos.md`
 - `docs/audits/importacao-inteligente-mvp-auditoria-final.md`
 
+Follow-ups já entregues em `main` depois do MVP inicial:
+
+- `#309` conciliação explícita entre renda documental e crédito bancário
+- `#310` parcelamento simples no cartão
+- `#311` bridge documental para holerite/CLT
+- `#312` polish e performance do preview grande
+- `#313` undo com cascata segura para derivados
+
 ---
 
 ## 2. Objetivo do backlog pós-MVP
 
-Fechar o principal gap operacional remanescente e abrir a próxima camada de evolução do produto sem reabrir escopo já entregue.
+Seguir evoluindo o produto a partir de uma base já estável, sem reabrir escopo já entregue e sem perder auditabilidade.
 
 ---
 
-## 3. P0 — Undo de importação com cascata para derivados
+## 3. P0 — Encerrado em `#313`
 
-### Prioridade
+O principal gap operacional do pós-MVP foi resolvido com:
 
-Crítica
+- planner de undo por sessão
+- cascata segura para `income_statements` revertíveis
+- cascata segura para `bills` revertíveis
+- bloqueio explícito para derivados evoluídos fora do fluxo seguro
 
-### Problema
-
-Hoje o desfazer importação pode reverter a sessão principal, mas ainda existe risco de deixar artefatos derivados ativos, o que quebra a consistência entre:
-
-- sessão de importação
-- entidades derivadas
-- histórico auditável
-- estado real do produto
-
-Em produto financeiro, “quase desfeito” é bug, não detalhe.
-
-### Escopo
-
-Implementar `undo` de importação com consistência transacional e/ou bloqueio explícito para derivados.
-
-#### Deve cobrir
-
-- reverter `transactions` da sessão
-- reverter ou bloquear `income_statements` derivados da sessão
-- reverter ou bloquear `bills` derivados da sessão
-- manter o histórico coerente com o estado real após reversão
-- preservar auditabilidade do que foi criado, revertido, bloqueado ou mantido
-
-### Regras de negócio
-
-- uma sessão desfeita não pode deixar artefato derivado ativo sem sinalização explícita
-- se não for possível reverter automaticamente um derivado, a operação deve:
-  - bloquear o undo completo com mensagem clara, ou
-  - marcar o derivado de forma explícita como pendente/incompatível e exigir ação consciente
-- histórico e estado persistido precisam contar a mesma história
-
-### Risco
-
-Alto
-
-### Critérios de aceite
-
-- sessão desfeita não deixa `transactions` ativas daquela importação
-- sessão desfeita não deixa `income_statements` derivados ativos sem tratamento explícito
-- sessão desfeita não deixa `bills` derivados ativos sem tratamento explícito
-- histórico reflete reversão completa ou bloqueio justificado
-- operação continua auditável ponta a ponta
-
-### Observações de implementação
-
-- preferir abordagem determinística e auditável
-- evitar `delete` cego; favorecer `soft-delete` ou `revert status` quando fizer sentido
-- garantir que o histórico final seja inteligível para usuário e auditoria interna
+A partir daqui, o backlog segue só com follow-ups reais de produto.
 
 ---
 
@@ -96,9 +60,11 @@ Alto
 
 ### 4.1 Conciliação explícita entre renda documental e crédito bancário
 
+**Status:** entregue no recorte inicial via `#309`
+
 #### Objetivo
 
-Parar de depender só de heurística implícita e tornar visível a ligação entre:
+Evoluir a visibilidade e a revisão do vínculo já existente entre:
 
 - documento de renda
 - crédito bancário correspondente
@@ -106,26 +72,28 @@ Parar de depender só de heurística implícita e tornar visível a ligação en
 
 #### Escopo
 
-- exibir vínculo entre documento e crédito conciliado
-- mostrar casos conciliados, pendentes e conflitantes
-- permitir revisão manual quando necessário
-- evitar dupla leitura de renda em fluxos ambíguos
+- painéis mais claros de conciliado, pendente e conflitante
+- revisão manual mais fluida
+- acabamento da comunicação de conflito
+- ampliar confiança do usuário na reconciliação já feita
 
 #### Critérios de aceite
 
-- usuário consegue ver quando uma renda documental já foi conciliada com um crédito bancário
-- conflitos ficam visíveis e não silenciosos
-- o produto não duplica renda em caso conciliado
+- usuário entende o vínculo conciliado sem precisar inferir pela UI
+- conflitos continuam visíveis e não silenciosos
+- o produto continua sem duplicar renda em caso conciliado
 
 ### 4.2 Evolução do cartão para casos mais reais
 
+**Status:** MVP entregue com parcelamento simples via `#310`
+
 #### Objetivo
 
-Sair do ciclo inicial de fatura para um modelo mais próximo do uso cotidiano.
+Ir além do ciclo inicial já entregue para um modelo mais próximo do uso cotidiano.
 
 #### Escopo
 
-- compras parceladas
+- parcelamento mais rico
 - melhor modelagem de fechamento e vencimento
 - relação mais clara entre compra, fatura e pagamento
 - possibilidade de múltiplos cenários reais de uso
@@ -138,13 +106,15 @@ Sair do ciclo inicial de fatura para um modelo mais próximo do uso cotidiano.
 
 ### 4.3 Expansão do pipeline documental além do trilho forte de INSS
 
+**Status:** bridge inicial de holerite/CLT entregue via `#311`
+
 #### Objetivo
 
-Generalizar o fluxo documental sem ficar dependente demais do caso mais forte atual.
+Generalizar ainda mais o fluxo documental sem ficar dependente demais dos casos já fortes.
 
 #### Escopo
 
-- ampliar cobertura para CLT/holerite
+- ampliar cobertura para outros formatos além de INSS/CLT
 - estruturar melhor casos de renda autônoma documental
 - manter a mesma disciplina de extração, confirmação e impacto no planejamento
 
@@ -156,13 +126,15 @@ Generalizar o fluxo documental sem ficar dependente demais do caso mais forte at
 
 ### 4.4 Performance e polish em imports grandes
 
+**Status:** MVP entregue no recorte inicial via `#312`
+
 #### Objetivo
 
-Melhorar experiência com massa maior de dados sem mexer desnecessariamente no domínio.
+Seguir melhorando a experiência com massa maior de dados sem mexer desnecessariamente no domínio.
 
 #### Escopo
 
-- refinamento de busca/filtros
+- refinamento contínuo de busca/filtros
 - UX para grandes volumes
 - revisão de performance em listas extensas
 - acabamento de preview/import
@@ -213,16 +185,15 @@ Ganhar conveniência sem transformar o produto em caixa-preta.
 
 ## 7. Ordem recomendada
 
-1. **P0 — undo com cascata para derivados**
-2. **P1 — conciliação explícita**
-3. **P1 — evolução de cartão**
-4. **P1 — expansão documental**
-5. **P1 — performance/polish**
-6. **P2 — refinamentos de UX e automações assistidas**
+1. **P1 — evolução de cartão**
+2. **P1 — expansão documental**
+3. **P1 — reconciliação com UX mais explícita**
+4. **P1 — performance/polish orientado por uso real**
+5. **P2 — refinamentos de UX e automações assistidas**
 
 ---
 
 ## 8. Veredito
 
 O pós-MVP certo não é abrir escopo novo por impulso.
-É fechar primeiro a **consistência operacional que ainda pode mentir sobre o estado real**, e depois evoluir reconciliação, cartão e pipeline documental com calma e critério.
+É evoluir reconciliação, cartão e pipeline documental com calma e critério, a partir de uma base operacional já consistente.


### PR DESCRIPTION
## Contexto

Depois dos merges #309 a #313, os documentos da trilha de importação inteligente ficaram defasados em relação ao estado real do produto.

## O que entra

- atualização da auditoria final do épico
- atualização do backlog pós-MVP
- alinhamento do docs/roadmap-execution.md ao estado atual em main

## Ajustes principais

- registra #309 a #313 como entregas já absorvidas em main
- remove o P0 de undo da lista de pendências, já que foi fechado em #313
- recalibra os gaps reais para o pós-MVP atual

## Escopo

Somente documentação.
Sem mudança de runtime.
Sem necessidade de rodar testes novamente.
