### PR TITLE
docs(product): normalize in-app product narrative

### DIFF
--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -663,7 +663,7 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory
         </div>
 
         <p className="mb-4 text-sm text-cf-text-secondary">
-          Envie um CSV, OFX ou PDF de extrato para pré-visualizar as transações válidas antes de importar.
+          Envie um CSV, OFX ou PDF para revisar, categorizar e confirmar o que entra no seu painel financeiro antes de importar.
         </p>
 
         <div className="rounded border border-cf-border bg-cf-surface p-3">
@@ -695,7 +695,10 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory
             className="block w-full text-sm text-cf-text-primary file:mr-3 file:rounded file:border file:border-cf-border file:bg-cf-bg-subtle file:px-3 file:py-1 file:text-sm file:font-semibold file:text-cf-text-primary hover:file:bg-cf-border"
           />
           <p className="mt-2 text-xs text-cf-text-secondary">
-            OFX é o formato preferencial quando o banco oferecer. CSV manual, CSV exportado por banco e PDF com OCR assistido entram como alternativas.
+            OFX é o formato preferencial quando o banco oferecer. CSV manual, CSV do banco e PDF com OCR assistido entram como alternativas.
+          </p>
+          <p className="mt-1 text-xs text-cf-text-secondary">
+            Use a pré-visualização para conferir categorias, renda e pendências antes de confirmar a importação.
           </p>
           <p className="mt-1 text-xs text-cf-text-secondary">
             Quando possível, a plataforma sugere automaticamente categorias com base nas descrições e nas categorias já cadastradas.
@@ -818,7 +821,7 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory
                 </ul>
                 {suggestionCard.kind === "profile" && !incomeStatementCreated ? (
                   <p className="mb-2 text-xs text-blue-700 dark:text-blue-300">
-                    Depois de usar este documento na sua renda, o app pode sugerir uma atualizacao
+                    Depois de usar este documento na sua renda, o app pode sugerir uma atualização
                     do perfil financeiro e do planejamento.
                   </p>
                 ) : null}

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -1660,7 +1660,7 @@ const App = ({
                   <span className="text-cf-text-primary">Finance</span>
                 </h1>
                 <p className="mt-1 text-xs text-cf-text-secondary sm:text-sm">
-                  Painel financeiro com importações, pendências, cartões e Central do Leão.
+                  Controle financeiro pessoal com importação, pendências, cartões, fontes de renda e apoio fiscal.
                 </p>
               </div>
               <div className="flex flex-wrap items-center justify-between gap-2 lg:justify-end">
@@ -2299,7 +2299,7 @@ const App = ({
               <div>
                 <h3 className="text-sm font-medium text-cf-text-primary">Visão do mês</h3>
                 <p className="mt-1 text-xs text-cf-text-secondary">
-                  Saldo, entradas e saídas em destaque antes das análises detalhadas.
+                  Saldo, entradas e saídas consolidados antes das análises detalhadas.
                 </p>
               </div>
               <input
@@ -2426,7 +2426,7 @@ const App = ({
                 Painel operacional
               </h3>
               <p className="mt-1 text-xs text-cf-text-secondary">
-                O que pede ação agora: projeção, pendências, cartões e renda principal.
+                O que pede ação agora: projeção, pendências, cartões, renda principal e sinais de risco.
               </p>
             </div>
 

--- a/apps/web/src/pages/BillingSettings.test.tsx
+++ b/apps/web/src/pages/BillingSettings.test.tsx
@@ -44,7 +44,7 @@ describe("BillingSettings", () => {
 
     expect(
       screen.getByText(
-        /Durante o trial, você testa o painel financeiro, metas, cartões, renda e a Central do Leão/i,
+        /Durante o trial, você acompanha painel financeiro, metas, cartões, renda e a Central do Leão/i,
       ),
     ).toBeInTheDocument();
     expect(

--- a/apps/web/src/pages/BillingSettings.tsx
+++ b/apps/web/src/pages/BillingSettings.tsx
@@ -29,11 +29,11 @@ const daysRemaining = (isoDate: string | null | undefined): number => {
 
 const resolvePlanSupportCopy = (summary: SubscriptionSummary): string => {
   if (summary.entitlementSource === "trial") {
-    return "Durante o trial, você testa o painel financeiro, metas, cartões, renda e a Central do Leão. Importação e exportação de extratos fazem parte do plano Pro.";
+    return "Durante o trial, você acompanha painel financeiro, metas, cartões, renda e a Central do Leão. Importação e exportação de extratos fazem parte do plano Pro.";
   }
 
   if (summary.entitlementSource === "free" && summary.trialExpired) {
-    return "Seu trial terminou. Faça upgrade para liberar importação de extratos, exportação e demais recursos avançados do Pro.";
+    return "Seu trial terminou. Faça upgrade para liberar importação e exportação de extratos e manter a experiência completa do Pro em cartões, renda e apoio fiscal.";
   }
 
   if (
@@ -41,10 +41,10 @@ const resolvePlanSupportCopy = (summary: SubscriptionSummary): string => {
     summary.entitlementSource === "subscription_grace" ||
     summary.entitlementSource === "prepaid"
   ) {
-    return "Seu plano Pro mantém importação e exportação de extratos, projeção financeira e os módulos avançados do produto.";
+    return "Seu plano Pro libera importação e exportação de extratos, projeção financeira e os módulos avançados para uma experiência financeira mais completa.";
   }
 
-  return "Consulte abaixo o que está disponível agora e o que faz parte do plano Pro.";
+  return "Consulte abaixo o que está disponível agora e o que o plano Pro adiciona ao seu controle financeiro.";
 };
 
 type PlanBadge = { label: string; className: string };
@@ -180,12 +180,10 @@ const BillingSettings = ({
         <section className="rounded border border-cf-border bg-cf-surface p-4">
           <div className="flex flex-wrap items-start justify-between gap-3">
             <div>
-              <h1 className="text-xl font-semibold text-cf-text-primary">
-                Settings - Assinatura
-              </h1>
-              <p className="mt-1 text-sm text-cf-text-secondary">
-                Gerencie seu plano e assinatura.
-              </p>
+                <h1 className="text-xl font-semibold text-cf-text-primary">Assinatura</h1>
+                <p className="mt-1 text-sm text-cf-text-secondary">
+                  Veja o que seu plano libera hoje e o que faz parte do Pro.
+                </p>
             </div>
             <div className="flex flex-wrap items-center gap-2">
               <button

--- a/apps/web/src/pages/CreditCardsPage.tsx
+++ b/apps/web/src/pages/CreditCardsPage.tsx
@@ -214,7 +214,7 @@ const CreditCardsPage = ({
             <div>
               <h1 className="text-xl font-bold text-cf-text-primary">Cartões</h1>
               <p className="text-sm text-cf-text-secondary">
-                Limite, compras abertas e ciclo da fatura sem misturar compra com saída imediata.
+                Acompanhe limite, compras e faturas sem confundir uso do cartão com saída imediata de caixa.
               </p>
             </div>
           </div>
@@ -246,7 +246,7 @@ const CreditCardsPage = ({
         ) : cards.length === 0 ? (
           <div className="rounded border border-dashed border-cf-border bg-cf-surface p-6 text-center">
             <p className="text-sm text-cf-text-secondary">
-              Nenhum cartão cadastrado ainda. Crie o primeiro para acompanhar limite e fatura.
+              Nenhum cartão cadastrado ainda. Crie o primeiro para acompanhar limite, compras e faturas do mês.
             </p>
           </div>
         ) : (

--- a/apps/web/src/pages/ProfileSettings.test.tsx
+++ b/apps/web/src/pages/ProfileSettings.test.tsx
@@ -337,6 +337,6 @@ describe("ProfileSettings — Assinatura", () => {
     );
     renderPage();
     await waitFor(() => expect(screen.getByText("Acesso ativo")).toBeInTheDocument());
-    expect(screen.getByText(/Detalhes do plano disponíveis em Faturamento/)).toBeInTheDocument();
+    expect(screen.getByText(/Consulte Faturamento para ver o que está liberado agora/)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/ProfileSettings.tsx
+++ b/apps/web/src/pages/ProfileSettings.tsx
@@ -209,7 +209,7 @@ const ProfileSettings = ({
           <div>
             <h1 className="text-xl font-semibold text-cf-text-primary">Configurações</h1>
             <p className="mt-1 text-sm text-cf-text-secondary">
-              Gerencie sua conta, preferências e plano.
+              Conta, preferências e plano para manter seu controle financeiro alinhado ao dia a dia.
             </p>
           </div>
           <div className="flex flex-wrap items-center gap-2">
@@ -265,7 +265,7 @@ const ProfileSettings = ({
             <section className="rounded border border-cf-border bg-cf-surface p-5">
               <SectionHeading
                 title="Dados da conta"
-                description="Nome exibido, avatar e informações de acesso."
+                description="Nome exibido, avatar e dados usados por renda, cartões e acesso."
               />
 
               <form onSubmit={handleSubmit} noValidate className="space-y-4">
@@ -580,8 +580,8 @@ const ProfileSettings = ({
                     <p className="text-sm font-semibold text-green-800">Trial ativo</p>
                     <p className="mt-0.5 text-xs text-green-700">
                       {daysRemaining > 0
-                        ? `${daysRemaining} dia${daysRemaining !== 1 ? "s" : ""} restante${daysRemaining !== 1 ? "s" : ""} — aproveite as funcionalidades liberadas no trial. Importação e exportação de extratos fazem parte do Pro.`
-                        : "Último dia de trial — as funcionalidades liberadas no teste seguem ativas até o fim do dia. Importação e exportação de extratos fazem parte do Pro."}
+                        ? `${daysRemaining} dia${daysRemaining !== 1 ? "s" : ""} restante${daysRemaining !== 1 ? "s" : ""} — use o trial para acompanhar painel, cartões, renda e Central do Leão. Importação e exportação de extratos fazem parte do Pro.`
+                        : "Último dia de trial — você ainda pode acompanhar painel, cartões, renda e Central do Leão até o fim do dia. Importação e exportação de extratos fazem parte do Pro."}
                     </p>
                   </div>
                   <span className="shrink-0 rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-semibold text-green-800">
@@ -593,7 +593,7 @@ const ProfileSettings = ({
                   <div>
                     <p className="text-sm font-semibold text-amber-800">Trial expirado</p>
                     <p className="mt-0.5 text-xs text-amber-700">
-                      Algumas funcionalidades ficaram limitadas. Faça upgrade para continuar com projeção, exportação e importação de extratos no Pro.
+                      Algumas funcionalidades ficaram limitadas. Faça upgrade para continuar com projeção, importação e exportação de extratos e os módulos avançados do Pro.
                     </p>
                   </div>
                   <div className="flex shrink-0 flex-col items-end gap-2">
@@ -616,7 +616,7 @@ const ProfileSettings = ({
                   <div>
                     <p className="text-sm font-semibold text-cf-text-primary">Acesso ativo</p>
                     <p className="mt-0.5 text-xs text-cf-text-secondary">
-                      Detalhes do plano disponíveis em Faturamento.
+                      Consulte Faturamento para ver o que está liberado agora e o que faz parte do Pro.
                     </p>
                   </div>
                   {onOpenBilling ? (


### PR DESCRIPTION
## Contexto

Este PR fecha o quarto slice da Sprint de Confiabilidade do Produto com foco apenas em narrativa e copy in-app.

## O que entra

- alinhamento da narrativa do dashboard com o domínio atual do produto
- copy mais clara em assinatura e perfil sobre trial, Pro e escopo real da experiência
- refinamento do texto do módulo de cartões para leitura mais confiável
- copy da importação mais coerente com revisão, categorização e confirmação antes do commit
- atualização dos testes que validavam texto literal

## Escopo

Somente copy e narrativa de produto.
Sem mudança de comportamento de domínio.
Sem mudança de entitlement.
