### PR TITLE
fix(copy): normalize billing and import language surfaces

### DIFF
--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -43,6 +43,66 @@ const getCurrentMonthValue = () => {
   return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
 };
 
+const formatReferenceMonth = (value) => {
+  const [year, month] = String(value || "").split("-");
+  if (year && month) {
+    return `${month}/${year}`;
+  }
+  return String(value || "");
+};
+
+const formatIsoDate = (value) => {
+  const [year, month, day] = String(value || "").split("-");
+  if (year && month && day) {
+    return `${day}/${month}/${year}`;
+  }
+  return String(value || "");
+};
+
+const getPreviewStatusLabel = (status) => {
+  switch (status) {
+    case "valid":
+      return "Pronta";
+    case "duplicate":
+      return "Já existente";
+    case "conflict":
+      return "Revisar";
+    default:
+      return "Inválida";
+  }
+};
+
+const getPreviewStatusDetail = (row) => {
+  if (!row) {
+    return "";
+  }
+
+  if (row.conflict?.type === "income_statement") {
+    const sourceName = row.conflict.sourceName || "Histórico de renda";
+    const referenceMonth = row.conflict.referenceMonth
+      ? `, competência ${formatReferenceMonth(row.conflict.referenceMonth)}`
+      : "";
+    const paymentDate = row.conflict.paymentDate
+      ? `, pagamento em ${formatIsoDate(row.conflict.paymentDate)}`
+      : "";
+    return `Esta renda já existe no histórico: ${sourceName}${referenceMonth}${paymentDate}.`;
+  }
+
+  if (row.status === "duplicate") {
+    return "Já existe um lançamento equivalente com esses dados.";
+  }
+
+  if (row.status === "conflict") {
+    return row.statusDetail || "Este item precisa de revisão antes de ser importado.";
+  }
+
+  if (row.status === "invalid") {
+    return row.statusDetail || "Não foi possível entender esta linha com segurança.";
+  }
+
+  return row.statusDetail || "";
+};
+
 const getProfileSuggestionTiming = (suggestion) => {
   const effectiveMonth = suggestion?.paymentDate?.slice(0, 7) || suggestion?.referenceMonth || "";
   if (!effectiveMonth) {
@@ -408,7 +468,7 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory
         setPlanningUpdateError(
           getApiErrorMessage(
             forecastError,
-            "Perfil atualizado, mas nao foi possivel atualizar o planejamento agora.",
+            "Perfil atualizado, mas não foi possível atualizar o planejamento agora.",
           ),
         );
       }
@@ -636,7 +696,7 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory
     } catch (error) {
       setRuleFeedback({
         type: "error",
-        message: getApiErrorMessage(error, "Nao foi possivel salvar a regra."),
+        message: getApiErrorMessage(error, "Não foi possível salvar a regra."),
       });
     } finally {
       setIsSavingImportRule(false);
@@ -664,7 +724,7 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory
     } catch (error) {
       setRuleFeedback({
         type: "error",
-        message: getApiErrorMessage(error, "Nao foi possivel remover a regra."),
+        message: getApiErrorMessage(error, "Não foi possível remover a regra."),
       });
     } finally {
       setDeletingImportRuleId(null);
@@ -1167,11 +1227,11 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory
                 <p className="text-sm font-semibold text-cf-text-primary">{dryRunResult.summary.invalidRows}</p>
               </div>
               <div className={`rounded border px-3 py-2 ${hasDuplicates ? "border-red-300 bg-red-50 dark:border-red-800 dark:bg-red-950/40" : "border-cf-border bg-cf-bg-subtle"}`}>
-                <p className="text-xs font-medium uppercase text-cf-text-secondary">Duplicadas</p>
+                <p className="text-xs font-medium uppercase text-cf-text-secondary">Já existentes</p>
                 <p className={`text-sm font-semibold ${hasDuplicates ? "text-red-600 dark:text-red-400" : "text-cf-text-primary"}`}>{dryRunResult.summary.duplicateRows ?? 0}</p>
               </div>
               <div className={`rounded border px-3 py-2 ${hasConflicts ? "border-amber-300 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/40" : "border-cf-border bg-cf-bg-subtle"}`}>
-                <p className="text-xs font-medium uppercase text-cf-text-secondary">Conflitos</p>
+                <p className="text-xs font-medium uppercase text-cf-text-secondary">Para revisar</p>
                 <p className={`text-sm font-semibold ${hasConflicts ? "text-amber-700 dark:text-amber-400" : "text-cf-text-primary"}`}>{dryRunResult.summary.conflictRows ?? 0}</p>
               </div>
               <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2">
@@ -1232,8 +1292,8 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory
                     >
                       <option value="all">Todos</option>
                       <option value="valid">Válidas</option>
-                      <option value="duplicate">Duplicadas</option>
-                      <option value="conflict">Conflitos</option>
+                      <option value="duplicate">Já existentes</option>
+                      <option value="conflict">Para revisar</option>
                       <option value="invalid">Inválidas</option>
                     </select>
                   </div>
@@ -1433,15 +1493,18 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory
                             </th>
                             <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Linha</th>
                             <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Status</th>
-                            <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Descricao</th>
+                            <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Descrição</th>
                             <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Valor</th>
                             <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Data</th>
                             <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Categoria</th>
-                            <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Erros</th>
+                            <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Observações</th>
                           </tr>
                         </thead>
                         <tbody>
-                    {renderedPreviewRows.map((row) => (
+                      {renderedPreviewRows.map((row) => {
+                        const statusDetailCopy = getPreviewStatusDetail(row);
+
+                        return (
                         <tr key={`import-row-${row.line}`} className="align-top">
                           <td className="border-b border-cf-border px-2 py-2">
                             {row.status === "valid" ? (
@@ -1467,16 +1530,10 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory
                                     : "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-400"
                               }`}
                             >
-                              {row.status === "valid"
-                                ? "Valida"
-                                : row.status === "duplicate"
-                                  ? "Duplicada"
-                                  : row.status === "conflict"
-                                    ? "Conflito"
-                                  : "Invalida"}
+                              {getPreviewStatusLabel(row.status)}
                             </span>
-                            {(row.status === "duplicate" || row.status === "conflict") && row.statusDetail && (
-                              <span className="ml-1.5 text-xs text-cf-text-secondary">{row.statusDetail}</span>
+                            {(row.status === "duplicate" || row.status === "conflict") && statusDetailCopy && (
+                              <span className="ml-1.5 text-xs text-cf-text-secondary">{statusDetailCopy}</span>
                             )}
                           </td>
                           <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
@@ -1562,12 +1619,13 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory
                         <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
                           {row.errors.length > 0
                             ? row.errors.map((error) => error.message).join(" | ")
-                            : row.statusDetail
-                              ? row.statusDetail
+                            : statusDetailCopy
+                              ? statusDetailCopy
                             : "-"}
                         </td>
                       </tr>
-                    ))}
+                    );
+                    })}
                       </tbody>
                     </table>
                   </>

--- a/apps/web/src/components/ImportCsvModal.test.jsx
+++ b/apps/web/src/components/ImportCsvModal.test.jsx
@@ -224,13 +224,13 @@ describe("ImportCsvModal", () => {
     await userEvent.click(screen.getByRole("button", { name: "Pré-visualizar" }));
 
     await waitFor(() => {
-      expect(screen.getAllByText("Conflitos")[0]).toBeInTheDocument();
+      expect(screen.getAllByText("Para revisar")[0]).toBeInTheDocument();
     });
 
-    expect(screen.getByText("Conflito")).toBeInTheDocument();
+    expect(screen.getByText("Revisar")).toBeInTheDocument();
     expect(
       screen.getAllByText(
-        "INSS Beneficio ja registrado no historico de renda (2026-03, 2026-03-05).",
+        "Esta renda já existe no histórico: INSS Beneficio, competência 03/2026, pagamento em 05/03/2026.",
       ).length,
     ).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: "Importar" })).toBeDisabled();

--- a/apps/web/src/components/ImportHistoryModal.jsx
+++ b/apps/web/src/components/ImportHistoryModal.jsx
@@ -24,7 +24,7 @@ const formatDateTime = (value) => {
 const resolveImportStatus = (item) => {
   if (item.committedAt) {
     return {
-      label: item.summary.imported > 0 ? "Committed" : "Reverted",
+      label: item.summary.imported > 0 ? "Importada" : "Desfeita",
       className:
         item.summary.imported > 0
           ? "bg-green-100 text-green-700"
@@ -36,15 +36,38 @@ const resolveImportStatus = (item) => {
 
   if (Number.isFinite(expiresAtTimestamp) && Date.now() > expiresAtTimestamp) {
     return {
-      label: "Expired",
+      label: "Expirada",
       className: "bg-red-100 text-red-700",
     };
   }
 
   return {
-    label: "Pending",
+    label: "Aguardando confirmação",
     className: "bg-yellow-100 text-yellow-700",
   };
+};
+
+const humanizeUndoBlockedReason = (value) => {
+  const message = String(value || "").trim();
+  if (!message) {
+    return "";
+  }
+
+  const normalized = message.toLowerCase();
+
+  if (normalized.includes("conta derivada")) {
+    return "Esta importação já gerou uma conta vinculada. Revise ou remova esse item antes de desfazer.";
+  }
+
+  if (normalized.includes("historico de renda") || normalized.includes("extrato de renda")) {
+    return "Esta importação já gerou um lançamento no histórico de renda. Revise esse item antes de desfazer.";
+  }
+
+  if (normalized.includes("derivados ativos vinculados")) {
+    return "Esta importação já gerou itens vinculados. Revise esses itens antes de desfazer.";
+  }
+
+  return message;
 };
 
 const formatDocumentType = (value) => {
@@ -89,7 +112,7 @@ const ImportHistoryModal = ({ isOpen, onClose, onImportSessionReverted = undefin
       setOffset(Number(response.pagination?.offset) || 0);
     } catch (error) {
       setItems([]);
-      setErrorMessage(getApiErrorMessage(error, "Não foi possível carregar o histórico de imports."));
+      setErrorMessage(getApiErrorMessage(error, "Não foi possível carregar o histórico de importações."));
     } finally {
       setIsLoading(false);
     }
@@ -213,14 +236,14 @@ const ImportHistoryModal = ({ isOpen, onClose, onImportSessionReverted = undefin
       >
         <div className="mb-4 flex items-center justify-between">
           <h2 id="import-history-modal-title" className="text-lg font-semibold text-cf-text-primary">
-            Histórico de imports
+            Histórico de importações
           </h2>
           <button
             ref={closeButtonRef}
             type="button"
             onClick={onClose}
             className="text-ui-200 transition-colors hover:text-ui-100"
-            aria-label="Fechar modal de histórico de imports"
+            aria-label="Fechar modal de histórico de importações"
           >
             X
           </button>
@@ -247,20 +270,20 @@ const ImportHistoryModal = ({ isOpen, onClose, onImportSessionReverted = undefin
 
         {isLoading ? (
           <div className="rounded border border-cf-border bg-cf-surface px-3 py-3 text-sm text-cf-text-secondary">
-            Carregando histórico...
+            Carregando histórico de importações...
           </div>
         ) : null}
 
         {!isLoading && !errorMessage && rowsWithStatus.length === 0 ? (
           <div className="rounded border border-cf-border bg-cf-surface px-3 py-3 text-sm text-cf-text-secondary">
-            Sem imports para exibir.
+            Nenhuma importação para mostrar.
           </div>
         ) : null}
 
         {!isLoading && !errorMessage && rowsWithStatus.length > 0 ? (
           <div className="space-y-3">
             <div className="text-xs text-cf-text-secondary">
-              Mostrando {rangeStart}-{rangeEnd}
+              Mostrando {rangeStart} a {rangeEnd}
             </div>
             <div className="max-h-96 overflow-auto rounded border border-cf-border">
               <table className="min-w-full border-collapse text-left text-xs">
@@ -295,9 +318,9 @@ const ImportHistoryModal = ({ isOpen, onClose, onImportSessionReverted = undefin
                       </td>
                       <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
                         <div className="space-y-1 text-[11px]">
-                          <p>Válidas: {item.summary.validRows}</p>
-                          <p>Duplicadas: {item.summary.duplicateRows}</p>
-                          <p>Conflitos: {item.summary.conflictRows}</p>
+                          <p>Prontas para importar: {item.summary.validRows}</p>
+                          <p>Já existentes: {item.summary.duplicateRows}</p>
+                          <p>Para revisar: {item.summary.conflictRows}</p>
                           <p>Inválidas: {item.summary.invalidRows}</p>
                           <p>Importadas: {item.summary.imported}</p>
                         </div>
@@ -320,10 +343,10 @@ const ImportHistoryModal = ({ isOpen, onClose, onImportSessionReverted = undefin
                           </button>
                         ) : (
                           <div className="space-y-1">
-                            <span className="text-[11px] text-cf-text-secondary">Sem ação</span>
+                            <span className="text-[11px] text-cf-text-secondary">Sem ação disponível</span>
                             {item.undoBlockedReason ? (
                               <p className="max-w-48 text-[11px] text-cf-text-secondary">
-                                {item.undoBlockedReason}
+                                {humanizeUndoBlockedReason(item.undoBlockedReason)}
                               </p>
                             ) : null}
                           </div>
@@ -349,7 +372,7 @@ const ImportHistoryModal = ({ isOpen, onClose, onImportSessionReverted = undefin
                 disabled={!hasNextPage || isLoading}
                 className="rounded border border-cf-border bg-cf-surface px-3 py-1.5 text-sm font-semibold text-cf-text-primary hover:bg-cf-bg-subtle disabled:cursor-not-allowed disabled:opacity-60"
               >
-                Proxima
+                Próxima
               </button>
             </div>
           </div>

--- a/apps/web/src/components/ImportHistoryModal.test.jsx
+++ b/apps/web/src/components/ImportHistoryModal.test.jsx
@@ -56,15 +56,15 @@ describe("ImportHistoryModal", () => {
 
     render(<ImportHistoryModal isOpen onClose={vi.fn()} />);
 
-    expect(await screen.findByText("Reverted")).toBeInTheDocument();
+    expect(await screen.findByText("Desfeita")).toBeInTheDocument();
     expect(screen.getByText("itau-90-dias.ofx")).toBeInTheDocument();
     expect(screen.getByText("Extrato bancário")).toBeInTheDocument();
-    expect(screen.getByText("Duplicadas: 1")).toBeInTheDocument();
-    expect(screen.getByText("Conflitos: 1")).toBeInTheDocument();
-    expect(screen.getByText("Sem ação")).toBeInTheDocument();
+    expect(screen.getByText("Já existentes: 1")).toBeInTheDocument();
+    expect(screen.getByText("Para revisar: 1")).toBeInTheDocument();
+    expect(screen.getByText("Sem ação disponível")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Nao e possivel desfazer esta importacao porque existem derivados ativos vinculados a ela: 1 conta derivada.",
+        "Esta importação já gerou uma conta vinculada. Revise ou remova esse item antes de desfazer.",
       ),
     ).toBeInTheDocument();
   });
@@ -139,7 +139,7 @@ describe("ImportHistoryModal", () => {
       />,
     );
 
-    expect(await screen.findByText("Committed")).toBeInTheDocument();
+    expect(await screen.findByText("Importada")).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("button", { name: "Desfazer" }));
 
@@ -154,6 +154,6 @@ describe("ImportHistoryModal", () => {
     });
 
     expect(await screen.findByText("Importação desfeita com sucesso.")).toBeInTheDocument();
-    expect(screen.getByText("Reverted")).toBeInTheDocument();
+    expect(screen.getByText("Desfeita")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/UpgradeModal.test.tsx
+++ b/apps/web/src/components/UpgradeModal.test.tsx
@@ -17,7 +17,7 @@ describe("UpgradeModal", () => {
       <MemoryRouter>
         <UpgradeModal
           isOpen
-          reason="Seu plano atual não inclui a importação de extratos. No Pro, você importa CSV, OFX e PDF com pré-visualização antes de confirmar."
+          reason="Importação de extratos é um recurso do Pro. No Pro, você importa CSV, OFX e PDF com prévia antes de confirmar."
           feature="csv_import"
           context="feature_gate"
           onClose={vi.fn()}
@@ -27,7 +27,7 @@ describe("UpgradeModal", () => {
 
     expect(screen.getByText("Importação disponível no Pro")).toBeInTheDocument();
     expect(
-      screen.getByText(/Seu plano atual não inclui a importação de extratos/i),
+      screen.getByText(/Importação de extratos é um recurso do Pro/i),
     ).toBeInTheDocument();
     expect(
       screen.getByText("Importar extratos (CSV, OFX e PDF)"),

--- a/apps/web/src/components/UpgradeModal.tsx
+++ b/apps/web/src/components/UpgradeModal.tsx
@@ -14,27 +14,27 @@ const PRICE_MONTHLY = "R$ 9,90";
 
 const FEATURES: { label: string; free: string; pro: string }[] = [
   { label: "Transações e categorias", free: "✓", pro: "✓" },
-  { label: "Metas mensais",           free: "✓", pro: "✓" },
-  { label: "Histórico de analytics",  free: "6 meses", pro: "24 meses" },
-  { label: "Previsão financeira",     free: "—", pro: "✓" },
-  { label: "Controle salarial",       free: "—", pro: "✓" },
+  { label: "Metas mensais", free: "✓", pro: "✓" },
+  { label: "Histórico do painel", free: "6 meses", pro: "24 meses" },
+  { label: "Projeção do mês", free: "—", pro: "✓" },
+  { label: "Renda e benefício", free: "—", pro: "✓" },
   { label: "Exportar transações em CSV", free: "—", pro: "✓" },
   { label: "Importar extratos (CSV, OFX e PDF)", free: "—", pro: "✓" },
 ];
 
 const BENEFITS = [
-  "Saiba quanto vai ter no saldo no fim do mês",
-  "Entenda exatamente para onde seu dinheiro está indo",
-  "Planeje seu salário com cálculo real de INSS e IRRF",
-  "Importe extratos com revisão antes de confirmar",
+  "Veja quanto deve sobrar no saldo até o fim do mês",
+  "Entenda melhor para onde seu dinheiro está indo",
+  "Planeje salário, INSS e IRRF no mesmo lugar",
+  "Importe extratos com prévia antes de confirmar",
 ];
 
 const FEATURE_TITLES: Partial<Record<PaywallFeature, string>> = {
   csv_import: "Importação disponível no Pro",
   csv_export: "Exportação disponível no Pro",
   forecast: "Projeção disponível no Pro",
-  analytics_trend: "Histórico avançado disponível no Pro",
-  salary: "Controle salarial disponível no Pro",
+  analytics_trend: "Histórico do painel disponível no Pro",
+  salary: "Renda e benefício disponíveis no Pro",
 };
 
 const UpgradeModal = ({
@@ -67,12 +67,12 @@ const UpgradeModal = ({
   const featureTitle = FEATURE_TITLES[feature];
   const title = isTrialExpired
     ? "Seu período de teste encerrou"
-    : featureTitle || "Desbloqueie o Control Finance Pro";
+    : featureTitle || "Desbloqueie os recursos do Pro";
   const subtitle = isTrialExpired
-    ? "Continue com acesso total por menos de R$ 0,33 por dia."
+    ? "Continue com os recursos do Pro por menos de R$ 0,33 por dia."
     : reason;
-  const ctaLabel = isTrialExpired ? "Reativar acesso Pro" : "Começar meu plano Pro";
-  const dismissLabel = isTrialExpired ? "Agora não" : "Continuar no plano gratuito";
+  const ctaLabel = isTrialExpired ? "Reativar acesso Pro" : "Assinar Pro";
+  const dismissLabel = isTrialExpired ? "Agora não" : "Voltar por enquanto";
 
   const handleUpgrade = () => {
     trackPaywallEvent({ feature, action: "clicked_upgrade", context });
@@ -111,7 +111,7 @@ const UpgradeModal = ({
         {/* Price anchor */}
         <div className="mt-5">
           <span className="inline-block rounded bg-brand-1 px-2 py-0.5 text-xs font-medium text-white">
-            Mais escolhido
+            Plano recomendado
           </span>
           <div className="mt-1 flex items-baseline gap-1">
             <span className="text-4xl font-bold text-cf-text-primary">
@@ -138,7 +138,7 @@ const UpgradeModal = ({
             <thead>
               <tr className="bg-cf-bg-subtle">
                 <th className="px-3 py-2 text-left font-medium text-cf-text-primary">Recurso</th>
-                <th className="px-3 py-2 text-center font-medium text-cf-text-secondary">Gratuito</th>
+                <th className="px-3 py-2 text-center font-medium text-cf-text-secondary">Atual</th>
                 <th className="bg-brand-1/5 px-3 py-2 text-center font-semibold text-brand-1">Pro</th>
               </tr>
             </thead>

--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -1877,9 +1877,9 @@ describe("App", () => {
 
     render(<App />);
 
-    await user.click(screen.getByRole("button", { name: "Histórico de imports" }));
+    await user.click(screen.getByRole("button", { name: "Histórico de importações" }));
 
-    expect(await screen.findByText("Carregando histórico...")).toBeInTheDocument();
+    expect(await screen.findByText("Carregando histórico de importações...")).toBeInTheDocument();
 
     resolveHistoryRequest(
       buildImportHistoryResponse({
@@ -1902,7 +1902,7 @@ describe("App", () => {
       }),
     );
 
-    expect(await screen.findByText("Committed")).toBeInTheDocument();
+    expect(await screen.findByText("Importada")).toBeInTheDocument();
     expect(transactionsService.getImportHistory).toHaveBeenCalledWith({
       limit: 20,
       offset: 0,
@@ -1919,9 +1919,9 @@ describe("App", () => {
 
     render(<App />);
 
-    await user.click(screen.getByRole("button", { name: "Histórico de imports" }));
+    await user.click(screen.getByRole("button", { name: "Histórico de importações" }));
 
-    expect(await screen.findByText("Sem imports para exibir.")).toBeInTheDocument();
+    expect(await screen.findByText("Nenhuma importação para mostrar.")).toBeInTheDocument();
   });
 
   it("exibe erro ao carregar historico de imports", async () => {
@@ -1936,7 +1936,7 @@ describe("App", () => {
 
     render(<App />);
 
-    await user.click(screen.getByRole("button", { name: "Histórico de imports" }));
+    await user.click(screen.getByRole("button", { name: "Histórico de importações" }));
 
     expect(await screen.findByText("Falha ao carregar historico.")).toBeInTheDocument();
   });
@@ -1995,11 +1995,11 @@ describe("App", () => {
 
     render(<App />);
 
-    await user.click(screen.getByRole("button", { name: "Histórico de imports" }));
-    expect(await screen.findByText("Mostrando 1-20")).toBeInTheDocument();
-    const historyDialog = screen.getByRole("dialog", { name: "Histórico de imports" });
+    await user.click(screen.getByRole("button", { name: "Histórico de importações" }));
+    expect(await screen.findByText("Mostrando 1 a 20")).toBeInTheDocument();
+    const historyDialog = screen.getByRole("dialog", { name: "Histórico de importações" });
 
-    await user.click(within(historyDialog).getByRole("button", { name: "Proxima" }));
+    await user.click(within(historyDialog).getByRole("button", { name: "Próxima" }));
 
     await waitFor(() => {
       expect(transactionsService.getImportHistory).toHaveBeenLastCalledWith({
@@ -2007,7 +2007,7 @@ describe("App", () => {
         offset: 20,
       });
     });
-    expect(await screen.findByText("Mostrando 21-21")).toBeInTheDocument();
+    expect(await screen.findByText("Mostrando 21 a 21")).toBeInTheDocument();
   });
 
   it("abre menu de acoes no mobile e fecha ao clicar fora sem disparar logout", async () => {

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -1793,7 +1793,7 @@ const App = ({
                       onClick={handleOpenImportHistoryModal}
                       className="rounded px-2 py-2 text-left text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                     >
-                      Histórico de imports
+                      Histórico de importações
                     </button>
                     {(onOpenProfileSettings || onOpenBillingSettings || onOpenSecuritySettings) ? (
                       <div className="my-1 h-px bg-cf-border" role="separator" />
@@ -1968,7 +1968,7 @@ const App = ({
                   onClick={handleOpenImportHistoryModal}
                   className="whitespace-nowrap rounded border border-cf-border bg-cf-surface px-2.5 py-1.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle"
                 >
-                  Histórico de imports
+                  Histórico de importações
                 </button>
                 {onOpenBills ? (
                   <button

--- a/apps/web/src/pages/BillingSettings.test.tsx
+++ b/apps/web/src/pages/BillingSettings.test.tsx
@@ -39,12 +39,12 @@ describe("BillingSettings", () => {
     render(<BillingSettings />);
 
     await waitFor(() =>
-      expect(screen.getByText("Trial do Control Finance")).toBeInTheDocument(),
+      expect(screen.getByText("Período de teste do Control Finance")).toBeInTheDocument(),
     );
 
     expect(
       screen.getByText(
-        /Durante o trial, você acompanha painel financeiro, metas, cartões, renda e a Central do Leão/i,
+        /Durante o período de teste, você acompanha painel financeiro, metas, cartões, renda e a Central do Leão/i,
       ),
     ).toBeInTheDocument();
     expect(

--- a/apps/web/src/pages/BillingSettings.tsx
+++ b/apps/web/src/pages/BillingSettings.tsx
@@ -29,11 +29,11 @@ const daysRemaining = (isoDate: string | null | undefined): number => {
 
 const resolvePlanSupportCopy = (summary: SubscriptionSummary): string => {
   if (summary.entitlementSource === "trial") {
-    return "Durante o trial, você acompanha painel financeiro, metas, cartões, renda e a Central do Leão. Importação e exportação de extratos fazem parte do plano Pro.";
+    return "Durante o período de teste, você acompanha painel financeiro, metas, cartões, renda e a Central do Leão. Importação e exportação de extratos fazem parte do plano Pro.";
   }
 
   if (summary.entitlementSource === "free" && summary.trialExpired) {
-    return "Seu trial terminou. Faça upgrade para liberar importação e exportação de extratos e manter a experiência completa do Pro em cartões, renda e apoio fiscal.";
+    return "Seu período de teste terminou. Faça upgrade para liberar importação e exportação de extratos e voltar a usar os recursos do Pro em cartões, renda e apoio fiscal.";
   }
 
   if (
@@ -41,7 +41,7 @@ const resolvePlanSupportCopy = (summary: SubscriptionSummary): string => {
     summary.entitlementSource === "subscription_grace" ||
     summary.entitlementSource === "prepaid"
   ) {
-    return "Seu plano Pro libera importação e exportação de extratos, projeção financeira e os módulos avançados para uma experiência financeira mais completa.";
+    return "Seu plano Pro libera importação e exportação de extratos, projeção do mês e os recursos avançados do Control Finance.";
   }
 
   return "Consulte abaixo o que está disponível agora e o que o plano Pro adiciona ao seu controle financeiro.";
@@ -55,7 +55,7 @@ const resolvePlanBadge = (summary: import("../services/billing.service").Subscri
   if (source === "trial") {
     const days = daysRemaining(summary.trialEndsAt);
     return {
-      label: `Trial — ${days} dia${days !== 1 ? "s" : ""} restante${days !== 1 ? "s" : ""}`,
+      label: `Período de teste — ${days} dia${days !== 1 ? "s" : ""} restante${days !== 1 ? "s" : ""}`,
       className: "border-blue-200 bg-blue-50 text-blue-700",
     };
   }
@@ -172,7 +172,7 @@ const BillingSettings = ({
   const showCheckoutPendingNotice =
     checkoutStatus === "success" && !isLoading && !loadError && !isPro;
   const showCheckoutCanceledNotice = checkoutStatus === "cancel";
-  const planTitle = source === "trial" ? "Trial do Control Finance" : summary?.displayName ?? "";
+  const planTitle = source === "trial" ? "Período de teste do Control Finance" : summary?.displayName ?? "";
 
   return (
     <div className="min-h-screen bg-cf-bg-page py-6">
@@ -232,13 +232,13 @@ const BillingSettings = ({
             <div className="mt-4 space-y-4">
               {showCheckoutPendingNotice ? (
                 <div className="rounded border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-700">
-                  Pagamento recebido. Confirmando liberação do plano Pro. Em métodos como boleto, a confirmação pode levar alguns minutos.
+                  Pagamento recebido. Estamos confirmando a liberação do plano Pro. Em métodos como boleto, essa atualização pode levar alguns minutos.
                 </div>
               ) : null}
 
               {showCheckoutCanceledNotice ? (
                 <div className="rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700">
-                  Checkout cancelado. Nenhuma cobranca foi confirmada.
+                  Checkout cancelado. Nenhuma cobrança foi processada.
                 </div>
               ) : null}
 
@@ -283,10 +283,10 @@ const BillingSettings = ({
                       {isActionLoading
                         ? "Aguarde..."
                         : source === "trial"
-                        ? "Assinar PRO agora"
+                        ? "Assinar Pro agora"
                         : source === "free" && summary?.trialExpired
                         ? "Reativar acesso Pro"
-                        : "Assinar PRO"}
+                        : "Assinar Pro"}
                     </button>
                   )}
                 </div>

--- a/apps/web/src/services/api.test.js
+++ b/apps/web/src/services/api.test.js
@@ -249,7 +249,7 @@ describe("api service", () => {
 
     expect(onPaymentRequired).toHaveBeenCalledWith({
       reason:
-        "Seu plano atual não inclui a importação de extratos. No Pro, você importa CSV, OFX e PDF com pré-visualização antes de confirmar.",
+        "Importação de extratos é um recurso do Pro. No Pro, você importa CSV, OFX e PDF com prévia antes de confirmar.",
       feature: "csv_import",
       context: "feature_gate",
     });

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -169,28 +169,28 @@ const PAYWALL_COPY: Array<{ pattern: RegExp; reason: string; feature: PaywallFea
   {
     pattern: /\/transactions\/import/,
     reason:
-      "Seu plano atual não inclui a importação de extratos. No Pro, você importa CSV, OFX e PDF com pré-visualização antes de confirmar.",
+      "Importação de extratos é um recurso do Pro. No Pro, você importa CSV, OFX e PDF com prévia antes de confirmar.",
     feature: "csv_import",
   },
   {
     pattern: /\/transactions\/export/,
     reason:
-      "Seu plano atual não inclui a exportação de transações em CSV. No Pro, você exporta seus dados para planilhas e ferramentas financeiras.",
+      "Exportação de transações em CSV é um recurso do Pro. No Pro, você leva seus dados para planilhas e outras ferramentas financeiras.",
     feature: "csv_export",
   },
   {
     pattern: /\/forecasts/,
-    reason: "Saiba exatamente quanto vai ter no saldo no fim do mês.",
+    reason: "A projeção do mês é um recurso do Pro. Veja quanto deve sobrar no saldo até o fim do mês.",
     feature: "forecast",
   },
   {
     pattern: /\/analytics\/trend/,
-    reason: "Acesse até 24 meses de histórico e veja sua evolução financeira completa.",
+    reason: "O histórico do painel é um recurso do Pro. Acompanhe até 24 meses da sua evolução financeira.",
     feature: "analytics_trend",
   },
   {
     pattern: /\/salary/,
-    reason: "Planeje seu salário com cálculo real de INSS e IRRF.",
+    reason: "Renda e benefício são recursos do Pro. Planeje salário, INSS e IRRF no mesmo lugar.",
     feature: "salary",
   },
 ];


### PR DESCRIPTION
## Resumo
- humaniza copy de billing, trial e paywall sem mexer em entitlement
- traduz status e mensagens do histórico e do preview de importação para linguagem de produto
- renomeia superfícies de histórico para "Histórico de importações"

## Validação
- npm -w apps/web run test:run
- npm -w apps/web run lint
- npm -w apps/web run typecheck
- npm -w apps/web run build