### PR TITLE
fix(copy): normalize tax review and fiscal history language

### DIFF
--- a/apps/web/src/components/TaxManualFactModal.tsx
+++ b/apps/web/src/components/TaxManualFactModal.tsx
@@ -19,14 +19,14 @@ interface TaxManualFactModalProps {
 }
 
 const FACT_TYPE_OPTIONS = [
-  { value: "taxable_income", label: "Rendimento tributavel" },
+  { value: "taxable_income", label: "Rendimento tributável" },
   { value: "exempt_income", label: "Rendimento isento" },
-  { value: "exclusive_tax_income", label: "Tributacao exclusiva" },
+  { value: "exclusive_tax_income", label: "Tributação exclusiva" },
   { value: "withheld_tax", label: "IR retido na fonte" },
   { value: "asset_balance", label: "Bens e direitos" },
-  { value: "debt_balance", label: "Dividas e onus" },
-  { value: "medical_deduction", label: "Deducao medica" },
-  { value: "education_deduction", label: "Deducao de instrucao" },
+  { value: "debt_balance", label: "Dívidas e ônus" },
+  { value: "medical_deduction", label: "Dedução médica" },
+  { value: "education_deduction", label: "Dedução de instrução" },
   { value: "other", label: "Outro fato fiscal" },
 ] as const;
 
@@ -82,17 +82,17 @@ const TaxManualFactModal = ({
     const parsedAmount = parseMoney(amount);
 
     if (!subcategory.trim()) {
-      setLocalError("Informe a descricao do fato fiscal.");
+      setLocalError("Informe a descrição do fato fiscal.");
       return;
     }
 
     if (!referencePeriod.trim()) {
-      setLocalError("Informe o periodo de referencia.");
+      setLocalError("Informe o período de referência.");
       return;
     }
 
     if (!Number.isFinite(parsedAmount) || parsedAmount <= 0) {
-      setLocalError("Informe um valor valido.");
+      setLocalError("Informe um valor válido.");
       return;
     }
 
@@ -126,7 +126,8 @@ const TaxManualFactModal = ({
             <div>
               <h2 className="text-lg font-semibold text-cf-text-primary">Adicionar fato manual</h2>
               <p className="mt-1 text-sm text-cf-text-secondary">
-                Exercício {taxYear}. Use quando o dado do IRPF ainda não entrou por documento ou sincronização.
+                Exercício {taxYear}. Use quando a informação do IRPF ainda não entrou por documento
+                ou sincronização.
               </p>
             </div>
             <button
@@ -167,7 +168,7 @@ const TaxManualFactModal = ({
 
                 <label className="block">
                   <span className="mb-1 block text-sm font-semibold text-cf-text-primary">
-                    Periodo de referencia
+                    Período de referência
                   </span>
                   <input
                     type="text"
@@ -182,14 +183,14 @@ const TaxManualFactModal = ({
 
               <label className="block">
                 <span className="mb-1 block text-sm font-semibold text-cf-text-primary">
-                  Descricao / subcategoria
+                  Descrição ou subcategoria fiscal
                 </span>
                 <input
                   type="text"
                   value={subcategory}
                   onChange={(event) => setSubcategory(event.target.value)}
                   disabled={isSubmitting}
-                  placeholder="Ex.: aluguel recebido, plano de saude, INSS complementar"
+                  placeholder="Ex.: aluguel recebido, plano de saúde, INSS complementar"
                   className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-2 text-sm text-cf-text-primary outline-none focus:border-brand-1"
                 />
               </label>
@@ -238,14 +239,14 @@ const TaxManualFactModal = ({
 
               <label className="block">
                 <span className="mb-1 block text-sm font-semibold text-cf-text-primary">
-                  Observacao (opcional)
+                  Observação (opcional)
                 </span>
                 <textarea
                   value={note}
                   onChange={(event) => setNote(event.target.value)}
                   disabled={isSubmitting}
                   rows={4}
-                  placeholder="Contexto para a revisao fiscal desse fato."
+                  placeholder="Contexto para a revisão fiscal deste fato."
                   className="w-full rounded border border-cf-border-input bg-cf-surface px-3 py-2 text-sm text-cf-text-primary outline-none focus:border-brand-1"
                 />
               </label>
@@ -277,7 +278,7 @@ const TaxManualFactModal = ({
                 disabled={isSubmitting}
                 className="rounded border border-brand-1 bg-brand-1 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-2 disabled:cursor-not-allowed disabled:opacity-60"
               >
-                {isSubmitting ? "Salvando..." : "Adicionar fato"}
+                {isSubmitting ? "Salvando..." : "Adicionar à revisão"}
               </button>
             </div>
           </form>

--- a/apps/web/src/components/TaxUploadModal.tsx
+++ b/apps/web/src/components/TaxUploadModal.tsx
@@ -81,7 +81,7 @@ const TaxUploadModal = ({
   const isBusy = stage === "uploading" || stage === "processing";
   const isSuccess = stage === "success";
   const helperText = useMemo(
-    () => "Formatos aceitos hoje: PDF, CSV, PNG ou JPG, com até 10 MB.",
+    () => "Envie um PDF, CSV ou imagem do documento fiscal. O limite atual é de 10 MB.",
     [],
   );
 
@@ -139,8 +139,7 @@ const TaxUploadModal = ({
           <div>
             <h2 className="text-lg font-semibold text-cf-text-primary">Enviar documento fiscal</h2>
             <p className="mt-1 text-sm text-cf-text-secondary">
-              Exercício {taxYear}. O sistema envia, processa e atualiza a fila de revisão na mesma
-              tela.
+              Exercício {taxYear}. O documento entra na revisão fiscal sem você sair desta tela.
             </p>
           </div>
           <button

--- a/apps/web/src/pages/TaxPage.test.tsx
+++ b/apps/web/src/pages/TaxPage.test.tsx
@@ -546,7 +546,7 @@ describe("TaxPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("permite adicionar um fato fiscal manual na fila de revisao", async () => {
+  it("permite adicionar um fato fiscal manual à fila de revisão", async () => {
     const user = userEvent.setup();
 
     vi.mocked(taxService.listFacts)
@@ -580,13 +580,13 @@ describe("TaxPage", () => {
 
     await user.click(screen.getByRole("button", { name: "Adicionar manualmente" }));
     await user.selectOptions(screen.getByLabelText("Tipo de fato fiscal"), "taxable_income");
-    await user.type(screen.getByLabelText("Periodo de referencia"), "2025-12");
-    await user.type(screen.getByLabelText("Descricao / subcategoria"), "Renda manual INSS");
+    await user.type(screen.getByLabelText("Período de referência"), "2025-12");
+    await user.type(screen.getByLabelText("Descrição ou subcategoria fiscal"), "Renda manual INSS");
     await user.type(screen.getByLabelText("Fonte pagadora / origem"), "INSS");
     await user.type(screen.getByLabelText("Documento da fonte (opcional)"), "29.979.036/0001-40");
     await user.type(screen.getByLabelText("Valor"), "2803,52");
-    await user.type(screen.getByLabelText("Observacao (opcional)"), "Lancamento manual de apoio.");
-    await user.click(screen.getByRole("button", { name: "Adicionar fato" }));
+    await user.type(screen.getByLabelText("Observação (opcional)"), "Lancamento manual de apoio.");
+    await user.click(screen.getByRole("button", { name: "Adicionar à revisão" }));
 
     await waitFor(() => {
       expect(taxService.createManualFact).toHaveBeenCalledWith({
@@ -601,7 +601,7 @@ describe("TaxPage", () => {
       });
     });
 
-    expect(await screen.findByText("Fato fiscal manual adicionado a fila de revisao.")).toBeInTheDocument();
+    expect(await screen.findByText("Fato manual adicionado à fila de revisão.")).toBeInTheDocument();
     expect(
       await screen.findByText((content) => content.includes("Renda manual INSS")),
     ).toBeInTheDocument();
@@ -780,7 +780,7 @@ describe("TaxPage", () => {
     });
 
     expect(
-      await screen.findByText("Documento excluído. 2 fato(s) fiscal(is) vinculado(s) foram removidos."),
+      await screen.findByText("Documento excluído. 2 fatos fiscais vinculados foram removidos."),
     ).toBeInTheDocument();
 
     confirmSpy.mockRestore();

--- a/apps/web/src/pages/TaxPage.tsx
+++ b/apps/web/src/pages/TaxPage.tsx
@@ -581,12 +581,12 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
       setIsManualFactModalOpen(false);
       showSuccess(
         createdFact.conflictCode
-          ? "Fato fiscal manual adicionado com alerta de possivel duplicidade. Revise antes de aprovar."
-          : "Fato fiscal manual adicionado a fila de revisao.",
+          ? "Fato manual adicionado com alerta de possível duplicidade. Revise antes de aprovar."
+          : "Fato manual adicionado à fila de revisão.",
       );
     } catch (error) {
       setManualFactErrorMessage(
-        getApiErrorMessage(error, "Nao foi possivel adicionar o fato fiscal manual."),
+        getApiErrorMessage(error, "Não foi possível adicionar o fato manual."),
       );
     } finally {
       setIsCreatingManualFact(false);
@@ -629,7 +629,9 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
       await refreshAfterDocumentLifecycle();
       showSuccess(
         result.deletedFactsCount > 0
-          ? `Documento excluído. ${result.deletedFactsCount} fato(s) fiscal(is) vinculado(s) foram removidos.`
+          ? result.deletedFactsCount === 1
+            ? "Documento excluído. 1 fato fiscal vinculado foi removido."
+            : `Documento excluído. ${result.deletedFactsCount} fatos fiscais vinculados foram removidos.`
           : "Documento excluído.",
       );
     } catch (error) {
@@ -1119,7 +1121,7 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
                     ? "Separando fatos que entram no cálculo oficial"
                     : excludedApprovedFactsCount > 0
                     ? `${excludedApprovedFactsCount} aprovado(s) ficaram fora por CPF divergente`
-                    : "Base que entra em obrigação e summary"
+                    : "Base que entra no cálculo e no resumo oficial"
                 }
               />
             </div>
@@ -1212,7 +1214,7 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
               </p>
               <p className="mt-1 text-sm text-cf-text-secondary">
                 {documentsPage.total === 0
-                  ? "Sem informe em PDF? Use “Adicionar manualmente” ou “Sincronizar do app” para gerar fatos pendentes a partir das rendas e lançamentos ja alimentados."
+                  ? "Sem informe em PDF? Use “Adicionar manualmente” ou “Sincronizar do app” para gerar fatos pendentes a partir das rendas e lançamentos já alimentados."
                   : "Quando já existem documentos fiscais no exercício, a sincronização vinda do app fica bloqueada para evitar mistura entre as trilhas."}
               </p>
             </div>
@@ -1336,12 +1338,12 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
             <FactSummaryCard
               title="Aprovados"
               value={String(obligation.approvedFactsCount)}
-              helper="Entram em obrigação e summary"
+              helper="Já contam no cálculo e no resumo"
             />
             <FactSummaryCard
-              title="Fila atual"
+              title="Na revisão agora"
               value={String(factsPage.total)}
-              helper="Itens retornados pela API"
+              helper="Fatos exibidos nesta revisão"
             />
           </div>
 
@@ -1480,7 +1482,7 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
               <div>
                 <h2 className="text-lg font-bold text-cf-text-primary">Corrigir fato fiscal</h2>
                 <p className="mt-1 text-sm text-cf-text-secondary">
-                  Ajuste o valor ou a subcategoria antes de mover o fato para `corrected`.
+                  Ajuste o valor ou a subcategoria antes de marcar este fato como corrigido.
                 </p>
               </div>
               <button


### PR DESCRIPTION
## Summary\n- humanize tax review queue, manual fact and document upload language in the Central do Leão\n- remove remaining technical wording from fiscal history, queue summary and correction copy\n- align tests with the clearer fiscal wording without touching tax rules or backend contracts\n\n## Validation\n- npm -w apps/web run test:run -- src/pages/TaxPage.test.tsx\n- npm -w apps/web run lint\n- npm -w apps/web run typecheck\n- npm -w apps/web run test:run\n- npm -w apps/web run build