### PR TITLE
feat(salary): expose active statement competence in benefit widget

### DIFF
--- a/apps/api/src/db/migrations/107_add_active_statement_to_salary_profiles.sql
+++ b/apps/api/src/db/migrations/107_add_active_statement_to_salary_profiles.sql
@@ -1,0 +1,5 @@
+ALTER TABLE salary_profiles
+ADD COLUMN IF NOT EXISTS active_statement_reference_month CHAR(7);
+
+ALTER TABLE salary_profiles
+ADD COLUMN IF NOT EXISTS active_statement_payment_date DATE;

--- a/apps/api/src/salary-profile.test.js
+++ b/apps/api/src/salary-profile.test.js
@@ -128,6 +128,8 @@ describe("salary-profile", () => {
         gross_salary: 4958.67,
         payment_day: 7,
         birth_year: 1955,
+        reference_month: "2026-03",
+        payment_date: "2026-04-07",
         consignacoes: [
           {
             description: "216 CONSIGNACAO EMPRESTIMO BANCARIO",
@@ -153,6 +155,10 @@ describe("salary-profile", () => {
       dependents: 2,
       paymentDay: 7,
       birthYear: 1955,
+      activeStatement: {
+        referenceMonth: "2026-03",
+        paymentDate: "2026-04-07",
+      },
     });
     expect(res.body.consignacoes).toEqual([
       expect.objectContaining({
@@ -175,6 +181,8 @@ describe("salary-profile", () => {
       gross_salary: 4958.67,
       payment_day: 7,
       birth_year: 1955,
+      reference_month: "2026-03",
+      payment_date: "2026-04-07",
       consignacoes: [
         {
           description: "216 CONSIGNACAO EMPRESTIMO BANCARIO",
@@ -205,10 +213,39 @@ describe("salary-profile", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.consignacoes).toHaveLength(2);
+    expect(res.body.activeStatement).toEqual({
+      referenceMonth: "2026-03",
+      paymentDate: "2026-04-07",
+    });
     expect(res.body.consignacoes.map((item) => item.description)).toEqual([
       "216 CONSIGNACAO EMPRESTIMO BANCARIO",
       "217 EMPRESTIMO SOBRE A RMC",
     ]);
+  });
+
+  it("PUT /salary/profile limpando para CLT remove a competência ativa do benefício", async () => {
+    const token = await registerAndLogin("sal-clear-active-statement@test.dev");
+
+    await request(app)
+      .put("/salary/profile/imported-benefit")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        gross_salary: 4958.67,
+        payment_day: 7,
+        birth_year: 1955,
+        reference_month: "2026-03",
+        payment_date: "2026-04-07",
+        consignacoes: [],
+      });
+
+    const res = await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 4000, profile_type: "clt", payment_day: 5 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.profileType).toBe("clt");
+    expect(res.body.activeStatement).toBeNull();
   });
 
   it("segundo upsert mantém mesmo id", async () => {

--- a/apps/api/src/services/salary-profile.service.js
+++ b/apps/api/src/services/salary-profile.service.js
@@ -5,6 +5,8 @@ import { calculateNetSalary } from "../domain/salary/salary.calculator.js";
 const PAYMENT_DAY_MIN = 1;
 const PAYMENT_DAY_MAX = 31;
 const CONSIGNACAO_DESCRIPTION_MAX_LENGTH = 100;
+const REFERENCE_MONTH_REGEX = /^\d{4}-\d{2}$/;
+const ISO_DATE_ONLY_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 
 const createError = (status, message) => {
   const err = new Error(message);
@@ -13,6 +15,15 @@ const createError = (status, message) => {
 };
 
 const toMoney = (value) => Number(Number(value || 0).toFixed(2));
+const toISODateOnly = (value) => {
+  if (value == null) return null;
+  const normalized = String(value).trim().slice(0, 10);
+  if (ISO_DATE_ONLY_REGEX.test(normalized)) return normalized;
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toISOString().slice(0, 10);
+};
 
 // ─── Validation ───────────────────────────────────────────────────────────────
 
@@ -79,6 +90,30 @@ const validateConsignacaoInput = ({ description, amount, consignacaoType }) => {
   }
 };
 
+const normalizeActiveStatementInput = ({ referenceMonth, paymentDate }) => {
+  const normalizedReferenceMonth =
+    typeof referenceMonth === "string" && referenceMonth.trim()
+      ? referenceMonth.trim()
+      : null;
+  const normalizedPaymentDate = toISODateOnly(paymentDate);
+
+  if (
+    normalizedReferenceMonth != null &&
+    !REFERENCE_MONTH_REGEX.test(normalizedReferenceMonth)
+  ) {
+    throw createError(422, "reference_month deve estar no formato YYYY-MM.");
+  }
+
+  if (paymentDate != null && normalizedPaymentDate == null) {
+    throw createError(422, "payment_date deve estar no formato YYYY-MM-DD.");
+  }
+
+  return {
+    referenceMonth: normalizedReferenceMonth,
+    paymentDate: normalizedPaymentDate,
+  };
+};
+
 const normalizeImportedConsignacoes = (value) => {
   if (value == null) return [];
   if (!Array.isArray(value)) {
@@ -118,6 +153,16 @@ const toProfile = (row) => ({
   paymentDay:  Number(row.payment_day),
   createdAt:   row.created_at,
   updatedAt:   row.updated_at,
+  activeStatement:
+    row.active_statement_reference_month != null || row.active_statement_payment_date != null
+      ? {
+          referenceMonth:
+            typeof row.active_statement_reference_month === "string"
+              ? row.active_statement_reference_month
+              : null,
+          paymentDate: toISODateOnly(row.active_statement_payment_date),
+        }
+      : null,
 });
 
 const toConsignacao = (row) => ({
@@ -162,6 +207,7 @@ const withCalculation = (profile, consignacoes = []) => {
 
 const FIND_SQL = `
   SELECT id, user_id, gross_salary, dependents, payment_day, profile_type, birth_year,
+         active_statement_reference_month, active_statement_payment_date,
          created_at, updated_at
   FROM   salary_profiles
   WHERE  user_id = $1
@@ -177,9 +223,11 @@ const FIND_CONSIGNACOES_SQL = `
 
 const INSERT_SQL = `
   INSERT INTO salary_profiles
-    (user_id, gross_salary, dependents, payment_day, profile_type, birth_year)
-  VALUES ($1, $2, $3, $4, $5, $6)
+    (user_id, gross_salary, dependents, payment_day, profile_type, birth_year,
+     active_statement_reference_month, active_statement_payment_date)
+  VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
   RETURNING id, user_id, gross_salary, dependents, payment_day, profile_type, birth_year,
+            active_statement_reference_month, active_statement_payment_date,
             created_at, updated_at
 `;
 
@@ -190,9 +238,12 @@ const UPDATE_SQL = `
       payment_day  = $3,
       profile_type = $4,
       birth_year   = $5,
+      active_statement_reference_month = $6,
+      active_statement_payment_date = $7,
       updated_at   = NOW()
-  WHERE user_id = $6
+  WHERE user_id = $8
   RETURNING id, user_id, gross_salary, dependents, payment_day, profile_type, birth_year,
+            active_statement_reference_month, active_statement_payment_date,
             created_at, updated_at
 `;
 
@@ -227,19 +278,43 @@ export const upsertSalaryProfileForUser = async (userId, body = {}) => {
 
   validateProfileInput({ grossSalary, dependents, paymentDay, profileType, birthYear });
 
+  const existing = await dbQuery(FIND_SQL, [userId]);
+
   const gross = Number(grossSalary);
   const dep   = Number(dependents);
   const day   = Number(paymentDay);
   const type  = profileType;
   const year  = birthYear != null ? Number(birthYear) : null;
+  const existingProfile = existing.rows[0] ? toProfile(existing.rows[0]) : null;
+  const activeStatementReferenceMonth =
+    type === "inss_beneficiary" ? existingProfile?.activeStatement?.referenceMonth ?? null : null;
+  const activeStatementPaymentDate =
+    type === "inss_beneficiary" ? existingProfile?.activeStatement?.paymentDate ?? null : null;
 
-  const existing = await dbQuery(FIND_SQL, [userId]);
   let result;
 
   if (existing.rows[0]) {
-    result = await dbQuery(UPDATE_SQL, [gross, dep, day, type, year, userId]);
+    result = await dbQuery(UPDATE_SQL, [
+      gross,
+      dep,
+      day,
+      type,
+      year,
+      activeStatementReferenceMonth,
+      activeStatementPaymentDate,
+      userId,
+    ]);
   } else {
-    result = await dbQuery(INSERT_SQL, [userId, gross, dep, day, type, year]);
+    result = await dbQuery(INSERT_SQL, [
+      userId,
+      gross,
+      dep,
+      day,
+      type,
+      year,
+      activeStatementReferenceMonth,
+      activeStatementPaymentDate,
+    ]);
   }
 
   const profile = toProfile(result.rows[0]);
@@ -287,6 +362,8 @@ export const syncImportedBenefitProfileForUser = async (userId, body = {}) =>
       birth_year: birthYear = existingProfile?.birthYear ?? null,
       dependents = existingProfile?.dependents ?? 0,
       consignacoes = [],
+      reference_month: rawReferenceMonth = existingProfile?.activeStatement?.referenceMonth ?? null,
+      payment_date: rawPaymentDate = existingProfile?.activeStatement?.paymentDate ?? null,
     } = body;
 
     validateProfileInput({
@@ -298,6 +375,10 @@ export const syncImportedBenefitProfileForUser = async (userId, body = {}) =>
     });
 
     const normalizedConsignacoes = normalizeImportedConsignacoes(consignacoes);
+    const activeStatement = normalizeActiveStatementInput({
+      referenceMonth: rawReferenceMonth,
+      paymentDate: rawPaymentDate,
+    });
     const gross = Number(grossSalary);
     const dep = Number(dependents);
     const day = Number(paymentDay);
@@ -305,9 +386,27 @@ export const syncImportedBenefitProfileForUser = async (userId, body = {}) =>
 
     let profileRows;
     if (existingProfile) {
-      profileRows = await client.query(UPDATE_SQL, [gross, dep, day, "inss_beneficiary", year, userId]);
+      profileRows = await client.query(UPDATE_SQL, [
+        gross,
+        dep,
+        day,
+        "inss_beneficiary",
+        year,
+        activeStatement.referenceMonth,
+        activeStatement.paymentDate,
+        userId,
+      ]);
     } else {
-      profileRows = await client.query(INSERT_SQL, [userId, gross, dep, day, "inss_beneficiary", year]);
+      profileRows = await client.query(INSERT_SQL, [
+        userId,
+        gross,
+        dep,
+        day,
+        "inss_beneficiary",
+        year,
+        activeStatement.referenceMonth,
+        activeStatement.paymentDate,
+      ]);
     }
 
     const profile = toProfile(profileRows.rows[0]);

--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -388,6 +388,8 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory
           gross_salary: selectedProfileSuggestion.grossAmount,
           payment_day: profilePatch.payday,
           birth_year: selectedProfileSuggestion.birthYear ?? null,
+          reference_month: selectedProfileSuggestion.referenceMonth ?? null,
+          payment_date: selectedProfileSuggestion.paymentDate ?? null,
           consignacoes: Array.isArray(selectedProfileSuggestion.deductions)
             ? selectedProfileSuggestion.deductions.map((deduction) => ({
                 description: `${deduction.code ? `${deduction.code} ` : ""}${deduction.label}`.trim(),

--- a/apps/web/src/components/ImportCsvModal.test.jsx
+++ b/apps/web/src/components/ImportCsvModal.test.jsx
@@ -1056,6 +1056,8 @@ describe("ImportCsvModal", () => {
         gross_salary: 1800,
         payment_day: 25,
         birth_year: null,
+        reference_month: "2026-02",
+        payment_date: "2026-02-25",
         consignacoes: [],
       });
       expect(forecastService.recompute).toHaveBeenCalled();

--- a/apps/web/src/components/SalaryWidget.test.tsx
+++ b/apps/web/src/components/SalaryWidget.test.tsx
@@ -15,7 +15,9 @@ vi.mock("../services/salary.service", () => ({
 
 // ─── Builders ─────────────────────────────────────────────────────────────────
 
-const buildCltProfile = (overrides: Partial<SalaryProfile> = {}): SalaryProfile => ({
+const buildCltProfile = (overrides: Partial<SalaryProfile> = {}): SalaryProfile => {
+  const { activeStatement = null, ...restOverrides } = overrides;
+  return ({
   id:          1,
   userId:      1,
   profileType: "clt",
@@ -25,6 +27,7 @@ const buildCltProfile = (overrides: Partial<SalaryProfile> = {}): SalaryProfile 
   paymentDay:  5,
   createdAt:   "2026-02-01T00:00:00Z",
   updatedAt:   "2026-02-01T00:00:00Z",
+  activeStatement,
   consignacoes: [],
   calculation: {
     grossMonthly: 5000,
@@ -34,10 +37,19 @@ const buildCltProfile = (overrides: Partial<SalaryProfile> = {}): SalaryProfile 
     netAnnual:    49941.84,
     taxAnnual:    10058.16,
   },
-  ...overrides,
-});
+  ...restOverrides,
+  });
+};
 
-const buildBenefitProfile = (overrides: Partial<SalaryProfile> = {}): SalaryProfile => ({
+const buildBenefitProfile = (overrides: Partial<SalaryProfile> = {}): SalaryProfile => {
+  const {
+    activeStatement = {
+      referenceMonth: "2026-02",
+      paymentDate: "2026-03-05",
+    },
+    ...restOverrides
+  } = overrides;
+  return ({
   id:          2,
   userId:      1,
   profileType: "inss_beneficiary",
@@ -47,6 +59,7 @@ const buildBenefitProfile = (overrides: Partial<SalaryProfile> = {}): SalaryProf
   paymentDay:  5,
   createdAt:   "2026-02-01T00:00:00Z",
   updatedAt:   "2026-02-01T00:00:00Z",
+  activeStatement,
   consignacoes: [],
   calculation: {
     grossMonthly:        4958.67,
@@ -63,8 +76,9 @@ const buildBenefitProfile = (overrides: Partial<SalaryProfile> = {}): SalaryProf
     isOverLoanLimit:     false,
     isOverCardLimit:     false,
   },
-  ...overrides,
-});
+  ...restOverrides,
+  });
+};
 
 const renderWidget = () => render(<SalaryWidget />);
 
@@ -384,6 +398,8 @@ describe("SalaryWidget — perfil beneficiário INSS", () => {
     await waitFor(() => {
       expect(screen.getByText(/Recebe dia/)).toBeInTheDocument();
     });
+    expect(screen.getByText("02/2026")).toBeInTheDocument();
+    expect(screen.getByText("05/03/2026")).toBeInTheDocument();
     expect(screen.getByText("5")).toBeInTheDocument();
     expect(screen.getByText("1955")).toBeInTheDocument();
     expect(screen.getByText("Beneficiário INSS")).toBeInTheDocument();

--- a/apps/web/src/components/SalaryWidget.tsx
+++ b/apps/web/src/components/SalaryWidget.tsx
@@ -28,6 +28,20 @@ const EMPTY_BENEFIT: BenefitFormState = { grossBenefit: "", birthYear: "", depen
 const CONSIGNACAO_DESCRIPTION_MAX_LENGTH = 100;
 const SALARY_PROFILE_UPDATED_EVENT = "salary-profile-updated";
 
+const formatReferenceMonthLabel = (value: string | null | undefined) => {
+  if (!value) return null;
+  const match = /^(\d{4})-(\d{2})$/.exec(value);
+  if (!match) return value;
+  return `${match[2]}/${match[1]}`;
+};
+
+const formatDateLabel = (value: string | null | undefined) => {
+  if (!value) return null;
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return value;
+  return `${match[3]}/${match[2]}/${match[1]}`;
+};
+
 const profileToCltForm = (p: SalaryProfile): CltFormState => ({
   grossSalary: String(p.grossSalary),
   dependents:  String(p.dependents),
@@ -363,6 +377,8 @@ function BenefitProfileView({
   const cardLimit = calculation.cardLimitAmount ?? 0;
   const loanTotal = calculation.loanTotal ?? 0;
   const cardTotal = calculation.cardTotal ?? 0;
+  const activeReferenceMonth = formatReferenceMonthLabel(profile.activeStatement?.referenceMonth);
+  const activePaymentDate = formatDateLabel(profile.activeStatement?.paymentDate);
 
   const [addingConsig, setAddingConsig] = useState(false);
   const [consigForm, setConsigForm] = useState({ description: "", amount: "", consignacaoType: "loan" as ConsignacaoType });
@@ -452,6 +468,18 @@ function BenefitProfileView({
 
       <div className="mb-3 rounded border border-cf-border bg-cf-bg-subtle px-3 py-2 text-xs text-cf-text-secondary">
         <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+          {activeReferenceMonth ? (
+            <span>
+              Competência ativa{" "}
+              <span className="font-semibold text-cf-text-primary">{activeReferenceMonth}</span>
+            </span>
+          ) : null}
+          {activePaymentDate ? (
+            <span>
+              Pagamento em{" "}
+              <span className="font-semibold text-cf-text-primary">{activePaymentDate}</span>
+            </span>
+          ) : null}
           <span>
             Recebe dia <span className="font-semibold text-cf-text-primary">{profile.paymentDay}</span>
           </span>

--- a/apps/web/src/services/salary.service.ts
+++ b/apps/web/src/services/salary.service.ts
@@ -31,6 +31,11 @@ export interface Consignacao {
   createdAt: string;
 }
 
+export interface ActiveBenefitStatement {
+  referenceMonth: string | null;
+  paymentDate: string | null;
+}
+
 export interface SalaryProfile {
   id: number;
   userId: number;
@@ -41,6 +46,7 @@ export interface SalaryProfile {
   paymentDay: number;
   createdAt: string;
   updatedAt: string;
+  activeStatement: ActiveBenefitStatement | null;
   consignacoes: Consignacao[];
   calculation: SalaryCalculation;
 }
@@ -63,6 +69,8 @@ export interface SyncImportedBenefitProfilePayload {
   gross_salary: number;
   payment_day: number;
   birth_year?: number | null;
+  reference_month?: string | null;
+  payment_date?: string | null;
   consignacoes: AddConsignacaoPayload[];
 }
 
@@ -103,6 +111,19 @@ const normalizeProfile = (raw: Record<string, unknown>): SalaryProfile => ({
   paymentDay:  Number(raw.paymentDay)  || 5,
   createdAt:   typeof raw.createdAt === "string" ? raw.createdAt : "",
   updatedAt:   typeof raw.updatedAt === "string" ? raw.updatedAt : "",
+  activeStatement:
+    raw.activeStatement && typeof raw.activeStatement === "object"
+      ? {
+          referenceMonth:
+            typeof (raw.activeStatement as Record<string, unknown>).referenceMonth === "string"
+              ? ((raw.activeStatement as Record<string, unknown>).referenceMonth as string)
+              : null,
+          paymentDate:
+            typeof (raw.activeStatement as Record<string, unknown>).paymentDate === "string"
+              ? ((raw.activeStatement as Record<string, unknown>).paymentDate as string)
+              : null,
+        }
+      : null,
   consignacoes: Array.isArray(raw.consignacoes)
     ? (raw.consignacoes as Record<string, unknown>[]).map(normalizeConsignacao)
     : [],


### PR DESCRIPTION
## Summary
- persist the active imported benefit competence and payment date on the salary profile
- send the selected competence metadata when syncing INSS benefit imports into salary
- render the active competence in the benefit widget with a safe fallback when no synced statement exists

## Validation
- npm -w apps/api run lint
- npm -w apps/api test -- src/salary-profile.test.js
- npm -w apps/web run test:run -- src/components/SalaryWidget.test.tsx src/components/ImportCsvModal.test.jsx
- npm -w apps/web run typecheck
- npm -w apps/web run lint
- npm -w apps/web run build