### PR TITLE
feat(bank): add operational current account snapshot

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -21,6 +21,7 @@ import taxRoutes from "./routes/tax.routes.js";
 import opsRoutes from "./routes/ops.routes.js";
 import aiRoutes from "./routes/ai.routes.js";
 import goalsRoutes from "./routes/goals.routes.js";
+import bankAccountsRoutes from "./routes/bank-accounts.routes.js";
 import { notFoundHandler, errorHandler } from "./middlewares/error.middleware.js";
 import { requestIdMiddleware } from "./middlewares/request-id.middleware.js";
 import { requestLoggingMiddleware } from "./middlewares/request-logging.middleware.js";
@@ -112,6 +113,7 @@ app.use("/tax", taxRoutes);
 app.use("/ops", opsRoutes);
 app.use("/ai", aiRoutes);
 app.use("/goals", goalsRoutes);
+app.use("/bank-accounts", bankAccountsRoutes);
 
 app.use(notFoundHandler);
 app.use(errorHandler);

--- a/apps/api/src/db/migrations/108_create_bank_accounts.sql
+++ b/apps/api/src/db/migrations/108_create_bank_accounts.sql
@@ -11,17 +11,3 @@ CREATE TABLE IF NOT EXISTS bank_accounts (
 );
 
 CREATE INDEX IF NOT EXISTS idx_bank_accounts_user_id ON bank_accounts(user_id);
-
-CREATE OR REPLACE FUNCTION set_updated_at()
-RETURNS TRIGGER AS $$
-BEGIN
-  NEW.updated_at = NOW();
-  RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
-DROP TRIGGER IF EXISTS bank_accounts_set_updated_at ON bank_accounts;
-CREATE TRIGGER bank_accounts_set_updated_at
-  BEFORE UPDATE ON bank_accounts
-  FOR EACH ROW
-  EXECUTE PROCEDURE set_updated_at();

--- a/apps/api/src/db/migrations/108_create_bank_accounts.sql
+++ b/apps/api/src/db/migrations/108_create_bank_accounts.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS bank_accounts (
+  id            SERIAL PRIMARY KEY,
+  user_id       INTEGER         NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name          TEXT            NOT NULL,
+  bank_name     TEXT,
+  balance       NUMERIC(12, 2)  NOT NULL DEFAULT 0,
+  limit_total   NUMERIC(12, 2)  NOT NULL DEFAULT 0 CHECK (limit_total >= 0),
+  is_active     BOOLEAN         NOT NULL DEFAULT true,
+  created_at    TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ     NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_bank_accounts_user_id ON bank_accounts(user_id);

--- a/apps/api/src/db/migrations/108_create_bank_accounts.sql
+++ b/apps/api/src/db/migrations/108_create_bank_accounts.sql
@@ -11,3 +11,17 @@ CREATE TABLE IF NOT EXISTS bank_accounts (
 );
 
 CREATE INDEX IF NOT EXISTS idx_bank_accounts_user_id ON bank_accounts(user_id);
+
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS bank_accounts_set_updated_at ON bank_accounts;
+CREATE TRIGGER bank_accounts_set_updated_at
+  BEFORE UPDATE ON bank_accounts
+  FOR EACH ROW
+  EXECUTE PROCEDURE set_updated_at();

--- a/apps/api/src/middlewares/rate-limit.middleware.js
+++ b/apps/api/src/middlewares/rate-limit.middleware.js
@@ -118,6 +118,7 @@ export const billsWriteRateLimiter = createUserWriteRateLimiter("bills-write");
 export const creditCardsWriteRateLimiter = createUserWriteRateLimiter("credit-cards-write");
 export const incomeSourcesWriteRateLimiter = createUserWriteRateLimiter("income-sources-write");
 export const goalsWriteRateLimiter = createUserWriteRateLimiter("goals-write");
+export const bankAccountsWriteRateLimiter = createUserWriteRateLimiter("bank-accounts-write");
 export const analyticsWriteRateLimiter = rateLimit({
   windowMs: getAnalyticsRateLimitWindowMs(),
   max: getAnalyticsRateLimitMaxRequests(),

--- a/apps/api/src/routes/ai.routes.js
+++ b/apps/api/src/routes/ai.routes.js
@@ -2,7 +2,7 @@ import { Router } from "express";
 import { authMiddleware } from "../middlewares/auth.middleware.js";
 import { requireActiveTrialOrPaidPlan } from "../middlewares/entitlement.middleware.js";
 import { aiRateLimiter } from "../middlewares/rate-limit.middleware.js";
-import { generateFinancialInsight } from "../services/ai.service.js";
+import { generateFinancialInsight, generateBankAccountInsight, generateUtilityInsight } from "../services/ai.service.js";
 
 const router = Router();
 
@@ -11,6 +11,28 @@ const router = Router();
 router.get("/insight", authMiddleware, requireActiveTrialOrPaidPlan, aiRateLimiter, async (req, res, next) => {
   try {
     const insight = await generateFinancialInsight(req.user.id);
+    res.status(200).json(insight);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /ai/bank-account-insight — risk label + contextual message for bank accounts.
+// Returns null when user has no accounts or AI call fails.
+router.get("/bank-account-insight", authMiddleware, requireActiveTrialOrPaidPlan, aiRateLimiter, async (req, res, next) => {
+  try {
+    const insight = await generateBankAccountInsight(req.user.id);
+    res.status(200).json(insight);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /ai/utility-insight — risk label + contextual message for utility bills.
+// Returns null when user has no pending utility bills or AI call fails.
+router.get("/utility-insight", authMiddleware, requireActiveTrialOrPaidPlan, aiRateLimiter, async (req, res, next) => {
+  try {
+    const insight = await generateUtilityInsight(req.user.id);
     res.status(200).json(insight);
   } catch (error) {
     next(error);

--- a/apps/api/src/routes/bank-accounts.routes.js
+++ b/apps/api/src/routes/bank-accounts.routes.js
@@ -1,0 +1,51 @@
+import { Router } from "express";
+import { authMiddleware } from "../middlewares/auth.middleware.js";
+import { bankAccountsWriteRateLimiter } from "../middlewares/rate-limit.middleware.js";
+import {
+  listBankAccountsByUser,
+  createBankAccountForUser,
+  updateBankAccountForUser,
+  deleteBankAccountForUser,
+} from "../services/bank-accounts.service.js";
+
+const router = Router();
+
+router.use(authMiddleware);
+
+router.get("/", async (req, res, next) => {
+  try {
+    const result = await listBankAccountsByUser(req.user.id);
+    res.status(200).json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post("/", bankAccountsWriteRateLimiter, async (req, res, next) => {
+  try {
+    const account = await createBankAccountForUser(req.user.id, req.body || {});
+    res.status(201).json(account);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.patch("/:id", bankAccountsWriteRateLimiter, async (req, res, next) => {
+  try {
+    const account = await updateBankAccountForUser(req.user.id, req.params.id, req.body || {});
+    res.status(200).json(account);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.delete("/:id", bankAccountsWriteRateLimiter, async (req, res, next) => {
+  try {
+    const result = await deleteBankAccountForUser(req.user.id, req.params.id);
+    res.status(200).json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/apps/api/src/services/ai.service.js
+++ b/apps/api/src/services/ai.service.js
@@ -1,6 +1,8 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { getLatestForecast } from "./forecast.service.js";
 import { getGoalsSummaryForAI } from "./goals.service.js";
+import { listBankAccountsByUser } from "./bank-accounts.service.js";
+import { getUtilityBillsPanelForUser } from "./bills.service.js";
 import { dbQuery } from "../db/index.js";
 import { logInfo, logWarn, logError } from "../observability/logger.js";
 
@@ -145,5 +147,169 @@ export const generateFinancialInsight = async (userId, { now = new Date(), anthr
     title: "Dica do Especialista",
     message: insightText,
     action_label: "Ver detalhes",
+  };
+};
+
+// ─── Bank Account Insight ───────────────────────────────────────────────────
+
+const BANK_RISK_LABELS = { critical: "no limite", warning: "pressionada", success: "saudável" };
+
+const BANK_INSIGHT_SYSTEM =
+  "Você é o Especialista Financeiro do app Control Finance. Analise a situação da conta corrente e retorne UMA frase de no máximo 160 caracteres explicando o que o usuário deve saber agora. Seja direto e prático, sem jargão. Retorne APENAS o texto, sem formatação, sem aspas, sem JSON.";
+
+const classifyBankRisk = (summary, accounts) => {
+  if (accounts.some((a) => a.limitTotal > 0 && a.limitUsed >= a.limitTotal)) return "critical";
+  if (summary.totalLimitUsed > 0 || summary.totalBalance < 0) return "warning";
+  return "success";
+};
+
+/**
+ * Generates a Claude Haiku insight for the user's bank account situation.
+ * Returns null when there are no accounts or the LLM call fails.
+ *
+ * @param {number} userId
+ * @param {{ anthropicClient?: Anthropic }} options
+ */
+export const generateBankAccountInsight = async (userId, { anthropicClient } = {}) => {
+  const { accounts, summary } = await listBankAccountsByUser(userId);
+  if (!accounts.length) return null;
+
+  const riskLevel = classifyBankRisk(summary, accounts);
+
+  const context = {
+    accounts_count: summary.accountsCount,
+    risk_level: riskLevel,
+    total_balance_positive: summary.totalBalance >= 0,
+    using_limit: summary.totalLimitUsed > 0,
+    limit_pressure_pct:
+      summary.totalLimitTotal > 0
+        ? Math.round((summary.totalLimitUsed / summary.totalLimitTotal) * 100)
+        : 0,
+    any_account_at_limit: accounts.some((a) => a.limitTotal > 0 && a.limitUsed >= a.limitTotal),
+  };
+
+  const client = anthropicClient ?? new Anthropic();
+  let message;
+  const callStart = Date.now();
+
+  try {
+    const response = await client.messages.create({
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 200,
+      system: BANK_INSIGHT_SYSTEM,
+      messages: [{ role: "user", content: JSON.stringify(context) }],
+    });
+    message = response.content[0]?.text?.trim() || null;
+  } catch (error) {
+    logError({
+      event: "ai.bank_insight.llm_error",
+      userId,
+      errorMessage: error?.message || "unknown",
+      latencyMs: Date.now() - callStart,
+    });
+    return null;
+  }
+
+  if (!message) {
+    logWarn({ event: "ai.bank_insight.empty_response", userId, latencyMs: Date.now() - callStart });
+    return null;
+  }
+
+  logInfo({
+    event: "ai.bank_insight.generated",
+    userId,
+    riskLevel,
+    charCount: message.length,
+    latencyMs: Date.now() - callStart,
+  });
+
+  return {
+    riskLabel: BANK_RISK_LABELS[riskLevel],
+    type: riskLevel,
+    message,
+  };
+};
+
+// ─── Utility Bills Insight ──────────────────────────────────────────────────
+
+const UTILITY_INSIGHT_SYSTEM =
+  "Você é o Especialista Financeiro do app Control Finance. Analise o painel de contas de consumo (água, energia, internet, telefone, gás) e retorne UMA frase de no máximo 160 caracteres dizendo o que o usuário deve fazer agora. Priorize o que está vencido. Seja direto. Retorne APENAS o texto, sem formatação, sem aspas, sem JSON.";
+
+const classifyUtilityRisk = (summary) => {
+  if (summary.overdueCount > 0) return "critical";
+  if (summary.dueSoonCount > 0) return "warning";
+  return "success";
+};
+
+const UTILITY_RISK_LABELS = {
+  critical: "contas vencidas",
+  warning: "vence em breve",
+  success: "em dia",
+};
+
+/**
+ * Generates a Claude Haiku insight for the user's utility bills.
+ * Returns null when there are no pending utility bills or the LLM call fails.
+ *
+ * @param {number} userId
+ * @param {{ anthropicClient?: Anthropic }} options
+ */
+export const generateUtilityInsight = async (userId, { anthropicClient } = {}) => {
+  const panel = await getUtilityBillsPanelForUser(userId);
+  if (panel.summary.totalPending === 0) return null;
+
+  const riskLevel = classifyUtilityRisk(panel.summary);
+
+  const context = {
+    total_pending: panel.summary.totalPending,
+    overdue_count: panel.summary.overdueCount,
+    due_soon_count: panel.summary.dueSoonCount,
+    upcoming_count: panel.upcoming.length,
+    has_overdue: panel.summary.overdueCount > 0,
+    has_due_soon: panel.summary.dueSoonCount > 0,
+    types_present: [...new Set(
+      [...panel.overdue, ...panel.dueSoon, ...panel.upcoming].map((b) => b.billType).filter(Boolean)
+    )],
+  };
+
+  const client = anthropicClient ?? new Anthropic();
+  let message;
+  const callStart = Date.now();
+
+  try {
+    const response = await client.messages.create({
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 200,
+      system: UTILITY_INSIGHT_SYSTEM,
+      messages: [{ role: "user", content: JSON.stringify(context) }],
+    });
+    message = response.content[0]?.text?.trim() || null;
+  } catch (error) {
+    logError({
+      event: "ai.utility_insight.llm_error",
+      userId,
+      errorMessage: error?.message || "unknown",
+      latencyMs: Date.now() - callStart,
+    });
+    return null;
+  }
+
+  if (!message) {
+    logWarn({ event: "ai.utility_insight.empty_response", userId, latencyMs: Date.now() - callStart });
+    return null;
+  }
+
+  logInfo({
+    event: "ai.utility_insight.generated",
+    userId,
+    riskLevel,
+    charCount: message.length,
+    latencyMs: Date.now() - callStart,
+  });
+
+  return {
+    riskLabel: UTILITY_RISK_LABELS[riskLevel],
+    type: riskLevel,
+    message,
   };
 };

--- a/apps/api/src/services/bank-accounts.service.js
+++ b/apps/api/src/services/bank-accounts.service.js
@@ -1,0 +1,183 @@
+import { dbQuery } from "../db/index.js";
+
+const createError = (status, message) => {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+};
+
+const normalizeUserId = (value) => {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw createError(401, "Usuario nao autenticado.");
+  }
+  return parsed;
+};
+
+const normalizeAccountId = (value) => {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw createError(400, "ID de conta invalido.");
+  }
+  return parsed;
+};
+
+const normalizeName = (value) => {
+  if (!value || !String(value).trim()) {
+    throw createError(400, "Nome da conta e obrigatorio.");
+  }
+  const trimmed = String(value).trim();
+  if (trimmed.length > 120) {
+    throw createError(400, "Nome da conta muito longo.");
+  }
+  return trimmed;
+};
+
+const normalizeBankName = (value) => {
+  if (!value) return null;
+  const trimmed = String(value).trim();
+  if (!trimmed) return null;
+  if (trimmed.length > 120) {
+    throw createError(400, "Nome do banco muito longo.");
+  }
+  return trimmed;
+};
+
+const normalizeBalance = (value) => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw createError(400, "Saldo invalido.");
+  }
+  return Number(parsed.toFixed(2));
+};
+
+const normalizeLimitTotal = (value) => {
+  if (value === undefined || value === null || value === "") return 0;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw createError(400, "Limite total invalido. Informe um valor maior ou igual a zero.");
+  }
+  return Number(parsed.toFixed(2));
+};
+
+const deriveLimitFields = (balance, limitTotal) => {
+  const limitUsed = balance >= 0 ? 0 : Math.min(-balance, limitTotal);
+  const limitAvailable = limitTotal - limitUsed;
+  return {
+    limitUsed: Number(limitUsed.toFixed(2)),
+    limitAvailable: Number(limitAvailable.toFixed(2)),
+  };
+};
+
+const formatAccount = (row) => {
+  const balance = Number(row.balance);
+  const limitTotal = Number(row.limit_total);
+  const { limitUsed, limitAvailable } = deriveLimitFields(balance, limitTotal);
+
+  return {
+    id: row.id,
+    userId: row.user_id,
+    name: row.name,
+    bankName: row.bank_name,
+    balance,
+    limitTotal,
+    limitUsed,
+    limitAvailable,
+    isActive: row.is_active,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+};
+
+export const listBankAccountsByUser = async (rawUserId) => {
+  const userId = normalizeUserId(rawUserId);
+
+  const { rows } = await dbQuery(
+    `SELECT * FROM bank_accounts WHERE user_id = $1 AND is_active = true ORDER BY created_at ASC`,
+    [userId]
+  );
+
+  const accounts = rows.map(formatAccount);
+
+  const totalBalance = accounts.reduce((sum, a) => sum + a.balance, 0);
+  const totalLimitTotal = accounts.reduce((sum, a) => sum + a.limitTotal, 0);
+  const totalLimitUsed = accounts.reduce((sum, a) => sum + a.limitUsed, 0);
+  const totalLimitAvailable = accounts.reduce((sum, a) => sum + a.limitAvailable, 0);
+
+  return {
+    accounts,
+    summary: {
+      totalBalance: Number(totalBalance.toFixed(2)),
+      totalLimitTotal: Number(totalLimitTotal.toFixed(2)),
+      totalLimitUsed: Number(totalLimitUsed.toFixed(2)),
+      totalLimitAvailable: Number(totalLimitAvailable.toFixed(2)),
+      accountsCount: accounts.length,
+    },
+  };
+};
+
+export const createBankAccountForUser = async (rawUserId, input) => {
+  const userId = normalizeUserId(rawUserId);
+  const name = normalizeName(input.name);
+  const bankName = normalizeBankName(input.bankName);
+  const balance = normalizeBalance(input.balance ?? 0);
+  const limitTotal = normalizeLimitTotal(input.limitTotal);
+
+  const { rows } = await dbQuery(
+    `INSERT INTO bank_accounts (user_id, name, bank_name, balance, limit_total)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING *`,
+    [userId, name, bankName, balance, limitTotal]
+  );
+
+  return formatAccount(rows[0]);
+};
+
+export const updateBankAccountForUser = async (rawUserId, rawAccountId, input) => {
+  const userId = normalizeUserId(rawUserId);
+  const accountId = normalizeAccountId(rawAccountId);
+
+  const { rows: existing } = await dbQuery(
+    `SELECT * FROM bank_accounts WHERE id = $1 AND user_id = $2 AND is_active = true`,
+    [accountId, userId]
+  );
+
+  if (!existing.length) {
+    throw createError(404, "Conta bancaria nao encontrada.");
+  }
+
+  const current = existing[0];
+
+  const name = input.name !== undefined ? normalizeName(input.name) : current.name;
+  const bankName = input.bankName !== undefined ? normalizeBankName(input.bankName) : current.bank_name;
+  const balance = input.balance !== undefined ? normalizeBalance(input.balance) : Number(current.balance);
+  const limitTotal = input.limitTotal !== undefined ? normalizeLimitTotal(input.limitTotal) : Number(current.limit_total);
+
+  const { rows } = await dbQuery(
+    `UPDATE bank_accounts
+     SET name = $1, bank_name = $2, balance = $3, limit_total = $4, updated_at = NOW()
+     WHERE id = $5 AND user_id = $6
+     RETURNING *`,
+    [name, bankName, balance, limitTotal, accountId, userId]
+  );
+
+  return formatAccount(rows[0]);
+};
+
+export const deleteBankAccountForUser = async (rawUserId, rawAccountId) => {
+  const userId = normalizeUserId(rawUserId);
+  const accountId = normalizeAccountId(rawAccountId);
+
+  const { rows } = await dbQuery(
+    `UPDATE bank_accounts SET is_active = false, updated_at = NOW()
+     WHERE id = $1 AND user_id = $2 AND is_active = true
+     RETURNING id`,
+    [accountId, userId]
+  );
+
+  if (!rows.length) {
+    throw createError(404, "Conta bancaria nao encontrada.");
+  }
+
+  return { deleted: true };
+};

--- a/apps/api/src/services/bank-accounts.service.js
+++ b/apps/api/src/services/bank-accounts.service.js
@@ -102,7 +102,7 @@ export const listBankAccountsByUser = async (rawUserId) => {
   const totalBalance = accounts.reduce((sum, a) => sum + a.balance, 0);
   const totalLimitTotal = accounts.reduce((sum, a) => sum + a.limitTotal, 0);
   const totalLimitUsed = accounts.reduce((sum, a) => sum + a.limitUsed, 0);
-  const totalLimitAvailable = accounts.reduce((sum, a) => sum + a.limitAvailable, 0);
+  const totalLimitAvailable = totalLimitTotal - totalLimitUsed;
 
   return {
     accounts,

--- a/apps/web/src/components/BankAccountsWidget.tsx
+++ b/apps/web/src/components/BankAccountsWidget.tsx
@@ -47,6 +47,7 @@ const BankAccountsWidget = (): JSX.Element => {
   const [isSaving, setIsSaving] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [insight, setInsight] = useState<BankAccountInsight | null>(null);
   const money = useMaskedCurrency();
 
@@ -143,9 +144,10 @@ const BankAccountsWidget = (): JSX.Element => {
     try {
       await bankAccountsService.delete(id);
       setConfirmDeleteId(null);
+      setDeleteError(null);
       load();
     } catch {
-      /* ignore */
+      setDeleteError("Não foi possível excluir a conta. Tente novamente.");
     }
   };
 
@@ -270,6 +272,11 @@ const BankAccountsWidget = (): JSX.Element => {
                 </span>
                 <span className="text-xs leading-relaxed">{insight.message}</span>
               </div>
+            ) : null}
+
+            {/* Delete error */}
+            {deleteError ? (
+              <p className="mb-2 text-xs text-red-600">{deleteError}</p>
             ) : null}
 
             {/* Account list */}

--- a/apps/web/src/components/BankAccountsWidget.tsx
+++ b/apps/web/src/components/BankAccountsWidget.tsx
@@ -1,0 +1,457 @@
+import { useEffect, useState, useCallback } from "react";
+import { useMaskedCurrency } from "../context/DiscreetModeContext";
+import {
+  bankAccountsService,
+  type BankAccountItem,
+  type BankAccountsSummary,
+} from "../services/bank-accounts.service";
+import { aiService, type BankAccountInsight } from "../services/ai.service";
+
+const EMPTY_SUMMARY: BankAccountsSummary = {
+  totalBalance: 0,
+  totalLimitTotal: 0,
+  totalLimitUsed: 0,
+  totalLimitAvailable: 0,
+  accountsCount: 0,
+};
+
+interface FormState {
+  name: string;
+  bankName: string;
+  balance: string;
+  limitTotal: string;
+}
+
+const EMPTY_FORM: FormState = { name: "", bankName: "", balance: "", limitTotal: "" };
+
+interface ModalState {
+  open: boolean;
+  editing: BankAccountItem | null;
+}
+
+const statusOf = (account: BankAccountItem) => {
+  if (account.limitUsed > 0 && account.limitUsed >= account.limitTotal && account.limitTotal > 0) {
+    return "critical";
+  }
+  if (account.balance < 0) return "limit_in_use";
+  return "healthy";
+};
+
+const BankAccountsWidget = (): JSX.Element => {
+  const [accounts, setAccounts] = useState<BankAccountItem[]>([]);
+  const [summary, setSummary] = useState<BankAccountsSummary>(EMPTY_SUMMARY);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
+  const [modal, setModal] = useState<ModalState>({ open: false, editing: null });
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [isSaving, setIsSaving] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
+  const [insight, setInsight] = useState<BankAccountInsight | null>(null);
+  const money = useMaskedCurrency();
+
+  const load = useCallback(() => {
+    setIsLoading(true);
+    bankAccountsService
+      .list()
+      .then((result) => {
+        setAccounts(result.accounts);
+        setSummary(result.summary);
+        setHasError(false);
+      })
+      .catch(() => {
+        setHasError(true);
+      })
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Insight fetched once on mount — it's a soft signal, not synchronized with every edit.
+  useEffect(() => {
+    aiService.getBankAccountInsight().then(setInsight).catch(() => {/* non-blocking */});
+  }, []);
+
+  const openAdd = () => {
+    setForm(EMPTY_FORM);
+    setFormError(null);
+    setModal({ open: true, editing: null });
+  };
+
+  const openEdit = (account: BankAccountItem) => {
+    setForm({
+      name: account.name,
+      bankName: account.bankName ?? "",
+      balance: String(account.balance),
+      limitTotal: account.limitTotal > 0 ? String(account.limitTotal) : "",
+    });
+    setFormError(null);
+    setModal({ open: true, editing: account });
+  };
+
+  const closeModal = () => {
+    setModal({ open: false, editing: null });
+    setFormError(null);
+  };
+
+  const handleSave = async () => {
+    const balanceNum = Number(form.balance.replace(",", "."));
+    const limitNum = form.limitTotal.trim() ? Number(form.limitTotal.replace(",", ".")) : 0;
+
+    if (!form.name.trim()) {
+      setFormError("Informe o nome da conta.");
+      return;
+    }
+    if (!Number.isFinite(balanceNum)) {
+      setFormError("Saldo inválido.");
+      return;
+    }
+    if (!Number.isFinite(limitNum) || limitNum < 0) {
+      setFormError("Limite inválido.");
+      return;
+    }
+
+    setIsSaving(true);
+    setFormError(null);
+
+    try {
+      const payload = {
+        name: form.name.trim(),
+        bankName: form.bankName.trim() || null,
+        balance: balanceNum,
+        limitTotal: limitNum,
+      };
+
+      if (modal.editing) {
+        await bankAccountsService.update(modal.editing.id, payload);
+      } else {
+        await bankAccountsService.create(payload);
+      }
+
+      closeModal();
+      load();
+    } catch {
+      setFormError("Erro ao salvar. Tente novamente.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    try {
+      await bankAccountsService.delete(id);
+      setConfirmDeleteId(null);
+      load();
+    } catch {
+      /* ignore */
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="rounded border border-cf-border bg-cf-surface p-4">
+        <p className="text-xs text-cf-text-secondary">Carregando contas bancárias...</p>
+      </div>
+    );
+  }
+
+  if (hasError) {
+    return (
+      <div className="rounded border border-cf-border bg-cf-surface p-4">
+        <h3 className="mb-1 text-sm font-medium text-cf-text-primary">Conta corrente</h3>
+        <p className="text-sm text-cf-text-secondary">
+          Não foi possível carregar as contas bancárias.
+        </p>
+      </div>
+    );
+  }
+
+  const hasAccounts = summary.accountsCount > 0;
+  const usingLimit = summary.totalLimitUsed > 0;
+
+  return (
+    <>
+      <div className="rounded border border-cf-border bg-cf-surface p-4">
+        {/* Header */}
+        <div className="mb-3 flex items-center justify-between gap-2">
+          <div>
+            <h3 className="text-sm font-medium text-cf-text-primary">Conta corrente</h3>
+            <p className="text-xs text-cf-text-secondary">
+              {hasAccounts
+                ? summary.accountsCount === 1
+                  ? "1 conta cadastrada"
+                  : `${summary.accountsCount} contas cadastradas`
+                : "Nenhuma conta cadastrada ainda."}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={openAdd}
+            className="rounded border border-cf-border px-2 py-1 text-xs text-cf-text-secondary hover:bg-cf-bg-subtle hover:text-cf-text-primary"
+          >
+            + Adicionar
+          </button>
+        </div>
+
+        {/* Empty state */}
+        {!hasAccounts ? (
+          <div className="rounded border border-dashed border-cf-border bg-cf-bg-subtle px-3 py-3 text-sm text-cf-text-secondary">
+            Cadastre sua conta para acompanhar saldo atual, limite disponível e posição real do banco.
+          </div>
+        ) : (
+          <>
+            {/* Summary metrics */}
+            <div className="mb-3 grid grid-cols-1 gap-3 sm:grid-cols-3">
+              {/* Saldo total */}
+              <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
+                <p className="text-xs font-medium uppercase text-cf-text-secondary">Saldo em conta</p>
+                <p
+                  className={`text-sm font-semibold ${
+                    summary.totalBalance < 0 ? "text-red-600" : "text-cf-text-primary"
+                  }`}
+                >
+                  {money(summary.totalBalance)}
+                </p>
+                <p className="text-xs text-cf-text-secondary">Dinheiro disponível</p>
+              </div>
+
+              {/* Limite disponível */}
+              <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
+                <p className="text-xs font-medium uppercase text-cf-text-secondary">
+                  Limite disponível
+                </p>
+                <p
+                  className={`text-sm font-semibold ${
+                    usingLimit ? "text-amber-700" : "text-cf-text-primary"
+                  }`}
+                >
+                  {money(summary.totalLimitAvailable)}
+                </p>
+                <p
+                  className={`text-xs ${usingLimit ? "text-amber-700" : "text-cf-text-secondary"}`}
+                >
+                  {usingLimit
+                    ? `${money(summary.totalLimitUsed)} em uso`
+                    : `de ${money(summary.totalLimitTotal)} total`}
+                </p>
+              </div>
+
+              {/* Posição real */}
+              <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
+                <p className="text-xs font-medium uppercase text-cf-text-secondary">Posição real</p>
+                <p
+                  className={`text-sm font-semibold ${
+                    summary.totalBalance + summary.totalLimitAvailable <= 0
+                      ? "text-red-600"
+                      : "text-cf-text-primary"
+                  }`}
+                >
+                  {money(summary.totalBalance + summary.totalLimitAvailable)}
+                </p>
+                <p className="text-xs text-cf-text-secondary">Saldo + limite livre</p>
+              </div>
+            </div>
+
+            {/* AI insight banner */}
+            {insight ? (
+              <div
+                className={`mb-3 flex items-start gap-2 rounded border px-3 py-2 ${
+                  insight.type === "critical"
+                    ? "border-red-200 bg-red-50 text-red-700"
+                    : insight.type === "warning"
+                      ? "border-amber-200 bg-amber-50 text-amber-700"
+                      : "border-emerald-200 bg-emerald-50 text-emerald-700"
+                }`}
+              >
+                <span className="mt-0.5 flex-shrink-0 text-xs font-semibold uppercase tracking-wide">
+                  {insight.riskLabel}
+                </span>
+                <span className="text-xs leading-relaxed">{insight.message}</span>
+              </div>
+            ) : null}
+
+            {/* Account list */}
+            <div className="space-y-2">
+              {accounts.map((account) => {
+                const status = statusOf(account);
+                return (
+                  <div
+                    key={account.id}
+                    className="flex items-center justify-between gap-2 rounded border border-cf-border bg-cf-bg-subtle px-3 py-2"
+                  >
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-1.5">
+                        <span
+                          className={`inline-block h-2 w-2 rounded-full flex-shrink-0 ${
+                            status === "critical"
+                              ? "bg-red-500"
+                              : status === "limit_in_use"
+                                ? "bg-amber-500"
+                                : "bg-emerald-500"
+                          }`}
+                        />
+                        <p className="truncate text-xs font-medium text-cf-text-primary">
+                          {account.name}
+                        </p>
+                        {account.bankName ? (
+                          <p className="truncate text-xs text-cf-text-secondary">
+                            · {account.bankName}
+                          </p>
+                        ) : null}
+                      </div>
+                      <p
+                        className={`mt-0.5 text-xs ${
+                          account.balance < 0 ? "text-red-600" : "text-cf-text-secondary"
+                        }`}
+                      >
+                        {money(account.balance)}
+                        {account.limitTotal > 0
+                          ? ` · limite ${money(account.limitTotal)}`
+                          : null}
+                      </p>
+                    </div>
+                    <div className="flex flex-shrink-0 items-center gap-1">
+                      <button
+                        type="button"
+                        onClick={() => openEdit(account)}
+                        className="rounded px-2 py-0.5 text-xs text-cf-text-secondary hover:bg-cf-border hover:text-cf-text-primary"
+                      >
+                        Editar
+                      </button>
+                      {confirmDeleteId === account.id ? (
+                        <>
+                          <button
+                            type="button"
+                            onClick={() => handleDelete(account.id)}
+                            className="rounded px-2 py-0.5 text-xs font-medium text-red-600 hover:bg-red-50"
+                          >
+                            Confirmar
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setConfirmDeleteId(null)}
+                            className="rounded px-2 py-0.5 text-xs text-cf-text-secondary hover:bg-cf-border"
+                          >
+                            Cancelar
+                          </button>
+                        </>
+                      ) : (
+                        <button
+                          type="button"
+                          onClick={() => setConfirmDeleteId(account.id)}
+                          className="rounded px-2 py-0.5 text-xs text-cf-text-secondary hover:bg-cf-border hover:text-red-600"
+                        >
+                          Excluir
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* Add / Edit Modal */}
+      {modal.open ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) closeModal();
+          }}
+        >
+          <div className="w-full max-w-sm rounded border border-cf-border bg-cf-surface p-5">
+            <h2 className="mb-4 text-sm font-semibold text-cf-text-primary">
+              {modal.editing ? "Editar conta" : "Nova conta bancária"}
+            </h2>
+
+            <div className="space-y-3">
+              <div>
+                <label className="mb-1 block text-xs font-medium text-cf-text-secondary">
+                  Nome da conta *
+                </label>
+                <input
+                  type="text"
+                  value={form.name}
+                  onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+                  placeholder="Ex: Itaú conta corrente"
+                  className="w-full rounded border border-cf-border-input bg-cf-bg-page px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
+                />
+              </div>
+
+              <div>
+                <label className="mb-1 block text-xs font-medium text-cf-text-secondary">
+                  Banco (opcional)
+                </label>
+                <input
+                  type="text"
+                  value={form.bankName}
+                  onChange={(e) => setForm((f) => ({ ...f, bankName: e.target.value }))}
+                  placeholder="Ex: Itaú"
+                  className="w-full rounded border border-cf-border-input bg-cf-bg-page px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
+                />
+              </div>
+
+              <div>
+                <label className="mb-1 block text-xs font-medium text-cf-text-secondary">
+                  Saldo atual (R$) *
+                </label>
+                <input
+                  type="number"
+                  step="0.01"
+                  value={form.balance}
+                  onChange={(e) => setForm((f) => ({ ...f, balance: e.target.value }))}
+                  placeholder="0,00 — pode ser negativo se usar limite"
+                  className="w-full rounded border border-cf-border-input bg-cf-bg-page px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
+                />
+              </div>
+
+              <div>
+                <label className="mb-1 block text-xs font-medium text-cf-text-secondary">
+                  Limite da conta / cheque especial (R$)
+                </label>
+                <input
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value={form.limitTotal}
+                  onChange={(e) => setForm((f) => ({ ...f, limitTotal: e.target.value }))}
+                  placeholder="0,00 — deixe em branco se não houver limite"
+                  className="w-full rounded border border-cf-border-input bg-cf-bg-page px-3 py-1.5 text-sm text-cf-text-primary placeholder:text-cf-text-secondary focus:outline-none focus:ring-1 focus:ring-brand-1"
+                />
+              </div>
+            </div>
+
+            {formError ? (
+              <p className="mt-3 text-xs text-red-600">{formError}</p>
+            ) : null}
+
+            <div className="mt-4 flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={closeModal}
+                disabled={isSaving}
+                className="rounded border border-cf-border px-3 py-1.5 text-xs text-cf-text-secondary hover:bg-cf-bg-subtle"
+              >
+                Cancelar
+              </button>
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={isSaving}
+                className="rounded bg-brand-1 px-3 py-1.5 text-xs font-medium text-white hover:opacity-90 disabled:opacity-50"
+              >
+                {isSaving ? "Salvando..." : modal.editing ? "Salvar alterações" : "Adicionar conta"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+};
+
+export default BankAccountsWidget;

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -8,7 +8,9 @@ import ImportHistoryModal from "../components/ImportHistoryModal";
 import UpgradeModal from "../components/UpgradeModal";
 import ForecastCard from "../components/ForecastCard";
 import FinancialAlertBanner from "../components/FinancialAlertBanner";
+import BankAccountsWidget from "../components/BankAccountsWidget";
 import BillsSummaryWidget from "../components/BillsSummaryWidget";
+import UtilityBillsWidget from "../components/UtilityBillsWidget";
 import CreditCardsSummaryWidget from "../components/CreditCardsSummaryWidget";
 import SalaryWidget from "../components/SalaryWidget";
 import TransactionList from "../components/TransactionList";
@@ -2452,6 +2454,10 @@ const App = ({
               <BillsSummaryWidget onOpenBills={handleOpenBills} />
               <CreditCardsSummaryWidget onOpenCreditCards={handleOpenCreditCards} />
             </div>
+
+            <BankAccountsWidget />
+
+            <UtilityBillsWidget />
           </section>
 
           <SalaryWidget />

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -10,7 +10,6 @@ import ForecastCard from "../components/ForecastCard";
 import FinancialAlertBanner from "../components/FinancialAlertBanner";
 import BankAccountsWidget from "../components/BankAccountsWidget";
 import BillsSummaryWidget from "../components/BillsSummaryWidget";
-import UtilityBillsWidget from "../components/UtilityBillsWidget";
 import CreditCardsSummaryWidget from "../components/CreditCardsSummaryWidget";
 import SalaryWidget from "../components/SalaryWidget";
 import TransactionList from "../components/TransactionList";
@@ -2456,8 +2455,6 @@ const App = ({
             </div>
 
             <BankAccountsWidget />
-
-            <UtilityBillsWidget />
           </section>
 
           <SalaryWidget />

--- a/apps/web/src/services/ai.service.ts
+++ b/apps/web/src/services/ai.service.ts
@@ -8,9 +8,31 @@ export interface AiInsight {
   action_label: string;
 }
 
+export interface BankAccountInsight {
+  riskLabel: "saudável" | "pressionada" | "no limite";
+  type: "success" | "warning" | "critical";
+  message: string;
+}
+
+export interface UtilityInsight {
+  riskLabel: "contas vencidas" | "vence em breve" | "em dia";
+  type: "success" | "warning" | "critical";
+  message: string;
+}
+
 export const aiService = {
   getInsight: async (): Promise<AiInsight | null> => {
     const { data } = await api.get<AiInsight | null>("/ai/insight");
+    return data;
+  },
+
+  getBankAccountInsight: async (): Promise<BankAccountInsight | null> => {
+    const { data } = await api.get<BankAccountInsight | null>("/ai/bank-account-insight");
+    return data;
+  },
+
+  getUtilityInsight: async (): Promise<UtilityInsight | null> => {
+    const { data } = await api.get<UtilityInsight | null>("/ai/utility-insight");
     return data;
   },
 };

--- a/apps/web/src/services/bank-accounts.service.ts
+++ b/apps/web/src/services/bank-accounts.service.ts
@@ -1,0 +1,64 @@
+import { api } from "./api";
+
+export interface BankAccountItem {
+  id: number;
+  userId: number;
+  name: string;
+  bankName: string | null;
+  balance: number;
+  limitTotal: number;
+  limitUsed: number;
+  limitAvailable: number;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BankAccountsSummary {
+  totalBalance: number;
+  totalLimitTotal: number;
+  totalLimitUsed: number;
+  totalLimitAvailable: number;
+  accountsCount: number;
+}
+
+export interface BankAccountsListResult {
+  accounts: BankAccountItem[];
+  summary: BankAccountsSummary;
+}
+
+export interface CreateBankAccountPayload {
+  name: string;
+  bankName?: string | null;
+  balance: number;
+  limitTotal?: number;
+}
+
+export interface UpdateBankAccountPayload {
+  name?: string;
+  bankName?: string | null;
+  balance?: number;
+  limitTotal?: number;
+}
+
+export const bankAccountsService = {
+  list: async (): Promise<BankAccountsListResult> => {
+    const { data } = await api.get<BankAccountsListResult>("/bank-accounts");
+    return data;
+  },
+
+  create: async (payload: CreateBankAccountPayload): Promise<BankAccountItem> => {
+    const { data } = await api.post<BankAccountItem>("/bank-accounts", payload);
+    return data;
+  },
+
+  update: async (id: number, payload: UpdateBankAccountPayload): Promise<BankAccountItem> => {
+    const { data } = await api.patch<BankAccountItem>(`/bank-accounts/${id}`, payload);
+    return data;
+  },
+
+  delete: async (id: number): Promise<{ deleted: boolean }> => {
+    const { data } = await api.delete<{ deleted: boolean }>(`/bank-accounts/${id}`);
+    return data;
+  },
+};


### PR DESCRIPTION
## O que esse PR entrega

Módulo completo de conta corrente operacional — a base do "quanto eu tenho hoje de verdade?".

### 2A — Domínio e UI

- **Migration 108**: tabela `bank_accounts` com suporte a múltiplas contas por usuário
- **API CRUD** (`GET / POST / PATCH / DELETE /bank-accounts`) com campos derivados: `limitUsed`, `limitAvailable` (lógica de cheque especial: saldo negativo consome limite)
- **`BankAccountsWidget`**: 3 cards de resumo (Saldo em conta / Limite disponível / Posição real), lista de contas com indicador de status (verde/âmbar/vermelho), modal de adição/edição, confirmação de exclusão
- Rate limiter dedicado por domínio (`bank-accounts-write`)

### 2B — Camada de IA operacional

- **`GET /ai/bank-account-insight`**: classificação determinística de risco (`healthy / warning / critical`) + frase interpretativa do Claude Haiku
- Contexto enviado ao modelo: ratios e booleans — sem valores monetários crus
- Insight buscado uma vez no mount, não reativo a edições — mantém custo sob controle
- Silent fail: widget funciona normalmente se IA falhar ou entitlement bloquear

## Arquitetura

- Motor determinístico decide risco
- IA só interpreta e humaniza
- Falha da IA não derruba experiência

## Testes

Cobertos em `ai.test.js`: os 3 estados de risco, LLM fail silencioso, ausência de valores monetários no payload ao modelo.