### PR TITLE
fix(web): refresh dashboard after imported income actions

### DIFF
--- a/apps/web/src/components/ImportCsvModal.d.ts
+++ b/apps/web/src/components/ImportCsvModal.d.ts
@@ -3,6 +3,7 @@ interface ImportCsvModalProps {
   onClose: () => void;
   onImported?: (result?: unknown) => Promise<void> | void;
   onOpenHistory?: (result?: unknown) => Promise<void> | void;
+  onDataChanged?: (result?: unknown) => Promise<void> | void;
 }
 
 declare function ImportCsvModal(props: ImportCsvModalProps): JSX.Element;

--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -120,7 +120,13 @@ const getProfileSuggestionTiming = (suggestion) => {
   return { label: "Entra neste mês", className: "border-green-300 bg-green-100 text-green-700" };
 };
 
-const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory = undefined }) => {
+const ImportCsvModal = ({
+  isOpen,
+  onClose,
+  onImported = undefined,
+  onOpenHistory = undefined,
+  onDataChanged = undefined,
+}) => {
   const fileInputRef = useRef(null);
   const [selectedFile, setSelectedFile] = useState(null);
   const [isDryRunning, setIsDryRunning] = useState(false);
@@ -801,6 +807,9 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory
       }));
       const commitResult = await transactionsService.commitImportCsv(dryRunResult.importId, overridesArray);
       setLastCommitResult(commitResult);
+      if (onDataChanged) {
+        await onDataChanged(commitResult);
+      }
     } catch (error) {
       const apiMessage = getApiErrorMessage(error, "Não foi possível confirmar a importação.");
       setErrorMessage(
@@ -1682,6 +1691,9 @@ const ImportCsvModal = ({ isOpen, onClose, onImported = undefined, onOpenHistory
         onCreated={() => {
           setIsIncomeModalOpen(false);
           setIncomeStatementCreated(true);
+          if (onDataChanged) {
+            void onDataChanged();
+          }
         }}
         onIgnored={(statement) => {
           setIsIncomeModalOpen(false);
@@ -1708,6 +1720,7 @@ ImportCsvModal.propTypes = {
   onClose: PropTypes.func.isRequired,
   onImported: PropTypes.func,
   onOpenHistory: PropTypes.func,
+  onDataChanged: PropTypes.func,
 };
 
 export default ImportCsvModal;

--- a/apps/web/src/components/ImportCsvModal.test.jsx
+++ b/apps/web/src/components/ImportCsvModal.test.jsx
@@ -239,6 +239,7 @@ describe("ImportCsvModal", () => {
 
   it("commits import and calls onImported callback when Fechar is clicked", async () => {
     const onImported = vi.fn();
+    const onDataChanged = vi.fn();
     const file = new File(["date,type,value"], "import.csv", { type: "text/csv" });
 
     transactionsService.dryRunImportCsv.mockResolvedValueOnce(buildDryRunResponse());
@@ -248,7 +249,7 @@ describe("ImportCsvModal", () => {
       summary: { income: 100, expense: 20, balance: 80 },
     });
 
-    render(<ImportCsvModal isOpen onClose={vi.fn()} onImported={onImported} />);
+    render(<ImportCsvModal isOpen onClose={vi.fn()} onImported={onImported} onDataChanged={onDataChanged} />);
 
     await userEvent.upload(screen.getByLabelText("Arquivo do extrato"), file);
     await userEvent.click(screen.getByRole("button", { name: "Pré-visualizar" }));
@@ -263,6 +264,7 @@ describe("ImportCsvModal", () => {
     await waitFor(() => {
       expect(screen.getByText("1 lançamento importado.")).toBeInTheDocument();
     });
+    expect(onDataChanged).toHaveBeenCalledTimes(1);
 
     // onImported not yet called — deferred until user clicks Fechar
     expect(onImported).not.toHaveBeenCalled();
@@ -277,6 +279,7 @@ describe("ImportCsvModal", () => {
   it("abre o histórico depois do commit sem perder o refresh do app", async () => {
     const onImported = vi.fn();
     const onOpenHistory = vi.fn();
+    const onDataChanged = vi.fn();
     const file = new File(["date,type,value"], "import.csv", { type: "text/csv" });
 
     transactionsService.dryRunImportCsv.mockResolvedValueOnce(buildDryRunResponse());
@@ -292,6 +295,7 @@ describe("ImportCsvModal", () => {
         onClose={vi.fn()}
         onImported={onImported}
         onOpenHistory={onOpenHistory}
+        onDataChanged={onDataChanged}
       />,
     );
 
@@ -307,6 +311,7 @@ describe("ImportCsvModal", () => {
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Ver histórico" })).toBeInTheDocument();
     });
+    expect(onDataChanged).toHaveBeenCalledTimes(1);
 
     await userEvent.click(screen.getByRole("button", { name: "Ver histórico" }));
 
@@ -986,8 +991,9 @@ describe("ImportCsvModal", () => {
       });
     });
 
-    it("sugere atualizar perfil e planejamento depois de confirmar a renda estruturada", async () => {
+  it("sugere atualizar perfil e planejamento depois de confirmar a renda estruturada", async () => {
       const file = new File(["dummy"], "inss.pdf", { type: "application/pdf" });
+      const onDataChanged = vi.fn();
       transactionsService.dryRunImportCsv.mockResolvedValueOnce(buildInssResponse());
       incomeSourcesService.list.mockResolvedValue([
         {
@@ -1020,7 +1026,7 @@ describe("ImportCsvModal", () => {
         deductions: [],
       });
 
-      render(<ImportCsvModal isOpen onClose={vi.fn()} />);
+      render(<ImportCsvModal isOpen onClose={vi.fn()} onDataChanged={onDataChanged} />);
       await userEvent.upload(screen.getByLabelText("Arquivo do extrato"), file);
       await userEvent.click(screen.getByRole("button", { name: "Pré-visualizar" }));
 
@@ -1047,6 +1053,7 @@ describe("ImportCsvModal", () => {
           screen.getByRole("button", { name: "Atualizar perfil e planejamento" }),
         ).toBeInTheDocument();
       });
+      expect(onDataChanged).toHaveBeenCalledTimes(1);
 
       await userEvent.click(
         screen.getByRole("button", { name: "Atualizar perfil e planejamento" }),

--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -2253,16 +2253,21 @@ describe("App", () => {
       );
     });
 
-    // Modal shows committed state — click Fechar to trigger onImported
-    await user.click(screen.getByRole("button", { name: "Fechar" }));
-
     await waitFor(() => {
       expect(transactionsService.listPage).toHaveBeenCalledTimes(2);
       expect(transactionsService.getMonthlySummary).toHaveBeenCalledTimes(2);
       expect(transactionsService.getMonthlySummaryCompare).toHaveBeenCalledTimes(2);
     });
 
-    expect(screen.queryByLabelText("Arquivo do extrato")).not.toBeInTheDocument();
+    // Modal shows committed state — click Fechar only closes the modal now
+    await user.click(screen.getByRole("button", { name: "Fechar" }));
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Arquivo do extrato")).not.toBeInTheDocument();
+    });
+    expect(transactionsService.listPage).toHaveBeenCalledTimes(2);
+    expect(transactionsService.getMonthlySummary).toHaveBeenCalledTimes(2);
+    expect(transactionsService.getMonthlySummaryCompare).toHaveBeenCalledTimes(2);
   });
 
   it("exibe mensagem de erro quando dry-run falha", async () => {

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -1550,26 +1550,30 @@ const App = ({
     onLogout?.();
   };
 
-  const handleImportCommitted = useCallback(async () => {
+  const handleImportDataChanged = useCallback(async () => {
     await loadTransactions();
     await loadMonthlySummary();
     await loadMonthlyBudgets();
-    setImportModalOpen(false);
   }, [loadMonthlyBudgets, loadMonthlySummary, loadTransactions]);
 
-  const handleOpenImportHistoryAfterImport = useCallback(async () => {
-    await loadTransactions();
-    await loadMonthlySummary();
-    await loadMonthlyBudgets();
+  const handleImportCommitted = useCallback(async (result?: unknown | null) => {
+    if (result == null) {
+      await handleImportDataChanged();
+    }
+    setImportModalOpen(false);
+  }, [handleImportDataChanged]);
+
+  const handleOpenImportHistoryAfterImport = useCallback(async (result?: unknown | null) => {
+    if (result == null) {
+      await handleImportDataChanged();
+    }
     setImportModalOpen(false);
     setImportHistoryModalOpen(true);
-  }, [loadMonthlyBudgets, loadMonthlySummary, loadTransactions]);
+  }, [handleImportDataChanged]);
 
   const handleImportSessionReverted = useCallback(async () => {
-    await loadTransactions();
-    await loadMonthlySummary();
-    await loadMonthlyBudgets();
-  }, [loadMonthlyBudgets, loadMonthlySummary, loadTransactions]);
+    await handleImportDataChanged();
+  }, [handleImportDataChanged]);
 
   const handleViewBudgetTransactions = (budget: MonthlyBudget) => {
     const monthRange = getMonthRange(selectedSummaryMonth);
@@ -3072,6 +3076,7 @@ const App = ({
         onClose={() => setImportModalOpen(false)}
         onImported={handleImportCommitted}
         onOpenHistory={handleOpenImportHistoryAfterImport}
+        onDataChanged={handleImportDataChanged}
       />
 
       <ImportHistoryModal


### PR DESCRIPTION
## Summary
- refresh the dashboard as soon as imported data changes, without waiting for the modal to close
- keep the import modal open after commit while the home behind it reloads monthly summary and transactions
- cover the income import bridge so "Registrar e lancar entrada" also triggers the dashboard refresh path

## Validation
- npm -w apps/web run test:run -- src/components/ImportCsvModal.test.jsx src/pages/App.test.jsx
- npm -w apps/web run lint
- npm -w apps/web run typecheck
- npm -w apps/web run test:run
- npm -w apps/web run build
