### PR TITLE
fix(ui): normalize large modal shells and remaining document flows

### DIFF
--- a/apps/web/src/components/ImportHistoryModal.jsx
+++ b/apps/web/src/components/ImportHistoryModal.jsx
@@ -224,175 +224,184 @@ const ImportHistoryModal = ({ isOpen, onClose, onImportSessionReverted = undefin
 
   return (
     <div
-      className="fixed inset-0 z-50 flex min-h-screen items-start justify-center bg-black/50 p-6 sm:items-center"
+      className="fixed inset-0 z-50 overflow-y-auto bg-black/50 p-4 sm:p-6"
       onClick={handleBackdropClick}
       role="presentation"
     >
-      <div
-        className="w-full max-w-5xl rounded-lg bg-cf-surface p-4 sm:p-6"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="import-history-modal-title"
-      >
-        <div className="mb-4 flex items-center justify-between">
-          <h2 id="import-history-modal-title" className="text-lg font-semibold text-cf-text-primary">
-            Histórico de importações
-          </h2>
-          <button
-            ref={closeButtonRef}
-            type="button"
-            onClick={onClose}
-            className="text-ui-200 transition-colors hover:text-ui-100"
-            aria-label="Fechar modal de histórico de importações"
-          >
-            X
-          </button>
-        </div>
-
-        {errorMessage ? (
-          <div className="mb-3 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
-            <p>{errorMessage}</p>
+      <div className="flex min-h-full items-center justify-center">
+        <div
+          className="flex w-full max-w-5xl max-h-[min(92vh,960px)] flex-col overflow-hidden rounded-lg border border-cf-border bg-cf-surface shadow-xl"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="import-history-modal-title"
+        >
+          <div className="flex items-start justify-between gap-4 border-b border-cf-border px-5 py-4">
+            <div>
+              <h2 id="import-history-modal-title" className="text-lg font-semibold text-cf-text-primary">
+                Histórico de importações
+              </h2>
+              <p className="mt-1 text-sm text-cf-text-secondary">
+                Veja o que entrou, o que foi desfeito e quando uma sessão ainda depende de itens vinculados.
+              </p>
+            </div>
             <button
+              ref={closeButtonRef}
               type="button"
-              onClick={() => void loadImportHistory(offset, limit)}
-              className="mt-2 rounded border border-red-300 px-2 py-1 text-xs font-semibold text-red-700 hover:bg-red-100"
+              onClick={onClose}
+              className="text-cf-text-secondary transition-colors hover:text-cf-text-primary"
+              aria-label="Fechar modal de histórico de importações"
             >
-              Tentar novamente
+              X
             </button>
           </div>
-        ) : null}
 
-        {successMessage ? (
-          <div className="mb-3 rounded border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">
-            {successMessage}
+          <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+            {errorMessage ? (
+              <div className="mb-3 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                <p>{errorMessage}</p>
+                <button
+                  type="button"
+                  onClick={() => void loadImportHistory(offset, limit)}
+                  className="mt-2 rounded border border-red-300 px-2 py-1 text-xs font-semibold text-red-700 hover:bg-red-100"
+                >
+                  Tentar novamente
+                </button>
+              </div>
+            ) : null}
+
+            {successMessage ? (
+              <div className="mb-3 rounded border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">
+                {successMessage}
+              </div>
+            ) : null}
+
+            {isLoading ? (
+              <div className="rounded border border-cf-border bg-cf-surface px-3 py-3 text-sm text-cf-text-secondary">
+                Carregando histórico de importações...
+              </div>
+            ) : null}
+
+            {!isLoading && !errorMessage && rowsWithStatus.length === 0 ? (
+              <div className="rounded border border-cf-border bg-cf-surface px-3 py-3 text-sm text-cf-text-secondary">
+                Nenhuma importação encontrada por enquanto.
+              </div>
+            ) : null}
+
+            {!isLoading && !errorMessage && rowsWithStatus.length > 0 ? (
+              <div className="space-y-3">
+                <div className="text-xs text-cf-text-secondary">
+                  Mostrando {rangeStart} a {rangeEnd} desta página
+                </div>
+                <div className="max-h-[min(60vh,520px)] overflow-auto rounded border border-cf-border">
+                  <table className="min-w-full border-collapse text-left text-xs">
+                    <thead className="bg-cf-bg-subtle">
+                      <tr>
+                        <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Criada em</th>
+                        <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Arquivo</th>
+                        <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Status</th>
+                        <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Revisão</th>
+                        <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Totais</th>
+                        <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Ações</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {rowsWithStatus.map((item) => (
+                        <tr key={item.id} className="align-top">
+                          <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
+                            {formatDateTime(item.createdAt)}
+                          </td>
+                          <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
+                            <p className="font-semibold text-cf-text-primary">
+                              {item.fileName || "Arquivo não informado"}
+                            </p>
+                            <p className="text-[11px] text-cf-text-secondary">
+                              {formatDocumentType(item.documentType)}
+                            </p>
+                          </td>
+                          <td className="border-b border-cf-border px-2 py-2">
+                            <span className={`rounded px-2 py-0.5 font-semibold ${item.status.className}`}>
+                              {item.status.label}
+                            </span>
+                          </td>
+                          <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
+                            <div className="space-y-1 text-[11px]">
+                              <p>Linhas prontas: {item.summary.validRows}</p>
+                              <p>Já existentes: {item.summary.duplicateRows}</p>
+                              <p>Pedem revisão: {item.summary.conflictRows}</p>
+                              <p>Inválidas: {item.summary.invalidRows}</p>
+                              <p>Aplicadas: {item.summary.imported}</p>
+                            </div>
+                          </td>
+                          <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
+                            <div className="space-y-1 text-[11px]">
+                              <p>Entradas: {formatCurrency(item.summary.income)}</p>
+                              <p>Saídas: {formatCurrency(item.summary.expense)}</p>
+                            </div>
+                          </td>
+                          <td className="border-b border-cf-border px-2 py-2">
+                            {item.canUndo ? (
+                              <button
+                                type="button"
+                                onClick={() => setPendingUndoItem(item)}
+                                disabled={undoingSessionId === item.id}
+                                className="rounded border border-red-300 bg-red-50 px-2 py-1 text-xs font-semibold text-red-600 hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-60"
+                              >
+                                {undoingSessionId === item.id ? "Desfazendo..." : "Desfazer"}
+                              </button>
+                            ) : (
+                              <div className="space-y-1">
+                                <span className="text-[11px] text-cf-text-secondary">Desfazer indisponível</span>
+                                {item.undoBlockedReason ? (
+                                  <p className="max-w-48 text-[11px] text-cf-text-secondary">
+                                    {humanizeUndoBlockedReason(item.undoBlockedReason)}
+                                  </p>
+                                ) : null}
+                              </div>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+                <div className="flex items-center justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={handlePreviousPage}
+                    disabled={!hasPreviousPage || isLoading}
+                    className="rounded border border-cf-border bg-cf-surface px-3 py-1.5 text-sm font-semibold text-cf-text-primary hover:bg-cf-bg-subtle disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    Anterior
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleNextPage}
+                    disabled={!hasNextPage || isLoading}
+                    className="rounded border border-cf-border bg-cf-surface px-3 py-1.5 text-sm font-semibold text-cf-text-primary hover:bg-cf-bg-subtle disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    Próxima
+                  </button>
+                </div>
+              </div>
+            ) : null}
           </div>
-        ) : null}
 
-        {isLoading ? (
-          <div className="rounded border border-cf-border bg-cf-surface px-3 py-3 text-sm text-cf-text-secondary">
-            Carregando histórico de importações...
+          <div className="flex justify-end border-t border-cf-border px-5 py-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-1.5 text-sm font-semibold text-cf-text-secondary"
+            >
+              Fechar
+            </button>
           </div>
-        ) : null}
-
-        {!isLoading && !errorMessage && rowsWithStatus.length === 0 ? (
-          <div className="rounded border border-cf-border bg-cf-surface px-3 py-3 text-sm text-cf-text-secondary">
-            Nenhuma importação para mostrar.
-          </div>
-        ) : null}
-
-        {!isLoading && !errorMessage && rowsWithStatus.length > 0 ? (
-          <div className="space-y-3">
-            <div className="text-xs text-cf-text-secondary">
-              Mostrando {rangeStart} a {rangeEnd}
-            </div>
-            <div className="max-h-96 overflow-auto rounded border border-cf-border">
-              <table className="min-w-full border-collapse text-left text-xs">
-                <thead className="bg-cf-bg-subtle">
-                  <tr>
-                    <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Data</th>
-                    <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Arquivo</th>
-                    <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Status</th>
-                    <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Resumo</th>
-                    <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Valores</th>
-                    <th className="border-b border-cf-border px-2 py-2 text-cf-text-primary">Ações</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {rowsWithStatus.map((item) => (
-                    <tr key={item.id} className="align-top">
-                      <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
-                        {formatDateTime(item.createdAt)}
-                      </td>
-                      <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
-                        <p className="font-semibold text-cf-text-primary">
-                          {item.fileName || "Arquivo não informado"}
-                        </p>
-                        <p className="text-[11px] text-cf-text-secondary">
-                          {formatDocumentType(item.documentType)}
-                        </p>
-                      </td>
-                      <td className="border-b border-cf-border px-2 py-2">
-                        <span className={`rounded px-2 py-0.5 font-semibold ${item.status.className}`}>
-                          {item.status.label}
-                        </span>
-                      </td>
-                      <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
-                        <div className="space-y-1 text-[11px]">
-                          <p>Prontas para importar: {item.summary.validRows}</p>
-                          <p>Já existentes: {item.summary.duplicateRows}</p>
-                          <p>Para revisar: {item.summary.conflictRows}</p>
-                          <p>Inválidas: {item.summary.invalidRows}</p>
-                          <p>Importadas: {item.summary.imported}</p>
-                        </div>
-                      </td>
-                      <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
-                        <div className="space-y-1 text-[11px]">
-                          <p>Entradas: {formatCurrency(item.summary.income)}</p>
-                          <p>Saídas: {formatCurrency(item.summary.expense)}</p>
-                        </div>
-                      </td>
-                      <td className="border-b border-cf-border px-2 py-2">
-                        {item.canUndo ? (
-                          <button
-                            type="button"
-                            onClick={() => setPendingUndoItem(item)}
-                            disabled={undoingSessionId === item.id}
-                            className="rounded border border-red-300 bg-red-50 px-2 py-1 text-xs font-semibold text-red-600 hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-60"
-                          >
-                            {undoingSessionId === item.id ? "Desfazendo..." : "Desfazer"}
-                          </button>
-                        ) : (
-                          <div className="space-y-1">
-                            <span className="text-[11px] text-cf-text-secondary">Sem ação disponível</span>
-                            {item.undoBlockedReason ? (
-                              <p className="max-w-48 text-[11px] text-cf-text-secondary">
-                                {humanizeUndoBlockedReason(item.undoBlockedReason)}
-                              </p>
-                            ) : null}
-                          </div>
-                        )}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-            <div className="flex items-center justify-end gap-2">
-              <button
-                type="button"
-                onClick={handlePreviousPage}
-                disabled={!hasPreviousPage || isLoading}
-                className="rounded border border-cf-border bg-cf-surface px-3 py-1.5 text-sm font-semibold text-cf-text-primary hover:bg-cf-bg-subtle disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                Anterior
-              </button>
-              <button
-                type="button"
-                onClick={handleNextPage}
-                disabled={!hasNextPage || isLoading}
-                className="rounded border border-cf-border bg-cf-surface px-3 py-1.5 text-sm font-semibold text-cf-text-primary hover:bg-cf-bg-subtle disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                Próxima
-              </button>
-            </div>
-          </div>
-        ) : null}
-
-        <div className="mt-4 flex justify-end">
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-1.5 text-sm font-semibold text-cf-text-secondary"
-          >
-            Fechar
-          </button>
         </div>
       </div>
 
       <ConfirmDialog
         isOpen={Boolean(pendingUndoItem)}
         title="Desfazer importação?"
-        description="Os lançamentos ativos desta sessão serão removidos e o histórico ficará marcado como revertido."
+        description="Os lançamentos ativos desta sessão serão removidos e o histórico ficará marcado como desfeito."
         confirmLabel="Desfazer importação"
         onConfirm={() => void handleConfirmUndo()}
         onCancel={() => setPendingUndoItem(null)}

--- a/apps/web/src/components/ImportHistoryModal.test.jsx
+++ b/apps/web/src/components/ImportHistoryModal.test.jsx
@@ -60,8 +60,8 @@ describe("ImportHistoryModal", () => {
     expect(screen.getByText("itau-90-dias.ofx")).toBeInTheDocument();
     expect(screen.getByText("Extrato bancário")).toBeInTheDocument();
     expect(screen.getByText("Já existentes: 1")).toBeInTheDocument();
-    expect(screen.getByText("Para revisar: 1")).toBeInTheDocument();
-    expect(screen.getByText("Sem ação disponível")).toBeInTheDocument();
+    expect(screen.getByText("Pedem revisão: 1")).toBeInTheDocument();
+    expect(screen.getByText("Desfazer indisponível")).toBeInTheDocument();
     expect(
       screen.getByText(
         "Esta importação já gerou uma conta vinculada. Revise ou remova esse item antes de desfazer.",

--- a/apps/web/src/components/IncomeStatementModal.tsx
+++ b/apps/web/src/components/IncomeStatementModal.tsx
@@ -103,7 +103,7 @@ const IncomeStatementModal = ({
 
       const net = parseCurrencyInput(netAmount);
       if (!Number.isFinite(net) || net <= 0) {
-        setErrorMessage("Valor liquido deve ser maior que zero.");
+        setErrorMessage("Valor líquido deve ser maior que zero.");
         return;
       }
 
@@ -157,139 +157,147 @@ const IncomeStatementModal = ({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex min-h-screen items-start justify-center bg-black/50 p-6 sm:items-center"
+      className="fixed inset-0 z-50 overflow-y-auto bg-black/50 p-4 sm:p-6"
       onClick={handleBackdropClick}
       role="presentation"
     >
-      <div className="w-full max-w-lg rounded-lg bg-cf-surface p-4 sm:p-6">
-        <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-cf-text-primary">
-            Gerar extrato — {sourceName}
-          </h2>
-          <button
-            type="button"
-            onClick={onClose}
-            className="text-cf-text-secondary transition-colors hover:text-cf-text-primary"
-            aria-label="Fechar modal"
-          >
-            X
-          </button>
-        </div>
-
-        <div className="space-y-4">
-          {/* Mes */}
-          <div className="flex flex-col gap-1.5">
-            <label htmlFor="stmt-month" className="text-sm font-medium text-cf-text-primary">
-              Mês de referência <span className="text-red-500">*</span>
-            </label>
-            <input
-              id="stmt-month"
-              type="month"
-              value={referenceMonth}
-              onChange={(e) => setReferenceMonth(e.target.value)}
-              className="rounded border border-cf-border-input px-3 py-2 text-sm text-cf-text-primary focus:outline-none focus:ring-1 focus:ring-brand-1 bg-cf-surface"
-              disabled={isSaving}
-            />
-          </div>
-
-          {/* Valor liquido */}
-          <div className="flex flex-col gap-1.5">
-            <label htmlFor="stmt-net" className="text-sm font-medium text-cf-text-primary">
-              Valor liquido creditado <span className="text-red-500">*</span>
-            </label>
-            <div className="flex items-center rounded border border-cf-border-input px-3 py-2">
-              <span className="mr-1 text-sm font-medium text-cf-text-secondary">R$</span>
-              <input
-                id="stmt-net"
-                type="text"
-                inputMode="decimal"
-                value={netAmount}
-                onChange={(e) => setNetAmount(e.target.value)}
-                placeholder="0,00"
-                className="flex-1 bg-transparent text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none"
-                disabled={isSaving}
-              />
-            </div>
-          </div>
-
-          {/* Data de credito */}
-          <div className="flex flex-col gap-1.5">
-            <label htmlFor="stmt-date" className="text-sm font-medium text-cf-text-primary">
-              Data de credito{" "}
-              <span className="text-xs font-normal text-cf-text-secondary">(opcional)</span>
-            </label>
-            <input
-              id="stmt-date"
-              type="date"
-              value={paymentDate}
-              onChange={(e) => setPaymentDate(e.target.value)}
-              className="rounded border border-cf-border-input px-3 py-2 text-sm text-cf-text-primary focus:outline-none focus:ring-1 focus:ring-brand-1 bg-cf-surface"
-              disabled={isSaving}
-            />
-          </div>
-
-          {/* Descontos */}
-          {activeDeductions.length > 0 ? (
+      <div className="flex min-h-full items-center justify-center">
+        <div className="flex w-full max-w-lg max-h-[min(92vh,900px)] flex-col overflow-hidden rounded-lg border border-cf-border bg-cf-surface shadow-xl">
+          <div className="flex items-start justify-between gap-4 border-b border-cf-border px-5 py-4">
             <div>
-              <p className="mb-1.5 text-sm font-medium text-cf-text-primary">Descontos</p>
-              <div className="divide-y divide-cf-border rounded border border-cf-border">
-                {activeDeductions.map((d) => (
-                  <div key={d.id} className="flex items-center justify-between px-3 py-2">
-                    <span className="text-sm text-cf-text-primary">{d.label}</span>
-                    {d.isVariable ? (
-                      <div className="flex items-center rounded border border-cf-border-input px-2 py-1 w-32">
-                        <span className="mr-1 text-xs text-cf-text-secondary">R$</span>
-                        <input
-                          type="text"
-                          inputMode="decimal"
-                          aria-label={`Valor de ${d.label}`}
-                          value={variableAmounts[String(d.id)] ?? ""}
-                          onChange={(e) =>
-                            setVariableAmounts((prev) => ({
-                              ...prev,
-                              [String(d.id)]: e.target.value,
-                            }))
-                          }
-                          placeholder="0,00"
-                          disabled={isSaving}
-                          className="flex-1 bg-transparent text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none"
-                        />
-                      </div>
-                    ) : (
-                      <span className="text-sm font-medium text-cf-text-secondary">
-                        {formatCurrency(d.amount)}
-                      </span>
-                    )}
-                  </div>
-                ))}
-              </div>
-
-              {/* Footer summary */}
-              <div className="mt-2 space-y-1 rounded border border-cf-border bg-cf-bg-subtle px-3 py-2 text-sm">
-                <div className="flex justify-between text-cf-text-secondary">
-                  <span>Total descontos</span>
-                  <span>{formatCurrency(totalDeductions)}</span>
-                </div>
-                {estimatedGross !== null ? (
-                  <div className="flex justify-between font-semibold text-cf-text-primary">
-                    <span>Bruto estimado</span>
-                    <span>{formatCurrency(estimatedGross)}</span>
-                  </div>
-                ) : null}
-              </div>
+              <h2 className="text-lg font-semibold text-cf-text-primary">
+                Gerar extrato — {sourceName}
+              </h2>
+              <p className="mt-1 text-sm text-cf-text-secondary">
+                Escolha o mês, confirme o valor líquido e revise os descontos antes de registrar.
+              </p>
             </div>
-          ) : null}
-
-          {errorMessage ? (
-            <div
-              className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
-              role="alert"
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-cf-text-secondary transition-colors hover:text-cf-text-primary"
+              aria-label="Fechar modal"
             >
-              {errorMessage}
-            </div>
-          ) : null}
+              X
+            </button>
+          </div>
 
-          <div className="flex justify-end gap-2 pt-1">
+          <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+            <div className="space-y-4">
+              {/* Mes */}
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor="stmt-month" className="text-sm font-medium text-cf-text-primary">
+                  Mês de referência <span className="text-red-500">*</span>
+                </label>
+                <input
+                  id="stmt-month"
+                  type="month"
+                  value={referenceMonth}
+                  onChange={(e) => setReferenceMonth(e.target.value)}
+                  className="rounded border border-cf-border-input px-3 py-2 text-sm text-cf-text-primary focus:outline-none focus:ring-1 focus:ring-brand-1 bg-cf-surface"
+                  disabled={isSaving}
+                />
+              </div>
+
+              {/* Valor liquido */}
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor="stmt-net" className="text-sm font-medium text-cf-text-primary">
+                  Valor líquido creditado <span className="text-red-500">*</span>
+                </label>
+                <div className="flex items-center rounded border border-cf-border-input px-3 py-2">
+                  <span className="mr-1 text-sm font-medium text-cf-text-secondary">R$</span>
+                  <input
+                    id="stmt-net"
+                    type="text"
+                    inputMode="decimal"
+                    value={netAmount}
+                    onChange={(e) => setNetAmount(e.target.value)}
+                    placeholder="0,00"
+                    className="flex-1 bg-transparent text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none"
+                    disabled={isSaving}
+                  />
+                </div>
+              </div>
+
+              {/* Data de credito */}
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor="stmt-date" className="text-sm font-medium text-cf-text-primary">
+                  Data do crédito{" "}
+                  <span className="text-xs font-normal text-cf-text-secondary">(opcional)</span>
+                </label>
+                <input
+                  id="stmt-date"
+                  type="date"
+                  value={paymentDate}
+                  onChange={(e) => setPaymentDate(e.target.value)}
+                  className="rounded border border-cf-border-input px-3 py-2 text-sm text-cf-text-primary focus:outline-none focus:ring-1 focus:ring-brand-1 bg-cf-surface"
+                  disabled={isSaving}
+                />
+              </div>
+
+              {/* Descontos */}
+              {activeDeductions.length > 0 ? (
+                <div>
+                  <p className="mb-1.5 text-sm font-medium text-cf-text-primary">Descontos</p>
+                  <div className="divide-y divide-cf-border rounded border border-cf-border">
+                    {activeDeductions.map((d) => (
+                      <div key={d.id} className="flex items-center justify-between px-3 py-2">
+                        <span className="text-sm text-cf-text-primary">{d.label}</span>
+                        {d.isVariable ? (
+                          <div className="flex w-32 items-center rounded border border-cf-border-input px-2 py-1">
+                            <span className="mr-1 text-xs text-cf-text-secondary">R$</span>
+                            <input
+                              type="text"
+                              inputMode="decimal"
+                              aria-label={`Valor de ${d.label}`}
+                              value={variableAmounts[String(d.id)] ?? ""}
+                              onChange={(e) =>
+                                setVariableAmounts((prev) => ({
+                                  ...prev,
+                                  [String(d.id)]: e.target.value,
+                                }))
+                              }
+                              placeholder="0,00"
+                              disabled={isSaving}
+                              className="flex-1 bg-transparent text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none"
+                            />
+                          </div>
+                        ) : (
+                          <span className="text-sm font-medium text-cf-text-secondary">
+                            {formatCurrency(d.amount)}
+                          </span>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+
+                  <div className="mt-2 space-y-1 rounded border border-cf-border bg-cf-bg-subtle px-3 py-2 text-sm">
+                    <div className="flex justify-between text-cf-text-secondary">
+                      <span>Total descontos</span>
+                      <span>{formatCurrency(totalDeductions)}</span>
+                    </div>
+                    {estimatedGross !== null ? (
+                      <div className="flex justify-between font-semibold text-cf-text-primary">
+                        <span>Bruto estimado</span>
+                        <span>{formatCurrency(estimatedGross)}</span>
+                      </div>
+                    ) : null}
+                  </div>
+                </div>
+              ) : null}
+
+              {errorMessage ? (
+                <div
+                  className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+                  role="alert"
+                >
+                  {errorMessage}
+                </div>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="flex flex-wrap justify-end gap-2 border-t border-cf-border px-5 py-4">
             <button
               type="button"
               onClick={onClose}
@@ -312,7 +320,7 @@ const IncomeStatementModal = ({
               disabled={isSaving}
               className="rounded bg-brand-1 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-2 disabled:cursor-not-allowed disabled:opacity-60"
             >
-              {isSaving ? "Lancando..." : "Lancar entrada"}
+              {isSaving ? "Lançando..." : "Lançar entrada"}
             </button>
           </div>
         </div>

--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -1921,7 +1921,7 @@ describe("App", () => {
 
     await user.click(screen.getByRole("button", { name: "Histórico de importações" }));
 
-    expect(await screen.findByText("Nenhuma importação para mostrar.")).toBeInTheDocument();
+    expect(await screen.findByText("Nenhuma importação encontrada por enquanto.")).toBeInTheDocument();
   });
 
   it("exibe erro ao carregar historico de imports", async () => {
@@ -1996,7 +1996,7 @@ describe("App", () => {
     render(<App />);
 
     await user.click(screen.getByRole("button", { name: "Histórico de importações" }));
-    expect(await screen.findByText("Mostrando 1 a 20")).toBeInTheDocument();
+    expect(await screen.findByText("Mostrando 1 a 20 desta página")).toBeInTheDocument();
     const historyDialog = screen.getByRole("dialog", { name: "Histórico de importações" });
 
     await user.click(within(historyDialog).getByRole("button", { name: "Próxima" }));
@@ -2007,7 +2007,7 @@ describe("App", () => {
         offset: 20,
       });
     });
-    expect(await screen.findByText("Mostrando 21 a 21")).toBeInTheDocument();
+    expect(await screen.findByText("Mostrando 21 a 21 desta página")).toBeInTheDocument();
   });
 
   it("abre menu de acoes no mobile e fecha ao clicar fora sem disparar logout", async () => {

--- a/apps/web/src/pages/IncomeSourcesPage.test.tsx
+++ b/apps/web/src/pages/IncomeSourcesPage.test.tsx
@@ -221,10 +221,10 @@ describe("IncomeSourcesPage", () => {
 
     expect(screen.getByRole("heading", { name: /Gerar extrato/ })).toBeInTheDocument();
     expect(screen.getByLabelText(/Mês de referência/)).toBeInTheDocument();
-    expect(screen.getByLabelText(/Valor liquido/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Valor líquido/)).toBeInTheDocument();
   });
 
-  it("Lancar entrada chama createStatement e postStatement e exibe mensagem de sucesso", async () => {
+  it("Lançar entrada chama createStatement e postStatement e exibe mensagem de sucesso", async () => {
     const user = userEvent.setup();
     vi.mocked(incomeSourcesService.createStatement).mockResolvedValue(buildStatementResult());
     vi.mocked(incomeSourcesService.postStatement).mockResolvedValue(buildPostResult());
@@ -235,9 +235,9 @@ describe("IncomeSourcesPage", () => {
 
     await user.click(screen.getByRole("button", { name: "Gerar extrato" }));
 
-    await user.type(screen.getByLabelText(/Valor liquido/), "2803,52");
+    await user.type(screen.getByLabelText(/Valor líquido/), "2803,52");
 
-    await user.click(screen.getByRole("button", { name: "Lancar entrada" }));
+    await user.click(screen.getByRole("button", { name: "Lançar entrada" }));
 
     await waitFor(() => {
       expect(incomeSourcesService.createStatement).toHaveBeenCalledWith(
@@ -305,7 +305,7 @@ describe("IncomeSourcesPage", () => {
 
     await user.click(screen.getByRole("button", { name: "Gerar extrato" }));
 
-    await user.type(screen.getByLabelText(/Valor liquido/), "2803,52");
+    await user.type(screen.getByLabelText(/Valor líquido/), "2803,52");
 
     await user.click(screen.getByRole("button", { name: "Salvar rascunho" }));
 
@@ -332,8 +332,8 @@ describe("IncomeSourcesPage", () => {
     await waitFor(() => expect(screen.getByText("Pensao INSS")).toBeInTheDocument());
 
     await user.click(screen.getByRole("button", { name: "Gerar extrato" }));
-    await user.type(screen.getByLabelText(/Valor liquido/), "2803,52");
-    await user.click(screen.getByRole("button", { name: "Lancar entrada" }));
+    await user.type(screen.getByLabelText(/Valor líquido/), "2803,52");
+    await user.click(screen.getByRole("button", { name: "Lançar entrada" }));
 
     await waitFor(() => {
       expect(screen.getByRole("alert")).toBeInTheDocument();


### PR DESCRIPTION
## Resumo\n- normaliza o shell responsivo do histórico de importações\n- aplica o mesmo padrão ao modal de gerar extrato de renda\n- humaniza estados vazios, paginação e textos auxiliares desses fluxos\n- ajusta os testes para a nova copy\n\n## Validação\n- npm -w apps/web run test:run -- src/components/ImportHistoryModal.test.jsx src/pages/IncomeSourcesPage.test.tsx\n- npm -w apps/web run lint\n- npm -w apps/web run typecheck\n- npm -w apps/web run test:run\n- npm -w apps/web run build