### PR TITLE
fix(product): align trial copy with real entitlements

### DIFF
--- a/apps/web/src/components/UpgradeModal.test.tsx
+++ b/apps/web/src/components/UpgradeModal.test.tsx
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import UpgradeModal from "./UpgradeModal";
+
+vi.mock("../utils/analytics", () => ({
+  trackPaywallEvent: vi.fn(),
+}));
+
+describe("UpgradeModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("mostra bloqueio de importação como limitação de plano, não erro técnico", () => {
+    render(
+      <MemoryRouter>
+        <UpgradeModal
+          isOpen
+          reason="Seu plano atual não inclui a importação de extratos. No Pro, você importa CSV, OFX e PDF com pré-visualização antes de confirmar."
+          feature="csv_import"
+          context="feature_gate"
+          onClose={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Importação disponível no Pro")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Seu plano atual não inclui a importação de extratos/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Importar extratos (CSV, OFX e PDF)"),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/UpgradeModal.tsx
+++ b/apps/web/src/components/UpgradeModal.tsx
@@ -18,16 +18,24 @@ const FEATURES: { label: string; free: string; pro: string }[] = [
   { label: "Histórico de analytics",  free: "6 meses", pro: "24 meses" },
   { label: "Previsão financeira",     free: "—", pro: "✓" },
   { label: "Controle salarial",       free: "—", pro: "✓" },
-  { label: "Exportar CSV",            free: "—", pro: "✓" },
-  { label: "Importar CSV",            free: "—", pro: "✓" },
+  { label: "Exportar transações em CSV", free: "—", pro: "✓" },
+  { label: "Importar extratos (CSV, OFX e PDF)", free: "—", pro: "✓" },
 ];
 
 const BENEFITS = [
   "Saiba quanto vai ter no saldo no fim do mês",
   "Entenda exatamente para onde seu dinheiro está indo",
   "Planeje seu salário com cálculo real de INSS e IRRF",
-  "Exporte e importe transações com facilidade",
+  "Importe extratos com revisão antes de confirmar",
 ];
+
+const FEATURE_TITLES: Partial<Record<PaywallFeature, string>> = {
+  csv_import: "Importação disponível no Pro",
+  csv_export: "Exportação disponível no Pro",
+  forecast: "Projeção disponível no Pro",
+  analytics_trend: "Histórico avançado disponível no Pro",
+  salary: "Controle salarial disponível no Pro",
+};
 
 const UpgradeModal = ({
   isOpen,
@@ -56,9 +64,10 @@ const UpgradeModal = ({
   if (!isOpen) return null;
 
   const isTrialExpired = reason.toLowerCase().includes("teste encerrado");
+  const featureTitle = FEATURE_TITLES[feature];
   const title = isTrialExpired
     ? "Seu período de teste encerrou"
-    : "Desbloqueie o Control Finance Pro";
+    : featureTitle || "Desbloqueie o Control Finance Pro";
   const subtitle = isTrialExpired
     ? "Continue com acesso total por menos de R$ 0,33 por dia."
     : reason;

--- a/apps/web/src/pages/BillingSettings.test.tsx
+++ b/apps/web/src/pages/BillingSettings.test.tsx
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import BillingSettings from "./BillingSettings";
+import { billingService, type SubscriptionSummary } from "../services/billing.service";
+
+vi.mock("../services/billing.service", () => ({
+  billingService: {
+    getSubscription: vi.fn(),
+    createCheckout: vi.fn(),
+    createPortal: vi.fn(),
+  },
+}));
+
+const buildSummary = (overrides: Partial<SubscriptionSummary> = {}): SubscriptionSummary => ({
+  plan: "free",
+  displayName: "Plano Gratuito",
+  features: {
+    csv_import: false,
+    csv_export: false,
+    analytics_months_max: 6,
+    budget_tracking: true,
+    salary_annual: true,
+  },
+  subscription: null,
+  entitlementSource: "trial",
+  trialEndsAt: new Date(Date.now() + 5 * 86_400_000).toISOString(),
+  trialExpired: false,
+  ...overrides,
+});
+
+describe("BillingSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("explica no trial que importação e exportação de extratos fazem parte do Pro", async () => {
+    vi.mocked(billingService.getSubscription).mockResolvedValue(buildSummary());
+
+    render(<BillingSettings />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Trial do Control Finance")).toBeInTheDocument(),
+    );
+
+    expect(
+      screen.getByText(
+        /Durante o trial, você testa o painel financeiro, metas, cartões, renda e a Central do Leão/i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Importação e exportação de extratos fazem parte do plano Pro/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/BillingSettings.tsx
+++ b/apps/web/src/pages/BillingSettings.tsx
@@ -27,6 +27,26 @@ const daysRemaining = (isoDate: string | null | undefined): number => {
   return Math.max(0, Math.ceil(ms / (1000 * 60 * 60 * 24)));
 };
 
+const resolvePlanSupportCopy = (summary: SubscriptionSummary): string => {
+  if (summary.entitlementSource === "trial") {
+    return "Durante o trial, você testa o painel financeiro, metas, cartões, renda e a Central do Leão. Importação e exportação de extratos fazem parte do plano Pro.";
+  }
+
+  if (summary.entitlementSource === "free" && summary.trialExpired) {
+    return "Seu trial terminou. Faça upgrade para liberar importação de extratos, exportação e demais recursos avançados do Pro.";
+  }
+
+  if (
+    summary.entitlementSource === "subscription" ||
+    summary.entitlementSource === "subscription_grace" ||
+    summary.entitlementSource === "prepaid"
+  ) {
+    return "Seu plano Pro mantém importação e exportação de extratos, projeção financeira e os módulos avançados do produto.";
+  }
+
+  return "Consulte abaixo o que está disponível agora e o que faz parte do plano Pro.";
+};
+
 type PlanBadge = { label: string; className: string };
 
 const resolvePlanBadge = (summary: import("../services/billing.service").SubscriptionSummary): PlanBadge => {
@@ -152,6 +172,7 @@ const BillingSettings = ({
   const showCheckoutPendingNotice =
     checkoutStatus === "success" && !isLoading && !loadError && !isPro;
   const showCheckoutCanceledNotice = checkoutStatus === "cancel";
+  const planTitle = source === "trial" ? "Trial do Control Finance" : summary?.displayName ?? "";
 
   return (
     <div className="min-h-screen bg-cf-bg-page py-6">
@@ -231,7 +252,7 @@ const BillingSettings = ({
                       Plano atual
                     </p>
                     <p className="mt-0.5 text-lg font-bold text-cf-text-primary">
-                      {summary.displayName}
+                      {planTitle}
                     </p>
                     {planBadge ? (
                       <span
@@ -240,6 +261,9 @@ const BillingSettings = ({
                         {planBadge.label}
                       </span>
                     ) : null}
+                    <p className="mt-2 max-w-2xl text-xs text-cf-text-secondary">
+                      {resolvePlanSupportCopy(summary)}
+                    </p>
                   </div>
 
                   {isPro ? (

--- a/apps/web/src/pages/ProfileSettings.test.tsx
+++ b/apps/web/src/pages/ProfileSettings.test.tsx
@@ -304,6 +304,7 @@ describe("ProfileSettings — Assinatura", () => {
     renderPage();
     await waitFor(() => expect(screen.getByText("Trial ativo")).toBeInTheDocument());
     expect(screen.getByText(/dias? restante/i)).toBeInTheDocument();
+    expect(screen.getByText(/importação e exportação de extratos fazem parte do Pro/i)).toBeInTheDocument();
   });
 
   it("shows trial expired with upgrade CTA", async () => {

--- a/apps/web/src/pages/ProfileSettings.tsx
+++ b/apps/web/src/pages/ProfileSettings.tsx
@@ -580,8 +580,8 @@ const ProfileSettings = ({
                     <p className="text-sm font-semibold text-green-800">Trial ativo</p>
                     <p className="mt-0.5 text-xs text-green-700">
                       {daysRemaining > 0
-                        ? `${daysRemaining} dia${daysRemaining !== 1 ? "s" : ""} restante${daysRemaining !== 1 ? "s" : ""} — acesso completo a todas as funcionalidades.`
-                        : "Último dia de trial — acesso completo a todas as funcionalidades."}
+                        ? `${daysRemaining} dia${daysRemaining !== 1 ? "s" : ""} restante${daysRemaining !== 1 ? "s" : ""} — aproveite as funcionalidades liberadas no trial. Importação e exportação de extratos fazem parte do Pro.`
+                        : "Último dia de trial — as funcionalidades liberadas no teste seguem ativas até o fim do dia. Importação e exportação de extratos fazem parte do Pro."}
                     </p>
                   </div>
                   <span className="shrink-0 rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-semibold text-green-800">
@@ -593,7 +593,7 @@ const ProfileSettings = ({
                   <div>
                     <p className="text-sm font-semibold text-amber-800">Trial expirado</p>
                     <p className="mt-0.5 text-xs text-amber-700">
-                      Algumas funcionalidades estão limitadas. Faça upgrade para continuar usando o Especialista IA, exportação e projeção de saldo.
+                      Algumas funcionalidades ficaram limitadas. Faça upgrade para continuar com projeção, exportação e importação de extratos no Pro.
                     </p>
                   </div>
                   <div className="flex shrink-0 flex-col items-end gap-2">

--- a/apps/web/src/services/api.test.js
+++ b/apps/web/src/services/api.test.js
@@ -236,6 +236,25 @@ describe("api service", () => {
     });
   });
 
+  it("resolve copy explicita para gate de importacao de extrato", async () => {
+    const onPaymentRequired = vi.fn();
+    setPaymentRequiredHandler(onPaymentRequired);
+
+    await expect(
+      responseErrorInterceptor({
+        response: { status: 402, data: { message: "Recurso disponivel apenas no plano Pro." } },
+        config: { url: "/transactions/import/dry-run" },
+      }),
+    ).rejects.toBeTruthy();
+
+    expect(onPaymentRequired).toHaveBeenCalledWith({
+      reason:
+        "Seu plano atual não inclui a importação de extratos. No Pro, você importa CSV, OFX e PDF com pré-visualização antes de confirmar.",
+      feature: "csv_import",
+      context: "feature_gate",
+    });
+  });
+
   it("nao falha se paymentRequiredHandler nao estiver definido (status 402)", async () => {
     await expect(
       responseErrorInterceptor({

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -168,12 +168,14 @@ api.interceptors.request.use((config: InternalAxiosRequestConfig) => {
 const PAYWALL_COPY: Array<{ pattern: RegExp; reason: string; feature: PaywallFeature }> = [
   {
     pattern: /\/transactions\/import/,
-    reason: "Importe transações de outros apps e bancos direto para o Control Finance.",
+    reason:
+      "Seu plano atual não inclui a importação de extratos. No Pro, você importa CSV, OFX e PDF com pré-visualização antes de confirmar.",
     feature: "csv_import",
   },
   {
     pattern: /\/transactions\/export/,
-    reason: "Exporte suas transações para planilhas e ferramentas financeiras.",
+    reason:
+      "Seu plano atual não inclui a exportação de transações em CSV. No Pro, você exporta seus dados para planilhas e ferramentas financeiras.",
     feature: "csv_export",
   },
   {


### PR DESCRIPTION
## Contexto\n\nEste PR fecha o primeiro slice da Sprint de Confiabilidade do Produto, removendo contradições entre o entitlement real do trial e a copy exibida na UI.\n\n## O que entra\n\n- copy do trial mais honesta em perfil e billing\n- mensagem de bloqueio de importação/exportação mais explícita no paywall\n- ajustes no modal de upgrade para deixar claro que o bloqueio é de plano, não erro técnico\n- testes cobrindo perfil, billing, modal de upgrade e payload do paywall\n\n## Validação\n\n- 
pm -w apps/web run lint ✅\n- 
pm -w apps/web run typecheck ✅\n- 
pm -w apps/web run test:run -- src/pages/ProfileSettings.test.tsx src/pages/BillingSettings.test.tsx src/components/UpgradeModal.test.tsx src/services/api.test.js ✅\n- 
pm -w apps/web run test:run ✅\n- 
pm -w apps/web run build ✅