### PR TITLE
feat(cards): allow reopening pending credit card invoices

### DIFF
--- a/apps/api/src/credit-cards.test.js
+++ b/apps/api/src/credit-cards.test.js
@@ -346,6 +346,128 @@ describe("credit cards", () => {
     expect(Number(txCountResult.rows[0].total)).toBe(1);
   });
 
+  it("POST /credit-cards/invoices/:invoiceId/reopen reabre fatura pendente e devolve compras para aberto", async () => {
+    const token = await registerAndLogin("credit-cards-reopen-invoice@test.dev");
+
+    const createCardRes = await request(app)
+      .post("/credit-cards")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        name: "Visa",
+        limitTotal: 1800,
+        closingDay: 10,
+        dueDay: 20,
+      });
+    const cardId = createCardRes.body.id;
+
+    await request(app)
+      .post(`/credit-cards/${cardId}/purchases`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        title: "Mercado",
+        amount: 180,
+        purchaseDate: "2026-03-05",
+      });
+
+    await request(app)
+      .post(`/credit-cards/${cardId}/purchases`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        title: "Farmácia",
+        amount: 70,
+        purchaseDate: "2026-03-08",
+      });
+
+    const closeRes = await request(app)
+      .post(`/credit-cards/${cardId}/close-invoice`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ closingDate: "2026-03-15" });
+
+    expect(closeRes.status).toBe(200);
+
+    const reopenRes = await request(app)
+      .post(`/credit-cards/invoices/${closeRes.body.invoice.id}/reopen`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(reopenRes.status).toBe(200);
+    expect(reopenRes.body).toMatchObject({
+      invoiceId: closeRes.body.invoice.id,
+      reopenedPurchasesCount: 2,
+      success: true,
+    });
+
+    const listRes = await request(app)
+      .get("/credit-cards")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(listRes.status).toBe(200);
+    expect(listRes.body.items[0]).toMatchObject({
+      openPurchasesCount: 2,
+      openPurchasesTotal: 250,
+      pendingInvoicesCount: 0,
+      pendingInvoicesTotal: 0,
+      usage: {
+        total: 1800,
+        used: 250,
+        available: 1550,
+        status: "using",
+      },
+    });
+
+    const billedPurchasesResult = await dbQuery(
+      `SELECT COUNT(*)::int AS total
+         FROM credit_card_purchases
+        WHERE credit_card_id = $1
+          AND status = 'billed'`,
+      [cardId],
+    );
+    expect(Number(billedPurchasesResult.rows[0].total)).toBe(0);
+  });
+
+  it("POST /credit-cards/invoices/:invoiceId/reopen bloqueia reabertura de fatura paga", async () => {
+    const token = await registerAndLogin("credit-cards-reopen-paid@test.dev");
+
+    const createCardRes = await request(app)
+      .post("/credit-cards")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        name: "Mastercard",
+        limitTotal: 1400,
+        closingDay: 10,
+        dueDay: 20,
+      });
+    const cardId = createCardRes.body.id;
+
+    await request(app)
+      .post(`/credit-cards/${cardId}/purchases`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        title: "Streaming",
+        amount: 59.9,
+        purchaseDate: "2026-03-05",
+      });
+
+    const closeRes = await request(app)
+      .post(`/credit-cards/${cardId}/close-invoice`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ closingDate: "2026-03-15" });
+
+    await request(app)
+      .patch(`/bills/${closeRes.body.invoice.id}/mark-paid`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ paidAt: "2026-03-20T10:00:00.000Z" });
+
+    const reopenRes = await request(app)
+      .post(`/credit-cards/invoices/${closeRes.body.invoice.id}/reopen`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expectErrorResponseWithRequestId(
+      reopenRes,
+      409,
+      "Apenas faturas pendentes podem ser reabertas.",
+    );
+  });
+
   it("fecha apenas a parcela elegivel do ciclo e preserva as proximas abertas", async () => {
     const token = await registerAndLogin("credit-cards-installment-cycle@test.dev");
 

--- a/apps/api/src/routes/credit-cards.routes.js
+++ b/apps/api/src/routes/credit-cards.routes.js
@@ -9,6 +9,7 @@ import {
   createCreditCardInstallmentsForUser,
   deleteCreditCardPurchaseForUser,
   closeCreditCardInvoiceForUser,
+  reopenCreditCardInvoiceForUser,
 } from "../services/credit-cards.service.js";
 
 const router = Router();
@@ -76,6 +77,15 @@ router.delete("/purchases/:purchaseId", creditCardsWriteRateLimiter, async (req,
 router.post("/:id/close-invoice", creditCardsWriteRateLimiter, async (req, res, next) => {
   try {
     const result = await closeCreditCardInvoiceForUser(req.user.id, req.params.id, req.body || {});
+    res.status(200).json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post("/invoices/:invoiceId/reopen", creditCardsWriteRateLimiter, async (req, res, next) => {
+  try {
+    const result = await reopenCreditCardInvoiceForUser(req.user.id, req.params.invoiceId);
     res.status(200).json(result);
   } catch (error) {
     next(error);

--- a/apps/api/src/services/credit-cards.service.js
+++ b/apps/api/src/services/credit-cards.service.js
@@ -42,6 +42,14 @@ const normalizePurchaseId = (value) => {
   return parsed;
 };
 
+const normalizeInvoiceId = (value) => {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw createError(400, "ID de fatura invalido.");
+  }
+  return parsed;
+};
+
 const normalizeName = (value) => {
   if (!value || !String(value).trim()) {
     throw createError(400, "Nome do cartao e obrigatorio.");
@@ -651,6 +659,69 @@ export const closeCreditCardInvoiceForUser = async (userId, cardId, payload = {}
       invoice: mapInvoiceRow(invoice),
       purchasesCount: purchases.length,
       total: invoiceAmount,
+    };
+  });
+};
+
+export const reopenCreditCardInvoiceForUser = async (userId, invoiceId) => {
+  const normalizedUserId = normalizeUserId(userId);
+  const normalizedInvoiceId = normalizeInvoiceId(invoiceId);
+
+  return withDbTransaction(async (client) => {
+    const invoiceResult = await client.query(
+      `SELECT *
+         FROM bills
+        WHERE id = $1
+          AND user_id = $2
+          AND bill_type = $3
+          AND credit_card_id IS NOT NULL
+        LIMIT 1`,
+      [normalizedInvoiceId, normalizedUserId, CREDIT_CARD_INVOICE_BILL_TYPE],
+    );
+
+    if (invoiceResult.rows.length === 0) {
+      throw createError(404, "Fatura nao encontrada.");
+    }
+
+    const invoice = invoiceResult.rows[0];
+
+    if (invoice.status !== "pending") {
+      throw createError(409, "Apenas faturas pendentes podem ser reabertas.");
+    }
+
+    const purchasesResult = await client.query(
+      `SELECT id
+         FROM credit_card_purchases
+        WHERE user_id = $1
+          AND bill_id = $2
+        ORDER BY id ASC`,
+      [normalizedUserId, normalizedInvoiceId],
+    );
+
+    if (purchasesResult.rows.length > 0) {
+      await client.query(
+        `UPDATE credit_card_purchases
+            SET status = 'open',
+                statement_month = NULL,
+                bill_id = NULL,
+                updated_at = NOW()
+          WHERE user_id = $1
+            AND bill_id = $2`,
+        [normalizedUserId, normalizedInvoiceId],
+      );
+    }
+
+    await client.query(
+      `DELETE FROM bills
+        WHERE id = $1
+          AND user_id = $2`,
+      [normalizedInvoiceId, normalizedUserId],
+    );
+
+    return {
+      invoiceId: normalizedInvoiceId,
+      reopenedPurchasesCount: purchasesResult.rows.length,
+      success: true,
     };
   });
 };

--- a/apps/web/src/pages/CreditCardsPage.test.tsx
+++ b/apps/web/src/pages/CreditCardsPage.test.tsx
@@ -20,6 +20,7 @@ vi.mock("../services/credit-cards.service", () => ({
     createInstallments: vi.fn(),
     removePurchase: vi.fn(),
     closeInvoice: vi.fn(),
+    reopenInvoice: vi.fn(),
   },
 }));
 
@@ -138,6 +139,11 @@ describe("CreditCardsPage", () => {
       purchasesCount: 1,
       total: 180,
     });
+    vi.mocked(creditCardsService.reopenInvoice).mockResolvedValue({
+      invoiceId: 91,
+      reopenedPurchasesCount: 1,
+      success: true,
+    });
     vi.mocked(billsService.markPaid).mockResolvedValue({
       bill: {} as never,
       transaction: {
@@ -247,6 +253,18 @@ describe("CreditCardsPage", () => {
 
     await waitFor(() => {
       expect(billsService.markPaid).toHaveBeenCalledWith(91);
+    });
+  });
+
+  it("reabre a fatura pendente pelo fluxo da tela", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await screen.findByText("Nubank");
+    await user.click(screen.getByRole("button", { name: "Reabrir" }));
+
+    await waitFor(() => {
+      expect(creditCardsService.reopenInvoice).toHaveBeenCalledWith(91);
     });
   });
 });

--- a/apps/web/src/pages/CreditCardsPage.tsx
+++ b/apps/web/src/pages/CreditCardsPage.tsx
@@ -133,6 +133,19 @@ const CreditCardsPage = ({
     }
   };
 
+  const handleReopenInvoice = async (invoiceId: number) => {
+    setPageError("");
+    try {
+      const result = await creditCardsService.reopenInvoice(invoiceId);
+      showSuccess(
+        `Fatura reaberta. ${result.reopenedPurchasesCount} compra${result.reopenedPurchasesCount === 1 ? "" : "s"} voltaram para aberto.`,
+      );
+      await loadCards();
+    } catch (error) {
+      setPageError(getApiErrorMessage(error, "Não foi possível reabrir a fatura."));
+    }
+  };
+
   const handleDeletePurchase = async (purchaseId: number) => {
     setPendingDeletePurchaseId(null);
     setPageError("");
@@ -354,13 +367,22 @@ const CreditCardsPage = ({
                                   {formatCurrency(invoice.amount)}
                                 </span>
                                 {invoice.status === "pending" ? (
-                                  <button
-                                    type="button"
-                                    onClick={() => void handlePayInvoice(invoice.id)}
-                                    className="rounded border border-green-300 px-2 py-1 text-xs font-semibold text-green-700 hover:bg-green-50"
-                                  >
-                                    Pagar fatura
-                                  </button>
+                                  <div className="flex items-center gap-2">
+                                    <button
+                                      type="button"
+                                      onClick={() => void handleReopenInvoice(invoice.id)}
+                                      className="rounded border border-amber-300 px-2 py-1 text-xs font-semibold text-amber-700 hover:bg-amber-50"
+                                    >
+                                      Reabrir
+                                    </button>
+                                    <button
+                                      type="button"
+                                      onClick={() => void handlePayInvoice(invoice.id)}
+                                      className="rounded border border-green-300 px-2 py-1 text-xs font-semibold text-green-700 hover:bg-green-50"
+                                    >
+                                      Pagar fatura
+                                    </button>
+                                  </div>
                                 ) : (
                                   <span className="rounded border border-green-200 bg-green-50 px-2 py-1 text-xs font-semibold text-green-700">
                                     Paga

--- a/apps/web/src/services/credit-cards.service.ts
+++ b/apps/web/src/services/credit-cards.service.ts
@@ -91,6 +91,12 @@ export interface CloseInvoiceResult {
   total: number;
 }
 
+export interface ReopenInvoiceResult {
+  invoiceId: number;
+  reopenedPurchasesCount: number;
+  success: boolean;
+}
+
 const normalizeString = (value: unknown) => (typeof value === "string" ? value.trim() : "");
 
 const normalizeStringOrNull = (value: unknown) => {
@@ -231,6 +237,20 @@ export const creditCardsService = {
       invoice: normalizeInvoice((raw.invoice ?? {}) as Record<string, unknown>),
       purchasesCount: Number(raw.purchasesCount) || 0,
       total: Number(raw.total) || 0,
+    };
+  },
+
+  reopenInvoice: async (invoiceId: number): Promise<ReopenInvoiceResult> => {
+    const { data } = await api.post(`/credit-cards/invoices/${invoiceId}/reopen`);
+    const raw = data as {
+      invoiceId?: unknown;
+      reopenedPurchasesCount?: unknown;
+      success?: unknown;
+    };
+    return {
+      invoiceId: Number(raw.invoiceId) || 0,
+      reopenedPurchasesCount: Number(raw.reopenedPurchasesCount) || 0,
+      success: Boolean(raw.success),
     };
   },
 };


### PR DESCRIPTION
## Contexto

O ciclo inicial de cartão já permitia fechar a fatura e pagar a saída real de caixa, mas ainda faltava uma saída segura para o erro operacional de fechar a fatura cedo ou por engano.

## O que entra

- endpoint POST /credit-cards/invoices/:invoiceId/reopen
- reabertura segura de fatura pendente
- compras vinculadas voltam para open
- remoção da bill de fatura quando a reabertura é concluída
- ação Reabrir na tela de cartões
- cobertura de API e web

## Regras

- apenas faturas pendentes podem ser reabertas
- faturas pagas continuam bloqueadas
- ao reabrir, as compras do ciclo voltam para aberto sem criar saída de caixa adicional

## Validação

- 
pm -w apps/api run lint ✅
- 
pm -w apps/api test -- src/credit-cards.test.js ✅
- 
pm -w apps/api test ✅ 751/751
- 
pm -w apps/web run lint ✅
- 
pm -w apps/web run typecheck ✅
- 
pm -w apps/web run test:run -- src/pages/CreditCardsPage.test.tsx ✅
- 
pm -w apps/web run test:run ✅ 321/321
- 
pm -w apps/web run build ✅
