### PR TITLE
fix(web): make import modals fit viewport

### DIFF
--- a/apps/web/src/components/BillModal.tsx
+++ b/apps/web/src/components/BillModal.tsx
@@ -189,26 +189,29 @@ const BillModal = ({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex min-h-screen items-start justify-center bg-black/50 p-6 sm:items-center"
+      className="fixed inset-0 z-50 flex min-h-screen items-start justify-center overflow-y-auto bg-black/50 p-2 sm:p-6 sm:items-center"
       onClick={handleBackdropClick}
       role="presentation"
     >
-      <div className="w-full max-w-md rounded-lg bg-cf-surface p-4 sm:p-6">
+      <div className="flex max-h-[calc(100dvh-1rem)] w-full max-w-md flex-col overflow-hidden rounded-lg bg-cf-surface shadow-xl sm:max-h-[calc(100dvh-3rem)]">
         {/* Header */}
-        <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-cf-text-primary">
-            {isEditing ? "Editar pendência" : "Nova pendência"}
-          </h2>
-          <button
-            type="button"
-            onClick={onClose}
-            className="text-cf-text-secondary transition-colors hover:text-cf-text-primary"
-            aria-label="Fechar modal"
-          >
-            X
-          </button>
+        <div className="border-b border-cf-border px-4 py-4 sm:px-6">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-cf-text-primary">
+              {isEditing ? "Editar pendência" : "Nova pendência"}
+            </h2>
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-cf-text-secondary transition-colors hover:text-cf-text-primary"
+              aria-label="Fechar modal"
+            >
+              X
+            </button>
+          </div>
         </div>
 
+        <div className="min-h-0 overflow-y-auto px-4 py-4 sm:px-6">
         <form onSubmit={handleSubmit} className="space-y-4">
           {/* Title */}
           <div className="flex flex-col gap-1.5">
@@ -397,6 +400,7 @@ const BillModal = ({
             </button>
           </div>
         </form>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -798,76 +798,83 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory
 
   return (
     <div
-      className="fixed inset-0 z-50 flex min-h-screen items-start justify-center bg-black/50 p-6 sm:items-center"
+      className="fixed inset-0 z-50 flex min-h-screen items-start justify-center overflow-y-auto bg-black/50 p-2 sm:p-6 sm:items-center"
       onClick={handleBackdropClick}
       role="presentation"
     >
       <div
-        className="w-full max-w-4xl rounded-lg bg-cf-surface p-4 sm:p-6"
+        className="flex max-h-[calc(100dvh-1rem)] w-full max-w-4xl flex-col overflow-hidden rounded-lg bg-cf-surface shadow-xl sm:max-h-[calc(100dvh-3rem)]"
         role="dialog"
         aria-modal="true"
         aria-labelledby="import-csv-modal-title"
+        data-testid="import-csv-modal-shell"
       >
-        <div className="mb-4 flex items-center justify-between">
-          <h2 id="import-csv-modal-title" className="text-lg font-semibold text-cf-text-primary">
-            Importar extrato
-          </h2>
-          <button
-            type="button"
-            onClick={onClose}
-            className="text-ui-200 transition-colors hover:text-ui-100"
-            aria-label="Fechar modal de importação de extrato"
-          >
-            X
-          </button>
+        <div className="border-b border-cf-border px-4 py-4 sm:px-6">
+          <div className="flex items-center justify-between">
+            <h2 id="import-csv-modal-title" className="text-lg font-semibold text-cf-text-primary">
+              Importar extrato
+            </h2>
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-ui-200 transition-colors hover:text-ui-100"
+              aria-label="Fechar modal de importação de extrato"
+            >
+              X
+            </button>
+          </div>
         </div>
 
-        <p className="mb-4 text-sm text-cf-text-secondary">
-          Envie um CSV, OFX ou PDF para revisar, categorizar e confirmar o que entra no seu painel financeiro antes de importar.
-        </p>
+        <div
+          className="min-h-0 overflow-y-auto px-4 py-4 sm:px-6"
+          data-testid="import-csv-modal-body"
+        >
+          <p className="mb-4 text-sm text-cf-text-secondary">
+            Envie um CSV, OFX ou PDF para revisar, categorizar e confirmar o que entra no seu painel financeiro antes de importar.
+          </p>
 
-        <div className="rounded border border-cf-border bg-cf-surface p-3">
-          <label
-            htmlFor="csv-file-input"
-            className="mb-1 block text-sm font-medium text-cf-text-primary"
-          >
-            Arquivo do extrato
-          </label>
-          <input
-            ref={fileInputRef}
-            id="csv-file-input"
-            type="file"
-            accept=".csv,.ofx,.pdf,text/csv,application/ofx,application/pdf"
-            onChange={(event) => {
-              const nextFile = event.target.files?.[0] || null;
-              setSelectedFile(nextFile);
-              setDryRunResult(null);
-              setErrorMessage("");
-              setSuccessMessage("");
-              setProfileApplied(false);
-              setShowProfileConfirm(false);
-              setCategoryOverrides({});
-              setInlineCreate(null);
-              setInlineCreateName("");
-              setLastCommitResult(null);
-              setShowUndoConfirm(false);
-              setSelectedProfileSuggestionKey("");
-            }}
-            className="block w-full text-sm text-cf-text-primary file:mr-3 file:rounded file:border file:border-cf-border file:bg-cf-bg-subtle file:px-3 file:py-1 file:text-sm file:font-semibold file:text-cf-text-primary hover:file:bg-cf-border"
-          />
-          <p className="mt-2 text-xs text-cf-text-secondary">
-            OFX é o formato preferencial quando o banco oferecer. CSV manual, CSV do banco e PDF com OCR assistido entram como alternativas.
-          </p>
-          <p className="mt-1 text-xs text-cf-text-secondary">
-            Use a pré-visualização para conferir categorias, renda e pendências antes de confirmar a importação.
-          </p>
-          <p className="mt-1 text-xs text-cf-text-secondary">
-            Quando possível, a plataforma sugere automaticamente categorias com base nas descrições e nas categorias já cadastradas.
-          </p>
-        </div>
+          <div className="rounded border border-cf-border bg-cf-surface p-3">
+            <label
+              htmlFor="csv-file-input"
+              className="mb-1 block text-sm font-medium text-cf-text-primary"
+            >
+              Arquivo do extrato
+            </label>
+            <input
+              ref={fileInputRef}
+              id="csv-file-input"
+              type="file"
+              accept=".csv,.ofx,.pdf,text/csv,application/ofx,application/pdf"
+              onChange={(event) => {
+                const nextFile = event.target.files?.[0] || null;
+                setSelectedFile(nextFile);
+                setDryRunResult(null);
+                setErrorMessage("");
+                setSuccessMessage("");
+                setProfileApplied(false);
+                setShowProfileConfirm(false);
+                setCategoryOverrides({});
+                setInlineCreate(null);
+                setInlineCreateName("");
+                setLastCommitResult(null);
+                setShowUndoConfirm(false);
+                setSelectedProfileSuggestionKey("");
+              }}
+              className="block w-full text-sm text-cf-text-primary file:mr-3 file:rounded file:border file:border-cf-border file:bg-cf-bg-subtle file:px-3 file:py-1 file:text-sm file:font-semibold file:text-cf-text-primary hover:file:bg-cf-border"
+            />
+            <p className="mt-2 text-xs text-cf-text-secondary">
+              OFX é o formato preferencial quando o banco oferecer. CSV manual, CSV do banco e PDF com OCR assistido entram como alternativas.
+            </p>
+            <p className="mt-1 text-xs text-cf-text-secondary">
+              Use a pré-visualização para conferir categorias, renda e pendências antes de confirmar a importação.
+            </p>
+            <p className="mt-1 text-xs text-cf-text-secondary">
+              Quando possível, a plataforma sugere automaticamente categorias com base nas descrições e nas categorias já cadastradas.
+            </p>
+          </div>
 
-        {lastCommitResult ? (
-          <div className="mt-3 rounded border border-green-200 bg-green-50 px-3 py-3 dark:border-green-800 dark:bg-green-950/40">
+          {lastCommitResult ? (
+            <div className="mt-3 rounded border border-green-200 bg-green-50 px-3 py-3 dark:border-green-800 dark:bg-green-950/40">
             <p className="mb-2 text-sm font-semibold text-green-700 dark:text-green-400">
               {lastCommitResult.imported === 1
                 ? "1 lançamento importado."
@@ -913,49 +920,49 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory
                 {isUndoing ? "Desfazendo..." : "Desfazer importação"}
               </button>
             </div>
-          </div>
-        ) : (
-          <div className="mt-3 flex flex-wrap items-center gap-2">
-            <button
-              type="button"
-              onClick={handleDryRun}
-              disabled={isDryRunning || isCommitting}
-              className="rounded border border-brand-1 bg-brand-1 px-3 py-1.5 text-sm font-semibold text-white hover:bg-brand-2 disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {isDryRunning ? "Processando..." : "Pré-visualizar"}
-            </button>
-            <button
-              type="button"
-              onClick={handleCommit}
-              disabled={!hasValidRows || isDryRunning || isCommitting}
-              className="rounded border border-cf-border bg-cf-surface px-3 py-1.5 text-sm font-semibold text-cf-text-primary hover:bg-cf-bg-subtle disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {isCommitting ? "Importando..." : "Importar"}
-            </button>
-            <button
-              type="button"
-              onClick={onClose}
-              className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-1.5 text-sm font-semibold text-cf-text-secondary"
-            >
-              Fechar
-            </button>
-          </div>
-        )}
+            </div>
+          ) : (
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                onClick={handleDryRun}
+                disabled={isDryRunning || isCommitting}
+                className="rounded border border-brand-1 bg-brand-1 px-3 py-1.5 text-sm font-semibold text-white hover:bg-brand-2 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isDryRunning ? "Processando..." : "Pré-visualizar"}
+              </button>
+              <button
+                type="button"
+                onClick={handleCommit}
+                disabled={!hasValidRows || isDryRunning || isCommitting}
+                className="rounded border border-cf-border bg-cf-surface px-3 py-1.5 text-sm font-semibold text-cf-text-primary hover:bg-cf-bg-subtle disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isCommitting ? "Importando..." : "Importar"}
+              </button>
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-1.5 text-sm font-semibold text-cf-text-secondary"
+              >
+                Fechar
+              </button>
+            </div>
+          )}
 
-        {errorMessage ? (
-          <div className="mt-3 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
-            {errorMessage}
-          </div>
-        ) : null}
+          {errorMessage ? (
+            <div className="mt-3 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+              {errorMessage}
+            </div>
+          ) : null}
 
-        {successMessage ? (
-          <div className="mt-3 rounded border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">
-            {successMessage}
-          </div>
-        ) : null}
+          {successMessage ? (
+            <div className="mt-3 rounded border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">
+              {successMessage}
+            </div>
+          ) : null}
 
-        {dryRunResult ? (
-          <div className="mt-4 space-y-3">
+          {dryRunResult ? (
+            <div className="mt-4 space-y-3">
             {documentTypeBadge ? (
               <div className="flex items-center gap-2">
                 <span className={`rounded border px-2 py-0.5 text-xs font-semibold ${documentTypeBadge.className}`}>
@@ -1568,8 +1575,9 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory
                 </div>
               </>
             )}
-          </div>
-        ) : null}
+            </div>
+          ) : null}
+        </div>
       </div>
 
       <BillModal

--- a/apps/web/src/components/ImportCsvModal.test.jsx
+++ b/apps/web/src/components/ImportCsvModal.test.jsx
@@ -134,6 +134,17 @@ describe("ImportCsvModal", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
+  it("keeps the import modal shell scrollable inside the viewport", async () => {
+    render(<ImportCsvModal isOpen onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(categoriesService.listCategories).toHaveBeenCalled();
+    });
+
+    expect(screen.getByTestId("import-csv-modal-shell")).toHaveClass("flex", "flex-col", "overflow-hidden");
+    expect(screen.getByTestId("import-csv-modal-body")).toHaveClass("min-h-0", "overflow-y-auto");
+  });
+
   it("shows validation message when preview is requested without file", async () => {
     render(<ImportCsvModal isOpen onClose={vi.fn()} />);
 

--- a/apps/web/src/components/IncomeStatementQuickModal.test.tsx
+++ b/apps/web/src/components/IncomeStatementQuickModal.test.tsx
@@ -84,6 +84,17 @@ describe("IncomeStatementQuickModal", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
+  it("keeps the income statement modal shell scrollable inside the viewport", async () => {
+    render(<IncomeStatementQuickModal isOpen onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("income-quick-modal-shell")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("income-quick-modal-shell")).toHaveClass("flex", "flex-col", "overflow-hidden");
+    expect(screen.getByTestId("income-quick-modal-body")).toHaveClass("min-h-0", "overflow-y-auto");
+  });
+
   it("shows guidance when no income sources exist", async () => {
     vi.mocked(incomeSourcesService.list).mockResolvedValue([]);
     render(<IncomeStatementQuickModal isOpen onClose={vi.fn()} />);

--- a/apps/web/src/components/IncomeStatementQuickModal.tsx
+++ b/apps/web/src/components/IncomeStatementQuickModal.tsx
@@ -276,37 +276,44 @@ export default function IncomeStatementQuickModal({
 
   return (
     <div
-      className="fixed inset-0 z-[60] flex min-h-screen items-start justify-center bg-black/50 p-6 sm:items-center"
+      className="fixed inset-0 z-[60] flex min-h-screen items-start justify-center overflow-y-auto bg-black/50 p-2 sm:p-6 sm:items-center"
       role="presentation"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
     >
       <div
-        className="w-full max-w-md rounded-lg bg-cf-surface p-4 sm:p-6"
+        className="flex max-h-[calc(100dvh-1rem)] w-full max-w-md flex-col overflow-hidden rounded-lg bg-cf-surface shadow-xl sm:max-h-[calc(100dvh-3rem)]"
         role="dialog"
         aria-modal="true"
         aria-labelledby="income-quick-modal-title"
+        data-testid="income-quick-modal-shell"
       >
-        <div className="mb-4 flex items-center justify-between">
-          <h2
-            id="income-quick-modal-title"
-            className="text-base font-semibold text-cf-text-primary"
-          >
-            Registrar no histórico de renda
-          </h2>
-          <button
-            type="button"
-            onClick={onClose}
-            className="text-cf-text-secondary hover:text-cf-text-primary"
-            aria-label="Fechar"
-          >
-            ✕
-          </button>
+        <div className="border-b border-cf-border px-4 py-4 sm:px-6">
+          <div className="flex items-center justify-between">
+            <h2
+              id="income-quick-modal-title"
+              className="text-base font-semibold text-cf-text-primary"
+            >
+              Registrar no histórico de renda
+            </h2>
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-cf-text-secondary hover:text-cf-text-primary"
+              aria-label="Fechar"
+            >
+              ✕
+            </button>
+          </div>
         </div>
 
-        {success ? (
-          <div className="space-y-2">
+        <div
+          className="min-h-0 overflow-y-auto px-4 py-4 sm:px-6"
+          data-testid="income-quick-modal-body"
+        >
+          {success ? (
+            <div className="space-y-2">
             <div className="rounded border border-green-200 bg-green-50 px-3 py-3 dark:border-green-800 dark:bg-green-950/40">
               <p className="text-sm font-semibold text-green-700 dark:text-green-400">
                 {finalizationStatus === "posted"
@@ -378,9 +385,9 @@ export default function IncomeStatementQuickModal({
             >
               Fechar
             </button>
-          </div>
-        ) : (
-          <>
+            </div>
+          ) : (
+            <>
             {isLoadingSources ? (
               <p className="mb-3 text-sm text-cf-text-secondary">Carregando fontes de renda...</p>
             ) : sources.length === 0 ? (
@@ -612,8 +619,9 @@ export default function IncomeStatementQuickModal({
                 </button>
               </div>
             </form>
-          </>
-        )}
+            </>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- make the import modal shell respect the viewport with internal scrolling instead of clipping long content
- apply the same viewport-safe modal pattern to the income statement quick modal and bill modal used during imports
- add regression coverage for the import modal and income quick modal shells

## Validation
- npm -w apps/web run test:run -- src/components/ImportCsvModal.test.jsx src/components/IncomeStatementQuickModal.test.tsx
- npm -w apps/web run typecheck
- npm -w apps/web run lint
- npm -w apps/web run build