### PR TITLE
feat(reconciliation): match utility payments against bank statement

### DIFF
--- a/apps/api/src/db/migrations/109_add_reconciliation_to_bills.sql
+++ b/apps/api/src/db/migrations/109_add_reconciliation_to_bills.sql
@@ -1,0 +1,14 @@
+ALTER TABLE bills
+  ADD COLUMN IF NOT EXISTS linked_transaction_id INTEGER REFERENCES transactions(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS match_status          TEXT NOT NULL DEFAULT 'unmatched'
+                                                 CHECK (match_status IN ('unmatched', 'matched')),
+  ADD COLUMN IF NOT EXISTS matched_at            TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS match_confidence      NUMERIC(5,4),
+  ADD COLUMN IF NOT EXISTS match_metadata        JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+-- Prevent the same transaction from being linked to more than one bill
+CREATE UNIQUE INDEX IF NOT EXISTS idx_bills_unique_linked_transaction
+  ON bills (linked_transaction_id)
+  WHERE linked_transaction_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_bills_match_status ON bills (match_status);

--- a/apps/api/src/reconciliation.test.js
+++ b/apps/api/src/reconciliation.test.js
@@ -1,0 +1,480 @@
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import app from "./app.js";
+import { clearDbClientForTests, dbQuery } from "./db/index.js";
+import { resetLoginProtectionState } from "./middlewares/login-protection.middleware.js";
+import {
+  resetImportRateLimiterState,
+  resetWriteRateLimiterState,
+} from "./middlewares/rate-limit.middleware.js";
+import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
+import { registerAndLogin, setupTestDb } from "./test-helpers.js";
+import { scoreBillTransactionMatch } from "./services/reconciliation.service.js";
+
+// ─── Date helpers ─────────────────────────────────────────────────────────────
+
+const today = () => {
+  const d = new Date();
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}`;
+};
+
+const offsetDate = (days) => {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + days);
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}`;
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const createBill = (token, overrides = {}) =>
+  request(app)
+    .post("/bills")
+    .set("Authorization", `Bearer ${token}`)
+    .send({ title: "Energia ENEL", amount: 200, dueDate: today(), provider: "ENEL", ...overrides });
+
+const createTx = (token, overrides = {}) =>
+  request(app)
+    .post("/transactions")
+    .set("Authorization", `Bearer ${token}`)
+    .send({ type: "Saida", value: 200, date: today(), description: "ENEL SP ENERGIA", ...overrides });
+
+// ─── Unit: scoring engine ─────────────────────────────────────────────────────
+
+describe("scoreBillTransactionMatch — unit", () => {
+  const makeBill = (amount, due_date, title = "ENEL", provider = "ENEL") => ({
+    amount,
+    due_date,
+    title,
+    provider,
+  });
+  const makeTx = (value, date, description = "ENEL SP ENERGIA") => ({
+    value,
+    date,
+    description,
+  });
+
+  it("retorna score 1.0 para match perfeito (mesmo valor, mesma data, provider match)", () => {
+    const result = scoreBillTransactionMatch(makeBill(200, "2026-03-25"), makeTx(200, "2026-03-25"));
+    expect(result).not.toBeNull();
+    expect(result.score).toBe(1.0);
+    expect(result.amountScore).toBe(0.5);
+    expect(result.dateScore).toBe(0.3);
+    expect(result.providerScore).toBe(0.2);
+    expect(result.divergencePercent).toBe(0);
+    expect(result.requiresDivergenceConfirmation).toBe(false);
+  });
+
+  it("amountScore = 0.35 para divergencia de 3%", () => {
+    const result = scoreBillTransactionMatch(makeBill(200, "2026-03-25"), makeTx(206, "2026-03-25"));
+    expect(result).not.toBeNull();
+    expect(result.amountScore).toBe(0.35);
+    expect(result.divergencePercent).toBe(3);
+    expect(result.requiresDivergenceConfirmation).toBe(false);
+  });
+
+  it("amountScore = 0.15 para divergencia de 10%", () => {
+    const result = scoreBillTransactionMatch(makeBill(200, "2026-03-25"), makeTx(220, "2026-03-25"));
+    expect(result).not.toBeNull();
+    expect(result.amountScore).toBe(0.15);
+    expect(result.requiresDivergenceConfirmation).toBe(true);
+  });
+
+  it("retorna null para divergencia de 20% (acima do limite)", () => {
+    const result = scoreBillTransactionMatch(makeBill(200, "2026-03-25"), makeTx(240, "2026-03-25"));
+    expect(result).toBeNull();
+  });
+
+  it("dateScore = 0.22 para delta de 2 dias", () => {
+    const result = scoreBillTransactionMatch(makeBill(200, "2026-03-25"), makeTx(200, "2026-03-27"));
+    expect(result).not.toBeNull();
+    expect(result.dateScore).toBe(0.22);
+  });
+
+  it("dateScore = 0.12 para delta de 5 dias", () => {
+    const result = scoreBillTransactionMatch(makeBill(200, "2026-03-25"), makeTx(200, "2026-03-30"));
+    expect(result).not.toBeNull();
+    expect(result.dateScore).toBe(0.12);
+  });
+
+  it("dateScore = 0 para delta de 8 dias", () => {
+    const result = scoreBillTransactionMatch(makeBill(200, "2026-03-25"), makeTx(200, "2026-04-02"));
+    expect(result).not.toBeNull();
+    expect(result.dateScore).toBe(0);
+  });
+
+  it("providerScore = 0 quando description nao contém provider nem title", () => {
+    const result = scoreBillTransactionMatch(
+      makeBill(200, "2026-03-25", "Conta Agua", "Sabesp"),
+      makeTx(200, "2026-03-25", "NETFLIX ASSINATURA")
+    );
+    expect(result).not.toBeNull();
+    expect(result.providerScore).toBe(0);
+  });
+
+  it("providerScore = 0.2 quando title aparece na description (sem provider)", () => {
+    const result = scoreBillTransactionMatch(
+      makeBill(200, "2026-03-25", "Sabesp Agua", null),
+      makeTx(200, "2026-03-25", "SABESP AGUA SP")
+    );
+    expect(result).not.toBeNull();
+    expect(result.providerScore).toBe(0.2);
+  });
+
+  it("requiresDivergenceConfirmation = true quando divergencia > 5%", () => {
+    const result = scoreBillTransactionMatch(makeBill(200, "2026-03-25"), makeTx(215, "2026-03-25"));
+    expect(result).not.toBeNull();
+    expect(result.requiresDivergenceConfirmation).toBe(true);
+  });
+});
+
+// ─── Integration ──────────────────────────────────────────────────────────────
+
+describe("reconciliation — integration", () => {
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  afterAll(async () => {
+    await clearDbClientForTests();
+  });
+
+  beforeEach(async () => {
+    resetLoginProtectionState();
+    resetImportRateLimiterState();
+    resetWriteRateLimiterState();
+    resetHttpMetricsForTests();
+    await dbQuery("DELETE FROM transactions");
+    await dbQuery("DELETE FROM bills");
+    await dbQuery("DELETE FROM users");
+  });
+
+  // ─── Auth ─────────────────────────────────────────────────────────────────
+
+  it("GET /bills/:id/match-candidates bloqueia sem token", async () => {
+    const res = await request(app).get("/bills/1/match-candidates");
+    expect(res.status).toBe(401);
+  });
+
+  it("POST /bills/:id/confirm-match bloqueia sem token", async () => {
+    const res = await request(app).post("/bills/1/confirm-match").send({});
+    expect(res.status).toBe(401);
+  });
+
+  it("DELETE /bills/:id/match bloqueia sem token", async () => {
+    const res = await request(app).delete("/bills/1/match");
+    expect(res.status).toBe(401);
+  });
+
+  // ─── GET match-candidates ─────────────────────────────────────────────────
+
+  it("GET /bills/:id/match-candidates retorna candidato com score alto", async () => {
+    const token = await registerAndLogin("recon-candidates-1@test.dev");
+
+    const billRes = await createBill(token);
+    const billId = billRes.body.id;
+
+    await createTx(token); // same date, same value, provider match → score 1.0
+
+    const res = await request(app)
+      .get(`/bills/${billId}/match-candidates`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.bill.id).toBe(billId);
+    expect(res.body.candidates).toHaveLength(1);
+    expect(res.body.candidates[0].score).toBeGreaterThanOrEqual(0.75);
+    expect(res.body.candidates[0].requiresDivergenceConfirmation).toBe(false);
+  });
+
+  it("GET /bills/:id/match-candidates exclui transacoes com divergencia > 15%", async () => {
+    const token = await registerAndLogin("recon-candidates-2@test.dev");
+
+    const billRes = await createBill(token, { amount: 200 });
+    const billId = billRes.body.id;
+
+    await createTx(token, { value: 240, description: "ENEL ENERGIA" }); // 20% divergência → null
+
+    const res = await request(app)
+      .get(`/bills/${billId}/match-candidates`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.candidates).toHaveLength(0);
+  });
+
+  it("GET /bills/:id/match-candidates exclui transacoes fora da janela de 10 dias", async () => {
+    const token = await registerAndLogin("recon-candidates-3@test.dev");
+
+    const billRes = await createBill(token, { dueDate: today() });
+    const billId = billRes.body.id;
+
+    // 15 days away — outside window
+    await createTx(token, { date: offsetDate(15), description: "ENEL ENERGIA" });
+
+    const res = await request(app)
+      .get(`/bills/${billId}/match-candidates`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.candidates).toHaveLength(0);
+  });
+
+  it("GET /bills/:id/match-candidates retorna 404 para bill de outro usuario", async () => {
+    const token1 = await registerAndLogin("recon-iso-1@test.dev");
+    const token2 = await registerAndLogin("recon-iso-2@test.dev");
+
+    const billRes = await createBill(token1);
+    const billId = billRes.body.id;
+
+    const res = await request(app)
+      .get(`/bills/${billId}/match-candidates`)
+      .set("Authorization", `Bearer ${token2}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  it("GET /bills/:id/match-candidates retorna candidatos vazio para bill ja conciliada", async () => {
+    const token = await registerAndLogin("recon-matched-cands@test.dev");
+
+    const billRes = await createBill(token);
+    const txRes = await createTx(token);
+    const billId = billRes.body.id;
+    const txId = txRes.body.id;
+
+    await request(app)
+      .post(`/bills/${billId}/confirm-match`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionId: txId });
+
+    const res = await request(app)
+      .get(`/bills/${billId}/match-candidates`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.candidates).toHaveLength(0);
+    expect(res.body.bill.matchStatus).toBe("matched");
+  });
+
+  it("GET /bills/:id/match-candidates exclui transacoes de Entrada", async () => {
+    const token = await registerAndLogin("recon-entrada@test.dev");
+
+    const billRes = await createBill(token);
+    const billId = billRes.body.id;
+
+    await request(app)
+      .post("/transactions")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ type: "Entrada", value: 200, date: today(), description: "ENEL ENERGIA" });
+
+    const res = await request(app)
+      .get(`/bills/${billId}/match-candidates`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.candidates).toHaveLength(0);
+  });
+
+  // ─── POST confirm-match ───────────────────────────────────────────────────
+
+  it("POST /bills/:id/confirm-match concilia bill com transacao", async () => {
+    const token = await registerAndLogin("recon-confirm-1@test.dev");
+
+    const billRes = await createBill(token);
+    const txRes = await createTx(token);
+    const billId = billRes.body.id;
+    const txId = txRes.body.id;
+
+    const res = await request(app)
+      .post(`/bills/${billId}/confirm-match`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionId: txId });
+
+    expect(res.status).toBe(200);
+    expect(res.body.billId).toBe(billId);
+    expect(res.body.matchStatus).toBe("matched");
+    expect(res.body.linkedTransactionId).toBe(txId);
+    expect(typeof res.body.matchedAt).toBe("string");
+    expect(res.body.divergencePercent).toBe(0);
+  });
+
+  it("POST /bills/:id/confirm-match retorna 409 para bill ja conciliada", async () => {
+    const token = await registerAndLogin("recon-confirm-dup@test.dev");
+
+    const billRes = await createBill(token);
+    const txRes = await createTx(token);
+    const billId = billRes.body.id;
+    const txId = txRes.body.id;
+
+    await request(app)
+      .post(`/bills/${billId}/confirm-match`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionId: txId });
+
+    const res = await request(app)
+      .post(`/bills/${billId}/confirm-match`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionId: txId });
+
+    expect(res.status).toBe(409);
+  });
+
+  it("POST /bills/:id/confirm-match retorna 422 com code quando divergencia > 5% sem confirmacao", async () => {
+    const token = await registerAndLogin("recon-diverg-noconfirm@test.dev");
+
+    const billRes = await createBill(token, { amount: 200 });
+    const txRes = await createTx(token, { value: 215, description: "ENEL SP" }); // 7.5% divergence
+    const billId = billRes.body.id;
+    const txId = txRes.body.id;
+
+    const res = await request(app)
+      .post(`/bills/${billId}/confirm-match`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionId: txId, confirmDivergence: false });
+
+    expect(res.status).toBe(422);
+    expect(res.body.code).toBe("DIVERGENCE_CONFIRMATION_REQUIRED");
+    expect(typeof res.body.divergencePercent).toBe("number");
+    expect(res.body.divergencePercent).toBeGreaterThan(5);
+  });
+
+  it("POST /bills/:id/confirm-match aceita divergencia > 5% com confirmDivergence: true", async () => {
+    const token = await registerAndLogin("recon-diverg-confirm@test.dev");
+
+    const billRes = await createBill(token, { amount: 200 });
+    const txRes = await createTx(token, { value: 215, description: "ENEL SP" }); // 7.5%
+    const billId = billRes.body.id;
+    const txId = txRes.body.id;
+
+    const res = await request(app)
+      .post(`/bills/${billId}/confirm-match`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionId: txId, confirmDivergence: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body.matchStatus).toBe("matched");
+    expect(res.body.divergencePercent).toBeGreaterThan(5);
+  });
+
+  it("POST /bills/:id/confirm-match retorna 409 quando transacao ja esta vinculada a outra bill", async () => {
+    const token = await registerAndLogin("recon-tx-unique@test.dev");
+
+    const bill1Res = await createBill(token, { title: "Energia Jan" });
+    const bill2Res = await createBill(token, { title: "Energia Fev" });
+    const txRes = await createTx(token);
+    const bill1Id = bill1Res.body.id;
+    const bill2Id = bill2Res.body.id;
+    const txId = txRes.body.id;
+
+    // Link to bill1
+    await request(app)
+      .post(`/bills/${bill1Id}/confirm-match`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionId: txId });
+
+    // Try to link same tx to bill2
+    const res = await request(app)
+      .post(`/bills/${bill2Id}/confirm-match`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionId: txId });
+
+    expect(res.status).toBe(409);
+  });
+
+  it("POST /bills/:id/confirm-match retorna 404 para bill de outro usuario", async () => {
+    const token1 = await registerAndLogin("recon-confirm-iso-1@test.dev");
+    const token2 = await registerAndLogin("recon-confirm-iso-2@test.dev");
+
+    const billRes = await createBill(token1);
+    const txRes = await createTx(token2);
+    const billId = billRes.body.id;
+    const txId = txRes.body.id;
+
+    const res = await request(app)
+      .post(`/bills/${billId}/confirm-match`)
+      .set("Authorization", `Bearer ${token2}`)
+      .send({ transactionId: txId });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("POST /bills/:id/confirm-match retorna 404 para transacao de outro usuario", async () => {
+    const token1 = await registerAndLogin("recon-tx-iso-1@test.dev");
+    const token2 = await registerAndLogin("recon-tx-iso-2@test.dev");
+
+    const billRes = await createBill(token1);
+    const txRes = await createTx(token2); // tx pertence ao token2
+    const billId = billRes.body.id;
+    const txId = txRes.body.id;
+
+    const res = await request(app)
+      .post(`/bills/${billId}/confirm-match`)
+      .set("Authorization", `Bearer ${token1}`) // token1 tenta usar tx de token2
+      .send({ transactionId: txId });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("POST /bills/:id/confirm-match retorna 422 para transacao do tipo Entrada", async () => {
+    const token = await registerAndLogin("recon-entrada-confirm@test.dev");
+
+    const billRes = await createBill(token);
+    const txRes = await request(app)
+      .post("/transactions")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ type: "Entrada", value: 200, date: today(), description: "Salario" });
+
+    const billId = billRes.body.id;
+    const txId = txRes.body.id;
+
+    const res = await request(app)
+      .post(`/bills/${billId}/confirm-match`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionId: txId });
+
+    expect(res.status).toBe(422);
+  });
+
+  // ─── DELETE match (unmatch) ───────────────────────────────────────────────
+
+  it("DELETE /bills/:id/match desfaz a conciliacao", async () => {
+    const token = await registerAndLogin("recon-unmatch-1@test.dev");
+
+    const billRes = await createBill(token);
+    const txRes = await createTx(token);
+    const billId = billRes.body.id;
+    const txId = txRes.body.id;
+
+    await request(app)
+      .post(`/bills/${billId}/confirm-match`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionId: txId });
+
+    const res = await request(app)
+      .delete(`/bills/${billId}/match`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.billId).toBe(billId);
+    expect(res.body.matchStatus).toBe("unmatched");
+
+    // Transacao pode ser usada novamente
+    const recandidates = await request(app)
+      .get(`/bills/${billId}/match-candidates`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(recandidates.body.candidates.length).toBeGreaterThan(0);
+  });
+
+  it("DELETE /bills/:id/match retorna 409 quando bill nao esta conciliada", async () => {
+    const token = await registerAndLogin("recon-unmatch-2@test.dev");
+
+    const billRes = await createBill(token);
+    const billId = billRes.body.id;
+
+    const res = await request(app)
+      .delete(`/bills/${billId}/match`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(409);
+  });
+});

--- a/apps/api/src/routes/bills.routes.js
+++ b/apps/api/src/routes/bills.routes.js
@@ -11,6 +11,11 @@ import {
   deleteBillForUser,
   markBillAsPaidForUser,
 } from "../services/bills.service.js";
+import {
+  getMatchCandidatesForBill,
+  confirmBillMatch,
+  unmatchBill,
+} from "../services/reconciliation.service.js";
 
 const router = Router();
 
@@ -88,6 +93,42 @@ router.delete("/:id", billsWriteRateLimiter, async (req, res, next) => {
   try {
     await deleteBillForUser(req.user.id, req.params.id);
     res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+// ─── Reconciliation ───────────────────────────────────────────────────────────
+
+router.get("/:id/match-candidates", async (req, res, next) => {
+  try {
+    const result = await getMatchCandidatesForBill(req.user.id, req.params.id);
+    res.status(200).json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post("/:id/confirm-match", billsWriteRateLimiter, async (req, res, next) => {
+  try {
+    const result = await confirmBillMatch(req.user.id, req.params.id, req.body || {});
+    res.status(200).json(result);
+  } catch (error) {
+    if (error.publicCode === "DIVERGENCE_CONFIRMATION_REQUIRED") {
+      return res.status(422).json({
+        message: error.message,
+        code: error.publicCode,
+        divergencePercent: error.divergencePercent,
+      });
+    }
+    next(error);
+  }
+});
+
+router.delete("/:id/match", billsWriteRateLimiter, async (req, res, next) => {
+  try {
+    const result = await unmatchBill(req.user.id, req.params.id);
+    res.status(200).json(result);
   } catch (error) {
     next(error);
   }

--- a/apps/api/src/services/bills.service.js
+++ b/apps/api/src/services/bills.service.js
@@ -190,6 +190,8 @@ const mapBillRow = (row) => ({
   referenceMonth: row.reference_month || null,
   billType: row.bill_type || null,
   sourceImportSessionId: row.source_import_session_id || null,
+  matchStatus: row.match_status ?? "unmatched",
+  linkedTransactionId: row.linked_transaction_id ? Number(row.linked_transaction_id) : null,
   createdAt: toISODateTime(row.created_at),
   updatedAt: toISODateTime(row.updated_at),
 });

--- a/apps/api/src/services/reconciliation.service.js
+++ b/apps/api/src/services/reconciliation.service.js
@@ -1,0 +1,267 @@
+import { dbQuery } from "../db/index.js";
+
+const createError = (status, message, extra = {}) => {
+  const error = new Error(message);
+  error.status = status;
+  Object.assign(error, extra);
+  return error;
+};
+
+// ─── Scoring ─────────────────────────────────────────────────────────────────
+
+/**
+ * Normalise text for provider matching: lowercase, strip accents, keep only
+ * alphanumeric characters and spaces.
+ */
+const normaliseText = (text) => {
+  if (!text) return "";
+  return text
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9\s]/g, "")
+    .trim();
+};
+
+const scoreAmount = (billAmount, txAmount) => {
+  const diff = Math.abs(billAmount - txAmount);
+  const pct = diff / billAmount;
+  if (pct <= 0.01) return { score: 0.5, divergencePercent: Number((pct * 100).toFixed(2)) };
+  if (pct <= 0.05) return { score: 0.35, divergencePercent: Number((pct * 100).toFixed(2)) };
+  if (pct <= 0.15) return { score: 0.15, divergencePercent: Number((pct * 100).toFixed(2)) };
+  return { score: 0, divergencePercent: Number((pct * 100).toFixed(2)) };
+};
+
+const scoreDateDelta = (billDueDate, txDate) => {
+  const due = new Date(billDueDate);
+  const tx = new Date(txDate);
+  const deltaDays = Math.abs(Math.round((tx - due) / 86_400_000));
+  if (deltaDays === 0) return 0.3;
+  if (deltaDays <= 3) return 0.22;
+  if (deltaDays <= 7) return 0.12;
+  return 0;
+};
+
+const scoreProvider = (billTitle, billProvider, txDescription) => {
+  const haystack = normaliseText(txDescription);
+  const needles = [normaliseText(billProvider), normaliseText(billTitle)].filter(Boolean);
+  return needles.some((n) => n && haystack.includes(n)) ? 0.2 : 0;
+};
+
+/**
+ * Score a bill against a transaction candidate.
+ * Returns null when amountScore = 0 (divergence > 15% — never show as candidate).
+ */
+export const scoreBillTransactionMatch = (bill, tx) => {
+  const { score: amountScore, divergencePercent } = scoreAmount(
+    Number(bill.amount),
+    Number(tx.value)
+  );
+
+  if (amountScore === 0) return null;
+
+  const dateScore = scoreDateDelta(bill.due_date, tx.date);
+  const providerScore = scoreProvider(bill.title, bill.provider, tx.description);
+  const score = Number((amountScore + dateScore + providerScore).toFixed(4));
+
+  return {
+    score,
+    amountScore,
+    dateScore,
+    providerScore,
+    divergencePercent,
+    requiresDivergenceConfirmation: divergencePercent > 5,
+  };
+};
+
+const SCORE_DISPLAY_THRESHOLD = 0.5;
+
+// ─── Read ─────────────────────────────────────────────────────────────────────
+
+const fetchBillForUser = async (userId, billId) => {
+  const parsed = Number(billId);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw createError(400, "ID de conta invalido.");
+  }
+
+  const { rows } = await dbQuery(
+    `SELECT id, user_id, title, amount, due_date, provider, match_status, linked_transaction_id
+       FROM bills
+      WHERE id = $1 AND user_id = $2`,
+    [parsed, userId]
+  );
+
+  if (!rows.length) throw createError(404, "Conta a pagar nao encontrada.");
+  return rows[0];
+};
+
+export const getMatchCandidatesForBill = async (rawUserId, rawBillId) => {
+  const userId = Number(rawUserId);
+  const bill = await fetchBillForUser(userId, rawBillId);
+
+  // No candidates for already-matched bills
+  if (bill.match_status === "matched") {
+    return {
+      bill: formatBill(bill),
+      candidates: [],
+    };
+  }
+
+  // Search window: due_date ± 10 days, type = Saida, same user
+  const { rows: transactions } = await dbQuery(
+    `SELECT id, description, value, date
+       FROM transactions
+      WHERE user_id = $1
+        AND type = 'Saida'
+        AND date BETWEEN $2::date - INTERVAL '10 days' AND $2::date + INTERVAL '10 days'
+      ORDER BY date ASC`,
+    [userId, bill.due_date]
+  );
+
+  const candidates = transactions
+    .map((tx) => {
+      const scoreResult = scoreBillTransactionMatch(bill, tx);
+      if (!scoreResult || scoreResult.score < SCORE_DISPLAY_THRESHOLD) return null;
+      return {
+        transactionId: tx.id,
+        description: tx.description ?? null,
+        amount: Number(tx.value),
+        date: tx.date instanceof Date
+          ? tx.date.toISOString().slice(0, 10)
+          : String(tx.date).slice(0, 10),
+        ...scoreResult,
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => b.score - a.score);
+
+  return {
+    bill: formatBill(bill),
+    candidates,
+  };
+};
+
+// ─── Confirm match ────────────────────────────────────────────────────────────
+
+export const confirmBillMatch = async (rawUserId, rawBillId, input) => {
+  const userId = Number(rawUserId);
+  const bill = await fetchBillForUser(userId, rawBillId);
+
+  if (bill.match_status === "matched") {
+    throw createError(409, "Conta ja esta conciliada.");
+  }
+
+  const txId = Number(input.transactionId);
+  if (!Number.isInteger(txId) || txId <= 0) {
+    throw createError(400, "transactionId invalido.");
+  }
+
+  // Fetch the transaction — must belong to same user and be Saida
+  const { rows: txRows } = await dbQuery(
+    `SELECT id, value, date, description, type
+       FROM transactions
+      WHERE id = $1 AND user_id = $2`,
+    [txId, userId]
+  );
+
+  if (!txRows.length) throw createError(404, "Transacao nao encontrada.");
+  const tx = txRows[0];
+
+  if (tx.type !== "Saida") {
+    throw createError(422, "Apenas transacoes de saida podem ser conciliadas com contas a pagar.");
+  }
+
+  // Uniqueness: no other matched bill uses this transaction
+  const { rows: conflict } = await dbQuery(
+    `SELECT id FROM bills WHERE linked_transaction_id = $1 AND match_status = 'matched' AND id != $2`,
+    [txId, bill.id]
+  );
+  if (conflict.length) {
+    throw createError(409, "Esta transacao ja esta vinculada a outra conta.");
+  }
+
+  // Compute score for metadata
+  const scoreResult = scoreBillTransactionMatch(bill, tx);
+  const divergencePercent = scoreResult ? scoreResult.divergencePercent : 0;
+
+  // Require explicit confirmation for divergence > 5%
+  if (divergencePercent > 5 && !input.confirmDivergence) {
+    throw createError(422, "Confirmacao de divergencia necessaria.", {
+      publicCode: "DIVERGENCE_CONFIRMATION_REQUIRED",
+      divergencePercent,
+    });
+  }
+
+  const metadata = scoreResult
+    ? {
+        amountScore: scoreResult.amountScore,
+        dateScore: scoreResult.dateScore,
+        providerScore: scoreResult.providerScore,
+        billAmount: Number(bill.amount),
+        txAmount: Number(tx.value),
+        divergencePercent,
+        providerMatched: scoreResult.providerScore > 0,
+      }
+    : { billAmount: Number(bill.amount), txAmount: Number(tx.value), divergencePercent };
+
+  const { rows: updated } = await dbQuery(
+    `UPDATE bills
+        SET linked_transaction_id = $1,
+            match_status          = 'matched',
+            matched_at            = NOW(),
+            match_confidence      = $2,
+            match_metadata        = $3,
+            updated_at            = NOW()
+      WHERE id = $4 AND user_id = $5
+      RETURNING id, match_status, linked_transaction_id, matched_at, match_confidence`,
+    [txId, scoreResult?.score ?? null, JSON.stringify(metadata), bill.id, userId]
+  );
+
+  const row = updated[0];
+  return {
+    billId: row.id,
+    matchStatus: row.match_status,
+    linkedTransactionId: row.linked_transaction_id,
+    matchedAt: row.matched_at,
+    matchConfidence: row.match_confidence !== null ? Number(row.match_confidence) : null,
+    divergencePercent,
+  };
+};
+
+// ─── Unmatch (undo) ───────────────────────────────────────────────────────────
+
+export const unmatchBill = async (rawUserId, rawBillId) => {
+  const userId = Number(rawUserId);
+  const bill = await fetchBillForUser(userId, rawBillId);
+
+  if (bill.match_status === "unmatched") {
+    throw createError(409, "Conta nao esta conciliada.");
+  }
+
+  await dbQuery(
+    `UPDATE bills
+        SET linked_transaction_id = NULL,
+            match_status          = 'unmatched',
+            matched_at            = NULL,
+            match_confidence      = NULL,
+            match_metadata        = '{}'::jsonb,
+            updated_at            = NOW()
+      WHERE id = $1 AND user_id = $2`,
+    [bill.id, userId]
+  );
+
+  return { billId: bill.id, matchStatus: "unmatched" };
+};
+
+// ─── Formatters ───────────────────────────────────────────────────────────────
+
+const formatBill = (row) => ({
+  id: row.id,
+  title: row.title,
+  amount: Number(row.amount),
+  dueDate: row.due_date instanceof Date
+    ? row.due_date.toISOString().slice(0, 10)
+    : String(row.due_date).slice(0, 10),
+  matchStatus: row.match_status,
+  linkedTransactionId: row.linked_transaction_id ?? null,
+});

--- a/apps/api/src/services/reconciliation.service.js
+++ b/apps/api/src/services/reconciliation.service.js
@@ -204,18 +204,28 @@ export const confirmBillMatch = async (rawUserId, rawBillId, input) => {
       }
     : { billAmount: Number(bill.amount), txAmount: Number(tx.value), divergencePercent };
 
-  const { rows: updated } = await dbQuery(
-    `UPDATE bills
-        SET linked_transaction_id = $1,
-            match_status          = 'matched',
-            matched_at            = NOW(),
-            match_confidence      = $2,
-            match_metadata        = $3,
-            updated_at            = NOW()
-      WHERE id = $4 AND user_id = $5
-      RETURNING id, match_status, linked_transaction_id, matched_at, match_confidence`,
-    [txId, scoreResult?.score ?? null, JSON.stringify(metadata), bill.id, userId]
-  );
+  let updated;
+  try {
+    const result = await dbQuery(
+      `UPDATE bills
+          SET linked_transaction_id = $1,
+              match_status          = 'matched',
+              matched_at            = NOW(),
+              match_confidence      = $2,
+              match_metadata        = $3,
+              updated_at            = NOW()
+        WHERE id = $4 AND user_id = $5
+        RETURNING id, match_status, linked_transaction_id, matched_at, match_confidence`,
+      [txId, scoreResult?.score ?? null, JSON.stringify(metadata), bill.id, userId]
+    );
+    updated = result.rows;
+  } catch (err) {
+    // Unique index violation: another concurrent request linked the same transaction first
+    if (err.code === "23505") {
+      throw createError(409, "Esta transacao ja esta vinculada a outra conta.");
+    }
+    throw err;
+  }
 
   const row = updated[0];
   return {

--- a/apps/web/src/components/UtilityBillsWidget.tsx
+++ b/apps/web/src/components/UtilityBillsWidget.tsx
@@ -275,6 +275,7 @@ const UtilityBillsWidget = (): JSX.Element => {
   const [hasError, setHasError] = useState(false);
   const [insight, setInsight] = useState<UtilityInsight | null>(null);
   const [reconcile, setReconcile] = useState<ReconcileState | null>(null);
+  const [unmatchError, setUnmatchError] = useState<string | null>(null);
   const money = useMaskedCurrency();
 
   const load = useCallback(() => {
@@ -341,11 +342,12 @@ const UtilityBillsWidget = (): JSX.Element => {
   };
 
   const handleUnmatch = async (bill: Bill) => {
+    setUnmatchError(null);
     try {
       await billsService.unmatch(bill.id);
       load();
     } catch {
-      // silent — non-blocking, reload will still show current state
+      setUnmatchError("Não foi possível desfazer a conciliação. Tente novamente.");
     }
   };
 
@@ -413,6 +415,11 @@ const UtilityBillsWidget = (): JSX.Element => {
         </div>
       ) : (
         <>
+          {/* Unmatch error */}
+          {unmatchError ? (
+            <p className="mb-2 text-xs text-red-600">{unmatchError}</p>
+          ) : null}
+
           {/* AI insight banner */}
           {insight ? (
             <div

--- a/apps/web/src/components/UtilityBillsWidget.tsx
+++ b/apps/web/src/components/UtilityBillsWidget.tsx
@@ -1,6 +1,11 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { useMaskedCurrency } from "../context/DiscreetModeContext";
-import { billsService, type Bill, type UtilityPanel } from "../services/bills.service";
+import {
+  billsService,
+  type Bill,
+  type UtilityPanel,
+  type MatchCandidate,
+} from "../services/bills.service";
 import { aiService, type UtilityInsight } from "../services/ai.service";
 
 const BILL_TYPE_LABELS: Record<string, string> = {
@@ -16,59 +21,239 @@ const formatDueDate = (iso: string): string => {
   return `${day}/${month}/${year}`;
 };
 
-const BillRow = ({
-  bill,
-  urgency,
+// ─── Reconciliation state per bill ───────────────────────────────────────────
+
+type ReconcilePhase =
+  | { phase: "idle" }
+  | { phase: "loading" }
+  | { phase: "candidates"; candidates: MatchCandidate[] }
+  | { phase: "confirm_divergence"; candidate: MatchCandidate; billAmount: number }
+  | { phase: "confirming" }
+  | { phase: "error"; message: string };
+
+interface ReconcileState {
+  billId: number;
+  inner: ReconcilePhase;
+}
+
+// ─── Candidate row ────────────────────────────────────────────────────────────
+
+const CandidateRow = ({
+  candidate,
   money,
+  onConfirm,
 }: {
-  bill: Bill;
-  urgency: "overdue" | "due_soon" | "upcoming";
+  candidate: MatchCandidate;
   money: (v: number) => string;
+  onConfirm: (c: MatchCandidate) => void;
 }) => {
-  const typeLabel = bill.billType ? (BILL_TYPE_LABELS[bill.billType] ?? bill.billType) : null;
+  const confidenceLabel = candidate.score >= 0.75 ? "Alta" : "Média";
+  const confidenceClass =
+    candidate.score >= 0.75
+      ? "bg-emerald-100 text-emerald-700"
+      : "bg-amber-100 text-amber-700";
 
   return (
     <div className="flex items-center justify-between gap-2 py-1.5">
       <div className="min-w-0">
-        <div className="flex items-center gap-1.5">
-          <span
-            className={`inline-block h-1.5 w-1.5 flex-shrink-0 rounded-full ${
-              urgency === "overdue"
-                ? "bg-red-500"
-                : urgency === "due_soon"
-                  ? "bg-amber-500"
-                  : "bg-cf-text-secondary"
-            }`}
-          />
-          <span className="truncate text-xs text-cf-text-primary">{bill.title}</span>
-          {typeLabel ? (
-            <span className="flex-shrink-0 rounded bg-cf-bg-subtle px-1 py-0.5 text-[10px] text-cf-text-secondary">
-              {typeLabel}
-            </span>
-          ) : null}
-        </div>
-        {bill.provider ? (
-          <p className="ml-3 text-[10px] text-cf-text-secondary">{bill.provider}</p>
-        ) : null}
+        <p className="truncate text-xs text-cf-text-primary">
+          {candidate.description ?? "Sem descrição"}
+        </p>
+        <p className="text-[10px] text-cf-text-secondary">
+          {formatDueDate(candidate.date)} · {money(candidate.amount)}
+          {candidate.divergencePercent > 1
+            ? ` · divergência ${candidate.divergencePercent.toFixed(1)}%`
+            : null}
+        </p>
       </div>
-      <div className="flex-shrink-0 text-right">
-        <p
-          className={`text-xs font-medium ${
-            urgency === "overdue" ? "text-red-600" : "text-cf-text-primary"
-          }`}
+      <div className="flex flex-shrink-0 items-center gap-1.5">
+        <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${confidenceClass}`}>
+          {confidenceLabel}
+        </span>
+        <button
+          type="button"
+          onClick={() => onConfirm(candidate)}
+          className="rounded border border-cf-border px-2 py-0.5 text-[10px] text-cf-text-secondary hover:border-emerald-400 hover:text-emerald-700"
         >
-          {money(bill.amount)}
-        </p>
-        <p
-          className={`text-[10px] ${urgency === "overdue" ? "text-red-500" : "text-cf-text-secondary"}`}
-        >
-          {urgency === "overdue" ? "venceu " : ""}
-          {formatDueDate(bill.dueDate)}
-        </p>
+          Confirmar
+        </button>
       </div>
     </div>
   );
 };
+
+// ─── Bill row ─────────────────────────────────────────────────────────────────
+
+const BillRow = ({
+  bill,
+  urgency,
+  money,
+  reconcile,
+  onConciliar,
+  onConfirmCandidate,
+  onConfirmDivergence,
+  onCancelReconcile,
+  onUnmatch,
+}: {
+  bill: Bill;
+  urgency: "overdue" | "due_soon" | "upcoming";
+  money: (v: number) => string;
+  reconcile: ReconcileState | null;
+  onConciliar: () => void;
+  onConfirmCandidate: (c: MatchCandidate) => void;
+  onConfirmDivergence: () => void;
+  onCancelReconcile: () => void;
+  onUnmatch: () => void;
+}) => {
+  const typeLabel = bill.billType ? (BILL_TYPE_LABELS[bill.billType] ?? bill.billType) : null;
+  const isMatched = bill.matchStatus === "matched";
+  const phase = reconcile?.billId === bill.id ? reconcile.inner : null;
+
+  return (
+    <div className="py-1.5">
+      {/* Main row */}
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex items-center gap-1.5">
+            <span
+              className={`inline-block h-1.5 w-1.5 flex-shrink-0 rounded-full ${
+                urgency === "overdue"
+                  ? "bg-red-500"
+                  : urgency === "due_soon"
+                    ? "bg-amber-500"
+                    : "bg-cf-text-secondary"
+              }`}
+            />
+            <span className="truncate text-xs text-cf-text-primary">{bill.title}</span>
+            {typeLabel ? (
+              <span className="flex-shrink-0 rounded bg-cf-bg-subtle px-1 py-0.5 text-[10px] text-cf-text-secondary">
+                {typeLabel}
+              </span>
+            ) : null}
+            {isMatched ? (
+              <span className="flex-shrink-0 rounded bg-emerald-100 px-1 py-0.5 text-[10px] font-medium text-emerald-700">
+                Conciliada
+              </span>
+            ) : null}
+          </div>
+          {bill.provider ? (
+            <p className="ml-3 text-[10px] text-cf-text-secondary">{bill.provider}</p>
+          ) : null}
+        </div>
+        <div className="flex flex-shrink-0 items-center gap-1.5">
+          <div className="text-right">
+            <p
+              className={`text-xs font-medium ${
+                urgency === "overdue" ? "text-red-600" : "text-cf-text-primary"
+              }`}
+            >
+              {money(bill.amount)}
+            </p>
+            <p
+              className={`text-[10px] ${urgency === "overdue" ? "text-red-500" : "text-cf-text-secondary"}`}
+            >
+              {urgency === "overdue" ? "venceu " : ""}
+              {formatDueDate(bill.dueDate)}
+            </p>
+          </div>
+          {isMatched ? (
+            <button
+              type="button"
+              onClick={onUnmatch}
+              title="Desfazer conciliação"
+              className="rounded px-1.5 py-0.5 text-[10px] text-cf-text-secondary hover:bg-cf-border hover:text-cf-text-primary"
+            >
+              Desfazer
+            </button>
+          ) : phase === null ? (
+            <button
+              type="button"
+              onClick={onConciliar}
+              className="rounded border border-cf-border px-1.5 py-0.5 text-[10px] text-cf-text-secondary hover:border-brand-1 hover:text-brand-1"
+            >
+              Conciliar
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      {/* Reconcile panel — inline below the row */}
+      {phase ? (
+        <div className="ml-3 mt-2 rounded border border-cf-border bg-cf-bg-page px-3 py-2">
+          {phase.phase === "loading" ? (
+            <p className="text-[10px] text-cf-text-secondary">Buscando transações...</p>
+          ) : phase.phase === "candidates" ? (
+            <>
+              {phase.candidates.length === 0 ? (
+                <p className="text-[10px] text-cf-text-secondary">
+                  Nenhuma transação compatível encontrada na janela de ±10 dias.
+                </p>
+              ) : (
+                <div className="divide-y divide-cf-border">
+                  {phase.candidates.map((c) => (
+                    <CandidateRow
+                      key={c.transactionId}
+                      candidate={c}
+                      money={money}
+                      onConfirm={onConfirmCandidate}
+                    />
+                  ))}
+                </div>
+              )}
+              <button
+                type="button"
+                onClick={onCancelReconcile}
+                className="mt-2 text-[10px] text-cf-text-secondary hover:text-cf-text-primary"
+              >
+                Cancelar
+              </button>
+            </>
+          ) : phase.phase === "confirm_divergence" ? (
+            <>
+              <p className="mb-2 text-[10px] text-amber-700">
+                Divergência de{" "}
+                <strong>{phase.candidate.divergencePercent.toFixed(1)}%</strong> entre a conta (
+                {money(phase.billAmount)}) e a transação ({money(phase.candidate.amount)}).
+                Confirmar mesmo assim?
+              </p>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={onConfirmDivergence}
+                  className="rounded bg-amber-600 px-2 py-0.5 text-[10px] font-medium text-white hover:opacity-90"
+                >
+                  Confirmar divergência
+                </button>
+                <button
+                  type="button"
+                  onClick={onCancelReconcile}
+                  className="text-[10px] text-cf-text-secondary hover:text-cf-text-primary"
+                >
+                  Cancelar
+                </button>
+              </div>
+            </>
+          ) : phase.phase === "confirming" ? (
+            <p className="text-[10px] text-cf-text-secondary">Salvando conciliação...</p>
+          ) : phase.phase === "error" ? (
+            <>
+              <p className="text-[10px] text-red-600">{phase.message}</p>
+              <button
+                type="button"
+                onClick={onCancelReconcile}
+                className="mt-1 text-[10px] text-cf-text-secondary hover:text-cf-text-primary"
+              >
+                Fechar
+              </button>
+            </>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+// ─── Widget ───────────────────────────────────────────────────────────────────
 
 const EMPTY_PANEL: UtilityPanel = {
   overdue: [],
@@ -89,9 +274,10 @@ const UtilityBillsWidget = (): JSX.Element => {
   const [isLoading, setIsLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
   const [insight, setInsight] = useState<UtilityInsight | null>(null);
+  const [reconcile, setReconcile] = useState<ReconcileState | null>(null);
   const money = useMaskedCurrency();
 
-  useEffect(() => {
+  const load = useCallback(() => {
     billsService
       .getUtilityPanel()
       .then((data) => {
@@ -102,10 +288,68 @@ const UtilityBillsWidget = (): JSX.Element => {
       .finally(() => setIsLoading(false));
   }, []);
 
+  useEffect(() => {
+    load();
+  }, [load]);
+
   // Insight fetched once on mount — soft triagem signal, not synchronized with data refreshes.
   useEffect(() => {
     aiService.getUtilityInsight().then(setInsight).catch(() => {/* non-blocking */});
   }, []);
+
+  // ─── Reconcile handlers ─────────────────────────────────────────────────────
+
+  const handleConciliar = async (bill: Bill) => {
+    setReconcile({ billId: bill.id, inner: { phase: "loading" } });
+    try {
+      const result = await billsService.getMatchCandidates(bill.id);
+      setReconcile({ billId: bill.id, inner: { phase: "candidates", candidates: result.candidates } });
+    } catch {
+      setReconcile({ billId: bill.id, inner: { phase: "error", message: "Erro ao buscar candidatos." } });
+    }
+  };
+
+  const handleConfirmCandidate = (bill: Bill, candidate: MatchCandidate) => {
+    if (candidate.requiresDivergenceConfirmation) {
+      setReconcile({
+        billId: bill.id,
+        inner: { phase: "confirm_divergence", candidate, billAmount: bill.amount },
+      });
+      return;
+    }
+    doConfirm(bill, candidate, false);
+  };
+
+  const handleConfirmDivergence = (bill: Bill) => {
+    const phase = reconcile?.inner;
+    if (phase?.phase !== "confirm_divergence") return;
+    doConfirm(bill, phase.candidate, true);
+  };
+
+  const doConfirm = async (bill: Bill, candidate: MatchCandidate, confirmDivergence: boolean) => {
+    setReconcile({ billId: bill.id, inner: { phase: "confirming" } });
+    try {
+      await billsService.confirmMatch(bill.id, candidate.transactionId, confirmDivergence);
+      setReconcile(null);
+      load();
+    } catch {
+      setReconcile({
+        billId: bill.id,
+        inner: { phase: "error", message: "Erro ao salvar conciliação. Tente novamente." },
+      });
+    }
+  };
+
+  const handleUnmatch = async (bill: Bill) => {
+    try {
+      await billsService.unmatch(bill.id);
+      load();
+    } catch {
+      // silent — non-blocking, reload will still show current state
+    }
+  };
+
+  // ─── Render ─────────────────────────────────────────────────────────────────
 
   if (isLoading) {
     return (
@@ -126,6 +370,21 @@ const UtilityBillsWidget = (): JSX.Element => {
 
   const { overdue, dueSoon, upcoming, summary } = panel;
   const hasAny = summary.totalPending > 0;
+
+  const renderBillRow = (bill: Bill, urgency: "overdue" | "due_soon" | "upcoming") => (
+    <BillRow
+      key={bill.id}
+      bill={bill}
+      urgency={urgency}
+      money={money}
+      reconcile={reconcile}
+      onConciliar={() => handleConciliar(bill)}
+      onConfirmCandidate={(c) => handleConfirmCandidate(bill, c)}
+      onConfirmDivergence={() => handleConfirmDivergence(bill)}
+      onCancelReconcile={() => setReconcile(null)}
+      onUnmatch={() => handleUnmatch(bill)}
+    />
+  );
 
   return (
     <div className="rounded border border-cf-border bg-cf-surface p-4">
@@ -182,9 +441,7 @@ const UtilityBillsWidget = (): JSX.Element => {
                 <p className="text-[10px] font-medium text-red-600">{money(summary.overdueAmount)}</p>
               </div>
               <div className="divide-y divide-cf-border rounded border border-red-200 bg-red-50 px-3">
-                {overdue.map((b) => (
-                  <BillRow key={b.id} bill={b} urgency="overdue" money={money} />
-                ))}
+                {overdue.map((b) => renderBillRow(b, "overdue"))}
               </div>
             </div>
           ) : null}
@@ -199,9 +456,7 @@ const UtilityBillsWidget = (): JSX.Element => {
                 <p className="text-[10px] font-medium text-amber-600">{money(summary.dueSoonAmount)}</p>
               </div>
               <div className="divide-y divide-cf-border rounded border border-amber-200 bg-amber-50 px-3">
-                {dueSoon.map((b) => (
-                  <BillRow key={b.id} bill={b} urgency="due_soon" money={money} />
-                ))}
+                {dueSoon.map((b) => renderBillRow(b, "due_soon"))}
               </div>
             </div>
           ) : null}
@@ -215,9 +470,7 @@ const UtilityBillsWidget = (): JSX.Element => {
                 </p>
               </div>
               <div className="divide-y divide-cf-border rounded border border-cf-border bg-cf-bg-subtle px-3">
-                {upcoming.map((b) => (
-                  <BillRow key={b.id} bill={b} urgency="upcoming" money={money} />
-                ))}
+                {upcoming.map((b) => renderBillRow(b, "upcoming"))}
               </div>
             </div>
           ) : null}

--- a/apps/web/src/pages/BillsPage.test.tsx
+++ b/apps/web/src/pages/BillsPage.test.tsx
@@ -43,6 +43,8 @@ const buildBill = (overrides: Partial<Bill> = {}): Bill => ({
   referenceMonth: null,
   billType: null,
   sourceImportSessionId: null,
+  matchStatus: "unmatched",
+  linkedTransactionId: null,
   createdAt: "2026-02-01T12:00:00.000Z",
   updatedAt: "2026-02-01T12:00:00.000Z",
   ...overrides,

--- a/apps/web/src/services/bills.service.ts
+++ b/apps/web/src/services/bills.service.ts
@@ -4,6 +4,7 @@ import { api } from "./api";
 
 export type BillStatus = "pending" | "paid";
 export type BillStatusFilter = "pending" | "paid" | "overdue" | undefined;
+export type MatchStatus = "unmatched" | "matched";
 
 export interface Bill {
   id: number;
@@ -20,6 +21,8 @@ export interface Bill {
   referenceMonth: string | null;
   billType: string | null;
   sourceImportSessionId: string | null;
+  matchStatus: MatchStatus;
+  linkedTransactionId: number | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -81,6 +84,53 @@ export interface MarkPaidResult {
   };
 }
 
+export interface MatchCandidate {
+  transactionId: number;
+  description: string | null;
+  amount: number;
+  date: string;
+  score: number;
+  amountScore: number;
+  dateScore: number;
+  providerScore: number;
+  divergencePercent: number;
+  requiresDivergenceConfirmation: boolean;
+}
+
+export interface MatchCandidatesBill {
+  id: number;
+  title: string;
+  amount: number;
+  dueDate: string;
+  matchStatus: MatchStatus;
+  linkedTransactionId: number | null;
+}
+
+export interface MatchCandidatesResult {
+  bill: MatchCandidatesBill;
+  candidates: MatchCandidate[];
+}
+
+export interface ConfirmMatchResult {
+  billId: number;
+  matchStatus: MatchStatus;
+  linkedTransactionId: number;
+  matchedAt: string;
+  matchConfidence: number | null;
+  divergencePercent: number;
+}
+
+export interface UnmatchResult {
+  billId: number;
+  matchStatus: MatchStatus;
+}
+
+export interface DivergenceConfirmationError {
+  code: "DIVERGENCE_CONFIRMATION_REQUIRED";
+  divergencePercent: number;
+  message: string;
+}
+
 // ─── Raw API payload type ─────────────────────────────────────────────────────
 
 interface BillApiPayload {
@@ -106,6 +156,9 @@ interface BillApiPayload {
   bill_type?: unknown;
   sourceImportSessionId?: unknown;
   source_import_session_id?: unknown;
+  matchStatus?: unknown;
+  linkedTransactionId?: unknown;
+  linked_transaction_id?: unknown;
   createdAt?: unknown;
   created_at?: unknown;
   updatedAt?: unknown;
@@ -150,6 +203,12 @@ const normalizeBill = (raw: BillApiPayload): Bill => {
     referenceMonth: normalizeStringOrNull(raw.referenceMonth ?? raw.reference_month),
     billType: normalizeStringOrNull(raw.billType ?? raw.bill_type),
     sourceImportSessionId: normalizeStringOrNull(raw.sourceImportSessionId ?? raw.source_import_session_id),
+    matchStatus: raw.matchStatus === "matched" ? "matched" : "unmatched",
+    linkedTransactionId: (() => {
+      const v = raw.linkedTransactionId ?? raw.linked_transaction_id;
+      const n = Number(v);
+      return Number.isInteger(n) && n > 0 ? n : null;
+    })(),
     createdAt: normalizeISOString(raw.createdAt ?? raw.created_at),
     updatedAt: normalizeISOString(raw.updatedAt ?? raw.updated_at),
   };
@@ -253,5 +312,27 @@ export const billsService = {
         description: typeof tx?.description === "string" ? tx.description : null,
       },
     };
+  },
+
+  getMatchCandidates: async (billId: number): Promise<MatchCandidatesResult> => {
+    const { data } = await api.get<MatchCandidatesResult>(`/bills/${billId}/match-candidates`);
+    return data;
+  },
+
+  confirmMatch: async (
+    billId: number,
+    transactionId: number,
+    confirmDivergence = false
+  ): Promise<ConfirmMatchResult> => {
+    const { data } = await api.post<ConfirmMatchResult>(`/bills/${billId}/confirm-match`, {
+      transactionId,
+      confirmDivergence,
+    });
+    return data;
+  },
+
+  unmatch: async (billId: number): Promise<UnmatchResult> => {
+    const { data } = await api.delete<UnmatchResult>(`/bills/${billId}/match`);
+    return data;
   },
 };


### PR DESCRIPTION
## O que entra

Conciliação assistida, determinística e auditável entre bills de consumo e transações bancárias. O score decide; o usuário confirma; o sistema não executa baixa automática.

## Migration 109

Colunas adicionadas a `bills`:
- `linked_transaction_id` — referência à transação vinculada
- `match_status` — `unmatched | matched`
- `matched_at`, `match_confidence`, `match_metadata` (JSONB com snapshot do score)
- Índice único parcial: uma transação → no máximo uma bill

## Motor de scoring (determinístico)

| Eixo | Peso | Lógica |
|------|------|--------|
| Valor | 0.50 | ≤1% → 0.50 · ≤5% → 0.35 · ≤15% → 0.15 · >15% → não exibe |
| Data | 0.30 | Δ0d → 0.30 · ≤3d → 0.22 · ≤7d → 0.12 · >7d → 0 |
| Provider | 0.20 | substring normalizado (sem acento, lowercase) em description |

Threshold de exibição: score ≥ 0.50. Candidatos ordenados por score desc.

## API

- `GET /bills/:id/match-candidates` — busca janela `due_date ± 10d`, apenas `Saida`
- `POST /bills/:id/confirm-match` — valida ownership, unicidade, divergência; retorna `422 DIVERGENCE_CONFIRMATION_REQUIRED` com `divergencePercent` quando >5% sem flag explícito
- `DELETE /bills/:id/match` — desfaz e libera a transação

## Frontend

- `Bill` type estendido com `matchStatus` e `linkedTransactionId`
- `UtilityBillsWidget` reescrito: botão "Conciliar" por bill → candidatos lazy → badge Alta/Média → confirmação inline de divergência → badge verde "Conciliada" + "Desfazer"

## Testes

- 9 unit (score exato, axes individuais, edge cases de divergência)
- 17 integration (candidates, window, Entrada filter, user isolation, uniqueness, divergência com/sem flag, unmatch)

## Fora de escopo

- Baixa automática (`bill.status = 'paid'`)
- Múltiplas transações por bill
- AI decidindo o match