### PR TITLE
feat(tax): allow manual IRPF facts in lion hub

### DIFF
--- a/apps/api/src/routes/tax.routes.js
+++ b/apps/api/src/routes/tax.routes.js
@@ -12,7 +12,7 @@ import {
 import { exportTaxDossierByYear } from "../services/tax-export.service.js";
 import { processTaxDocumentByIdForUser } from "../services/tax-extraction.service.js";
 import { syncAppTaxFactsByYear } from "../services/tax-app-sync.service.js";
-import { listTaxFactsByUser } from "../services/tax-facts.service.js";
+import { createManualTaxFactByUser, listTaxFactsByUser } from "../services/tax-facts.service.js";
 import { getTaxObligationByYear } from "../services/tax-obligation.service.js";
 import { bulkApproveTaxFactsByUser, reviewTaxFactByUser } from "../services/tax-reviews.service.js";
 import { getTaxRuleSetsByYear } from "../services/tax-rules.service.js";
@@ -148,6 +148,15 @@ router.get("/facts", async (req, res, next) => {
   try {
     const facts = await listTaxFactsByUser(req.user.id, req.query ?? {});
     res.status(200).json(facts);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post("/facts", async (req, res, next) => {
+  try {
+    const result = await createManualTaxFactByUser(req.user.id, req.body ?? {});
+    res.status(201).json(result);
   } catch (error) {
     next(error);
   }

--- a/apps/api/src/services/tax-facts.service.js
+++ b/apps/api/src/services/tax-facts.service.js
@@ -1,11 +1,23 @@
-import { dbQuery } from "../db/index.js";
+import { dbQuery, withDbTransaction } from "../db/index.js";
+import { generateTaxFactDedupeKey } from "../domain/tax/tax-fact-normalizer.js";
 import {
+  createTaxError,
   normalizeOptionalTaxFactReviewStatus,
   normalizePagination,
+  normalizeTaxFactType,
   normalizeTaxUserId,
   normalizeTaxYear,
   toISOStringOrNull,
 } from "../domain/tax/tax.validation.js";
+
+const TAX_FACT_DUPLICATE_CONFLICT_CODE = "TAX_FACT_DUPLICATE";
+const TAX_FACT_DUPLICATE_CONFLICT_MESSAGE =
+  "Fato potencialmente duplicado com outro documento fiscal do usuario.";
+const MAX_MANUAL_SUBCATEGORY_LENGTH = 120;
+const MAX_MANUAL_PAYER_NAME_LENGTH = 160;
+const MAX_MANUAL_PAYER_DOCUMENT_LENGTH = 40;
+const MAX_MANUAL_REFERENCE_PERIOD_LENGTH = 32;
+const MAX_MANUAL_NOTE_LENGTH = 500;
 
 const normalizeJsonObject = (value) => {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -13,6 +25,100 @@ const normalizeJsonObject = (value) => {
   }
 
   return value;
+};
+
+const normalizeDocumentNumber = (value) => String(value || "").replace(/\D/g, "");
+
+const normalizeRequiredString = (value, fieldName, maxLength) => {
+  const normalizedValue = String(value || "").trim();
+
+  if (!normalizedValue) {
+    throw createTaxError(400, `${fieldName} invalido.`);
+  }
+
+  if (normalizedValue.length > maxLength) {
+    throw createTaxError(400, `${fieldName} excede o limite de ${maxLength} caracteres.`);
+  }
+
+  return normalizedValue;
+};
+
+const normalizeOptionalString = (value, fieldName, maxLength) => {
+  if (typeof value === "undefined" || value === null || value === "") {
+    return "";
+  }
+
+  const normalizedValue = String(value).trim();
+
+  if (!normalizedValue) {
+    return "";
+  }
+
+  if (normalizedValue.length > maxLength) {
+    throw createTaxError(400, `${fieldName} excede o limite de ${maxLength} caracteres.`);
+  }
+
+  return normalizedValue;
+};
+
+const normalizeManualAmount = (value) => {
+  const parsedValue =
+    typeof value === "string" ? Number(value.replace(",", ".")) : Number(value);
+
+  if (!Number.isFinite(parsedValue) || parsedValue <= 0) {
+    throw createTaxError(400, "amount invalido.");
+  }
+
+  return Number(parsedValue.toFixed(2));
+};
+
+const getUserTaxpayerDocument = async (client, userId) => {
+  const result = await client.query(
+    `SELECT taxpayer_cpf
+     FROM user_profiles
+     WHERE user_id = $1
+     LIMIT 1`,
+    [userId],
+  );
+
+  return normalizeDocumentNumber(result.rows[0]?.taxpayer_cpf || "");
+};
+
+const findExistingStrongFactByDedupeKey = async (client, userId, dedupeKey) => {
+  const result = await client.query(
+    `SELECT id, source_document_id
+     FROM tax_facts
+     WHERE user_id = $1
+       AND dedupe_strength = 'strong'
+       AND dedupe_key = $2
+     LIMIT 1`,
+    [userId, dedupeKey],
+  );
+
+  return result.rows[0] || null;
+};
+
+const buildManualFactMetadata = ({
+  note,
+  ownerDocument,
+  duplicateOfFactId = null,
+  duplicateOfDocumentId = null,
+}) => {
+  const metadata = {
+    sourceOrigin: "manual_entry",
+    ownerDocument: ownerDocument || undefined,
+    note: note || undefined,
+  };
+
+  if (duplicateOfFactId) {
+    metadata.duplicateOfFactId = duplicateOfFactId;
+  }
+
+  if (duplicateOfDocumentId) {
+    metadata.duplicateOfDocumentId = duplicateOfDocumentId;
+  }
+
+  return metadata;
 };
 
 const mapTaxFactRow = (row) => {
@@ -124,6 +230,126 @@ export const listTaxFactsByUser = async (userId, query = {}) => {
     pageSize: pagination.pageSize,
     total: Number(countResult.rows[0]?.total || 0),
   };
+};
+
+export const createManualTaxFactByUser = async (userId, payload = {}) => {
+  const normalizedUserId = normalizeTaxUserId(userId);
+  const taxYear = normalizeTaxYear(payload.taxYear);
+  const factType = normalizeTaxFactType(payload.factType);
+  const subcategory = normalizeRequiredString(
+    payload.subcategory,
+    "subcategory",
+    MAX_MANUAL_SUBCATEGORY_LENGTH,
+  );
+  const payerName =
+    normalizeOptionalString(payload.payerName, "payerName", MAX_MANUAL_PAYER_NAME_LENGTH) ||
+    "Lancamento manual";
+  const payerDocument = normalizeDocumentNumber(
+    normalizeOptionalString(
+      payload.payerDocument,
+      "payerDocument",
+      MAX_MANUAL_PAYER_DOCUMENT_LENGTH,
+    ),
+  );
+  const referencePeriod = normalizeRequiredString(
+    payload.referencePeriod,
+    "referencePeriod",
+    MAX_MANUAL_REFERENCE_PERIOD_LENGTH,
+  );
+  const amount = normalizeManualAmount(payload.amount);
+  const note = normalizeOptionalString(payload.note, "note", MAX_MANUAL_NOTE_LENGTH);
+  const dedupeKey = generateTaxFactDedupeKey({
+    userId: normalizedUserId,
+    taxYear,
+    factType,
+    payerDocument,
+    referencePeriod,
+    amount,
+    dedupeDiscriminator: subcategory,
+  });
+
+  return withDbTransaction(async (client) => {
+    const ownerDocument = await getUserTaxpayerDocument(client, normalizedUserId);
+    const duplicateFact = await findExistingStrongFactByDedupeKey(client, normalizedUserId, dedupeKey);
+    const metadataJson = buildManualFactMetadata({
+      note,
+      ownerDocument,
+      duplicateOfFactId: duplicateFact ? Number(duplicateFact.id) : null,
+      duplicateOfDocumentId:
+        duplicateFact &&
+        duplicateFact.source_document_id !== null &&
+        typeof duplicateFact.source_document_id !== "undefined"
+          ? Number(duplicateFact.source_document_id)
+          : null,
+    });
+    const result = await client.query(
+      `INSERT INTO tax_facts (
+         user_id,
+         tax_year,
+         source_document_id,
+         fact_type,
+         category,
+         subcategory,
+         payer_name,
+         payer_document,
+         reference_period,
+         currency,
+         amount,
+         confidence_score,
+         dedupe_key,
+         dedupe_strength,
+         metadata_json,
+         review_status,
+         conflict_code,
+         conflict_message
+       )
+       VALUES (
+         $1, $2, NULL, $3, $4, $5, $6, $7, $8, 'BRL',
+         $9, $10, $11, $12, $13::jsonb, 'pending', $14, $15
+       )
+       RETURNING
+         id,
+         tax_year,
+         source_document_id,
+         fact_type,
+         category,
+         subcategory,
+         payer_name,
+         payer_document,
+         reference_period,
+         currency,
+         amount,
+         confidence_score,
+         metadata_json,
+         dedupe_strength,
+         review_status,
+         conflict_code,
+         conflict_message,
+         created_at,
+         updated_at`,
+      [
+        normalizedUserId,
+        taxYear,
+        factType,
+        "manual_entry",
+        subcategory,
+        payerName,
+        payerDocument,
+        referencePeriod,
+        amount,
+        1,
+        dedupeKey,
+        duplicateFact ? "weak" : "strong",
+        JSON.stringify(metadataJson),
+        duplicateFact ? TAX_FACT_DUPLICATE_CONFLICT_CODE : null,
+        duplicateFact ? TAX_FACT_DUPLICATE_CONFLICT_MESSAGE : null,
+      ],
+    );
+
+    return {
+      fact: mapTaxFactRow(result.rows[0]),
+    };
+  });
 };
 
 export const mapStoredTaxFactRow = mapTaxFactRow;

--- a/apps/api/src/tax.test.js
+++ b/apps/api/src/tax.test.js
@@ -90,6 +90,22 @@ describe("Tax API foundation", () => {
     );
   });
 
+  it("POST /tax/facts retorna 401 sem token", async () => {
+    const response = await request(app).post("/tax/facts").send({
+      taxYear: 2026,
+      factType: "taxable_income",
+      subcategory: "Renda manual",
+      referencePeriod: "2025-12",
+      amount: 1200,
+    });
+
+    expectErrorResponseWithRequestId(
+      response,
+      401,
+      "Token de autenticacao ausente ou invalido.",
+    );
+  });
+
   it("POST /tax/documents retorna 401 sem token", async () => {
     const response = await request(app)
       .post("/tax/documents")
@@ -1254,6 +1270,79 @@ describe("Tax API foundation", () => {
         }),
       }),
     ]);
+  });
+
+  it("POST /tax/facts cria fato manual pendente para a fila de revisao", async () => {
+    const token = await registerAndLogin("tax-facts-manual@test.dev");
+    const userResult = await dbQuery(
+      `SELECT id
+       FROM users
+       WHERE email = $1
+       LIMIT 1`,
+      ["tax-facts-manual@test.dev"],
+    );
+    const userId = Number(userResult.rows[0].id);
+
+    await dbQuery(
+      `INSERT INTO user_profiles (user_id, taxpayer_cpf)
+       VALUES ($1, $2)`,
+      [userId, "52998224725"],
+    );
+
+    const createResponse = await request(app)
+      .post("/tax/facts")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        taxYear: 2026,
+        factType: "taxable_income",
+        subcategory: "Renda manual INSS",
+        payerName: "INSS",
+        payerDocument: "29.979.036/0001-40",
+        referencePeriod: "2025-12",
+        amount: 2803.52,
+        note: "Lancamento manual de apoio.",
+      });
+
+    expect(createResponse.status).toBe(201);
+    expect(createResponse.body.fact).toMatchObject({
+      factType: "taxable_income",
+      category: "manual_entry",
+      subcategory: "Renda manual INSS",
+      payerName: "INSS",
+      payerDocument: "29979036000140",
+      referencePeriod: "2025-12",
+      amount: 2803.52,
+      reviewStatus: "pending",
+      sourceDocument: null,
+      conflictCode: null,
+    });
+    expect(createResponse.body.fact.metadata).toMatchObject({
+      sourceOrigin: "manual_entry",
+      ownerDocument: "52998224725",
+      note: "Lancamento manual de apoio.",
+    });
+
+    const persistedFactResult = await dbQuery(
+      `SELECT
+         category,
+         review_status,
+         metadata_json
+       FROM tax_facts
+       WHERE user_id = $1
+       ORDER BY id DESC
+       LIMIT 1`,
+      [userId],
+    );
+
+    expect(persistedFactResult.rows[0]).toMatchObject({
+      category: "manual_entry",
+      review_status: "pending",
+    });
+    expect(persistedFactResult.rows[0].metadata_json).toMatchObject({
+      sourceOrigin: "manual_entry",
+      ownerDocument: "52998224725",
+      note: "Lancamento manual de apoio.",
+    });
   });
 
   it("PATCH /tax/facts/:id/review aprova fato e registra trilha em tax_reviews", async () => {

--- a/apps/web/src/components/TaxManualFactModal.tsx
+++ b/apps/web/src/components/TaxManualFactModal.tsx
@@ -1,0 +1,290 @@
+import { useEffect, useState, type FormEvent, type MouseEvent } from "react";
+
+interface TaxManualFactModalProps {
+  isOpen: boolean;
+  taxYear: number;
+  isSubmitting?: boolean;
+  errorMessage?: string;
+  onClose: () => void;
+  onSubmit: (payload: {
+    taxYear: number;
+    factType: string;
+    subcategory: string;
+    payerName: string;
+    payerDocument: string;
+    referencePeriod: string;
+    amount: number;
+    note: string;
+  }) => Promise<void> | void;
+}
+
+const FACT_TYPE_OPTIONS = [
+  { value: "taxable_income", label: "Rendimento tributavel" },
+  { value: "exempt_income", label: "Rendimento isento" },
+  { value: "exclusive_tax_income", label: "Tributacao exclusiva" },
+  { value: "withheld_tax", label: "IR retido na fonte" },
+  { value: "asset_balance", label: "Bens e direitos" },
+  { value: "debt_balance", label: "Dividas e onus" },
+  { value: "medical_deduction", label: "Deducao medica" },
+  { value: "education_deduction", label: "Deducao de instrucao" },
+  { value: "other", label: "Outro fato fiscal" },
+] as const;
+
+const DEFAULT_FACT_TYPE = FACT_TYPE_OPTIONS[0].value;
+
+const parseMoney = (value: string) => Number(value.replace(",", "."));
+
+const TaxManualFactModal = ({
+  isOpen,
+  taxYear,
+  isSubmitting = false,
+  errorMessage = "",
+  onClose,
+  onSubmit,
+}: TaxManualFactModalProps): JSX.Element | null => {
+  const [factType, setFactType] = useState<string>(DEFAULT_FACT_TYPE);
+  const [subcategory, setSubcategory] = useState("");
+  const [payerName, setPayerName] = useState("");
+  const [payerDocument, setPayerDocument] = useState("");
+  const [referencePeriod, setReferencePeriod] = useState("");
+  const [amount, setAmount] = useState("");
+  const [note, setNote] = useState("");
+  const [localError, setLocalError] = useState("");
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    setFactType(DEFAULT_FACT_TYPE);
+    setSubcategory("");
+    setPayerName("");
+    setPayerDocument("");
+    setReferencePeriod("");
+    setAmount("");
+    setNote("");
+    setLocalError("");
+  }, [isOpen]);
+
+  const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget && !isSubmitting) {
+      onClose();
+    }
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (isSubmitting) {
+      return;
+    }
+
+    const parsedAmount = parseMoney(amount);
+
+    if (!subcategory.trim()) {
+      setLocalError("Informe a descricao do fato fiscal.");
+      return;
+    }
+
+    if (!referencePeriod.trim()) {
+      setLocalError("Informe o periodo de referencia.");
+      return;
+    }
+
+    if (!Number.isFinite(parsedAmount) || parsedAmount <= 0) {
+      setLocalError("Informe um valor valido.");
+      return;
+    }
+
+    setLocalError("");
+
+    await onSubmit({
+      taxYear,
+      factType,
+      subcategory: subcategory.trim(),
+      payerName: payerName.trim(),
+      payerDocument: payerDocument.trim(),
+      referencePeriod: referencePeriod.trim(),
+      amount: Number(parsedAmount.toFixed(2)),
+      note: note.trim(),
+    });
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-40 overflow-y-auto bg-black/50 p-4 sm:p-6"
+      onClick={handleBackdropClick}
+      role="presentation"
+    >
+      <div className="flex min-h-full items-center justify-center">
+        <div className="flex w-full max-w-2xl max-h-[min(92vh,900px)] flex-col overflow-hidden rounded-lg border border-cf-border bg-cf-surface shadow-xl">
+          <div className="flex items-start justify-between gap-4 border-b border-cf-border px-5 py-4">
+            <div>
+              <h2 className="text-lg font-semibold text-cf-text-primary">Adicionar fato manual</h2>
+              <p className="mt-1 text-sm text-cf-text-secondary">
+                Exercício {taxYear}. Use quando o dado do IRPF ainda não entrou por documento ou sincronização.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={isSubmitting}
+              className="text-sm font-semibold text-cf-text-secondary hover:text-cf-text-primary disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              Fechar
+            </button>
+          </div>
+
+          <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
+            <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-5 py-4">
+              <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-3 text-sm text-cf-text-secondary">
+                O fato entra como <span className="font-semibold text-cf-text-primary">pendente</span> na fila de revisão.
+                Depois você aprova, corrige ou rejeita na própria Central do Leão.
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <label className="block">
+                  <span className="mb-1 block text-sm font-semibold text-cf-text-primary">
+                    Tipo de fato fiscal
+                  </span>
+                  <select
+                    value={factType}
+                    onChange={(event) => setFactType(event.target.value)}
+                    disabled={isSubmitting}
+                    className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-2 text-sm text-cf-text-primary outline-none focus:border-brand-1"
+                  >
+                    {FACT_TYPE_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="block">
+                  <span className="mb-1 block text-sm font-semibold text-cf-text-primary">
+                    Periodo de referencia
+                  </span>
+                  <input
+                    type="text"
+                    value={referencePeriod}
+                    onChange={(event) => setReferencePeriod(event.target.value)}
+                    disabled={isSubmitting}
+                    placeholder="Ex.: 2025, 2025-12 ou 2025-12-31"
+                    className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-2 text-sm text-cf-text-primary outline-none focus:border-brand-1"
+                  />
+                </label>
+              </div>
+
+              <label className="block">
+                <span className="mb-1 block text-sm font-semibold text-cf-text-primary">
+                  Descricao / subcategoria
+                </span>
+                <input
+                  type="text"
+                  value={subcategory}
+                  onChange={(event) => setSubcategory(event.target.value)}
+                  disabled={isSubmitting}
+                  placeholder="Ex.: aluguel recebido, plano de saude, INSS complementar"
+                  className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-2 text-sm text-cf-text-primary outline-none focus:border-brand-1"
+                />
+              </label>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <label className="block">
+                  <span className="mb-1 block text-sm font-semibold text-cf-text-primary">
+                    Fonte pagadora / origem
+                  </span>
+                  <input
+                    type="text"
+                    value={payerName}
+                    onChange={(event) => setPayerName(event.target.value)}
+                    disabled={isSubmitting}
+                    placeholder="Ex.: INSS, Banco XYZ, ACME LTDA"
+                    className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-2 text-sm text-cf-text-primary outline-none focus:border-brand-1"
+                  />
+                </label>
+
+                <label className="block">
+                  <span className="mb-1 block text-sm font-semibold text-cf-text-primary">
+                    Documento da fonte (opcional)
+                  </span>
+                  <input
+                    type="text"
+                    value={payerDocument}
+                    onChange={(event) => setPayerDocument(event.target.value)}
+                    disabled={isSubmitting}
+                    placeholder="CNPJ ou CPF da fonte"
+                    className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-2 text-sm text-cf-text-primary outline-none focus:border-brand-1"
+                  />
+                </label>
+              </div>
+
+              <label className="block">
+                <span className="mb-1 block text-sm font-semibold text-cf-text-primary">Valor</span>
+                <input
+                  type="text"
+                  value={amount}
+                  onChange={(event) => setAmount(event.target.value)}
+                  disabled={isSubmitting}
+                  placeholder="0,00"
+                  className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-2 text-sm text-cf-text-primary outline-none focus:border-brand-1"
+                />
+              </label>
+
+              <label className="block">
+                <span className="mb-1 block text-sm font-semibold text-cf-text-primary">
+                  Observacao (opcional)
+                </span>
+                <textarea
+                  value={note}
+                  onChange={(event) => setNote(event.target.value)}
+                  disabled={isSubmitting}
+                  rows={4}
+                  placeholder="Contexto para a revisao fiscal desse fato."
+                  className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-2 text-sm text-cf-text-primary outline-none focus:border-brand-1"
+                />
+              </label>
+
+              {localError ? (
+                <div className="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
+                  {localError}
+                </div>
+              ) : null}
+
+              {!localError && errorMessage ? (
+                <div className="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
+                  {errorMessage}
+                </div>
+              ) : null}
+            </div>
+
+            <div className="flex items-center justify-end gap-3 border-t border-cf-border px-5 py-4">
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={isSubmitting}
+                className="rounded border border-cf-border bg-cf-bg-subtle px-4 py-2 text-sm font-semibold text-cf-text-primary hover:bg-cf-surface disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                Cancelar
+              </button>
+              <button
+                type="submit"
+                disabled={isSubmitting}
+                className="rounded border border-brand-1 bg-brand-1 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-2 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isSubmitting ? "Salvando..." : "Adicionar fato"}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TaxManualFactModal;

--- a/apps/web/src/pages/TaxPage.test.tsx
+++ b/apps/web/src/pages/TaxPage.test.tsx
@@ -25,6 +25,7 @@ vi.mock("../services/tax.service", () => ({
     rebuildSummary: vi.fn(),
     getObligation: vi.fn(),
     listFacts: vi.fn(),
+    createManualFact: vi.fn(),
     reviewFact: vi.fn(),
     bulkApproveFacts: vi.fn(),
   },
@@ -202,6 +203,16 @@ describe("TaxPage", () => {
       pageSize: 25,
       total: 1,
     });
+    vi.mocked(taxService.createManualFact).mockResolvedValue(
+      buildFact({
+        id: 301,
+        sourceDocumentId: null,
+        sourceDocument: null,
+        category: "manual_entry",
+        subcategory: "Renda manual INSS",
+        payerName: "INSS",
+      }),
+    );
     vi.mocked(taxService.rebuildSummary).mockResolvedValue(buildSummary({ snapshotVersion: 2 }));
     vi.mocked(taxService.bulkApproveFacts).mockResolvedValue({ updatedCount: 1 });
     vi.mocked(taxService.reviewFact).mockResolvedValue(buildFact({ reviewStatus: "approved" }));
@@ -494,6 +505,67 @@ describe("TaxPage", () => {
       await screen.findByText(
         "Importamos 2 fatos fiscais pendentes a partir dos dados do app. Revise-os para entrarem no cálculo oficial.",
       ),
+    ).toBeInTheDocument();
+  });
+
+  it("permite adicionar um fato fiscal manual na fila de revisao", async () => {
+    const user = userEvent.setup();
+
+    vi.mocked(taxService.listFacts)
+      .mockResolvedValueOnce({
+        items: [],
+        page: 1,
+        pageSize: 25,
+        total: 0,
+      })
+      .mockResolvedValue({
+        items: [
+          buildFact({
+            id: 301,
+            sourceDocumentId: null,
+            sourceDocument: null,
+            category: "manual_entry",
+            subcategory: "Renda manual INSS",
+            payerName: "INSS",
+          }),
+        ],
+        page: 1,
+        pageSize: 25,
+        total: 1,
+      });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Adicionar manualmente" })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Adicionar manualmente" }));
+    await user.selectOptions(screen.getByLabelText("Tipo de fato fiscal"), "taxable_income");
+    await user.type(screen.getByLabelText("Periodo de referencia"), "2025-12");
+    await user.type(screen.getByLabelText("Descricao / subcategoria"), "Renda manual INSS");
+    await user.type(screen.getByLabelText("Fonte pagadora / origem"), "INSS");
+    await user.type(screen.getByLabelText("Documento da fonte (opcional)"), "29.979.036/0001-40");
+    await user.type(screen.getByLabelText("Valor"), "2803,52");
+    await user.type(screen.getByLabelText("Observacao (opcional)"), "Lancamento manual de apoio.");
+    await user.click(screen.getByRole("button", { name: "Adicionar fato" }));
+
+    await waitFor(() => {
+      expect(taxService.createManualFact).toHaveBeenCalledWith({
+        taxYear: 2026,
+        factType: "taxable_income",
+        subcategory: "Renda manual INSS",
+        payerName: "INSS",
+        payerDocument: "29.979.036/0001-40",
+        referencePeriod: "2025-12",
+        amount: 2803.52,
+        note: "Lancamento manual de apoio.",
+      });
+    });
+
+    expect(await screen.findByText("Fato fiscal manual adicionado a fila de revisao.")).toBeInTheDocument();
+    expect(
+      await screen.findByText((content) => content.includes("Renda manual INSS")),
     ).toBeInTheDocument();
   });
 

--- a/apps/web/src/pages/TaxPage.tsx
+++ b/apps/web/src/pages/TaxPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 import TaxUploadModal, { type TaxUploadStage } from "../components/TaxUploadModal";
+import TaxManualFactModal from "../components/TaxManualFactModal";
 import { profileService } from "../services/profile.service";
 import {
   taxService,
@@ -234,9 +235,12 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
   const [successMessage, setSuccessMessage] = useState("");
   const [correctionDraft, setCorrectionDraft] = useState<CorrectionDraft | null>(null);
   const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
+  const [isManualFactModalOpen, setIsManualFactModalOpen] = useState(false);
+  const [isCreatingManualFact, setIsCreatingManualFact] = useState(false);
   const [uploadStage, setUploadStage] = useState<TaxUploadStage>("idle");
   const [uploadStatusMessage, setUploadStatusMessage] = useState("");
   const [uploadErrorMessage, setUploadErrorMessage] = useState("");
+  const [manualFactErrorMessage, setManualFactErrorMessage] = useState("");
   const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const showSuccess = useCallback((message: string) => {
@@ -350,6 +354,11 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
     setIsUploadModalOpen(true);
   };
 
+  const handleOpenManualFactModal = () => {
+    setManualFactErrorMessage("");
+    setIsManualFactModalOpen(true);
+  };
+
   const handleCloseUploadModal = () => {
     if (uploadStage === "uploading" || uploadStage === "processing") {
       return;
@@ -357,6 +366,15 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
 
     setIsUploadModalOpen(false);
     resetUploadFlow();
+  };
+
+  const handleCloseManualFactModal = () => {
+    if (isCreatingManualFact) {
+      return;
+    }
+
+    setIsManualFactModalOpen(false);
+    setManualFactErrorMessage("");
   };
 
   const handleUploadDocument = async ({
@@ -409,6 +427,38 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
       setUploadErrorMessage(
         getApiErrorMessage(uploadError, "Não foi possível enviar o documento fiscal."),
       );
+    }
+  };
+
+  const handleCreateManualFact = async (payload: {
+    taxYear: number;
+    factType: string;
+    subcategory: string;
+    payerName: string;
+    payerDocument: string;
+    referencePeriod: string;
+    amount: number;
+    note: string;
+  }) => {
+    setManualFactErrorMessage("");
+    setPageError("");
+    setIsCreatingManualFact(true);
+
+    try {
+      const createdFact = await taxService.createManualFact(payload);
+      await loadPageData();
+      setIsManualFactModalOpen(false);
+      showSuccess(
+        createdFact.conflictCode
+          ? "Fato fiscal manual adicionado com alerta de possivel duplicidade. Revise antes de aprovar."
+          : "Fato fiscal manual adicionado a fila de revisao.",
+      );
+    } catch (error) {
+      setManualFactErrorMessage(
+        getApiErrorMessage(error, "Nao foi possivel adicionar o fato fiscal manual."),
+      );
+    } finally {
+      setIsCreatingManualFact(false);
     }
   };
 
@@ -741,6 +791,13 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
                 </button>
                 <button
                   type="button"
+                  onClick={handleOpenManualFactModal}
+                  className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2 text-sm font-semibold text-cf-text-primary hover:bg-cf-surface"
+                >
+                  Adicionar manualmente
+                </button>
+                <button
+                  type="button"
                   onClick={() => void handleSyncAppData()}
                   disabled={!canSyncFromApp || isSyncingAppData}
                   className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2 text-sm font-semibold text-cf-text-primary hover:bg-cf-surface disabled:cursor-not-allowed disabled:opacity-60"
@@ -1018,7 +1075,7 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
               </p>
               <p className="mt-1 text-sm text-cf-text-secondary">
                 {documentsPage.total === 0
-                  ? "Sem informe em PDF? Use “Sincronizar do app” para gerar fatos pendentes a partir das rendas e lançamentos já alimentados."
+                  ? "Sem informe em PDF? Use “Adicionar manualmente” ou “Sincronizar do app” para gerar fatos pendentes a partir das rendas e lançamentos ja alimentados."
                   : "Quando já existem documentos fiscais no exercício, a sincronização vinda do app fica bloqueada para evitar mistura entre as trilhas."}
               </p>
             </div>
@@ -1378,6 +1435,14 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
         errorMessage={uploadErrorMessage}
         onClose={handleCloseUploadModal}
         onSubmit={handleUploadDocument}
+      />
+      <TaxManualFactModal
+        isOpen={isManualFactModalOpen}
+        taxYear={taxYear}
+        isSubmitting={isCreatingManualFact}
+        errorMessage={manualFactErrorMessage}
+        onClose={handleCloseManualFactModal}
+        onSubmit={handleCreateManualFact}
       />
     </div>
   );

--- a/apps/web/src/services/tax.service.ts
+++ b/apps/web/src/services/tax.service.ts
@@ -176,6 +176,17 @@ export interface TaxAppSyncResult {
   summariesRebuilt: number;
 }
 
+export interface CreateManualTaxFactPayload {
+  taxYear: number;
+  factType: string;
+  subcategory: string;
+  payerName?: string;
+  payerDocument?: string;
+  referencePeriod: string;
+  amount: number;
+  note?: string;
+}
+
 interface TaxFactApiPayload {
   id?: unknown;
   taxYear?: unknown;
@@ -691,6 +702,11 @@ export const taxService = {
       pageSize: normalizeNumber(raw.pageSize) || 20,
       total: normalizeNumber(raw.total),
     };
+  },
+
+  createManualFact: async (payload: CreateManualTaxFactPayload): Promise<TaxFact> => {
+    const { data } = await api.post("/tax/facts", payload);
+    return normalizeTaxFact(normalizeObject(data).fact);
   },
 
   reviewFact: async (


### PR DESCRIPTION
## Summary
- add manual tax fact creation to the Central do Leao flow
- create pending manual facts in the same tax review queue used by imports and app sync
- add a manual fact modal to TaxPage so IRPF can be fed without depending only on import

## Testing
- npm -w apps/api test -- src/tax.test.js
- npm -w apps/web run test:run -- src/pages/TaxPage.test.tsx
- npm -w apps/api run lint
- npm -w apps/web run lint
- npm -w apps/web run typecheck
- npm -w apps/web run build