### PR TITLE
feat(income): harden statement reimport and competence dedup

### DIFF
--- a/apps/api/src/income-sources.test.js
+++ b/apps/api/src/income-sources.test.js
@@ -499,6 +499,128 @@ describe("income-sources", () => {
     expectErrorResponseWithRequestId(res, 409, "Ja existe um extrato para 2026-01.");
   });
 
+  it("POST /income-sources/:id/statements permite ignorar competência já existente", async () => {
+    const token = await registerAndLogin("inss-stmt-ignore@test.dev");
+
+    const srcRes = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Pensao" });
+    const sourceId = srcRes.body.id;
+
+    const first = await request(app)
+      .post(`/income-sources/${sourceId}/statements`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ referenceMonth: "2026-01", netAmount: 2500, paymentDate: "2026-01-25" });
+
+    const res = await request(app)
+      .post(`/income-sources/${sourceId}/statements`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        referenceMonth: "2026-01",
+        netAmount: 2803.52,
+        paymentDate: "2026-01-31",
+        existingCompetenceAction: "ignore",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.outcome).toBe("ignored");
+    expect(res.body.statement).toMatchObject({
+      id: first.body.statement.id,
+      referenceMonth: "2026-01",
+      netAmount: 2500,
+      paymentDate: "2026-01-25",
+    });
+
+    const listRes = await request(app)
+      .get(`/income-sources/${sourceId}/statements`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(listRes.status).toBe(200);
+    expect(listRes.body.statements).toHaveLength(1);
+    expect(listRes.body.statements[0].netAmount).toBe(2500);
+  });
+
+  it("POST /income-sources/:id/statements substitui competência existente sem duplicar e atualiza transação sintética", async () => {
+    const token = await registerAndLogin("inss-stmt-replace@test.dev");
+
+    const srcRes = await request(app)
+      .post("/income-sources")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Pensao INSS" });
+    const sourceId = srcRes.body.id;
+
+    const first = await request(app)
+      .post(`/income-sources/${sourceId}/statements`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        referenceMonth: "2026-02",
+        netAmount: 2500,
+        paymentDate: "2026-03-05",
+        grossAmount: 4000,
+        deductions: [
+          { label: "216 CONSIGNACAO EMPRESTIMO BANCARIO", amount: 100, isVariable: false },
+        ],
+      });
+
+    const statementId = first.body.statement.id;
+
+    const postRes = await request(app)
+      .post(`/income-sources/statements/${statementId}/post`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(postRes.status).toBe(200);
+
+    const res = await request(app)
+      .post(`/income-sources/${sourceId}/statements`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        referenceMonth: "2026-02",
+        netAmount: 2803.52,
+        paymentDate: "2026-03-07",
+        grossAmount: 4958.67,
+        deductions: [
+          { label: "216 CONSIGNACAO EMPRESTIMO BANCARIO", amount: 156, isVariable: false },
+          { label: "268 CONSIGNACAO - CARTAO", amount: 247.93, isVariable: false },
+        ],
+        existingCompetenceAction: "replace",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.outcome).toBe("replaced");
+    expect(res.body.statement).toMatchObject({
+      id: statementId,
+      referenceMonth: "2026-02",
+      netAmount: 2803.52,
+      grossAmount: 4958.67,
+      totalDeductions: 403.93,
+      paymentDate: "2026-03-07",
+      status: "posted",
+    });
+    expect(res.body.deductions).toHaveLength(2);
+
+    const listRes = await request(app)
+      .get(`/income-sources/${sourceId}/statements`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(listRes.status).toBe(200);
+    expect(listRes.body.statements).toHaveLength(1);
+    expect(listRes.body.statements[0].id).toBe(statementId);
+
+    const txRes = await dbQuery(
+      `SELECT value, date, description
+         FROM transactions
+        WHERE id = $1`,
+      [postRes.body.transaction.id],
+    );
+
+    expect(txRes.rows[0]).toMatchObject({
+      value: 2803.52,
+      description: "Pensao INSS – 2026-02",
+    });
+    expect(new Date(txRes.rows[0].date).toISOString().slice(0, 10)).toBe("2026-03-07");
+  });
+
   it("POST /income-sources/:id/statements persiste grossAmount e details", async () => {
     const token = await registerAndLogin("inss-stmt-gross@test.dev");
 

--- a/apps/api/src/routes/income-sources.routes.js
+++ b/apps/api/src/routes/income-sources.routes.js
@@ -106,7 +106,7 @@ router.get("/:id/statements", async (req, res, next) => {
 router.post("/:id/statements", incomeSourcesWriteRateLimiter, async (req, res, next) => {
   try {
     const result = await createStatementDraftForSource(req.user.id, req.params.id, req.body || {});
-    res.status(201).json(result);
+    res.status(result.outcome === "created" ? 201 : 200).json(result);
   } catch (error) {
     next(error);
   }

--- a/apps/api/src/services/income-sources.service.js
+++ b/apps/api/src/services/income-sources.service.js
@@ -173,6 +173,20 @@ const normalizeOptionalImportSessionId = (value) => {
   return trimmed || null;
 };
 
+const normalizeExistingCompetenceAction = (value) => {
+  if (value == null || value === "") return "error";
+  if (typeof value !== "string") {
+    throw createError(400, "Acao de competencia existente invalida.");
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (!["error", "ignore", "replace"].includes(normalized)) {
+    throw createError(400, "Acao de competencia existente invalida.");
+  }
+
+  return normalized;
+};
+
 const normalizeStatementSnapshotDeductions = (value) => {
   if (value == null) {
     return [];
@@ -691,6 +705,31 @@ const requireStatementOwnership = async (uid, statementId) => {
   return rows[0];
 };
 
+const loadStatementSnapshotDeductions = async (client, statementId) => {
+  const { rows } = await client.query(
+    `SELECT * FROM income_statement_deductions WHERE statement_id = $1 ORDER BY id ASC`,
+    [statementId],
+  );
+  return rows.map(mapStatementDeductionRow);
+};
+
+const insertStatementSnapshotDeductions = async (client, statementId, snapshotTemplateRows) => {
+  const snapshotDeductions = [];
+
+  for (const deduction of snapshotTemplateRows) {
+    const { rows } = await client.query(
+      `INSERT INTO income_statement_deductions
+         (statement_id, label, amount, is_variable)
+       VALUES ($1, $2, $3, $4)
+       RETURNING *`,
+      [statementId, deduction.label, deduction.amount, deduction.isVariable],
+    );
+    snapshotDeductions.push(mapStatementDeductionRow(rows[0]));
+  }
+
+  return snapshotDeductions;
+};
+
 export const createStatementDraftForSource = async (userId, sourceId, payload) => {
   const uid = normalizeUserId(userId);
   const sid = normalizeSourceId(sourceId);
@@ -705,12 +744,27 @@ export const createStatementDraftForSource = async (userId, sourceId, payload) =
   const sourceImportSessionId = normalizeOptionalImportSessionId(
     payload.sourceImportSessionId ?? null,
   );
+  const existingCompetenceAction = normalizeExistingCompetenceAction(
+    payload.existingCompetenceAction ?? null,
+  );
   const hasExplicitSnapshotDeductions = Object.prototype.hasOwnProperty.call(payload, "deductions");
   const explicitSnapshotDeductions = hasExplicitSnapshotDeductions
     ? normalizeStatementSnapshotDeductions(payload.deductions)
     : null;
 
   return withDbTransaction(async (client) => {
+    const { rows: sourceRows } = await client.query(
+      `SELECT id, name, category_id
+         FROM income_sources
+        WHERE id = $1 AND user_id = $2
+        LIMIT 1`,
+      [sid, uid],
+    );
+    if (!sourceRows[0]) {
+      throw createError(404, "Fonte de renda nao encontrada.");
+    }
+    const sourceRow = sourceRows[0];
+
     let snapshotTemplateRows = [];
 
     if (explicitSnapshotDeductions !== null) {
@@ -735,6 +789,94 @@ export const createStatementDraftForSource = async (userId, sourceId, payload) =
       0,
     );
 
+    const { rows: existingRows } = await client.query(
+      `SELECT st.*
+         FROM income_statements st
+        WHERE st.income_source_id = $1 AND st.reference_month = $2
+        LIMIT 1`,
+      [sid, referenceMonth],
+    );
+    const existingStatement = existingRows[0] ?? null;
+
+    if (existingStatement) {
+      if (existingCompetenceAction === "ignore") {
+        const deductions = await loadStatementSnapshotDeductions(client, existingStatement.id);
+        return {
+          outcome: "ignored",
+          statement: mapStatementRow(existingStatement),
+          deductions,
+        };
+      }
+
+      if (existingCompetenceAction !== "replace") {
+        throw createError(409, `Ja existe um extrato para ${referenceMonth}.`);
+      }
+
+      const { rows: updatedRows } = await client.query(
+        `UPDATE income_statements
+            SET net_amount = $1,
+                total_deductions = $2,
+                payment_date = $3,
+                gross_amount = $4,
+                details_json = $5,
+                source_import_session_id = $6,
+                updated_at = NOW()
+          WHERE id = $7
+          RETURNING *`,
+        [
+          netAmount,
+          toMoney(totalDeductions),
+          paymentDate,
+          grossAmount,
+          details != null ? JSON.stringify(details) : null,
+          sourceImportSessionId,
+          existingStatement.id,
+        ],
+      );
+      const stmtRow = updatedRows[0];
+
+      await client.query(`DELETE FROM income_statement_deductions WHERE statement_id = $1`, [
+        stmtRow.id,
+      ]);
+
+      const snapshotDeductions = await insertStatementSnapshotDeductions(
+        client,
+        stmtRow.id,
+        snapshotTemplateRows,
+      );
+
+      if (stmtRow.posted_transaction_id != null) {
+        const syntheticDescription = `${sourceRow.name} – ${referenceMonth}`;
+        await client.query(
+          `UPDATE transactions
+              SET value = $1,
+                  date = $2,
+                  description = $3,
+                  category_id = $4
+            WHERE id = $5
+              AND user_id = $6
+              AND type = $7
+              AND description = $8`,
+          [
+            netAmount,
+            paymentDate ?? toISODate(),
+            syntheticDescription,
+            sourceRow.category_id ?? null,
+            Number(stmtRow.posted_transaction_id),
+            uid,
+            TRANSACTION_TYPE_ENTRY,
+            syntheticDescription,
+          ],
+        );
+      }
+
+      return {
+        outcome: "replaced",
+        statement: mapStatementRow(stmtRow),
+        deductions: snapshotDeductions,
+      };
+    }
+
     // Create statement (409 if unique constraint fires)
     let stmtRow;
     try {
@@ -757,20 +899,14 @@ export const createStatementDraftForSource = async (userId, sourceId, payload) =
       throw err;
     }
 
-    // Persist snapshot deductions for this specific statement/competence.
-    const snapshotDeductions = [];
-    for (const deduction of snapshotTemplateRows) {
-      const { rows } = await client.query(
-        `INSERT INTO income_statement_deductions
-           (statement_id, label, amount, is_variable)
-         VALUES ($1, $2, $3, $4)
-         RETURNING *`,
-        [stmtRow.id, deduction.label, deduction.amount, deduction.isVariable],
-      );
-      snapshotDeductions.push(mapStatementDeductionRow(rows[0]));
-    }
+    const snapshotDeductions = await insertStatementSnapshotDeductions(
+      client,
+      stmtRow.id,
+      snapshotTemplateRows,
+    );
 
     return {
+      outcome: "created",
       statement: mapStatementRow(stmtRow),
       deductions: snapshotDeductions,
     };

--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -1591,6 +1591,12 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory
           setIsIncomeModalOpen(false);
           setIncomeStatementCreated(true);
         }}
+        onIgnored={(statement) => {
+          setIsIncomeModalOpen(false);
+          setSuccessMessage(
+            `Competência ${statement.referenceMonth} já existia e foi ignorada. Nenhum dado foi alterado.`,
+          );
+        }}
       />
 
       <ConfirmDialog

--- a/apps/web/src/components/ImportCsvModal.test.jsx
+++ b/apps/web/src/components/ImportCsvModal.test.jsx
@@ -30,6 +30,7 @@ vi.mock("../services/categories.service", () => ({
 vi.mock("../services/incomeSources.service", () => ({
   incomeSourcesService: {
     list: vi.fn(),
+    listStatements: vi.fn(),
     createStatement: vi.fn(),
     linkTransaction: vi.fn(),
     postStatement: vi.fn(),
@@ -98,6 +99,7 @@ describe("ImportCsvModal", () => {
     categoriesService.listCategories.mockResolvedValue([]);
     transactionsService.listImportCategoryRules.mockResolvedValue([]);
     incomeSourcesService.list.mockResolvedValue([]);
+    incomeSourcesService.listStatements.mockResolvedValue([]);
     incomeSourcesService.postStatement.mockResolvedValue({
       statement: {
         id: 11,

--- a/apps/web/src/components/IncomeStatementQuickModal.test.tsx
+++ b/apps/web/src/components/IncomeStatementQuickModal.test.tsx
@@ -10,6 +10,7 @@ import {
 vi.mock("../services/incomeSources.service", () => ({
   incomeSourcesService: {
     list: vi.fn(),
+    listStatements: vi.fn(),
     createStatement: vi.fn(),
     linkTransaction: vi.fn(),
     postStatement: vi.fn(),
@@ -68,7 +69,9 @@ describe("IncomeStatementQuickModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(incomeSourcesService.list).mockResolvedValue([buildSource()]);
+    vi.mocked(incomeSourcesService.listStatements).mockResolvedValue([]);
     vi.mocked(incomeSourcesService.createStatement).mockResolvedValue({
+      outcome: "created",
       statement: mockStatement,
       deductions: [],
     });
@@ -128,9 +131,9 @@ describe("IncomeStatementQuickModal", () => {
         prefill={{
           referenceMonth: "2026-02",
           netAmount: 1412,
-          deductions: [{ code: "268", label: "CONSIGNACAO - CARTAO", amount: 247.93 }],
-        }}
-        onCreated={onCreated}
+        deductions: [{ code: "268", label: "CONSIGNACAO - CARTAO", amount: 247.93 }],
+      }}
+      onCreated={onCreated}
       />,
     );
     await waitFor(() => {
@@ -156,6 +159,92 @@ describe("IncomeStatementQuickModal", () => {
     });
     expect(incomeSourcesService.linkTransaction).not.toHaveBeenCalled();
     expect(incomeSourcesService.postStatement).not.toHaveBeenCalled();
+  });
+
+  it("exige decisão explícita quando a competência já existe", async () => {
+    vi.mocked(incomeSourcesService.listStatements).mockResolvedValue([
+      { ...mockStatement, referenceMonth: "2026-02", netAmount: 1412, paymentDate: "2026-02-25" },
+    ]);
+
+    render(
+      <IncomeStatementQuickModal
+        isOpen
+        onClose={vi.fn()}
+        prefill={{ referenceMonth: "2026-02", netAmount: 1412 }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/competência já existente/i)).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Registrar somente no historico" }));
+
+    expect(
+      screen.getByText(/Escolha se deseja ignorar ou substituir a competência existente/i),
+    ).toBeInTheDocument();
+    expect(incomeSourcesService.createStatement).not.toHaveBeenCalled();
+  });
+
+  it("permite ignorar competência existente sem alterar dados", async () => {
+    const onIgnored = vi.fn();
+    vi.mocked(incomeSourcesService.listStatements).mockResolvedValue([
+      { ...mockStatement, referenceMonth: "2026-02", netAmount: 1412, paymentDate: "2026-02-25" },
+    ]);
+
+    render(
+      <IncomeStatementQuickModal
+        isOpen
+        onClose={vi.fn()}
+        prefill={{ referenceMonth: "2026-02", netAmount: 1412 }}
+        onIgnored={onIgnored}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/competência já existente/i)).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Ignorar" }));
+    await userEvent.click(screen.getByRole("button", { name: "Ignorar competência" }));
+
+    expect(onIgnored).toHaveBeenCalledWith(
+      expect.objectContaining({ referenceMonth: "2026-02" }),
+    );
+    expect(incomeSourcesService.createStatement).not.toHaveBeenCalled();
+  });
+
+  it("envia replace explícito ao substituir competência existente", async () => {
+    vi.mocked(incomeSourcesService.listStatements).mockResolvedValue([
+      { ...mockStatement, referenceMonth: "2026-02", netAmount: 1412, paymentDate: "2026-02-25" },
+    ]);
+    vi.mocked(incomeSourcesService.createStatement).mockResolvedValue({
+      outcome: "replaced",
+      statement: mockStatement,
+      deductions: [],
+    });
+
+    render(
+      <IncomeStatementQuickModal
+        isOpen
+        onClose={vi.fn()}
+        prefill={{ referenceMonth: "2026-02", netAmount: 1412 }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/competência já existente/i)).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Substituir" }));
+    await userEvent.click(screen.getByRole("button", { name: "Registrar somente no historico" }));
+
+    await waitFor(() => {
+      expect(incomeSourcesService.createStatement).toHaveBeenCalledWith(1, expect.objectContaining({
+        referenceMonth: "2026-02",
+        existingCompetenceAction: "replace",
+      }));
+    });
   });
 
   it("shows error message when createStatement rejects", async () => {
@@ -226,6 +315,50 @@ describe("IncomeStatementQuickModal", () => {
 
     expect(incomeSourcesService.postStatement).toHaveBeenCalledWith(10);
     expect(onCreated).toHaveBeenCalledWith(mockPostResult.statement);
+  });
+
+  it("não relança a entrada ao substituir competência já lançada", async () => {
+    vi.mocked(incomeSourcesService.listStatements).mockResolvedValue([
+      {
+        ...mockStatement,
+        referenceMonth: "2026-02",
+        status: "posted",
+        postedTransactionId: 99,
+        paymentDate: "2026-02-25",
+      },
+    ]);
+    vi.mocked(incomeSourcesService.createStatement).mockResolvedValue({
+      outcome: "replaced",
+      statement: {
+        ...mockStatement,
+        status: "posted",
+        postedTransactionId: 99,
+        paymentDate: "2026-02-25",
+      },
+      deductions: [],
+    });
+
+    render(
+      <IncomeStatementQuickModal
+        isOpen
+        onClose={vi.fn()}
+        defaultComposeIncome
+        prefill={{ referenceMonth: "2026-02", netAmount: 1412, paymentDate: "2026-02-25" }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/competência já existente/i)).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Substituir" }));
+    await userEvent.click(screen.getByRole("button", { name: "Registrar e lancar entrada" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/competência existente foi substituída/i)).toBeInTheDocument();
+    });
+
+    expect(incomeSourcesService.postStatement).not.toHaveBeenCalled();
   });
 
   it("shows amber warning when linkage fails after successful statement creation", async () => {

--- a/apps/web/src/components/IncomeStatementQuickModal.tsx
+++ b/apps/web/src/components/IncomeStatementQuickModal.tsx
@@ -3,6 +3,7 @@ import {
   incomeSourcesService,
   type IncomeSourceWithDeductions,
   type IncomeStatement,
+  type IncomeStatementWithDeductions,
   type PostStatementResult,
 } from "../services/incomeSources.service";
 import { getApiErrorMessage } from "../utils/apiError";
@@ -33,6 +34,7 @@ interface Props {
   transactionId?: number | null;
   defaultComposeIncome?: boolean;
   onCreated?: (statement: IncomeStatement) => void;
+  onIgnored?: (statement: IncomeStatement) => void;
 }
 
 type FinalizationMode = "none" | "link" | "post";
@@ -45,6 +47,7 @@ export default function IncomeStatementQuickModal({
   transactionId,
   defaultComposeIncome = false,
   onCreated,
+  onIgnored,
 }: Props) {
   const [sources, setSources] = useState<IncomeSourceWithDeductions[]>([]);
   const [isLoadingSources, setIsLoadingSources] = useState(false);
@@ -60,6 +63,10 @@ export default function IncomeStatementQuickModal({
   const [finalizationMode, setFinalizationMode] = useState<FinalizationMode>("none");
   const [finalizationStatus, setFinalizationStatus] = useState<FinalizationStatus>("idle");
   const [finalizationError, setFinalizationError] = useState("");
+  const [statementOutcome, setStatementOutcome] = useState<IncomeStatementWithDeductions["outcome"]>();
+  const [existingStatement, setExistingStatement] = useState<IncomeStatement | null>(null);
+  const [isCheckingExistingStatement, setIsCheckingExistingStatement] = useState(false);
+  const [existingCompetenceAction, setExistingCompetenceAction] = useState<"" | "ignore" | "replace">("");
 
   // Reset + fetch sources on open
   useEffect(() => {
@@ -75,6 +82,10 @@ export default function IncomeStatementQuickModal({
       setFinalizationMode("none");
       setFinalizationStatus("idle");
       setFinalizationError("");
+      setStatementOutcome(undefined);
+      setExistingStatement(null);
+      setIsCheckingExistingStatement(false);
+      setExistingCompetenceAction("");
       setSources([]);
       return;
     }
@@ -87,6 +98,10 @@ export default function IncomeStatementQuickModal({
     setFinalizationMode("none");
     setFinalizationStatus("idle");
     setFinalizationError("");
+    setStatementOutcome(undefined);
+    setExistingStatement(null);
+    setIsCheckingExistingStatement(false);
+    setExistingCompetenceAction("");
 
     setIsLoadingSources(true);
     incomeSourcesService
@@ -100,6 +115,51 @@ export default function IncomeStatementQuickModal({
       .catch(() => {})
       .finally(() => setIsLoadingSources(false));
   }, [defaultComposeIncome, isOpen, prefill?.netAmount, prefill?.paymentDate, prefill?.referenceMonth, transactionId]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    const trimmedReferenceMonth = referenceMonth.trim();
+    if (!sourceId || !trimmedReferenceMonth) {
+      setExistingStatement(null);
+      setIsCheckingExistingStatement(false);
+      setExistingCompetenceAction("");
+      return undefined;
+    }
+
+    let cancelled = false;
+    setIsCheckingExistingStatement(true);
+
+    incomeSourcesService
+      .listStatements(Number(sourceId))
+      .then((statements) => {
+        if (cancelled) {
+          return;
+        }
+
+        const match =
+          statements.find((statement) => statement.referenceMonth === trimmedReferenceMonth) ?? null;
+
+        setExistingStatement(match);
+        setExistingCompetenceAction("");
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setExistingStatement(null);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsCheckingExistingStatement(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, referenceMonth, sourceId]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -119,14 +179,27 @@ export default function IncomeStatementQuickModal({
       return;
     }
 
+    if (existingStatement && !existingCompetenceAction) {
+      setErrorMessage("Escolha se deseja ignorar ou substituir a competência existente.");
+      return;
+    }
+
+    if (existingStatement && existingCompetenceAction === "ignore") {
+      setErrorMessage("");
+      onIgnored?.(existingStatement);
+      return;
+    }
+
     setIsSubmitting(true);
     setErrorMessage("");
     try {
-      const { statement } = await incomeSourcesService.createStatement(parsedSourceId, {
+      const result = await incomeSourcesService.createStatement(parsedSourceId, {
         referenceMonth: referenceMonth.trim(),
         netAmount: parsedNet,
         paymentDate: paymentDate.trim() || null,
         grossAmount: prefill?.grossAmount ?? null,
+        existingCompetenceAction:
+          existingStatement && existingCompetenceAction ? existingCompetenceAction : undefined,
         deductions: Array.isArray(prefill?.deductions)
           ? prefill.deductions.map((deduction) => ({
               label: `${deduction.code ? `${deduction.code} ` : ""}${deduction.label}`.trim(),
@@ -137,38 +210,51 @@ export default function IncomeStatementQuickModal({
         details: prefill?.details ?? null,
         sourceImportSessionId: prefill?.sourceImportSessionId ?? null,
       });
+      const { statement } = result;
+      setStatementOutcome(result.outcome);
 
       let finalStatement = statement;
       let shouldNotifyCreated = true;
+      const statementAlreadyPosted = finalStatement.status === "posted";
 
       if (composeIncome) {
         if (transactionId) {
-          setFinalizationMode("link");
-          setFinalizationStatus("linking");
-          try {
-            finalStatement = await incomeSourcesService.linkTransaction(statement.id, transactionId);
+          if (statementAlreadyPosted && finalStatement.postedTransactionId === transactionId) {
+            setFinalizationMode("link");
             setFinalizationStatus("linked");
-          } catch (linkErr) {
-            setFinalizationStatus("failed");
-            setFinalizationError(
-              getApiErrorMessage(linkErr, "Nao foi possivel vincular a transacao importada."),
-            );
-            shouldNotifyCreated = false;
+          } else {
+            setFinalizationMode("link");
+            setFinalizationStatus("linking");
+            try {
+              finalStatement = await incomeSourcesService.linkTransaction(statement.id, transactionId);
+              setFinalizationStatus("linked");
+            } catch (linkErr) {
+              setFinalizationStatus("failed");
+              setFinalizationError(
+                getApiErrorMessage(linkErr, "Nao foi possivel vincular a transacao importada."),
+              );
+              shouldNotifyCreated = false;
+            }
           }
         } else {
-          setFinalizationMode("post");
-          setFinalizationStatus("posting");
-          try {
-            const postResult = await incomeSourcesService.postStatement(statement.id);
-            finalStatement = postResult.statement;
-            setPostedTransaction(postResult.transaction);
+          if (statementAlreadyPosted) {
+            setFinalizationMode("post");
             setFinalizationStatus("posted");
-          } catch (postErr) {
-            setFinalizationStatus("failed");
-            setFinalizationError(
-              getApiErrorMessage(postErr, "Nao foi possivel lancar a entrada automaticamente."),
-            );
-            shouldNotifyCreated = false;
+          } else {
+            setFinalizationMode("post");
+            setFinalizationStatus("posting");
+            try {
+              const postResult = await incomeSourcesService.postStatement(statement.id);
+              finalStatement = postResult.statement;
+              setPostedTransaction(postResult.transaction);
+              setFinalizationStatus("posted");
+            } catch (postErr) {
+              setFinalizationStatus("failed");
+              setFinalizationError(
+                getApiErrorMessage(postErr, "Nao foi possivel lancar a entrada automaticamente."),
+              );
+              shouldNotifyCreated = false;
+            }
           }
         }
       }
@@ -227,6 +313,12 @@ export default function IncomeStatementQuickModal({
                   ? "Renda registrada e entrada lancada com sucesso."
                   : "Lancamento registrado com sucesso."}
               </p>
+
+              {statementOutcome === "replaced" ? (
+                <p className="mt-1 text-xs font-medium text-green-700 dark:text-green-400">
+                  A competência existente foi substituída com segurança.
+                </p>
+              ) : null}
 
               {finalizationStatus === "linking" && (
                 <p className="mt-1 text-xs text-green-600 dark:text-green-400">
@@ -339,6 +431,55 @@ export default function IncomeStatementQuickModal({
                 />
               </div>
 
+              {isCheckingExistingStatement ? (
+                <div className="rounded border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300">
+                  Verificando se esta competência já existe nesta fonte...
+                </div>
+              ) : null}
+
+              {existingStatement ? (
+                <div className="rounded border border-amber-300 bg-amber-50 px-3 py-3 dark:border-amber-800 dark:bg-amber-950/40">
+                  <p className="text-xs font-semibold uppercase text-amber-800 dark:text-amber-300">
+                    Competência já existente
+                  </p>
+                  <p className="mt-1 text-xs text-amber-700 dark:text-amber-300">
+                    Já existe um extrato para {existingStatement.referenceMonth} nesta fonte.
+                  </p>
+                  <ul className="mt-2 space-y-0.5 text-xs text-amber-700 dark:text-amber-300">
+                    <li>Status: {existingStatement.status === "posted" ? "Lançado" : "Rascunho"}</li>
+                    <li>Valor líquido: R$ {existingStatement.netAmount.toFixed(2).replace(".", ",")}</li>
+                    {existingStatement.paymentDate ? <li>Pagamento: {existingStatement.paymentDate}</li> : null}
+                  </ul>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      onClick={() => setExistingCompetenceAction("ignore")}
+                      className={`rounded border px-3 py-1 text-xs font-semibold ${
+                        existingCompetenceAction === "ignore"
+                          ? "border-amber-600 bg-amber-600 text-white"
+                          : "border-amber-300 bg-white text-amber-700 hover:bg-amber-100 dark:border-amber-700 dark:bg-transparent dark:text-amber-300 dark:hover:bg-amber-900/30"
+                      }`}
+                    >
+                      Ignorar
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setExistingCompetenceAction("replace")}
+                      className={`rounded border px-3 py-1 text-xs font-semibold ${
+                        existingCompetenceAction === "replace"
+                          ? "border-blue-600 bg-blue-600 text-white"
+                          : "border-blue-300 bg-white text-blue-700 hover:bg-blue-100 dark:border-blue-700 dark:bg-transparent dark:text-blue-300 dark:hover:bg-blue-900/30"
+                      }`}
+                    >
+                      Substituir
+                    </button>
+                  </div>
+                  <p className="mt-2 text-[11px] text-amber-700 dark:text-amber-300">
+                    Ignorar não altera nada. Substituir reescreve esta competência sem duplicar consignações.
+                  </p>
+                </div>
+              ) : null}
+
               <div>
                 <label
                   htmlFor="income-quick-net"
@@ -449,11 +590,13 @@ export default function IncomeStatementQuickModal({
               <div className="flex gap-2 pt-1">
                 <button
                   type="submit"
-                  disabled={isSubmitting || sources.length === 0}
+                  disabled={isSubmitting || sources.length === 0 || isCheckingExistingStatement}
                   className="rounded border border-brand-1 bg-brand-1 px-3 py-1.5 text-sm font-semibold text-white hover:bg-brand-2 disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   {isSubmitting
                     ? "Registrando..."
+                    : existingStatement && existingCompetenceAction === "ignore"
+                      ? "Ignorar competência"
                     : composeIncome
                       ? transactionId
                         ? "Registrar e vincular entrada"

--- a/apps/web/src/services/incomeSources.service.ts
+++ b/apps/web/src/services/incomeSources.service.ts
@@ -72,6 +72,7 @@ export interface IncomeSourceWithDeductions extends IncomeSource {
 }
 
 export interface IncomeStatementWithDeductions {
+  outcome?: "created" | "ignored" | "replaced";
   statement: IncomeStatement;
   deductions: IncomeStatementDeduction[];
 }
@@ -112,6 +113,7 @@ export interface CreateStatementPayload {
   grossAmount?: number | null;
   details?: Record<string, unknown> | null;
   sourceImportSessionId?: string | null;
+  existingCompetenceAction?: "ignore" | "replace";
   deductions?: Array<{
     label: string;
     amount: number;
@@ -185,6 +187,12 @@ interface RawStatementReconciliation {
   summary?: unknown;
   linkedTransaction?: unknown;
   candidates?: unknown;
+}
+
+interface RawStatementWithDeductions {
+  outcome?: unknown;
+  statement?: unknown;
+  deductions?: unknown;
 }
 
 // ─── Normalization ─────────────────────────────────────────────────────────────
@@ -307,15 +315,19 @@ const normalizeSource = (raw: RawSource): IncomeSourceWithDeductions => {
   };
 };
 
-const normalizeStatementWithDeductions = (raw: {
-  statement?: unknown;
-  deductions?: unknown;
-}): IncomeStatementWithDeductions => {
+const normalizeStatementWithDeductions = (raw: RawStatementWithDeductions): IncomeStatementWithDeductions => {
   const stmt = raw.statement as RawStatement;
   const deds = Array.isArray(raw.deductions)
     ? (raw.deductions as RawStatementDeduction[]).map(normalizeStatementDeduction)
     : [];
-  return { statement: normalizeStatement(stmt ?? {}), deductions: deds };
+  return {
+    outcome:
+      raw.outcome === "created" || raw.outcome === "ignored" || raw.outcome === "replaced"
+        ? raw.outcome
+        : undefined,
+    statement: normalizeStatement(stmt ?? {}),
+    deductions: deds,
+  };
 };
 
 // ─── Service ──────────────────────────────────────────────────────────────────
@@ -362,7 +374,7 @@ export const incomeSourcesService = {
     payload: CreateStatementPayload,
   ): Promise<IncomeStatementWithDeductions> => {
     const { data } = await api.post(`/income-sources/${sourceId}/statements`, payload);
-    return normalizeStatementWithDeductions(data as { statement?: unknown; deductions?: unknown });
+    return normalizeStatementWithDeductions(data as RawStatementWithDeductions);
   },
 
   updateStatement: async (


### PR DESCRIPTION
## Contexto

Este PR endurece o fluxo de reimportação de extratos de renda por competência.

Depois do `#322`, o INSS já entrava por competência com data correta, descontos linha a linha e sync do benefício no dashboard. O risco seguinte ficou claro: reimportar a mesma competência podia virar duplicidade silenciosa ou comportamento implícito demais.

## O que entra

- deduplicação de competência por `income_source + reference_month`
- contrato explícito no backend para competência já existente:
  - `ignore`
  - `replace`
- replace seguro do extrato existente, sem criar novo statement
- atualização segura da transação sintética já lançada quando o extrato substituído já estava postado
- detecção de competência existente no modal de renda
- decisão explícita no fluxo:
  - `Ignorar`
  - `Substituir`
- proteção para não relançar entrada já postada ao substituir a mesma competência
- feedback claro no import quando a competência é ignorada

## Regra

- mesma competência da mesma fonte não entra duplicada por acidente
- ignorar não altera statement, perfil, consignações nem widget
- substituir reescreve a competência existente com segurança
- reimportar e substituir mantém uma única competência ativa e não duplica consignações
- o widget e o perfil continuam coerentes depois da troca

## Validação

- `npm -w apps/api run lint` ✅
- `npm -w apps/api test -- src/income-sources.test.js` ✅
- `npm -w apps/web run lint` ✅
- `npm -w apps/web run typecheck` ✅
- `npm -w apps/web run test:run -- src/components/IncomeStatementQuickModal.test.tsx src/components/ImportCsvModal.test.jsx` ✅

## Smoke real

PDF validado: `DOC-20260327-WA0027..pdf`

Fluxo executado:
1. primeira importação da competência `2026-02`
2. reimport com `Ignorar`
3. reimport com `Substituir`

Resultado:
- após a primeira importação:
  - `statementCount = 1`
  - `consignacaoCount = 10`
  - `salary_profile = inss_beneficiary`, `gross_salary = 4958.67`, `payment_day = 5`
- após `Ignorar`:
  - `statementCount = 1`
  - `consignacaoCount = 10`
- após `Substituir`:
  - `statementCount = 1`
  - `consignacaoCount = 10`
  - `salary_profile` permaneceu coerente

Ou seja: a competência ficou única em todo o fluxo, e as consignações não duplicaram.
