### PR TITLE
feat(cards): harden invoice status and card overview ux

### DIFF
--- a/apps/web/src/pages/CreditCardsPage.test.tsx
+++ b/apps/web/src/pages/CreditCardsPage.test.tsx
@@ -48,7 +48,7 @@ const buildOpenPurchase = (): CreditCardPurchase => ({
   updatedAt: "2026-03-15T10:00:00.000Z",
 });
 
-const buildInvoice = (): CreditCardInvoice => ({
+const buildInvoice = (overrides: Partial<CreditCardInvoice> = {}): CreditCardInvoice => ({
   id: 91,
   title: "Fatura Nubank 2026-03",
   amount: 300,
@@ -57,6 +57,7 @@ const buildInvoice = (): CreditCardInvoice => ({
   paidAt: null,
   referenceMonth: "2026-03",
   isOverdue: false,
+  ...overrides,
 });
 
 const buildCard = (overrides: Partial<CreditCardItem> = {}): CreditCardItem => ({
@@ -163,6 +164,56 @@ describe("CreditCardsPage", () => {
     expect(screen.getByText("Mercado")).toBeInTheDocument();
     expect(screen.getByText("Fatura Nubank 2026-03")).toBeInTheDocument();
     expect(screen.getByText("24.00% do limite")).toBeInTheDocument();
+    expect(screen.getAllByText("Em uso").length).toBeGreaterThan(0);
+    expect(screen.getByText("Fatura atual")).toBeInTheDocument();
+    expect(screen.getByText("Pendente")).toBeInTheDocument();
+  });
+
+  it("desabilita fechar fatura quando nao ha compras abertas", async () => {
+    vi.mocked(creditCardsService.list).mockResolvedValueOnce({
+      items: [
+        buildCard({
+          openPurchasesCount: 0,
+          openPurchasesTotal: 0,
+          openPurchases: [],
+          invoices: [],
+          pendingInvoicesCount: 0,
+          pendingInvoicesTotal: 0,
+          usage: {
+            total: 2000,
+            used: 0,
+            available: 2000,
+            exceededBy: 0,
+            usagePct: 0,
+            status: "unused",
+          },
+        }),
+      ],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("Nubank")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Fechar fatura" })).toBeDisabled();
+  });
+
+  it("destaca fatura atrasada com badge explicito", async () => {
+    vi.mocked(creditCardsService.list).mockResolvedValueOnce({
+      items: [
+        buildCard({
+          invoices: [
+            buildInvoice({
+              isOverdue: true,
+            }),
+          ],
+        }),
+      ],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("Nubank")).toBeInTheDocument();
+    expect(screen.getByText("Atrasada")).toBeInTheDocument();
   });
 
   it("cria cartão novo pelo modal", async () => {

--- a/apps/web/src/pages/CreditCardsPage.tsx
+++ b/apps/web/src/pages/CreditCardsPage.tsx
@@ -19,6 +19,45 @@ const formatDate = (value: string) => {
   return `${day}/${month}/${year}`;
 };
 
+const USAGE_STATUS_LABELS = {
+  unused: "Sem uso no ciclo",
+  using: "Em uso",
+  exceeded: "Limite estourado",
+} as const;
+
+const USAGE_STATUS_BADGE_CLASSNAMES = {
+  unused: "border-cf-border bg-cf-bg-subtle text-cf-text-secondary",
+  using: "border-amber-200 bg-amber-50 text-amber-700",
+  exceeded: "border-red-200 bg-red-50 text-red-700",
+} as const;
+
+const INVOICE_STATUS_BADGE_CLASSNAMES = {
+  pending: "border-amber-200 bg-amber-50 text-amber-700",
+  paid: "border-green-200 bg-green-50 text-green-700",
+  overdue: "border-red-200 bg-red-50 text-red-700",
+} as const;
+
+const getInvoiceBadge = (invoice: CreditCardItem["invoices"][number]) => {
+  if (invoice.status === "paid") {
+    return {
+      className: INVOICE_STATUS_BADGE_CLASSNAMES.paid,
+      label: "Paga",
+    };
+  }
+
+  if (invoice.isOverdue) {
+    return {
+      className: INVOICE_STATUS_BADGE_CLASSNAMES.overdue,
+      label: "Atrasada",
+    };
+  }
+
+  return {
+    className: INVOICE_STATUS_BADGE_CLASSNAMES.pending,
+    label: "Pendente",
+  };
+};
+
 const CreditCardsPage = ({
   onBack = undefined,
 }: CreditCardsPageProps): JSX.Element => {
@@ -212,13 +251,31 @@ const CreditCardsPage = ({
           </div>
         ) : (
           <div className="space-y-4">
-            {cards.map((card) => (
-              <section key={card.id} className="rounded border border-cf-border bg-cf-surface p-4">
+            {cards.map((card) => {
+              const pendingInvoice =
+                card.invoices.find((invoice) => invoice.status === "pending") ?? null;
+              const usageStatusLabel = USAGE_STATUS_LABELS[card.usage.status];
+              const usageStatusClassName = USAGE_STATUS_BADGE_CLASSNAMES[card.usage.status];
+
+              return (
+                <section key={card.id} className="rounded border border-cf-border bg-cf-surface p-4">
                 <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                   <div>
-                    <h2 className="text-lg font-semibold text-cf-text-primary">{card.name}</h2>
-                    <p className="text-xs text-cf-text-secondary">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h2 className="text-lg font-semibold text-cf-text-primary">{card.name}</h2>
+                      <span
+                        className={`rounded-full border px-2 py-0.5 text-xs font-semibold ${usageStatusClassName}`}
+                      >
+                        {usageStatusLabel}
+                      </span>
+                    </div>
+                    <p className="mt-1 text-xs text-cf-text-secondary">
                       Fecha no dia {card.closingDay} e vence no dia {card.dueDay}
+                    </p>
+                    <p className="mt-1 text-xs text-cf-text-secondary">
+                      {card.openPurchasesCount} compra{card.openPurchasesCount === 1 ? "" : "s"} aberta
+                      {card.openPurchasesCount === 1 ? "" : "s"} · {card.pendingInvoicesCount} fatura
+                      {card.pendingInvoicesCount === 1 ? "" : "s"} pendente{card.pendingInvoicesCount === 1 ? "" : "s"}
                     </p>
                   </div>
                   <div className="flex flex-wrap gap-2">
@@ -232,7 +289,8 @@ const CreditCardsPage = ({
                     <button
                       type="button"
                       onClick={() => void handleCloseInvoice(card)}
-                      className="rounded border border-brand-1 px-3 py-1.5 text-xs font-semibold text-brand-1 hover:bg-brand-1/10"
+                      disabled={card.openPurchasesCount === 0}
+                      className="rounded border border-brand-1 px-3 py-1.5 text-xs font-semibold text-brand-1 hover:bg-brand-1/10 disabled:cursor-not-allowed disabled:opacity-60"
                     >
                       Fechar fatura
                     </button>
@@ -251,31 +309,122 @@ const CreditCardsPage = ({
 
                 <div className="mb-4 grid gap-3 sm:grid-cols-4">
                   <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
-                    <p className="text-xs font-medium uppercase text-cf-text-secondary">Limite</p>
+                    <p className="text-xs font-medium uppercase text-cf-text-secondary">Limite total</p>
                     <p className="mt-1 text-lg font-bold text-cf-text-primary">{formatCurrency(card.usage.total)}</p>
+                    <p className="text-xs text-cf-text-secondary">Capacidade total do cartão</p>
                   </div>
                   <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
-                    <p className="text-xs font-medium uppercase text-cf-text-secondary">Usado</p>
+                    <div className="flex items-center justify-between gap-2">
+                      <p className="text-xs font-medium uppercase text-cf-text-secondary">Limite usado</p>
+                      <span
+                        className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${usageStatusClassName}`}
+                      >
+                        {usageStatusLabel}
+                      </span>
+                    </div>
                     <p className="mt-1 text-lg font-bold text-cf-text-primary">{formatCurrency(card.usage.used)}</p>
                     <p className="text-xs text-cf-text-secondary">{card.usage.usagePct.toFixed(2)}% do limite</p>
                   </div>
                   <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
-                    <p className="text-xs font-medium uppercase text-cf-text-secondary">Disponível</p>
+                    <p className="text-xs font-medium uppercase text-cf-text-secondary">Limite disponível</p>
                     <p className="mt-1 text-lg font-bold text-cf-text-primary">{formatCurrency(card.usage.available)}</p>
                     {card.usage.exceededBy > 0 ? (
                       <p className="text-xs text-red-600">Estourado em {formatCurrency(card.usage.exceededBy)}</p>
-                    ) : null}
+                    ) : (
+                      <p className="text-xs text-cf-text-secondary">Ainda livre para novas compras</p>
+                    )}
                   </div>
                   <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
-                    <p className="text-xs font-medium uppercase text-cf-text-secondary">Faturas pendentes</p>
-                    <p className="mt-1 text-lg font-bold text-cf-text-primary">{formatCurrency(card.pendingInvoicesTotal)}</p>
-                    <p className="text-xs text-cf-text-secondary">
-                      {card.pendingInvoicesCount} {card.pendingInvoicesCount === 1 ? "fatura" : "faturas"}
+                    <p className="text-xs font-medium uppercase text-cf-text-secondary">Fatura atual</p>
+                    <p className="mt-1 text-lg font-bold text-cf-text-primary">
+                      {pendingInvoice
+                        ? formatCurrency(pendingInvoice.amount)
+                        : card.openPurchasesCount > 0
+                          ? formatCurrency(card.openPurchasesTotal)
+                          : formatCurrency(0)}
                     </p>
+                    {pendingInvoice ? (
+                      <p className="text-xs text-cf-text-secondary">
+                        {pendingInvoice.isOverdue
+                          ? `Atrasada desde ${formatDate(pendingInvoice.dueDate)}`
+                          : `Vence em ${formatDate(pendingInvoice.dueDate)}`}
+                      </p>
+                    ) : card.openPurchasesCount > 0 ? (
+                      <p className="text-xs text-cf-text-secondary">Compras abertas aguardando fechamento</p>
+                    ) : (
+                      <p className="text-xs text-cf-text-secondary">Sem fatura pendente no momento</p>
+                    )}
                   </div>
                 </div>
 
                 <div className="grid gap-4 lg:grid-cols-2">
+                  <div>
+                    <div className="mb-2 flex items-center justify-between">
+                      <h3 className="text-sm font-semibold text-cf-text-primary">Faturas</h3>
+                      <span className="text-xs text-cf-text-secondary">
+                        {card.invoices.length} lançada{card.invoices.length === 1 ? "" : "s"}
+                      </span>
+                    </div>
+                    {card.invoices.length === 0 ? (
+                      <div className="rounded border border-dashed border-cf-border px-3 py-4 text-sm text-cf-text-secondary">
+                        Nenhuma fatura fechada ainda.
+                      </div>
+                    ) : (
+                      <div className="space-y-2">
+                        {card.invoices.map((invoice) => {
+                          const invoiceBadge = getInvoiceBadge(invoice);
+
+                          return (
+                            <div key={invoice.id} className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-3">
+                              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                                <div>
+                                  <div className="flex flex-wrap items-center gap-2">
+                                    <p className="text-sm font-medium text-cf-text-primary">{invoice.title}</p>
+                                    <span
+                                      className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${invoiceBadge.className}`}
+                                    >
+                                      {invoiceBadge.label}
+                                    </span>
+                                  </div>
+                                  <p className="text-xs text-cf-text-secondary">
+                                    Ref. {invoice.referenceMonth || "—"} · vence {formatDate(invoice.dueDate)}
+                                  </p>
+                                </div>
+                                <div className="flex items-center gap-2">
+                                  <span className="text-sm font-semibold text-cf-text-primary">
+                                    {formatCurrency(invoice.amount)}
+                                  </span>
+                                  {invoice.status === "pending" ? (
+                                    <div className="flex items-center gap-2">
+                                      <button
+                                        type="button"
+                                        onClick={() => void handleReopenInvoice(invoice.id)}
+                                        className="rounded border border-amber-300 px-2 py-1 text-xs font-semibold text-amber-700 hover:bg-amber-50"
+                                      >
+                                        Reabrir
+                                      </button>
+                                      <button
+                                        type="button"
+                                        onClick={() => void handlePayInvoice(invoice.id)}
+                                        className="rounded border border-green-300 px-2 py-1 text-xs font-semibold text-green-700 hover:bg-green-50"
+                                      >
+                                        Pagar fatura
+                                      </button>
+                                    </div>
+                                  ) : (
+                                    <span className="rounded border border-green-200 bg-green-50 px-2 py-1 text-xs font-semibold text-green-700">
+                                      Paga
+                                    </span>
+                                  )}
+                                </div>
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+
                   <div>
                     <div className="mb-2 flex items-center justify-between">
                       <h3 className="text-sm font-semibold text-cf-text-primary">Compras abertas</h3>
@@ -339,65 +488,10 @@ const CreditCardsPage = ({
                       </div>
                     )}
                   </div>
-
-                  <div>
-                    <div className="mb-2 flex items-center justify-between">
-                      <h3 className="text-sm font-semibold text-cf-text-primary">Faturas</h3>
-                      <span className="text-xs text-cf-text-secondary">
-                        {card.invoices.length} lançada{card.invoices.length === 1 ? "" : "s"}
-                      </span>
-                    </div>
-                    {card.invoices.length === 0 ? (
-                      <div className="rounded border border-dashed border-cf-border px-3 py-4 text-sm text-cf-text-secondary">
-                        Nenhuma fatura fechada ainda.
-                      </div>
-                    ) : (
-                      <div className="space-y-2">
-                        {card.invoices.map((invoice) => (
-                          <div key={invoice.id} className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-3">
-                            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                              <div>
-                                <p className="text-sm font-medium text-cf-text-primary">{invoice.title}</p>
-                                <p className="text-xs text-cf-text-secondary">
-                                  Ref. {invoice.referenceMonth || "—"} · vence {formatDate(invoice.dueDate)}
-                                </p>
-                              </div>
-                              <div className="flex items-center gap-2">
-                                <span className="text-sm font-semibold text-cf-text-primary">
-                                  {formatCurrency(invoice.amount)}
-                                </span>
-                                {invoice.status === "pending" ? (
-                                  <div className="flex items-center gap-2">
-                                    <button
-                                      type="button"
-                                      onClick={() => void handleReopenInvoice(invoice.id)}
-                                      className="rounded border border-amber-300 px-2 py-1 text-xs font-semibold text-amber-700 hover:bg-amber-50"
-                                    >
-                                      Reabrir
-                                    </button>
-                                    <button
-                                      type="button"
-                                      onClick={() => void handlePayInvoice(invoice.id)}
-                                      className="rounded border border-green-300 px-2 py-1 text-xs font-semibold text-green-700 hover:bg-green-50"
-                                    >
-                                      Pagar fatura
-                                    </button>
-                                  </div>
-                                ) : (
-                                  <span className="rounded border border-green-200 bg-green-50 px-2 py-1 text-xs font-semibold text-green-700">
-                                    Paga
-                                  </span>
-                                )}
-                              </div>
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </div>
                 </div>
-              </section>
-            ))}
+                </section>
+              );
+            })}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Contexto

Este PR fecha o bloco `Cards Confidence` da Sprint de Confiabilidade do Produto.

O módulo de cartões já tinha a base funcional, mas ainda pedia leitura cuidadosa demais para responder perguntas simples: quanto do limite já foi usado, em que estado está a fatura e o que ainda está aguardando fechamento.

## O que entra

- badges explícitas de status do cartão (`Sem uso no ciclo`, `Em uso`, `Limite estourado`)
- resumo do ciclo com destaque para:
  - limite total
  - limite usado
  - limite disponível
  - fatura atual
- status de fatura mais legível (`Pendente`, `Paga`, `Atrasada`)
- bloqueio visual do botão `Fechar fatura` quando não há compras abertas
- testes atualizados para travar a nova leitura de UX

## Objetivo de UX

Fazer a tela responder rápido estas perguntas:

- quanto ainda tenho de limite?
- a fatura atual existe, está pendente ou atrasada?
- tenho compras abertas aguardando fechamento?
- a ação correta agora é fechar, pagar ou reabrir?

## Validação

- `npm -w apps/web run lint` ✅
- `npm -w apps/web run typecheck` ✅
- `npm -w apps/web run test:run -- src/pages/CreditCardsPage.test.tsx` ✅
- `npm -w apps/web run test:run` ✅
- `npm -w apps/web run build` ✅
