### PR TITLE
fix(copy): normalize cards and payments language surfaces

### DIFF
--- a/apps/web/src/components/BillModal.tsx
+++ b/apps/web/src/components/BillModal.tsx
@@ -216,14 +216,14 @@ const BillModal = ({
           {/* Title */}
           <div className="flex flex-col gap-1.5">
             <label htmlFor="bill-title" className="text-sm font-medium text-cf-text-primary">
-              Titulo <span className="text-red-500">*</span>
+              Título <span className="text-red-500">*</span>
             </label>
             <input
               id="bill-title"
               type="text"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
-              placeholder="Ex: Conta de Agua"
+              placeholder="Ex.: Conta de água"
               className="rounded border border-cf-border-input px-3 py-2 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1 bg-cf-surface"
               disabled={isSaving}
               maxLength={200}
@@ -289,7 +289,7 @@ const BillModal = ({
           {/* Provider */}
           <div className="flex flex-col gap-1.5">
             <label htmlFor="bill-provider" className="text-sm font-medium text-cf-text-primary">
-              Fornecedor <span className="text-xs font-normal text-cf-text-secondary">(opcional)</span>
+              Empresa / emissor <span className="text-xs font-normal text-cf-text-secondary">(opcional)</span>
             </label>
             <input
               id="bill-provider"
@@ -305,7 +305,7 @@ const BillModal = ({
           {/* Reference Month */}
           <div className="flex flex-col gap-1.5">
             <label htmlFor="bill-ref-month" className="text-sm font-medium text-cf-text-primary">
-              Mês de referência <span className="text-xs font-normal text-cf-text-secondary">(opcional, YYYY-MM)</span>
+              Mês de referência <span className="text-xs font-normal text-cf-text-secondary">(opcional)</span>
             </label>
             <input
               id="bill-ref-month"
@@ -315,18 +315,21 @@ const BillModal = ({
               className="rounded border border-cf-border-input px-3 py-2 text-sm text-cf-text-primary focus:outline-none focus:ring-1 focus:ring-brand-1 bg-cf-surface"
               disabled={isSaving}
             />
+            <p className="text-xs text-cf-text-secondary">
+              Use quando a conta pertence a um mês específico, mesmo que o vencimento seja em outro dia.
+            </p>
           </div>
 
           {/* Notes */}
           <div className="flex flex-col gap-1.5">
             <label htmlFor="bill-notes" className="text-sm font-medium text-cf-text-primary">
-              Notas <span className="text-xs font-normal text-cf-text-secondary">(opcional)</span>
+              Observações <span className="text-xs font-normal text-cf-text-secondary">(opcional)</span>
             </label>
             <textarea
               id="bill-notes"
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
-              placeholder="Observacoes..."
+              placeholder="Anote algo útil para lembrar depois"
               rows={2}
               className="rounded border border-cf-border-input px-3 py-2 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1 bg-cf-surface resize-none"
               disabled={isSaving}
@@ -360,7 +363,7 @@ const BillModal = ({
                     className="w-16 rounded border border-cf-border-input px-2 py-1.5 text-sm text-cf-text-primary focus:outline-none focus:ring-1 focus:ring-brand-1 bg-cf-surface"
                   />
                   <span className="text-sm text-cf-text-secondary">
-                    parcelas mensais a partir de {dueDate || "—"}
+                    Gerar parcelas mensais a partir de {dueDate || "—"}
                   </span>
                 </div>
               ) : null}

--- a/apps/web/src/components/CreditCardModal.tsx
+++ b/apps/web/src/components/CreditCardModal.tsx
@@ -158,7 +158,7 @@ const CreditCardModal = ({
           <div className="grid grid-cols-2 gap-3">
             <div className="flex flex-col gap-1.5">
               <label htmlFor="credit-card-closing-day" className="text-sm font-medium text-cf-text-primary">
-                Fechamento
+                Dia do fechamento
               </label>
               <input
                 id="credit-card-closing-day"
@@ -173,7 +173,7 @@ const CreditCardModal = ({
             </div>
             <div className="flex flex-col gap-1.5">
               <label htmlFor="credit-card-due-day" className="text-sm font-medium text-cf-text-primary">
-                Vencimento
+                Dia do vencimento
               </label>
               <input
                 id="credit-card-due-day"

--- a/apps/web/src/components/CreditCardPurchaseModal.tsx
+++ b/apps/web/src/components/CreditCardPurchaseModal.tsx
@@ -123,7 +123,9 @@ const CreditCardPurchaseModal = ({
         <div className="mb-4 flex items-center justify-between">
           <div>
             <h2 className="text-lg font-semibold text-cf-text-primary">Nova compra</h2>
-            <p className="text-xs text-cf-text-secondary">{cardName}</p>
+            <p className="text-xs text-cf-text-secondary">
+              {cardName ? `${cardName} · entra no ciclo do cartão antes de virar pagamento.` : "Compra do cartão"}
+            </p>
           </div>
           <button
             type="button"
@@ -182,13 +184,14 @@ const CreditCardPurchaseModal = ({
 
           <div className="flex flex-col gap-1.5">
             <label htmlFor="credit-card-purchase-notes" className="text-sm font-medium text-cf-text-primary">
-              Notas
+              Observações <span className="text-xs font-normal text-cf-text-secondary">(opcional)</span>
             </label>
             <textarea
               id="credit-card-purchase-notes"
               value={notes}
               onChange={(event) => setNotes(event.target.value)}
               rows={3}
+              placeholder="Ex.: farmácia, mercado ou parcela de curso"
               className="rounded border border-cf-border-input bg-cf-surface px-3 py-2 text-sm text-cf-text-primary"
               disabled={isSaving}
             />
@@ -225,7 +228,7 @@ const CreditCardPurchaseModal = ({
                     disabled={isSaving}
                   />
                   <span className="text-xs text-cf-text-secondary">
-                    As parcelas futuras entram nos próximos fechamentos mensais.
+                    As próximas parcelas entram nos fechamentos futuros do cartão.
                   </span>
                 </div>
               </div>
@@ -255,7 +258,7 @@ const CreditCardPurchaseModal = ({
               {isSaving
                 ? "Salvando..."
                 : isInstallment
-                  ? `Adicionar em ${parseInt(installmentCount, 10) || MIN_INSTALLMENT_COUNT}x`
+                  ? `Adicionar parcelado em ${parseInt(installmentCount, 10) || MIN_INSTALLMENT_COUNT}x`
                   : "Adicionar compra"}
             </button>
           </div>

--- a/apps/web/src/pages/BillsPage.test.tsx
+++ b/apps/web/src/pages/BillsPage.test.tsx
@@ -89,8 +89,8 @@ describe("BillsPage", () => {
     });
 
     expect(screen.getAllByText(/132[,.]90/).length).toBeGreaterThan(0);
-    expect(screen.getByText("2 contas")).toBeInTheDocument();
-    expect(screen.getByText("1 conta")).toBeInTheDocument();
+    expect(screen.getByText("2 contas em aberto")).toBeInTheDocument();
+    expect(screen.getByText("1 conta em atraso")).toBeInTheDocument();
   });
 
   it("renderiza lista de bills com titulo e valor", async () => {
@@ -147,7 +147,7 @@ describe("BillsPage", () => {
 
     expect(screen.queryByRole("button", { name: "Editar" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Excluir" })).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Marcar como paga" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Registrar pagamento" })).toBeInTheDocument();
   });
 
   it("clicar filtro Pendentes chama list com status pending", async () => {
@@ -197,7 +197,7 @@ describe("BillsPage", () => {
       expect(screen.getByText("Conta de Agua")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button", { name: "Marcar como paga" }));
+    await user.click(screen.getByRole("button", { name: "Registrar pagamento" }));
 
     await waitFor(() => {
       expect(billsService.markPaid).toHaveBeenCalledWith(1);
@@ -244,7 +244,7 @@ describe("BillsPage", () => {
     renderPage();
 
     await waitFor(() => {
-      expect(screen.getByText("Nenhuma pendência encontrada.")).toBeInTheDocument();
+      expect(screen.getByText("Nenhuma conta encontrada para este filtro.")).toBeInTheDocument();
     });
   });
 
@@ -288,7 +288,7 @@ describe("BillsPage", () => {
     await waitFor(() => expect(screen.getByText("Conta de Agua")).toBeInTheDocument());
 
     await user.click(screen.getByRole("button", { name: /Nova pendência/ }));
-    await user.type(screen.getByLabelText(/Titulo/), "IPTU");
+    await user.type(screen.getByLabelText(/Título/), "IPTU");
     await user.type(screen.getByLabelText(/Valor/), "500");
     await user.click(screen.getByRole("checkbox", { name: /Parcelar/ }));
 
@@ -319,7 +319,7 @@ describe("BillsPage", () => {
     await waitFor(() => expect(screen.getByText("Conta de Agua")).toBeInTheDocument());
 
     await user.click(screen.getByRole("button", { name: /Nova pendência/ }));
-    await user.type(screen.getByLabelText(/Titulo/), "IPTU");
+    await user.type(screen.getByLabelText(/Título/), "IPTU");
     await user.type(screen.getByLabelText(/Valor/), "500");
     await user.click(screen.getByRole("checkbox", { name: /Parcelar/ }));
     await user.click(screen.getByRole("button", { name: "Gerar 2 parcelas" }));

--- a/apps/web/src/pages/BillsPage.tsx
+++ b/apps/web/src/pages/BillsPage.tsx
@@ -27,6 +27,13 @@ const formatDueDate = (dateStr: string): string => {
   return `${day}/${month}/${year}`;
 };
 
+const formatReferenceMonth = (value: string | null): string => {
+  if (!value) return "";
+  const [year, month] = value.split("-");
+  if (!year || !month) return value;
+  return `${month}/${year}`;
+};
+
 const isCreditCardInvoice = (bill: Bill) => bill.billType === "credit_card_invoice";
 
 // ─── Status badge ─────────────────────────────────────────────────────────────
@@ -258,7 +265,12 @@ const BillsPage = ({
                 ← Voltar
               </button>
             ) : null}
-            <h1 className="text-xl font-bold text-cf-text-primary">Pendências</h1>
+            <div>
+              <h1 className="text-xl font-bold text-cf-text-primary">Pendências</h1>
+              <p className="text-sm text-cf-text-secondary">
+                Acompanhe contas em aberto, vencidas e faturas sem perder prazos.
+              </p>
+            </div>
           </div>
           <button
             type="button"
@@ -281,7 +293,7 @@ const BillsPage = ({
                   {formatCurrency(summary?.pendingTotal ?? 0)}
                 </p>
                 <p className="mt-0.5 text-xs text-cf-text-secondary">
-                  {summary?.pendingCount ?? 0} {(summary?.pendingCount ?? 0) === 1 ? "conta" : "contas"}
+                  {summary?.pendingCount ?? 0} {(summary?.pendingCount ?? 0) === 1 ? "conta em aberto" : "contas em aberto"}
                 </p>
               </>
             )}
@@ -300,7 +312,7 @@ const BillsPage = ({
                   {formatCurrency(summary?.overdueTotal ?? 0)}
                 </p>
                 <p className="mt-0.5 text-xs text-cf-text-secondary">
-                  {summary?.overdueCount ?? 0} {(summary?.overdueCount ?? 0) === 1 ? "conta" : "contas"}
+                  {summary?.overdueCount ?? 0} {(summary?.overdueCount ?? 0) === 1 ? "conta em atraso" : "contas em atraso"}
                 </p>
               </>
             )}
@@ -355,7 +367,7 @@ const BillsPage = ({
             </p>
           ) : items.length === 0 ? (
             <p className="py-4 text-center text-sm text-cf-text-secondary">
-              Nenhuma pendência encontrada.
+              Nenhuma conta encontrada para este filtro.
             </p>
           ) : (
             items.map((bill) => (
@@ -380,7 +392,7 @@ const BillsPage = ({
                     </span>
                     {bill.referenceMonth ? (
                       <span className="text-xs text-cf-text-secondary">
-                        Ref. {bill.referenceMonth}
+                        Referência {formatReferenceMonth(bill.referenceMonth)}
                       </span>
                     ) : null}
                     {isCreditCardInvoice(bill) ? (
@@ -401,7 +413,7 @@ const BillsPage = ({
                       onClick={() => void handleMarkPaid(bill)}
                       className="whitespace-nowrap rounded border border-green-300 px-2 py-1 text-xs font-semibold text-green-700 hover:bg-green-50"
                     >
-                      Marcar como paga
+                      Registrar pagamento
                     </button>
                   ) : null}
 
@@ -452,7 +464,7 @@ const BillsPage = ({
         {!isLoadingList && items.length > 0 ? (
           <div className="mt-4 flex items-center justify-between gap-3">
             <span className="text-xs text-cf-text-secondary">
-              Mostrando {rangeStart}–{rangeEnd} de {paginationTotal}
+              Mostrando {rangeStart} a {rangeEnd} de {paginationTotal}
             </span>
             <div className="flex gap-2">
               <button

--- a/apps/web/src/pages/CreditCardsPage.test.tsx
+++ b/apps/web/src/pages/CreditCardsPage.test.tsx
@@ -164,8 +164,8 @@ describe("CreditCardsPage", () => {
     expect(screen.getByText("Mercado")).toBeInTheDocument();
     expect(screen.getByText("Fatura Nubank 2026-03")).toBeInTheDocument();
     expect(screen.getByText("24.00% do limite")).toBeInTheDocument();
-    expect(screen.getAllByText("Em uso").length).toBeGreaterThan(0);
-    expect(screen.getByText("Fatura atual")).toBeInTheDocument();
+    expect(screen.getAllByText("Com compras no ciclo").length).toBeGreaterThan(0);
+    expect(screen.getByText("Fatura do ciclo")).toBeInTheDocument();
     expect(screen.getByText("Pendente")).toBeInTheDocument();
   });
 
@@ -226,10 +226,10 @@ describe("CreditCardsPage", () => {
     await user.type(screen.getByLabelText("Nome do cartão"), "Inter");
     await user.clear(screen.getByLabelText("Limite total"));
     await user.type(screen.getByLabelText("Limite total"), "1500");
-    await user.clear(screen.getByLabelText("Fechamento"));
-    await user.type(screen.getByLabelText("Fechamento"), "12");
-    await user.clear(screen.getByLabelText("Vencimento"));
-    await user.type(screen.getByLabelText("Vencimento"), "22");
+    await user.clear(screen.getByLabelText("Dia do fechamento"));
+    await user.type(screen.getByLabelText("Dia do fechamento"), "12");
+    await user.clear(screen.getByLabelText("Dia do vencimento"));
+    await user.type(screen.getByLabelText("Dia do vencimento"), "22");
     await user.click(screen.getByRole("button", { name: "Criar cartão" }));
 
     await waitFor(() => {
@@ -275,7 +275,7 @@ describe("CreditCardsPage", () => {
     const countInput = screen.getByRole("spinbutton", { name: "Parcelas" });
     await user.clear(countInput);
     await user.type(countInput, "3");
-    await user.click(screen.getByRole("button", { name: "Adicionar em 3x" }));
+    await user.click(screen.getByRole("button", { name: "Adicionar parcelado em 3x" }));
 
     await waitFor(() => {
       expect(creditCardsService.createInstallments).toHaveBeenCalledWith(
@@ -300,7 +300,7 @@ describe("CreditCardsPage", () => {
       expect(creditCardsService.closeInvoice).toHaveBeenCalledWith(1);
     });
 
-    await user.click(screen.getByRole("button", { name: "Pagar fatura" }));
+    await user.click(screen.getByRole("button", { name: "Registrar pagamento" }));
 
     await waitFor(() => {
       expect(billsService.markPaid).toHaveBeenCalledWith(91);

--- a/apps/web/src/pages/CreditCardsPage.tsx
+++ b/apps/web/src/pages/CreditCardsPage.tsx
@@ -19,10 +19,17 @@ const formatDate = (value: string) => {
   return `${day}/${month}/${year}`;
 };
 
+const formatReferenceMonth = (value: string | null) => {
+  if (!value) return "—";
+  const [year, month] = value.split("-");
+  if (!year || !month) return value;
+  return `${month}/${year}`;
+};
+
 const USAGE_STATUS_LABELS = {
-  unused: "Sem uso no ciclo",
-  using: "Em uso",
-  exceeded: "Limite estourado",
+  unused: "Sem compras no ciclo",
+  using: "Com compras no ciclo",
+  exceeded: "Acima do limite",
 } as const;
 
 const USAGE_STATUS_BADGE_CLASSNAMES = {
@@ -153,7 +160,7 @@ const CreditCardsPage = ({
     try {
       const result = await creditCardsService.closeInvoice(card.id);
       showSuccess(
-        `Fatura fechada em ${formatCurrency(result.total)} com ${result.purchasesCount} compra${result.purchasesCount === 1 ? "" : "s"}.`,
+        `Fatura fechada em ${formatCurrency(result.total)} com ${result.purchasesCount} compra${result.purchasesCount === 1 ? "" : "s"} lançada${result.purchasesCount === 1 ? "" : "s"}.`,
       );
       await loadCards();
     } catch (error) {
@@ -165,7 +172,7 @@ const CreditCardsPage = ({
     setPageError("");
     try {
       await billsService.markPaid(invoiceId);
-      showSuccess("Fatura paga e saída de caixa registrada.");
+      showSuccess("Pagamento da fatura registrado na sua conta.");
       await loadCards();
     } catch (error) {
       setPageError(getApiErrorMessage(error, "Não foi possível pagar a fatura."));
@@ -177,7 +184,7 @@ const CreditCardsPage = ({
     try {
       const result = await creditCardsService.reopenInvoice(invoiceId);
       showSuccess(
-        `Fatura reaberta. ${result.reopenedPurchasesCount} compra${result.reopenedPurchasesCount === 1 ? "" : "s"} voltaram para aberto.`,
+        `Fatura reaberta. ${result.reopenedPurchasesCount} compra${result.reopenedPurchasesCount === 1 ? "" : "s"} voltou${result.reopenedPurchasesCount === 1 ? "" : "aram"} para compras em aberto.`,
       );
       await loadCards();
     } catch (error) {
@@ -214,7 +221,7 @@ const CreditCardsPage = ({
             <div>
               <h1 className="text-xl font-bold text-cf-text-primary">Cartões</h1>
               <p className="text-sm text-cf-text-secondary">
-                Acompanhe limite, compras e faturas sem confundir uso do cartão com saída imediata de caixa.
+                Acompanhe limite, compras e faturas sem misturar uso do cartão com saída imediata da conta.
               </p>
             </div>
           </div>
@@ -246,7 +253,7 @@ const CreditCardsPage = ({
         ) : cards.length === 0 ? (
           <div className="rounded border border-dashed border-cf-border bg-cf-surface p-6 text-center">
             <p className="text-sm text-cf-text-secondary">
-              Nenhum cartão cadastrado ainda. Crie o primeiro para acompanhar limite, compras e faturas do mês.
+              Nenhum cartão cadastrado ainda. Crie o primeiro para acompanhar limite, compras do ciclo e faturas para pagar.
             </p>
           </div>
         ) : (
@@ -273,7 +280,7 @@ const CreditCardsPage = ({
                       Fecha no dia {card.closingDay} e vence no dia {card.dueDay}
                     </p>
                     <p className="mt-1 text-xs text-cf-text-secondary">
-                      {card.openPurchasesCount} compra{card.openPurchasesCount === 1 ? "" : "s"} aberta
+                      {card.openPurchasesCount} compra{card.openPurchasesCount === 1 ? "" : "s"} em aberto
                       {card.openPurchasesCount === 1 ? "" : "s"} · {card.pendingInvoicesCount} fatura
                       {card.pendingInvoicesCount === 1 ? "" : "s"} pendente{card.pendingInvoicesCount === 1 ? "" : "s"}
                     </p>
@@ -329,13 +336,13 @@ const CreditCardsPage = ({
                     <p className="text-xs font-medium uppercase text-cf-text-secondary">Limite disponível</p>
                     <p className="mt-1 text-lg font-bold text-cf-text-primary">{formatCurrency(card.usage.available)}</p>
                     {card.usage.exceededBy > 0 ? (
-                      <p className="text-xs text-red-600">Estourado em {formatCurrency(card.usage.exceededBy)}</p>
+                      <p className="text-xs text-red-600">Acima do limite em {formatCurrency(card.usage.exceededBy)}</p>
                     ) : (
-                      <p className="text-xs text-cf-text-secondary">Ainda livre para novas compras</p>
+                      <p className="text-xs text-cf-text-secondary">Valor ainda livre para novas compras</p>
                     )}
                   </div>
                   <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
-                    <p className="text-xs font-medium uppercase text-cf-text-secondary">Fatura atual</p>
+                    <p className="text-xs font-medium uppercase text-cf-text-secondary">Fatura do ciclo</p>
                     <p className="mt-1 text-lg font-bold text-cf-text-primary">
                       {pendingInvoice
                         ? formatCurrency(pendingInvoice.amount)
@@ -350,7 +357,7 @@ const CreditCardsPage = ({
                           : `Vence em ${formatDate(pendingInvoice.dueDate)}`}
                       </p>
                     ) : card.openPurchasesCount > 0 ? (
-                      <p className="text-xs text-cf-text-secondary">Compras abertas aguardando fechamento</p>
+                      <p className="text-xs text-cf-text-secondary">Compras deste ciclo aguardando fechamento</p>
                     ) : (
                       <p className="text-xs text-cf-text-secondary">Sem fatura pendente no momento</p>
                     )}
@@ -362,12 +369,12 @@ const CreditCardsPage = ({
                     <div className="mb-2 flex items-center justify-between">
                       <h3 className="text-sm font-semibold text-cf-text-primary">Faturas</h3>
                       <span className="text-xs text-cf-text-secondary">
-                        {card.invoices.length} lançada{card.invoices.length === 1 ? "" : "s"}
+                        {card.invoices.length} no histórico
                       </span>
                     </div>
                     {card.invoices.length === 0 ? (
                       <div className="rounded border border-dashed border-cf-border px-3 py-4 text-sm text-cf-text-secondary">
-                        Nenhuma fatura fechada ainda.
+                        Nenhuma fatura fechada por enquanto.
                       </div>
                     ) : (
                       <div className="space-y-2">
@@ -387,7 +394,7 @@ const CreditCardsPage = ({
                                     </span>
                                   </div>
                                   <p className="text-xs text-cf-text-secondary">
-                                    Ref. {invoice.referenceMonth || "—"} · vence {formatDate(invoice.dueDate)}
+                                    Referência {formatReferenceMonth(invoice.referenceMonth)} · vence {formatDate(invoice.dueDate)}
                                   </p>
                                 </div>
                                 <div className="flex items-center gap-2">
@@ -408,7 +415,7 @@ const CreditCardsPage = ({
                                         onClick={() => void handlePayInvoice(invoice.id)}
                                         className="rounded border border-green-300 px-2 py-1 text-xs font-semibold text-green-700 hover:bg-green-50"
                                       >
-                                        Pagar fatura
+                                        Registrar pagamento
                                       </button>
                                     </div>
                                   ) : (
@@ -434,7 +441,7 @@ const CreditCardsPage = ({
                     </div>
                     {card.openPurchases.length === 0 ? (
                       <div className="rounded border border-dashed border-cf-border px-3 py-4 text-sm text-cf-text-secondary">
-                        Nenhuma compra aberta neste cartão.
+                        Nenhuma compra em aberto neste cartão.
                       </div>
                     ) : (
                       <div className="space-y-2">


### PR DESCRIPTION
## Summary\n- humanize labels and helper copy in cards, invoices and bills surfaces\n- clarify payment, due date, cycle and empty-state messaging without changing behavior\n- keep tests aligned with the new product language in cards and pending bills\n\n## Validation\n- npm -w apps/web run test:run -- src/pages/CreditCardsPage.test.tsx src/pages/BillsPage.test.tsx\n- npm -w apps/web run lint\n- npm -w apps/web run typecheck\n- npm -w apps/web run test:run\n- npm -w apps/web run build