### PR TITLE
fix(web): align shell and tax dashboard with current product

### DIFF
--- a/apps/web/src/components/CreditCardsSummaryWidget.test.tsx
+++ b/apps/web/src/components/CreditCardsSummaryWidget.test.tsx
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CreditCardsSummaryWidget from "./CreditCardsSummaryWidget";
+import { creditCardsService, type CreditCardItem } from "../services/credit-cards.service";
+
+vi.mock("../services/credit-cards.service", () => ({
+  creditCardsService: {
+    list: vi.fn(),
+  },
+}));
+
+const buildCard = (overrides: Partial<CreditCardItem> = {}): CreditCardItem => ({
+  id: 1,
+  userId: 1,
+  name: "Nubank",
+  limitTotal: 3000,
+  closingDay: 10,
+  dueDay: 17,
+  isActive: true,
+  createdAt: "2026-03-27T00:00:00.000Z",
+  updatedAt: "2026-03-27T00:00:00.000Z",
+  usage: {
+    total: 3000,
+    used: 1480,
+    available: 1520,
+    exceededBy: 0,
+    usagePct: 49.33,
+    status: "using",
+  },
+  openPurchasesCount: 3,
+  openPurchasesTotal: 480,
+  pendingInvoicesCount: 1,
+  pendingInvoicesTotal: 1000,
+  openPurchases: [],
+  invoices: [],
+  ...overrides,
+});
+
+const renderWidget = (onOpenCreditCards?: () => void) =>
+  render(<CreditCardsSummaryWidget onOpenCreditCards={onOpenCreditCards} />);
+
+describe("CreditCardsSummaryWidget", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(creditCardsService.list).mockResolvedValue({
+      items: [buildCard()],
+    });
+  });
+
+  it("renderiza loading enquanto busca os cartões", () => {
+    vi.mocked(creditCardsService.list).mockReturnValue(new Promise(() => {}));
+    renderWidget();
+    expect(screen.getByText("Carregando cartões...")).toBeInTheDocument();
+  });
+
+  it("agrega limite disponível, compras abertas e faturas pendentes", async () => {
+    vi.mocked(creditCardsService.list).mockResolvedValue({
+      items: [
+        buildCard(),
+        buildCard({
+          id: 2,
+          name: "Inter",
+          usage: {
+            total: 2000,
+            used: 700,
+            available: 1300,
+            exceededBy: 0,
+            usagePct: 35,
+            status: "using",
+          },
+          openPurchasesTotal: 200,
+          pendingInvoicesCount: 2,
+          pendingInvoicesTotal: 900,
+        }),
+      ],
+    });
+
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText("2 cartões ativos")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/2\.820,00|2820,00/)).toBeInTheDocument();
+    expect(screen.getByText(/680,00|680,00/)).toBeInTheDocument();
+    expect(screen.getByText(/1\.900,00|1900,00/)).toBeInTheDocument();
+    expect(screen.getByText("3 faturas")).toBeInTheDocument();
+  });
+
+  it("mostra estado vazio amigável quando não há cartão cadastrado", async () => {
+    vi.mocked(creditCardsService.list).mockResolvedValue({ items: [] });
+
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText("Nenhum cartão cadastrado ainda.")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(/Cadastre um cartão para acompanhar limite disponível/i),
+    ).toBeInTheDocument();
+  });
+
+  it("mostra mensagem honesta quando o resumo de cartões falha", async () => {
+    vi.mocked(creditCardsService.list).mockRejectedValue(new Error("network"));
+
+    renderWidget();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Não foi possível carregar o resumo de cartões agora."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("abre a área de cartões quando o CTA é clicado", async () => {
+    const user = userEvent.setup();
+    const onOpenCreditCards = vi.fn();
+    renderWidget(onOpenCreditCards);
+
+    await waitFor(() => {
+      expect(screen.getByText("Ver cartões →")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("Ver cartões →"));
+    expect(onOpenCreditCards).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/components/CreditCardsSummaryWidget.tsx
+++ b/apps/web/src/components/CreditCardsSummaryWidget.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useMemo, useState } from "react";
+import { useMaskedCurrency } from "../context/DiscreetModeContext";
+import { creditCardsService, type CreditCardItem } from "../services/credit-cards.service";
+
+interface CreditCardsSummaryWidgetProps {
+  onOpenCreditCards?: () => void;
+}
+
+interface CreditCardsAggregate {
+  cardsCount: number;
+  availableTotal: number;
+  openPurchasesTotal: number;
+  pendingInvoicesTotal: number;
+  pendingInvoicesCount: number;
+}
+
+const buildAggregate = (items: CreditCardItem[]): CreditCardsAggregate =>
+  items.reduce<CreditCardsAggregate>(
+    (aggregate, card) => ({
+      cardsCount: aggregate.cardsCount + 1,
+      availableTotal: aggregate.availableTotal + card.usage.available,
+      openPurchasesTotal: aggregate.openPurchasesTotal + card.openPurchasesTotal,
+      pendingInvoicesTotal: aggregate.pendingInvoicesTotal + card.pendingInvoicesTotal,
+      pendingInvoicesCount: aggregate.pendingInvoicesCount + card.pendingInvoicesCount,
+    }),
+    {
+      cardsCount: 0,
+      availableTotal: 0,
+      openPurchasesTotal: 0,
+      pendingInvoicesTotal: 0,
+      pendingInvoicesCount: 0,
+    },
+  );
+
+const CreditCardsSummaryWidget = ({
+  onOpenCreditCards,
+}: CreditCardsSummaryWidgetProps): JSX.Element | null => {
+  const [cards, setCards] = useState<CreditCardItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
+  const money = useMaskedCurrency();
+
+  useEffect(() => {
+    creditCardsService
+      .list()
+      .then((result) => {
+        setCards(result.items);
+        setHasError(false);
+      })
+      .catch(() => {
+        setCards([]);
+        setHasError(true);
+      })
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  const aggregate = useMemo(() => buildAggregate(cards), [cards]);
+
+  if (isLoading) {
+    return (
+      <div className="rounded border border-cf-border bg-cf-surface p-4">
+        <p className="text-xs text-cf-text-secondary">Carregando cartões...</p>
+      </div>
+    );
+  }
+
+  if (hasError) {
+    return (
+      <div className="rounded border border-cf-border bg-cf-surface p-4">
+        <div className="mb-2 flex items-center justify-between gap-2">
+          <h3 className="text-sm font-medium text-cf-text-primary">Cartões</h3>
+          {onOpenCreditCards ? (
+            <button
+              type="button"
+              onClick={onOpenCreditCards}
+              className="text-xs text-brand-1 hover:underline"
+            >
+              Ver cartões →
+            </button>
+          ) : null}
+        </div>
+        <p className="text-sm text-cf-text-secondary">
+          Não foi possível carregar o resumo de cartões agora.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded border border-cf-border bg-cf-surface p-4">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <div>
+          <h3 className="text-sm font-medium text-cf-text-primary">Cartões</h3>
+          <p className="text-xs text-cf-text-secondary">
+            {aggregate.cardsCount === 0
+              ? "Nenhum cartão cadastrado ainda."
+              : aggregate.cardsCount === 1
+                ? "1 cartão ativo"
+                : `${aggregate.cardsCount} cartões ativos`}
+          </p>
+        </div>
+        {onOpenCreditCards ? (
+          <button
+            type="button"
+            onClick={onOpenCreditCards}
+            className="text-xs text-brand-1 hover:underline"
+          >
+            Ver cartões →
+          </button>
+        ) : null}
+      </div>
+
+      {aggregate.cardsCount === 0 ? (
+        <div className="rounded border border-dashed border-cf-border bg-cf-bg-subtle px-3 py-3 text-sm text-cf-text-secondary">
+          Cadastre um cartão para acompanhar limite disponível, compras abertas e faturas pendentes.
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
+            <p className="text-xs font-medium uppercase text-cf-text-secondary">Disponível</p>
+            <p className="text-sm font-semibold text-cf-text-primary">
+              {money(aggregate.availableTotal)}
+            </p>
+            <p className="text-xs text-cf-text-secondary">Soma dos limites livres</p>
+          </div>
+
+          <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
+            <p className="text-xs font-medium uppercase text-cf-text-secondary">Compras abertas</p>
+            <p className="text-sm font-semibold text-cf-text-primary">
+              {money(aggregate.openPurchasesTotal)}
+            </p>
+            <p className="text-xs text-cf-text-secondary">Ainda não fechadas em fatura</p>
+          </div>
+
+          <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
+            <p className="text-xs font-medium uppercase text-cf-text-secondary">Faturas pendentes</p>
+            <p
+              className={`text-sm font-semibold ${
+                aggregate.pendingInvoicesCount > 0 ? "text-amber-700" : "text-cf-text-primary"
+              }`}
+            >
+              {money(aggregate.pendingInvoicesTotal)}
+            </p>
+            <p
+              className={`text-xs ${
+                aggregate.pendingInvoicesCount > 0 ? "text-amber-700" : "text-cf-text-secondary"
+              }`}
+            >
+              {aggregate.pendingInvoicesCount}{" "}
+              {aggregate.pendingInvoicesCount === 1 ? "fatura" : "faturas"}
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CreditCardsSummaryWidget;

--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -8,6 +8,7 @@ import { analyticsService } from "../services/analytics.service";
 import { forecastService } from "../services/forecast.service";
 import { profileService } from "../services/profile.service";
 import { billsService } from "../services/bills.service";
+import { creditCardsService } from "../services/credit-cards.service";
 import { salaryService } from "../services/salary.service";
 
 vi.mock("../hooks/useTheme", () => ({
@@ -82,6 +83,12 @@ vi.mock("../services/profile.service", () => ({
 vi.mock("../services/bills.service", () => ({
   billsService: {
     getSummary: vi.fn(),
+  },
+}));
+
+vi.mock("../services/credit-cards.service", () => ({
+  creditCardsService: {
+    list: vi.fn(),
   },
 }));
 
@@ -330,6 +337,9 @@ describe("App", () => {
       overdueCount: 0,
       overdueTotal: 0,
     });
+    creditCardsService.list.mockResolvedValue({
+      items: [],
+    });
     salaryService.getProfile.mockResolvedValue(null);
     transactionsService.exportCsv.mockResolvedValue({
       blob: new Blob(["id,type\n1,Entrada"], { type: "text/csv;charset=utf-8" }),
@@ -359,6 +369,49 @@ describe("App", () => {
     await user.click(screen.getByRole("button", { name: "Cartões" }));
 
     expect(onOpenCreditCards).toHaveBeenCalledTimes(1);
+  });
+
+  it("exibe resumo agregado de cartões no painel operacional", async () => {
+    creditCardsService.list.mockResolvedValueOnce({
+      items: [
+        {
+          id: 1,
+          userId: 1,
+          name: "Nubank",
+          limitTotal: 3000,
+          closingDay: 10,
+          dueDay: 17,
+          isActive: true,
+          createdAt: "",
+          updatedAt: "",
+          usage: {
+            total: 3000,
+            used: 1480,
+            available: 1520,
+            exceededBy: 0,
+            usagePct: 49.33,
+            status: "using",
+          },
+          openPurchasesCount: 3,
+          openPurchasesTotal: 480,
+          pendingInvoicesCount: 1,
+          pendingInvoicesTotal: 1000,
+          openPurchases: [],
+          invoices: [],
+        },
+      ],
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Painel operacional")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Cartões")).toBeInTheDocument();
+    expect(screen.getByText(/1 cartão ativo/i)).toBeInTheDocument();
+    expect(screen.getByText("Compras abertas")).toBeInTheDocument();
+    expect(screen.getByText("Faturas pendentes")).toBeInTheDocument();
   });
 
   it("carrega transacoes paginadas da API ao iniciar", async () => {

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -9,6 +9,7 @@ import UpgradeModal from "../components/UpgradeModal";
 import ForecastCard from "../components/ForecastCard";
 import FinancialAlertBanner from "../components/FinancialAlertBanner";
 import BillsSummaryWidget from "../components/BillsSummaryWidget";
+import CreditCardsSummaryWidget from "../components/CreditCardsSummaryWidget";
 import SalaryWidget from "../components/SalaryWidget";
 import TransactionList from "../components/TransactionList";
 import {
@@ -1633,12 +1634,20 @@ const App = ({
   return (
     <div className="App min-h-screen bg-cf-bg-page pb-10">
       <header className="w-full bg-cf-header-bg py-3 shadow-md sm:py-4">
-        <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 sm:flex-row sm:items-center sm:justify-between sm:px-6">
-          <h1 className="text-2xl font-semibold sm:text-3xl lg:text-4xl">
-            <span className="text-brand-1">Control</span>
-            <span className="text-cf-text-primary">Finance</span>
-          </h1>
-          <div className="flex flex-wrap items-center justify-end gap-2">
+        <div className="mx-auto w-full max-w-6xl px-4 sm:px-6">
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-3 lg:grid lg:grid-cols-[1fr_auto_1fr] lg:items-center">
+              <div className="hidden lg:block" />
+              <div className="flex flex-col items-center text-center lg:justify-self-center">
+                <h1 className="text-2xl font-semibold sm:text-3xl lg:text-4xl">
+                  <span className="text-brand-1">Control</span>
+                  <span className="text-cf-text-primary">Finance</span>
+                </h1>
+                <p className="mt-1 text-xs text-cf-text-secondary sm:text-sm">
+                  Painel financeiro com importações, pendências, cartões e Central do Leão.
+                </p>
+              </div>
+              <div className="flex flex-wrap items-center justify-between gap-2 lg:justify-end">
             {useMobileActionsMenu ? (
               <div className="relative flex items-center gap-2">
                 <button
@@ -1797,7 +1806,7 @@ const App = ({
                 ) : null}
               </div>
             ) : (
-              <div className="flex min-w-0 items-center gap-1 rounded border border-cf-border bg-cf-surface/70 p-1 sm:gap-2">
+              <div className="flex flex-wrap items-center justify-end gap-2">
                 <button
                   type="button"
                   onClick={cycleTheme}
@@ -1806,73 +1815,6 @@ const App = ({
                 >
                   {themeLabel}
                 </button>
-                <button
-                  type="button"
-                  onClick={handleExportCsv}
-                  disabled={isExportingCsv}
-                  className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle disabled:cursor-not-allowed disabled:opacity-60"
-                >
-                  {isExportingCsv ? "Exportando CSV..." : "Exportar CSV"}
-                </button>
-                <button
-                  type="button"
-                  onClick={handleOpenImportModal}
-                  className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
-                >
-                  Importar extrato
-                </button>
-                <button
-                  type="button"
-                  onClick={handleOpenImportHistoryModal}
-                  className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
-                >
-                  Histórico de imports
-                </button>
-                {onOpenBills ? (
-                  <button
-                    type="button"
-                    onClick={handleOpenBills}
-                    className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
-                  >
-                    Pendências
-                  </button>
-                ) : null}
-                {onOpenCreditCards ? (
-                  <button
-                    type="button"
-                    onClick={handleOpenCreditCards}
-                    className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
-                  >
-                    Cartões
-                  </button>
-                ) : null}
-                {onOpenIncomeSources ? (
-                  <button
-                    type="button"
-                    onClick={handleOpenIncomeSources}
-                    className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
-                  >
-                    Fontes de Renda
-                  </button>
-                ) : null}
-                {onOpenTax ? (
-                  <button
-                    type="button"
-                    onClick={handleOpenTax}
-                    className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
-                  >
-                    Central do Leão
-                  </button>
-                ) : null}
-                {onOpenCategoriesSettings ? (
-                  <button
-                    type="button"
-                    onClick={handleOpenCategoriesSettings}
-                    className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
-                  >
-                    Categorias
-                  </button>
-                ) : null}
                 {(onOpenProfileSettings || onOpenBillingSettings || onOpenSecuritySettings || onLogout) ? (
                   <div className="relative">
                     <button
@@ -1951,6 +1893,83 @@ const App = ({
             >
               Registrar novo valor
             </button>
+              </div>
+            </div>
+
+            {!useMobileActionsMenu ? (
+              <nav
+                aria-label="Atalhos principais"
+                className="flex flex-wrap items-center justify-center gap-2 rounded border border-cf-border bg-cf-surface/70 p-2"
+              >
+                <button
+                  type="button"
+                  onClick={handleExportCsv}
+                  disabled={isExportingCsv}
+                  className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isExportingCsv ? "Exportando CSV..." : "Exportar CSV"}
+                </button>
+                <button
+                  type="button"
+                  onClick={handleOpenImportModal}
+                  className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
+                >
+                  Importar extrato
+                </button>
+                <button
+                  type="button"
+                  onClick={handleOpenImportHistoryModal}
+                  className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
+                >
+                  Histórico de imports
+                </button>
+                {onOpenBills ? (
+                  <button
+                    type="button"
+                    onClick={handleOpenBills}
+                    className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
+                  >
+                    Pendências
+                  </button>
+                ) : null}
+                {onOpenCreditCards ? (
+                  <button
+                    type="button"
+                    onClick={handleOpenCreditCards}
+                    className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
+                  >
+                    Cartões
+                  </button>
+                ) : null}
+                {onOpenIncomeSources ? (
+                  <button
+                    type="button"
+                    onClick={handleOpenIncomeSources}
+                    className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
+                  >
+                    Fontes de Renda
+                  </button>
+                ) : null}
+                {onOpenTax ? (
+                  <button
+                    type="button"
+                    onClick={handleOpenTax}
+                    className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
+                  >
+                    Central do Leão
+                  </button>
+                ) : null}
+                {onOpenCategoriesSettings ? (
+                  <button
+                    type="button"
+                    onClick={handleOpenCategoriesSettings}
+                    className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
+                  >
+                    Categorias
+                  </button>
+                ) : null}
+              </nav>
+            ) : null}
           </div>
         </div>
       </header>
@@ -2435,15 +2454,28 @@ const App = ({
               </div>
             ) : null}
           </section>
-        <ForecastCard onOpenProfileSettings={onOpenProfileSettings} />
+        <section className="space-y-4" aria-labelledby="operational-overview-title">
+          <div>
+            <h3 id="operational-overview-title" className="text-sm font-medium text-cf-text-primary">
+              Painel operacional
+            </h3>
+            <p className="mt-1 text-xs text-cf-text-secondary">
+              Pendências, cartões, renda e projeção em um ponto só para o mês atual.
+            </p>
+          </div>
+
+          <div className="grid gap-4 xl:grid-cols-3">
+            <ForecastCard onOpenProfileSettings={onOpenProfileSettings} />
+            <BillsSummaryWidget onOpenBills={handleOpenBills} />
+            <CreditCardsSummaryWidget onOpenCreditCards={handleOpenCreditCards} />
+          </div>
+        </section>
+
+        <SalaryWidget />
 
         <Suspense fallback={null}>
           <HealthOverview />
         </Suspense>
-
-        <BillsSummaryWidget onOpenBills={handleOpenBills} />
-
-        <SalaryWidget />
 
         <Suspense fallback={null}>
           <GoalsSection />

--- a/apps/web/src/pages/ProfileSettings.test.tsx
+++ b/apps/web/src/pages/ProfileSettings.test.tsx
@@ -156,9 +156,11 @@ describe("ProfileSettings — Dados da conta", () => {
     );
 
     renderPage();
-    await waitFor(() => expect(screen.getByLabelText("Limite bancário (R$)")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByLabelText("Limite da conta / cheque especial (R$)")).toBeInTheDocument(),
+    );
 
-    const bankLimitInput = screen.getByLabelText("Limite bancário (R$)");
+    const bankLimitInput = screen.getByLabelText("Limite da conta / cheque especial (R$)");
     expect(bankLimitInput).toHaveValue(850);
 
     await user.clear(bankLimitInput);

--- a/apps/web/src/pages/ProfileSettings.tsx
+++ b/apps/web/src/pages/ProfileSettings.tsx
@@ -281,7 +281,7 @@ const ProfileSettings = ({
                       htmlFor="avatar_url"
                       className="block text-sm font-semibold text-cf-text-primary"
                     >
-                      URL do avatar
+                      Foto do perfil (URL)
                     </label>
                     <input
                       id="avatar_url"
@@ -292,7 +292,7 @@ const ProfileSettings = ({
                       className="mt-1 w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
                     />
                     <p className="mt-0.5 text-xs text-cf-text-secondary">
-                      Deve começar com https://. Deixe vazio para usar as iniciais.
+                      Por enquanto, use uma imagem em https://. Se deixar vazio, usamos suas iniciais.
                     </p>
                   </div>
                 </div>
@@ -385,7 +385,7 @@ const ProfileSettings = ({
                       htmlFor="bank_limit_total"
                       className="block text-sm font-semibold text-cf-text-primary"
                     >
-                      Limite bancário (R$)
+                      Limite da conta / cheque especial (R$)
                     </label>
                     <input
                       id="bank_limit_total"
@@ -398,7 +398,7 @@ const ProfileSettings = ({
                       className="mt-1 w-full rounded border border-cf-border-input bg-cf-surface px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
                     />
                     <p className="mt-0.5 text-xs text-cf-text-secondary">
-                      Usado para mostrar quanto da projeção do mês entraria no limite da conta.
+                      Use se o banco oferece cheque especial ou limite automático. A projeção mostra quanto desse valor seria consumido.
                     </p>
                   </div>
                   <div>

--- a/apps/web/src/pages/TaxPage.test.tsx
+++ b/apps/web/src/pages/TaxPage.test.tsx
@@ -322,7 +322,7 @@ describe("TaxPage", () => {
     });
   });
 
-  it("gerar resumo chama rebuildSummary", async () => {
+  it("gerar resumo chama rebuildSummary e recarrega o espelho fiscal completo", async () => {
     const user = userEvent.setup();
     renderPage();
 
@@ -334,6 +334,13 @@ describe("TaxPage", () => {
 
     await waitFor(() => {
       expect(taxService.rebuildSummary).toHaveBeenCalledWith(2026);
+    });
+
+    await waitFor(() => {
+      expect(taxService.getSummary).toHaveBeenCalledTimes(2);
+      expect(taxService.getObligation).toHaveBeenCalledTimes(2);
+      expect(taxService.listDocuments).toHaveBeenCalledTimes(2);
+      expect(taxService.listFacts).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/apps/web/src/pages/TaxPage.tsx
+++ b/apps/web/src/pages/TaxPage.tsx
@@ -272,24 +272,12 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
     if (summaryResult.status === "fulfilled") {
       setSummary(summaryResult.value);
     } else {
-      setSummary({
-        ...EMPTY_SUMMARY,
-        taxYear,
-        exerciseYear: taxYear,
-        calendarYear: taxYear - 1,
-      });
       nextErrors.push(getApiErrorMessage(summaryResult.reason, "Não foi possível carregar o resumo fiscal."));
     }
 
     if (obligationResult.status === "fulfilled") {
       setObligation(obligationResult.value);
     } else {
-      setObligation({
-        ...EMPTY_OBLIGATION,
-        taxYear,
-        exerciseYear: taxYear,
-        calendarYear: taxYear - 1,
-      });
       nextErrors.push(
         getApiErrorMessage(
           obligationResult.reason,
@@ -301,12 +289,6 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
     if (factsResult.status === "fulfilled") {
       setFactsPage(factsResult.value);
     } else {
-      setFactsPage({
-        items: [],
-        page: 1,
-        pageSize: DEFAULT_FACTS_PAGE_SIZE,
-        total: 0,
-      });
       nextErrors.push(
         getApiErrorMessage(factsResult.reason, "Não foi possível carregar a fila de revisão."),
       );
@@ -315,7 +297,6 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
     if (documentsResult.status === "fulfilled") {
       setDocumentsPage(documentsResult.value);
     } else {
-      setDocumentsPage(EMPTY_DOCUMENTS_PAGE);
       nextErrors.push(
         getApiErrorMessage(documentsResult.reason, "Não foi possível carregar os documentos do exercício."),
       );
@@ -323,8 +304,6 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
 
     if (profileResult.status === "fulfilled") {
       setTaxpayerCpf(profileResult.value.profile?.taxpayerCpf ?? null);
-    } else {
-      setTaxpayerCpf(null);
     }
 
     setPageError(nextErrors[0] || "");
@@ -485,9 +464,8 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
 
     try {
       const rebuiltSummary = await taxService.rebuildSummary(taxYear);
-      const nextObligation = await taxService.getObligation(taxYear);
       setSummary(rebuiltSummary);
-      setObligation(nextObligation);
+      await loadPageData();
       showSuccess(
         rebuiltSummary.snapshotVersion
           ? `Resumo fiscal atualizado na versão ${rebuiltSummary.snapshotVersion}.`
@@ -645,7 +623,19 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
   };
 
   const headerCalendarYear = summary.calendarYear || obligation.calendarYear || taxYear - 1;
-  const methodLabel = summary.bestMethod ? METHOD_LABELS[summary.bestMethod] : "Ainda não definido";
+  const hasResolvedFiscalData =
+    summary.status === "generated" ||
+    summary.snapshotVersion !== null ||
+    summary.generatedAt !== null ||
+    obligation.approvedFactsCount > 0 ||
+    documentsPage.total > 0 ||
+    factsPage.total > 0;
+  const showLoadingPlaceholders = isLoadingPage && !hasResolvedFiscalData;
+  const methodLabel = showLoadingPlaceholders
+    ? "Carregando..."
+    : summary.bestMethod
+      ? METHOD_LABELS[summary.bestMethod]
+      : "Ainda não definido";
   const liveTaxableIncome = obligation.totals.annualTaxableIncome;
   const liveExemptIncome = obligation.totals.annualExemptIncome;
   const liveExclusiveIncome = obligation.totals.annualExclusiveIncome;
@@ -686,14 +676,23 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
     });
   }
 
-  const showNoObligationInfo = !obligation.mustDeclare;
+  const visibleFactWarnings = showLoadingPlaceholders ? [] : factWarnings;
+  const showNoObligationInfo = !showLoadingPlaceholders && !obligation.mustDeclare;
   const canSyncFromApp = !isLoadingPage && documentsPage.total === 0;
+  const generatedStatusLabel = showLoadingPlaceholders
+    ? "Carregando dados..."
+    : summary.status === "generated"
+      ? "Gerado"
+      : "Ainda não gerado";
+  const documentsCountLabel = showLoadingPlaceholders
+    ? "Carregando..."
+    : `${documentsPage.total} documento(s)`;
 
   return (
     <div className="min-h-screen bg-cf-bg-page px-4 py-6 sm:px-6">
       <div className="mx-auto max-w-6xl">
         <div className="mb-6 flex flex-col gap-4 rounded border border-cf-border bg-cf-surface p-5">
-          <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div className="flex flex-col gap-4">
             <div>
               <div className="flex items-center gap-3">
                 {onBack ? (
@@ -715,53 +714,74 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
               </p>
             </div>
 
-            <div className="flex flex-wrap gap-2">
-              <button
-                type="button"
-                onClick={handleOpenUploadModal}
-                className="rounded border border-brand-1 bg-brand-1 px-3 py-2 text-sm font-semibold text-white hover:bg-brand-2"
-              >
-                Enviar documento
-              </button>
-              <button
-                type="button"
-                onClick={() => void handleSyncAppData()}
-                disabled={!canSyncFromApp || isSyncingAppData}
-                className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2 text-sm font-semibold text-cf-text-primary hover:bg-cf-surface disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                {isSyncingAppData ? "Sincronizando..." : "Sincronizar do app"}
-              </button>
-              <button
-                type="button"
-                onClick={() => void loadPageData()}
-                className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2 text-sm font-semibold text-cf-text-primary hover:bg-cf-surface"
-              >
-                Atualizar
-              </button>
-              <button
-                type="button"
-                onClick={handleRebuildSummary}
-                disabled={isRebuildingSummary}
-                className="rounded border border-brand-1 bg-brand-1 px-3 py-2 text-sm font-semibold text-white hover:bg-brand-2 disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                {isRebuildingSummary ? "Gerando resumo..." : "Gerar resumo"}
-              </button>
-              <button
-                type="button"
-                onClick={() => void handleExport("json")}
-                disabled={exportingFormat !== null}
-                className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2 text-sm font-semibold text-cf-text-primary hover:bg-cf-surface disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                {exportingFormat === "json" ? "Baixando JSON..." : "Baixar JSON"}
-              </button>
-              <button
-                type="button"
-                onClick={() => void handleExport("csv")}
-                disabled={exportingFormat !== null}
-                className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2 text-sm font-semibold text-cf-text-primary hover:bg-cf-surface disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                {exportingFormat === "csv" ? "Baixando CSV..." : "Baixar CSV"}
-              </button>
+            <div className="flex flex-wrap items-center gap-2 text-xs text-cf-text-secondary">
+              <span className="rounded-full border border-cf-border bg-cf-bg-subtle px-2.5 py-1 font-semibold">
+                {generatedStatusLabel}
+              </span>
+              {summary.generatedAt && !showLoadingPlaceholders ? (
+                <span className="rounded-full border border-cf-border bg-cf-bg-subtle px-2.5 py-1 font-medium">
+                  Atualizado em {formatDateTime(summary.generatedAt)}
+                </span>
+              ) : null}
+              {summary.snapshotVersion != null && !showLoadingPlaceholders ? (
+                <span className="rounded-full border border-cf-border bg-cf-bg-subtle px-2.5 py-1 font-medium">
+                  Snapshot v{summary.snapshotVersion}
+                </span>
+              ) : null}
+            </div>
+
+            <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={handleOpenUploadModal}
+                  className="rounded border border-brand-1 bg-brand-1 px-3 py-2 text-sm font-semibold text-white hover:bg-brand-2"
+                >
+                  Enviar documento
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void handleSyncAppData()}
+                  disabled={!canSyncFromApp || isSyncingAppData}
+                  className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2 text-sm font-semibold text-cf-text-primary hover:bg-cf-surface disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isSyncingAppData ? "Sincronizando..." : "Sincronizar do app"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void loadPageData()}
+                  className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2 text-sm font-semibold text-cf-text-primary hover:bg-cf-surface"
+                >
+                  Atualizar
+                </button>
+                <button
+                  type="button"
+                  onClick={handleRebuildSummary}
+                  disabled={isRebuildingSummary}
+                  className="rounded border border-brand-1 bg-brand-1 px-3 py-2 text-sm font-semibold text-white hover:bg-brand-2 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isRebuildingSummary ? "Gerando resumo..." : "Gerar resumo"}
+                </button>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={() => void handleExport("json")}
+                  disabled={exportingFormat !== null}
+                  className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2 text-sm font-semibold text-cf-text-primary hover:bg-cf-surface disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {exportingFormat === "json" ? "Baixando JSON..." : "Baixar JSON"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void handleExport("csv")}
+                  disabled={exportingFormat !== null}
+                  className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2 text-sm font-semibold text-cf-text-primary hover:bg-cf-surface disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {exportingFormat === "csv" ? "Baixando CSV..." : "Baixar CSV"}
+                </button>
+              </div>
             </div>
           </div>
 
@@ -787,21 +807,33 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
         <div className="grid gap-4 lg:grid-cols-4">
           <FactSummaryCard
             title="Obrigatoriedade"
-            value={obligation.mustDeclare ? "Obrigatório declarar" : "Sem obrigatoriedade hoje"}
+            value={
+              showLoadingPlaceholders
+                ? "Carregando..."
+                : obligation.mustDeclare
+                  ? "Obrigatório declarar"
+                  : "Sem obrigatoriedade hoje"
+            }
             helper={
-              obligation.mustDeclare
+              showLoadingPlaceholders
+                ? "Lendo fatos revisados e status do exercício"
+                : obligation.mustDeclare
                 ? `${obligation.reasons.length} motivo(s) ativo(s) com base em fatos revisados`
                 : "Mesmo isento, o espelho do exercício continua disponível"
             }
           />
           <FactSummaryCard
             title="Rendimentos Tributáveis"
-            value={formatCurrency(displayAnnualTaxableIncome)}
+            value={
+              showLoadingPlaceholders ? "Carregando..." : formatCurrency(displayAnnualTaxableIncome)
+            }
             helper="Base considerada para o gatilho principal"
           />
           <FactSummaryCard
             title="IRRF Acumulado"
-            value={formatCurrency(displayAnnualWithheldTax)}
+            value={
+              showLoadingPlaceholders ? "Carregando..." : formatCurrency(displayAnnualWithheldTax)
+            }
             helper="Valor separado do imposto pela tabela, mesmo abaixo do limite"
           />
           <FactSummaryCard
@@ -834,46 +866,70 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
                 </p>
               </div>
               <span className="rounded-full border border-cf-border bg-cf-bg-subtle px-2.5 py-1 text-xs font-semibold text-cf-text-secondary">
-                {summary.status === "generated" ? "Gerado" : "Ainda não gerado"}
+                {generatedStatusLabel}
               </span>
             </div>
 
             <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
               <FactSummaryCard
                 title="Imposto pela Tabela"
-                value={summary.estimatedAnnualTax == null ? "—" : formatCurrency(summary.estimatedAnnualTax)}
+                value={
+                  showLoadingPlaceholders
+                    ? "Carregando..."
+                    : summary.estimatedAnnualTax == null
+                      ? "—"
+                      : formatCurrency(summary.estimatedAnnualTax)
+                }
                 helper="Sem compensar IRRF"
               />
               <FactSummaryCard
                 title="Rendimentos Isentos"
-                value={formatCurrency(displayAnnualExemptIncome)}
+                value={
+                  showLoadingPlaceholders ? "Carregando..." : formatCurrency(displayAnnualExemptIncome)
+                }
                 helper="Ex.: aposentadoria 65+, parcelas isentas e afins"
               />
               <FactSummaryCard
                 title="Exclusivos na Fonte"
-                value={formatCurrency(displayAnnualExclusiveIncome)}
+                value={
+                  showLoadingPlaceholders
+                    ? "Carregando..."
+                    : formatCurrency(displayAnnualExclusiveIncome)
+                }
                 helper="Ex.: 13º e aplicações"
               />
               <FactSummaryCard
                 title="Deduções Legais"
-                value={formatCurrency(displayLegalDeductions)}
+                value={
+                  showLoadingPlaceholders ? "Carregando..." : formatCurrency(displayLegalDeductions)
+                }
                 helper="Médicas e instrução já revisadas"
               />
               <FactSummaryCard
                 title="Desconto Simplificado"
-                value={formatCurrency(summary.simplifiedDiscountUsed)}
+                value={
+                  showLoadingPlaceholders
+                    ? "Carregando..."
+                    : formatCurrency(summary.simplifiedDiscountUsed)
+                }
                 helper="Cap aplicado pelas regras ativas"
               />
               <FactSummaryCard
                 title="Documentos"
-                value={String(summary.sourceCounts.documents)}
+                value={
+                  showLoadingPlaceholders ? "Carregando..." : String(summary.sourceCounts.documents)
+                }
                 helper="Arquivos vinculados ao exercício"
               />
               <FactSummaryCard
                 title="Fatos no Cálculo"
-                value={String(obligation.approvedFactsCount)}
+                value={
+                  showLoadingPlaceholders ? "Carregando..." : String(obligation.approvedFactsCount)
+                }
                 helper={
-                  excludedApprovedFactsCount > 0
+                  showLoadingPlaceholders
+                    ? "Separando fatos que entram no cálculo oficial"
+                    : excludedApprovedFactsCount > 0
                     ? `${excludedApprovedFactsCount} aprovado(s) ficaram fora por CPF divergente`
                     : "Base que entra em obrigação e summary"
                 }
@@ -891,26 +947,36 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
               <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-3">
                 <p className="text-xs font-semibold uppercase text-cf-text-secondary">Tributáveis</p>
                 <p className="mt-1 text-lg font-bold text-cf-text-primary">
-                  {formatCurrency(obligation.thresholds.taxableIncome)}
+                  {showLoadingPlaceholders
+                    ? "Carregando..."
+                    : formatCurrency(obligation.thresholds.taxableIncome)}
                 </p>
               </div>
               <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-3">
                 <p className="text-xs font-semibold uppercase text-cf-text-secondary">Isentos + exclusivos</p>
                 <p className="mt-1 text-lg font-bold text-cf-text-primary">
-                  {formatCurrency(obligation.thresholds.exemptAndExclusiveIncome)}
+                  {showLoadingPlaceholders
+                    ? "Carregando..."
+                    : formatCurrency(obligation.thresholds.exemptAndExclusiveIncome)}
                 </p>
               </div>
               <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-3">
                 <p className="text-xs font-semibold uppercase text-cf-text-secondary">Patrimônio</p>
                 <p className="mt-1 text-lg font-bold text-cf-text-primary">
-                  {formatCurrency(obligation.thresholds.assets)}
+                  {showLoadingPlaceholders
+                    ? "Carregando..."
+                    : formatCurrency(obligation.thresholds.assets)}
                 </p>
               </div>
             </div>
 
             <div className="mt-4 rounded border border-cf-border bg-cf-bg-subtle px-3 py-3">
               <p className="text-xs font-semibold uppercase text-cf-text-secondary">Motivos ativos</p>
-              {obligation.reasons.length === 0 ? (
+              {showLoadingPlaceholders ? (
+                <p className="mt-2 text-sm text-cf-text-secondary">
+                  Carregando gatilhos e fatos revisados do exercício...
+                </p>
+              ) : obligation.reasons.length === 0 ? (
                 <p className="mt-2 text-sm text-cf-text-secondary">
                   Pelos fatos revisados até agora, você continua abaixo dos limites objetivos do exercício.
                 </p>
@@ -927,11 +993,11 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
           </section>
         </div>
 
-        {factWarnings.length > 0 ? (
+        {visibleFactWarnings.length > 0 ? (
           <section className="mt-4 rounded border border-amber-200 bg-amber-50 p-5">
             <h2 className="text-lg font-bold text-amber-900">Alertas e observações fiscais</h2>
             <div className="mt-3 space-y-2">
-              {factWarnings.map((warning) => (
+              {visibleFactWarnings.map((warning) => (
                 <div
                   key={warning.code}
                   className="rounded border border-amber-200 bg-white/60 px-3 py-2 text-sm text-amber-900"
@@ -957,7 +1023,7 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
               </p>
             </div>
             <span className="rounded-full border border-cf-border bg-cf-bg-subtle px-2.5 py-1 text-xs font-semibold text-cf-text-secondary">
-              {documentsPage.total} documento(s)
+              {documentsCountLabel}
             </span>
           </div>
 


### PR DESCRIPTION
## Contexto

Este PR fecha um gap claro de front-end: o produto já evoluiu bastante em cartões, pendências e Central do Leão, mas o shell principal e parte da UX ainda estavam com cara de uma versão anterior.

## O que entra

- header do dashboard reorganizado em duas camadas no desktop
- painel operacional do dashboard com resumo real de cartões
- Central do Leão com carregamento mais honesto e refresh completo após gerar resumo
- cópia de perfil mais clara para limite da conta / cheque especial
- testes cobrindo o novo widget de cartões e o refresh da Central do Leão

## Escopo

- somente web
- sem mudança de contrato de API
- sem incluir o .env local

## Validação

- 
pm -w apps/web run typecheck ✅
- 
pm -w apps/web run lint ✅
- 
pm -w apps/web run test:run ✅
- 
pm -w apps/web run build ✅
