### PR TITLE
fix(ui): normalize document review modal shells

### DIFF
--- a/apps/web/src/components/ImportCsvModal.test.jsx
+++ b/apps/web/src/components/ImportCsvModal.test.jsx
@@ -960,10 +960,10 @@ describe("ImportCsvModal", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByRole("button", { name: "Registrar e lancar entrada" })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Registrar e lançar entrada" })).toBeInTheDocument();
       });
 
-      await userEvent.click(screen.getByRole("button", { name: "Registrar e lancar entrada" }));
+      await userEvent.click(screen.getByRole("button", { name: "Registrar e lançar entrada" }));
 
       await waitFor(() => {
         expect(incomeSourcesService.createStatement).toHaveBeenCalledWith(1, {
@@ -1035,11 +1035,11 @@ describe("ImportCsvModal", () => {
 
       await waitFor(() => {
         expect(
-          screen.getByRole("button", { name: "Registrar e lancar entrada" }),
+          screen.getByRole("button", { name: "Registrar e lançar entrada" }),
         ).toBeInTheDocument();
       });
 
-      await userEvent.click(screen.getByRole("button", { name: "Registrar e lancar entrada" }));
+      await userEvent.click(screen.getByRole("button", { name: "Registrar e lançar entrada" }));
 
       await waitFor(() => {
         expect(
@@ -1142,11 +1142,11 @@ describe("ImportCsvModal", () => {
 
       await waitFor(() => {
         expect(
-          screen.getByRole("button", { name: "Registrar e lancar entrada" }),
+          screen.getByRole("button", { name: "Registrar e lançar entrada" }),
         ).toBeInTheDocument();
       });
 
-      await userEvent.click(screen.getByRole("button", { name: "Registrar e lancar entrada" }));
+      await userEvent.click(screen.getByRole("button", { name: "Registrar e lançar entrada" }));
 
       await waitFor(() => {
         expect(

--- a/apps/web/src/components/IncomeStatementQuickModal.test.tsx
+++ b/apps/web/src/components/IncomeStatementQuickModal.test.tsx
@@ -142,19 +142,19 @@ describe("IncomeStatementQuickModal", () => {
         prefill={{
           referenceMonth: "2026-02",
           netAmount: 1412,
-        deductions: [{ code: "268", label: "CONSIGNACAO - CARTAO", amount: 247.93 }],
-      }}
-      onCreated={onCreated}
+          deductions: [{ code: "268", label: "CONSIGNACAO - CARTAO", amount: 247.93 }],
+        }}
+        onCreated={onCreated}
       />,
     );
     await waitFor(() => {
       expect(screen.getByRole("combobox", { name: /Fonte de renda/i })).toHaveValue("1");
     });
     await userEvent.click(
-      screen.getByRole("button", { name: "Registrar somente no historico" }),
+      screen.getByRole("button", { name: "Registrar somente no histórico" }),
     );
     await waitFor(() => {
-      expect(screen.getByText("Lancamento registrado com sucesso.")).toBeInTheDocument();
+      expect(screen.getByText("Lançamento registrado com sucesso.")).toBeInTheDocument();
     });
     expect(onCreated).toHaveBeenCalledWith(mockStatement);
     expect(incomeSourcesService.createStatement).toHaveBeenCalledWith(1, {
@@ -189,7 +189,7 @@ describe("IncomeStatementQuickModal", () => {
       expect(screen.getByText(/competência já existente/i)).toBeInTheDocument();
     });
 
-    await userEvent.click(screen.getByRole("button", { name: "Registrar somente no historico" }));
+    await userEvent.click(screen.getByRole("button", { name: "Registrar somente no histórico" }));
 
     expect(
       screen.getByText(/Escolha se deseja ignorar ou substituir a competência existente/i),
@@ -248,7 +248,7 @@ describe("IncomeStatementQuickModal", () => {
     });
 
     await userEvent.click(screen.getByRole("button", { name: "Substituir" }));
-    await userEvent.click(screen.getByRole("button", { name: "Registrar somente no historico" }));
+    await userEvent.click(screen.getByRole("button", { name: "Registrar somente no histórico" }));
 
     await waitFor(() => {
       expect(incomeSourcesService.createStatement).toHaveBeenCalledWith(1, expect.objectContaining({
@@ -271,7 +271,7 @@ describe("IncomeStatementQuickModal", () => {
       expect(screen.getByRole("combobox", { name: /Fonte de renda/i })).toHaveValue("1");
     });
     await userEvent.click(
-      screen.getByRole("button", { name: "Registrar somente no historico" }),
+      screen.getByRole("button", { name: "Registrar somente no histórico" }),
     );
     await waitFor(() => {
       expect(screen.getByText("Falha de rede")).toBeInTheDocument();
@@ -294,7 +294,7 @@ describe("IncomeStatementQuickModal", () => {
       screen.getByRole("button", { name: "Registrar e vincular entrada" }),
     );
     await waitFor(() => {
-      expect(screen.getByText(/vinculo com a transacao importada confirmado/i)).toBeInTheDocument();
+      expect(screen.getByText(/vínculo com a transação importada confirmado/i)).toBeInTheDocument();
     });
     expect(incomeSourcesService.linkTransaction).toHaveBeenCalledWith(10, 99);
     expect(incomeSourcesService.postStatement).not.toHaveBeenCalled();
@@ -316,9 +316,9 @@ describe("IncomeStatementQuickModal", () => {
       expect(screen.getByRole("combobox", { name: /Fonte de renda/i })).toHaveValue("1");
     });
 
-    expect(screen.getByLabelText(/Este documento compoe minha renda/i)).toBeChecked();
+    expect(screen.getByLabelText(/Este documento compõe minha renda/i)).toBeChecked();
 
-    await userEvent.click(screen.getByRole("button", { name: "Registrar e lancar entrada" }));
+    await userEvent.click(screen.getByRole("button", { name: "Registrar e lançar entrada" }));
 
     await waitFor(() => {
       expect(screen.getByText(/entrada gerada/i)).toBeInTheDocument();
@@ -363,7 +363,7 @@ describe("IncomeStatementQuickModal", () => {
     });
 
     await userEvent.click(screen.getByRole("button", { name: "Substituir" }));
-    await userEvent.click(screen.getByRole("button", { name: "Registrar e lancar entrada" }));
+    await userEvent.click(screen.getByRole("button", { name: "Registrar e lançar entrada" }));
 
     await waitFor(() => {
       expect(screen.getByText(/competência existente foi substituída/i)).toBeInTheDocument();
@@ -392,11 +392,11 @@ describe("IncomeStatementQuickModal", () => {
     );
     await waitFor(() => {
       expect(
-        screen.getByText(/historico registrado, mas o vinculo com a transacao/i),
+        screen.getByText(/histórico registrado, mas o vínculo com a transação/i),
       ).toBeInTheDocument();
     });
     expect(screen.getByText(/vincular manualmente/i)).toBeInTheDocument();
-    expect(screen.getByText("Lancamento registrado com sucesso.")).toBeInTheDocument();
+    expect(screen.getByText("Lançamento registrado com sucesso.")).toBeInTheDocument();
   });
 
   it("shows validation error when source not selected", async () => {
@@ -410,7 +410,7 @@ describe("IncomeStatementQuickModal", () => {
     });
     await userEvent.selectOptions(screen.getByRole("combobox"), "");
     await userEvent.click(
-      screen.getByRole("button", { name: "Registrar somente no historico" }),
+      screen.getByRole("button", { name: "Registrar somente no histórico" }),
     );
     expect(screen.getByText(/selecione uma fonte/i)).toBeInTheDocument();
   });

--- a/apps/web/src/components/IncomeStatementQuickModal.tsx
+++ b/apps/web/src/components/IncomeStatementQuickModal.tsx
@@ -231,7 +231,7 @@ export default function IncomeStatementQuickModal({
             } catch (linkErr) {
               setFinalizationStatus("failed");
               setFinalizationError(
-                getApiErrorMessage(linkErr, "Nao foi possivel vincular a transacao importada."),
+                getApiErrorMessage(linkErr, "Não foi possível vincular a transação importada."),
               );
               shouldNotifyCreated = false;
             }
@@ -251,7 +251,7 @@ export default function IncomeStatementQuickModal({
             } catch (postErr) {
               setFinalizationStatus("failed");
               setFinalizationError(
-                getApiErrorMessage(postErr, "Nao foi possivel lancar a entrada automaticamente."),
+                getApiErrorMessage(postErr, "Não foi possível lançar a entrada automaticamente."),
               );
               shouldNotifyCreated = false;
             }
@@ -264,7 +264,7 @@ export default function IncomeStatementQuickModal({
         onCreated?.(finalStatement);
       }
     } catch (err) {
-      setErrorMessage(getApiErrorMessage(err, "Nao foi possivel registrar o lancamento."));
+      setErrorMessage(getApiErrorMessage(err, "Não foi possível registrar o lançamento."));
     } finally {
       setIsSubmitting(false);
     }
@@ -276,128 +276,143 @@ export default function IncomeStatementQuickModal({
 
   return (
     <div
-      className="fixed inset-0 z-[60] flex min-h-screen items-start justify-center overflow-y-auto bg-black/50 p-2 sm:p-6 sm:items-center"
+      className="fixed inset-0 z-[60] overflow-y-auto bg-black/50 p-2 sm:p-6"
       role="presentation"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div
-        className="flex max-h-[calc(100dvh-1rem)] w-full max-w-md flex-col overflow-hidden rounded-lg bg-cf-surface shadow-xl sm:max-h-[calc(100dvh-3rem)]"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="income-quick-modal-title"
-        data-testid="income-quick-modal-shell"
-      >
-        <div className="border-b border-cf-border px-4 py-4 sm:px-6">
-          <div className="flex items-center justify-between">
-            <h2
-              id="income-quick-modal-title"
-              className="text-base font-semibold text-cf-text-primary"
-            >
-              Registrar no histórico de renda
-            </h2>
-            <button
-              type="button"
-              onClick={onClose}
-              className="text-cf-text-secondary hover:text-cf-text-primary"
-              aria-label="Fechar"
-            >
-              ✕
-            </button>
-          </div>
-        </div>
-
+      <div className="flex min-h-full items-center justify-center">
         <div
-          className="min-h-0 overflow-y-auto px-4 py-4 sm:px-6"
-          data-testid="income-quick-modal-body"
+          className="flex max-h-[min(92vh,960px)] w-full max-w-md flex-col overflow-hidden rounded-lg border border-cf-border bg-cf-surface shadow-xl"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="income-quick-modal-title"
+          data-testid="income-quick-modal-shell"
         >
+          <div className="border-b border-cf-border px-4 py-4 sm:px-6">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h2
+                  id="income-quick-modal-title"
+                  className="text-base font-semibold text-cf-text-primary"
+                >
+                  Registrar no histórico de renda
+                </h2>
+                <p className="mt-1 text-sm text-cf-text-secondary">
+                  Revise a competência, o valor líquido e o destino desta renda antes de salvar.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={onClose}
+                className="text-cf-text-secondary hover:text-cf-text-primary"
+                aria-label="Fechar"
+              >
+                ✕
+              </button>
+            </div>
+          </div>
+ 
           {success ? (
-            <div className="space-y-2">
-            <div className="rounded border border-green-200 bg-green-50 px-3 py-3 dark:border-green-800 dark:bg-green-950/40">
-              <p className="text-sm font-semibold text-green-700 dark:text-green-400">
-                {finalizationStatus === "posted"
-                  ? "Renda registrada e entrada lancada com sucesso."
-                  : "Lancamento registrado com sucesso."}
-              </p>
-
-              {statementOutcome === "replaced" ? (
-                <p className="mt-1 text-xs font-medium text-green-700 dark:text-green-400">
-                  A competência existente foi substituída com segurança.
-                </p>
-              ) : null}
-
-              {finalizationStatus === "linking" && (
-                <p className="mt-1 text-xs text-green-600 dark:text-green-400">
-                  Vinculando a transacao importada...
-                </p>
-              )}
-              {finalizationStatus === "linked" && (
-                <p className="mt-1 text-xs font-medium text-green-700 dark:text-green-400">
-                  Vinculo com a transacao importada confirmado.
-                </p>
-              )}
-              {finalizationStatus === "posting" && (
-                <p className="mt-1 text-xs text-green-600 dark:text-green-400">
-                  Lancando a entrada do mes...
-                </p>
-              )}
-              {finalizationStatus === "posted" && postedTransaction && (
-                <p className="mt-1 text-xs font-medium text-green-700 dark:text-green-400">
-                  Entrada gerada: R$ {postedTransaction.value.toFixed(2).replace(".", ",")}
-                </p>
-              )}
-            </div>
-
-            {finalizationStatus === "failed" && finalizationMode === "link" && (
-              <div className="rounded border border-amber-200 bg-amber-50 px-3 py-2 dark:border-amber-800 dark:bg-amber-950/40">
-                <p className="text-xs font-medium text-amber-700 dark:text-amber-400">
-                  Historico registrado, mas o vinculo com a transacao importada nao foi concluido.
-                </p>
-                {finalizationError && (
-                  <p className="mt-0.5 text-xs text-amber-600 dark:text-amber-400">{finalizationError}</p>
-                )}
-                <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
-                  Voce pode vincular manualmente pelo historico de renda.
-                </p>
-              </div>
-            )}
-
-            {finalizationStatus === "failed" && finalizationMode === "post" && (
-              <div className="rounded border border-amber-200 bg-amber-50 px-3 py-2 dark:border-amber-800 dark:bg-amber-950/40">
-                <p className="text-xs font-medium text-amber-700 dark:text-amber-400">
-                  Historico registrado, mas a entrada ainda nao foi lancada na renda mensal.
-                </p>
-                {finalizationError && (
-                  <p className="mt-0.5 text-xs text-amber-600 dark:text-amber-400">{finalizationError}</p>
-                )}
-                <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
-                  Voce pode revisar o extrato e lancar a entrada depois pela area de fontes de renda.
-                </p>
-              </div>
-            )}
-
-            <button
-              type="button"
-              onClick={onClose}
-              disabled={finalizationStatus === "linking" || finalizationStatus === "posting"}
-              className="rounded border border-green-400 bg-green-100 px-3 py-1.5 text-sm font-semibold text-green-700 hover:bg-green-200 disabled:cursor-not-allowed disabled:opacity-60 dark:border-green-700 dark:bg-green-900/40 dark:text-green-300"
-            >
-              Fechar
-            </button>
-            </div>
-          ) : (
             <>
-            {isLoadingSources ? (
-              <p className="mb-3 text-sm text-cf-text-secondary">Carregando fontes de renda...</p>
-            ) : sources.length === 0 ? (
-              <div className="mb-3 rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-400">
-                Nenhuma fonte de renda cadastrada. Cadastre uma fonte antes de registrar um
-                lançamento.
-              </div>
-            ) : null}
+              <div
+                className="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6"
+                data-testid="income-quick-modal-body"
+              >
+                <div className="space-y-2">
+                  <div className="rounded border border-green-200 bg-green-50 px-3 py-3 dark:border-green-800 dark:bg-green-950/40">
+                    <p className="text-sm font-semibold text-green-700 dark:text-green-400">
+                      {finalizationStatus === "posted"
+                        ? "Renda registrada e entrada lançada com sucesso."
+                        : "Lançamento registrado com sucesso."}
+                    </p>
 
-            <form onSubmit={handleSubmit} className="space-y-3">
+                    {statementOutcome === "replaced" ? (
+                      <p className="mt-1 text-xs font-medium text-green-700 dark:text-green-400">
+                        A competência existente foi substituída com segurança.
+                      </p>
+                    ) : null}
+
+                    {finalizationStatus === "linking" && (
+                      <p className="mt-1 text-xs text-green-600 dark:text-green-400">
+                        Vinculando a transação importada...
+                      </p>
+                    )}
+                    {finalizationStatus === "linked" && (
+                      <p className="mt-1 text-xs font-medium text-green-700 dark:text-green-400">
+                        Vínculo com a transação importada confirmado.
+                      </p>
+                    )}
+                    {finalizationStatus === "posting" && (
+                      <p className="mt-1 text-xs text-green-600 dark:text-green-400">
+                        Lançando a entrada do mês...
+                      </p>
+                    )}
+                    {finalizationStatus === "posted" && postedTransaction && (
+                      <p className="mt-1 text-xs font-medium text-green-700 dark:text-green-400">
+                        Entrada gerada: R$ {postedTransaction.value.toFixed(2).replace(".", ",")}
+                      </p>
+                    )}
+                  </div>
+
+                  {finalizationStatus === "failed" && finalizationMode === "link" && (
+                    <div className="rounded border border-amber-200 bg-amber-50 px-3 py-2 dark:border-amber-800 dark:bg-amber-950/40">
+                      <p className="text-xs font-medium text-amber-700 dark:text-amber-400">
+                        Histórico registrado, mas o vínculo com a transação importada não foi concluído.
+                      </p>
+                      {finalizationError && (
+                        <p className="mt-0.5 text-xs text-amber-600 dark:text-amber-400">{finalizationError}</p>
+                      )}
+                      <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
+                        Você pode vincular manualmente pelo histórico de renda.
+                      </p>
+                    </div>
+                  )}
+
+                  {finalizationStatus === "failed" && finalizationMode === "post" && (
+                    <div className="rounded border border-amber-200 bg-amber-50 px-3 py-2 dark:border-amber-800 dark:bg-amber-950/40">
+                      <p className="text-xs font-medium text-amber-700 dark:text-amber-400">
+                        Histórico registrado, mas a entrada ainda não foi lançada na renda mensal.
+                      </p>
+                      {finalizationError && (
+                        <p className="mt-0.5 text-xs text-amber-600 dark:text-amber-400">{finalizationError}</p>
+                      )}
+                      <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
+                        Você pode revisar o extrato e lançar a entrada depois pela área de fontes de renda.
+                      </p>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              <div className="flex justify-end border-t border-cf-border px-4 py-4 sm:px-6">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  disabled={finalizationStatus === "linking" || finalizationStatus === "posting"}
+                  className="rounded border border-green-400 bg-green-100 px-3 py-1.5 text-sm font-semibold text-green-700 hover:bg-green-200 disabled:cursor-not-allowed disabled:opacity-60 dark:border-green-700 dark:bg-green-900/40 dark:text-green-300"
+                >
+                  Fechar
+                </button>
+              </div>
+            </>
+          ) : (
+            <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
+              <div
+                className="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6"
+                data-testid="income-quick-modal-body"
+              >
+                <div className="space-y-3">
+                  {isLoadingSources ? (
+                    <p className="text-sm text-cf-text-secondary">Carregando fontes de renda...</p>
+                  ) : sources.length === 0 ? (
+                    <div className="rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-400">
+                      Nenhuma fonte de renda cadastrada. Cadastre uma fonte antes de registrar um
+                      lançamento.
+                    </div>
+                  ) : null}
+
               <div>
                 <label
                   htmlFor="income-quick-source"
@@ -577,14 +592,14 @@ export default function IncomeStatementQuickModal({
                     onChange={(e) => setComposeIncome(e.target.checked)}
                     className="mt-0.5 h-4 w-4 rounded border-cf-border accent-brand-1"
                   />
-                  <span>Este documento compoe minha renda</span>
+                  <span>Este documento compõe minha renda</span>
                 </label>
                 <p className="mt-1 text-xs text-cf-text-secondary">
                   {composeIncome
                     ? transactionId
-                      ? "Ao registrar, o historico sera vinculado a entrada importada deste extrato."
-                      : "Ao registrar, o historico sera lancado como entrada do mes."
-                    : "Ao registrar, o documento fica so no historico e nao entra na renda mensal ainda."}
+                      ? "Ao registrar, o histórico será vinculado à entrada importada deste extrato."
+                      : "Ao registrar, o histórico será lançado como entrada do mês."
+                    : "Ao registrar, o documento fica só no histórico e não entra na renda mensal ainda."}
                 </p>
               </div>
 
@@ -593,8 +608,10 @@ export default function IncomeStatementQuickModal({
                   {errorMessage}
                 </p>
               ) : null}
+                </div>
+              </div>
 
-              <div className="flex gap-2 pt-1">
+              <div className="flex flex-wrap justify-end gap-2 border-t border-cf-border px-4 py-4 sm:px-6">
                 <button
                   type="submit"
                   disabled={isSubmitting || sources.length === 0 || isCheckingExistingStatement}
@@ -607,8 +624,8 @@ export default function IncomeStatementQuickModal({
                     : composeIncome
                       ? transactionId
                         ? "Registrar e vincular entrada"
-                        : "Registrar e lancar entrada"
-                      : "Registrar somente no historico"}
+                        : "Registrar e lançar entrada"
+                      : "Registrar somente no histórico"}
                 </button>
                 <button
                   type="button"
@@ -619,7 +636,6 @@ export default function IncomeStatementQuickModal({
                 </button>
               </div>
             </form>
-            </>
           )}
         </div>
       </div>

--- a/apps/web/src/components/TaxUploadModal.test.tsx
+++ b/apps/web/src/components/TaxUploadModal.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import TaxUploadModal from "./TaxUploadModal";
+
+describe("TaxUploadModal", () => {
+  it("does not render when closed", () => {
+    render(
+      <TaxUploadModal
+        isOpen={false}
+        taxYear={2026}
+        stage="idle"
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("keeps the tax upload modal shell scrollable inside the viewport", () => {
+    render(
+      <TaxUploadModal
+        isOpen
+        taxYear={2026}
+        stage="idle"
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("dialog", { name: "Enviar documento fiscal" })).toBeInTheDocument();
+    expect(screen.getByTestId("tax-upload-modal-shell")).toHaveClass("flex", "flex-col", "overflow-hidden");
+    expect(screen.getByTestId("tax-upload-modal-body")).toHaveClass("min-h-0", "overflow-y-auto");
+  });
+
+  it("shows human processing guidance while the document is being reviewed", () => {
+    render(
+      <TaxUploadModal
+        isOpen
+        taxYear={2026}
+        stage="processing"
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Lendo o arquivo e preparando a revisão fiscal...",
+    );
+  });
+});

--- a/apps/web/src/components/TaxUploadModal.tsx
+++ b/apps/web/src/components/TaxUploadModal.tsx
@@ -84,6 +84,25 @@ const TaxUploadModal = ({
     () => "Envie um PDF, CSV ou imagem do documento fiscal. O limite atual é de 10 MB.",
     [],
   );
+  const displayStatusMessage = useMemo(() => {
+    if (statusMessage.trim()) {
+      return statusMessage;
+    }
+
+    if (stage === "uploading") {
+      return "Enviando documento fiscal...";
+    }
+
+    if (stage === "processing") {
+      return "Lendo o arquivo e preparando a revisão fiscal...";
+    }
+
+    if (stage === "success") {
+      return "Documento enviado e processado.";
+    }
+
+    return "";
+  }, [stage, statusMessage]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -130,151 +149,167 @@ const TaxUploadModal = ({
 
   return (
     <div
-      className="fixed inset-0 z-40 flex items-center justify-center bg-black/50 p-4 sm:p-6"
+      className="fixed inset-0 z-40 overflow-y-auto bg-black/50 p-4 sm:p-6"
       onClick={handleBackdropClick}
       role="presentation"
     >
-      <div className="w-full max-w-lg rounded-lg border border-cf-border bg-cf-surface p-5 shadow-xl">
-        <div className="mb-4 flex items-start justify-between gap-4">
-          <div>
-            <h2 className="text-lg font-semibold text-cf-text-primary">Enviar documento fiscal</h2>
-            <p className="mt-1 text-sm text-cf-text-secondary">
-              Exercício {taxYear}. O documento entra na revisão fiscal sem você sair desta tela.
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            disabled={isBusy}
-            className="text-sm font-semibold text-cf-text-secondary hover:text-cf-text-primary disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            Fechar
-          </button>
-        </div>
-
-        {isSuccess ? (
-          <div className="space-y-4">
-            <div
-              className="rounded border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700"
-              role="status"
-              aria-live="polite"
-            >
-              {statusMessage || "Documento enviado e processado."}
+      <div className="flex min-h-full items-center justify-center">
+        <div
+          className="flex w-full max-w-lg max-h-[min(92vh,900px)] flex-col overflow-hidden rounded-lg border border-cf-border bg-cf-surface shadow-xl"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="tax-upload-modal-title"
+          data-testid="tax-upload-modal-shell"
+        >
+          <div className="flex items-start justify-between gap-4 border-b border-cf-border px-5 py-4">
+            <div>
+              <h2 id="tax-upload-modal-title" className="text-lg font-semibold text-cf-text-primary">
+                Enviar documento fiscal
+              </h2>
+              <p className="mt-1 text-sm text-cf-text-secondary">
+                Exercício {taxYear}. O arquivo entra na revisão fiscal sem você sair desta tela.
+              </p>
             </div>
             <button
               type="button"
               onClick={onClose}
-              className="rounded border border-brand-1 bg-brand-1 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-2"
+              disabled={isBusy}
+              className="text-sm font-semibold text-cf-text-secondary hover:text-cf-text-primary disabled:cursor-not-allowed disabled:opacity-60"
             >
               Fechar
             </button>
           </div>
-        ) : (
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-3">
-              <p className="text-sm text-cf-text-primary">{helperText}</p>
-            </div>
 
-            <div className="flex flex-col gap-2">
-              <label htmlFor="tax-document-file" className="text-sm font-medium text-cf-text-primary">
-                Arquivo fiscal
-              </label>
-              <input
-                id="tax-document-file"
-                type="file"
-                accept={ACCEPT_ATTRIBUTE}
-                disabled={isBusy}
-                onChange={(event) => {
-                  const nextFile = event.target.files?.[0] ?? null;
-                  setSelectedFile(nextFile);
-                  setLocalError(validateSelectedFile(nextFile));
-                }}
-                className="rounded border border-cf-border-input bg-cf-surface px-3 py-2 text-sm text-cf-text-primary file:mr-3 file:rounded file:border-0 file:bg-cf-bg-subtle file:px-3 file:py-2 file:text-sm file:font-semibold file:text-cf-text-primary"
-              />
-              {selectedFile ? (
-                <p className="text-xs text-cf-text-secondary">
-                  {selectedFile.name} ({(selectedFile.size / (1024 * 1024)).toFixed(2)} MB)
-                </p>
-              ) : null}
-            </div>
-
-            <div className="flex flex-col gap-2">
-              <label htmlFor="tax-document-source-label" className="text-sm font-medium text-cf-text-primary">
-                Fonte ou instituição
-              </label>
-              <input
-                id="tax-document-source-label"
-                type="text"
-                value={sourceLabel}
-                disabled={isBusy}
-                maxLength={120}
-                onChange={(event) => setSourceLabel(event.target.value)}
-                placeholder="Ex.: Banco Inter, ACME LTDA, INSS"
-                className="rounded border border-cf-border-input bg-cf-surface px-3 py-2 text-sm text-cf-text-primary outline-none focus:border-brand-1"
-              />
-            </div>
-
-            <div className="flex flex-col gap-2">
-              <label htmlFor="tax-document-source-hint" className="text-sm font-medium text-cf-text-primary">
-                Observação
-              </label>
-              <input
-                id="tax-document-source-hint"
-                type="text"
-                value={sourceHint}
-                disabled={isBusy}
-                maxLength={200}
-                onChange={(event) => setSourceHint(event.target.value)}
-                placeholder="Ex.: Informe 2025, plano de saúde, recibo"
-                className="rounded border border-cf-border-input bg-cf-surface px-3 py-2 text-sm text-cf-text-primary outline-none focus:border-brand-1"
-              />
-            </div>
-
-            {stage === "uploading" || stage === "processing" ? (
-              <div
-                className="rounded border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-700"
-                role="status"
-                aria-live="polite"
-              >
-                {statusMessage}
+          {isSuccess ? (
+            <>
+              <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4" data-testid="tax-upload-modal-body">
+                <div
+                  className="rounded border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700"
+                  role="status"
+                  aria-live="polite"
+                >
+                  {displayStatusMessage}
+                </div>
               </div>
-            ) : null}
-
-            {!localError && errorMessage ? (
-              <div className="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
-                {errorMessage}
+              <div className="flex justify-end border-t border-cf-border px-5 py-4">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="rounded border border-brand-1 bg-brand-1 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-2"
+                >
+                  Fechar
+                </button>
               </div>
-            ) : null}
+            </>
+          ) : (
+            <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
+              <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-5 py-4" data-testid="tax-upload-modal-body">
+                <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-3">
+                  <p className="text-sm text-cf-text-primary">{helperText}</p>
+                </div>
 
-            {localError ? (
-              <div className="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
-                {localError}
+                <div className="flex flex-col gap-2">
+                  <label htmlFor="tax-document-file" className="text-sm font-medium text-cf-text-primary">
+                    Arquivo fiscal
+                  </label>
+                  <input
+                    id="tax-document-file"
+                    type="file"
+                    accept={ACCEPT_ATTRIBUTE}
+                    disabled={isBusy}
+                    onChange={(event) => {
+                      const nextFile = event.target.files?.[0] ?? null;
+                      setSelectedFile(nextFile);
+                      setLocalError(validateSelectedFile(nextFile));
+                    }}
+                    className="rounded border border-cf-border-input bg-cf-surface px-3 py-2 text-sm text-cf-text-primary file:mr-3 file:rounded file:border-0 file:bg-cf-bg-subtle file:px-3 file:py-2 file:text-sm file:font-semibold file:text-cf-text-primary"
+                  />
+                  {selectedFile ? (
+                    <p className="text-xs text-cf-text-secondary">
+                      {selectedFile.name} ({(selectedFile.size / (1024 * 1024)).toFixed(2)} MB)
+                    </p>
+                  ) : null}
+                </div>
+
+                <div className="flex flex-col gap-2">
+                  <label htmlFor="tax-document-source-label" className="text-sm font-medium text-cf-text-primary">
+                    Fonte ou instituição
+                  </label>
+                  <input
+                    id="tax-document-source-label"
+                    type="text"
+                    value={sourceLabel}
+                    disabled={isBusy}
+                    maxLength={120}
+                    onChange={(event) => setSourceLabel(event.target.value)}
+                    placeholder="Ex.: Banco Inter, ACME LTDA, INSS"
+                    className="rounded border border-cf-border-input bg-cf-surface px-3 py-2 text-sm text-cf-text-primary outline-none focus:border-brand-1"
+                  />
+                </div>
+
+                <div className="flex flex-col gap-2">
+                  <label htmlFor="tax-document-source-hint" className="text-sm font-medium text-cf-text-primary">
+                    Observação
+                  </label>
+                  <input
+                    id="tax-document-source-hint"
+                    type="text"
+                    value={sourceHint}
+                    disabled={isBusy}
+                    maxLength={200}
+                    onChange={(event) => setSourceHint(event.target.value)}
+                    placeholder="Ex.: Informe 2025, plano de saúde, recibo"
+                    className="rounded border border-cf-border-input bg-cf-surface px-3 py-2 text-sm text-cf-text-primary outline-none focus:border-brand-1"
+                  />
+                </div>
+
+                {stage === "uploading" || stage === "processing" ? (
+                  <div
+                    className="rounded border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-700"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    {displayStatusMessage}
+                  </div>
+                ) : null}
+
+                {!localError && errorMessage ? (
+                  <div className="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
+                    {errorMessage}
+                  </div>
+                ) : null}
+
+                {localError ? (
+                  <div className="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
+                    {localError}
+                  </div>
+                ) : null}
               </div>
-            ) : null}
 
-            <div className="flex items-center justify-end gap-3">
-              <button
-                type="button"
-                onClick={onClose}
-                disabled={isBusy}
-                className="rounded border border-cf-border bg-cf-bg-subtle px-4 py-2 text-sm font-semibold text-cf-text-primary hover:bg-cf-surface disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                Cancelar
-              </button>
-              <button
-                type="submit"
-                disabled={isBusy}
-                className="rounded border border-brand-1 bg-brand-1 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-2 disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                {stage === "uploading"
-                  ? "Enviando..."
-                  : stage === "processing"
-                    ? "Processando..."
-                    : "Enviar e processar"}
-              </button>
-            </div>
-          </form>
-        )}
+              <div className="flex flex-wrap items-center justify-end gap-3 border-t border-cf-border px-5 py-4">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  disabled={isBusy}
+                  className="rounded border border-cf-border bg-cf-bg-subtle px-4 py-2 text-sm font-semibold text-cf-text-primary hover:bg-cf-surface disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  Cancelar
+                </button>
+                <button
+                  type="submit"
+                  disabled={isBusy}
+                  className="rounded border border-brand-1 bg-brand-1 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-2 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {stage === "uploading"
+                    ? "Enviando..."
+                    : stage === "processing"
+                      ? "Processando..."
+                      : "Enviar e processar"}
+                </button>
+              </div>
+            </form>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Resumo\n- normaliza o shell do upload fiscal para respeitar viewport com scroll interno\n- separa header, body e footer do review rápido de renda para listas e decisões longas\n- humaniza estados de loading, sucesso e falha nesses fluxos documentais\n- adiciona cobertura direta do modal de upload fiscal e ajusta os testes do review rápido\n\n## Validação\n- npm -w apps/web run test:run -- src/components/TaxUploadModal.test.tsx src/components/IncomeStatementQuickModal.test.tsx src/pages/TaxPage.test.tsx\n- npm -w apps/web run lint\n- npm -w apps/web run typecheck\n- npm -w apps/web run test:run\n- npm -w apps/web run build