### PR TITLE
feat(cards): import credit card invoice pdf and reconcile payment

### DIFF
--- a/apps/api/src/credit-card-invoices.test.js
+++ b/apps/api/src/credit-card-invoices.test.js
@@ -1,0 +1,325 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+import request from "supertest";
+import app from "./app.js";
+import { clearDbClientForTests, dbQuery } from "./db/index.js";
+import { setupTestDb, registerAndLogin, expectErrorResponseWithRequestId } from "./test-helpers.js";
+import { resetLoginProtectionState } from "./middlewares/login-protection.middleware.js";
+import { resetImportRateLimiterState, resetWriteRateLimiterState } from "./middlewares/rate-limit.middleware.js";
+import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
+
+// ─── Mock pdf-ocr so tests run without real PDF toolchain ─────────────────────
+
+const mockExtractText = vi.hoisted(() => vi.fn());
+
+vi.mock("./domain/imports/pdf-ocr.js", () => ({
+  extractTextFromPdfWithOcr: mockExtractText,
+  isImportOcrEnabled: () => false,
+  shouldRunPdfOcrFallback: () => false,
+}));
+
+// ─── Sample Itaú invoice text ─────────────────────────────────────────────────
+
+const VALID_ITAU_TEXT = `
+BANCO ITAÚ S.A.
+**** 1234
+PERÍODO DE 08/02/2026 A 07/03/2026
+VENCIMENTO  15/03/2026
+TOTAL DA FATURA    R$ 1.247,80
+PAGAMENTO MÍNIMO R$ 124,78
+`.trim();
+
+const ITAU_TEXT_NO_PERIOD = `
+BANCO ITAÚ S.A.
+VENCIMENTO  15/03/2026
+TOTAL DA FATURA    R$ 850,00
+`.trim();
+
+const INVALID_TEXT = `Este texto nao tem nenhum dado de fatura.`;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const createCard = (token, overrides = {}) =>
+  request(app)
+    .post("/credit-cards")
+    .set("Authorization", `Bearer ${token}`)
+    .send({ name: "Itaú Mastercard", limitTotal: 5000, closingDay: 7, dueDay: 15, ...overrides });
+
+const uploadInvoice = (token, cardId, bufferContent = "fake-pdf") =>
+  request(app)
+    .post(`/credit-cards/${cardId}/invoices/parse-pdf`)
+    .set("Authorization", `Bearer ${token}`)
+    .attach("file", Buffer.from(bufferContent, "utf8"), {
+      filename: "fatura.pdf",
+      contentType: "application/pdf",
+    });
+
+// ─── State reset ──────────────────────────────────────────────────────────────
+
+const resetState = async () => {
+  resetLoginProtectionState();
+  resetImportRateLimiterState();
+  resetWriteRateLimiterState();
+  resetHttpMetricsForTests();
+  mockExtractText.mockReset();
+  await dbQuery("DELETE FROM credit_card_invoices");
+  await dbQuery("DELETE FROM credit_card_purchases");
+  await dbQuery("DELETE FROM bills");
+  await dbQuery("DELETE FROM credit_cards");
+  await dbQuery("DELETE FROM users");
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("credit-card-invoices", () => {
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  afterAll(async () => {
+    await clearDbClientForTests();
+  });
+
+  beforeEach(resetState);
+
+  // ─── Auth ───────────────────────────────────────────────────────────────────
+
+  it("POST /credit-cards/:id/invoices/parse-pdf bloqueia sem token", async () => {
+    const res = await request(app)
+      .post("/credit-cards/1/invoices/parse-pdf")
+      .attach("file", Buffer.from("fake", "utf8"), { filename: "f.pdf", contentType: "application/pdf" });
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /credit-cards/:id/invoices bloqueia sem token", async () => {
+    const res = await request(app).get("/credit-cards/1/invoices");
+    expect(res.status).toBe(401);
+  });
+
+  // ─── parse-pdf ──────────────────────────────────────────────────────────────
+
+  it("POST parse-pdf retorna 201 com campos corretos para fatura valida", async () => {
+    const token = await registerAndLogin("inv-parse-ok@test.dev");
+    mockExtractText.mockResolvedValue(VALID_ITAU_TEXT);
+
+    const cardRes = await createCard(token);
+    const cardId = cardRes.body.id;
+
+    const res = await uploadInvoice(token, cardId);
+
+    expect(res.status).toBe(201);
+    expect(res.body.creditCardId).toBe(cardId);
+    expect(res.body.issuer).toBe("itau");
+    expect(res.body.cardLast4).toBe("1234");
+    expect(res.body.totalAmount).toBe(1247.80);
+    expect(res.body.dueDate).toBe("2026-03-15");
+    expect(res.body.periodStart).toBe("2026-02-08");
+    expect(res.body.periodEnd).toBe("2026-03-07");
+    expect(res.body.minimumPayment).toBe(124.78);
+    expect(res.body.parseConfidence).toBe("high");
+    expect(res.body.linkedBillId).toBeNull();
+  });
+
+  it("POST parse-pdf infere periodo quando ausente no PDF (parse_confidence=low)", async () => {
+    const token = await registerAndLogin("inv-infer@test.dev");
+    mockExtractText.mockResolvedValue(ITAU_TEXT_NO_PERIOD);
+
+    // closing_day=7, dueDate=15/03/2026 → period_end=07/03/2026, period_start=08/02/2026
+    const cardRes = await createCard(token, { closingDay: 7, dueDay: 15 });
+    const cardId = cardRes.body.id;
+
+    const res = await uploadInvoice(token, cardId);
+
+    expect(res.status).toBe(201);
+    expect(res.body.parseConfidence).toBe("low");
+    expect(res.body.periodStart).not.toBeNull();
+    expect(res.body.periodEnd).not.toBeNull();
+    expect(res.body.parseMetadata.fieldsSources.periodStart).toBe("inference:closing_day");
+    expect(res.body.parseMetadata.inferenceContext.closingDay).toBe(7);
+  });
+
+  it("POST parse-pdf retorna 422 INVOICE_PARSE_FAILED para texto ilegivel", async () => {
+    const token = await registerAndLogin("inv-parse-fail@test.dev");
+    mockExtractText.mockResolvedValue(INVALID_TEXT);
+
+    const cardRes = await createCard(token);
+    const cardId = cardRes.body.id;
+
+    const res = await uploadInvoice(token, cardId);
+
+    expect(res.status).toBe(422);
+    expect(res.body.code).toBe("INVOICE_PARSE_FAILED");
+  });
+
+  it("POST parse-pdf retorna 404 para cartao de outro usuario", async () => {
+    const token1 = await registerAndLogin("inv-iso-1@test.dev");
+    const token2 = await registerAndLogin("inv-iso-2@test.dev");
+    mockExtractText.mockResolvedValue(VALID_ITAU_TEXT);
+
+    const cardRes = await createCard(token1);
+    const cardId = cardRes.body.id;
+
+    const res = await uploadInvoice(token2, cardId);
+
+    expect(res.status).toBe(404);
+  });
+
+  it("POST parse-pdf retorna 400 quando arquivo nao e PDF", async () => {
+    const token = await registerAndLogin("inv-not-pdf@test.dev");
+    const cardRes = await createCard(token);
+    const cardId = cardRes.body.id;
+
+    const res = await request(app)
+      .post(`/credit-cards/${cardId}/invoices/parse-pdf`)
+      .set("Authorization", `Bearer ${token}`)
+      .attach("file", Buffer.from("col1,col2\n1,2", "utf8"), {
+        filename: "data.csv",
+        contentType: "text/csv",
+      });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("POST parse-pdf retorna 400 quando file nao enviado", async () => {
+    const token = await registerAndLogin("inv-no-file@test.dev");
+    const cardRes = await createCard(token);
+    const cardId = cardRes.body.id;
+
+    const res = await request(app)
+      .post(`/credit-cards/${cardId}/invoices/parse-pdf`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(400);
+  });
+
+  // ─── GET invoices ────────────────────────────────────────────────────────────
+
+  it("GET /invoices retorna lista de faturas do cartao", async () => {
+    const token = await registerAndLogin("inv-list@test.dev");
+    mockExtractText.mockResolvedValue(VALID_ITAU_TEXT);
+
+    const cardRes = await createCard(token);
+    const cardId = cardRes.body.id;
+
+    await uploadInvoice(token, cardId);
+    await uploadInvoice(token, cardId); // second upload same text (fine for test)
+
+    const res = await request(app)
+      .get(`/credit-cards/${cardId}/invoices`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBe(2);
+    expect(res.body[0].creditCardId).toBe(cardId);
+  });
+
+  it("GET /invoices retorna 404 para cartao de outro usuario", async () => {
+    const token1 = await registerAndLogin("inv-list-iso-1@test.dev");
+    const token2 = await registerAndLogin("inv-list-iso-2@test.dev");
+
+    const cardRes = await createCard(token1);
+    const cardId = cardRes.body.id;
+
+    const res = await request(app)
+      .get(`/credit-cards/${cardId}/invoices`)
+      .set("Authorization", `Bearer ${token2}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  // ─── link-bill ───────────────────────────────────────────────────────────────
+
+  it("POST link-bill vincula fatura a uma pendencia", async () => {
+    const token = await registerAndLogin("inv-link@test.dev");
+    mockExtractText.mockResolvedValue(VALID_ITAU_TEXT);
+
+    const cardRes = await createCard(token);
+    const cardId = cardRes.body.id;
+
+    const invRes = await uploadInvoice(token, cardId);
+    const invoiceId = invRes.body.id;
+
+    // Create a bill with matching credit_card_id
+    const billRes = await request(app)
+      .post("/bills")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        title: "Fatura Itaú março",
+        amount: 1247.80,
+        dueDate: "2026-03-15",
+        billType: "credit_card_invoice",
+      });
+    // Manually set credit_card_id on the bill since the API doesn't expose it directly
+    await dbQuery(
+      `UPDATE bills SET credit_card_id = $1 WHERE id = $2`,
+      [cardId, billRes.body.id]
+    );
+    const billId = billRes.body.id;
+
+    const res = await request(app)
+      .post(`/credit-cards/${cardId}/invoices/${invoiceId}/link-bill`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ billId });
+
+    expect(res.status).toBe(200);
+    expect(res.body.linkedBillId).toBe(billId);
+  });
+
+  it("POST link-bill retorna 409 quando fatura ja esta vinculada", async () => {
+    const token = await registerAndLogin("inv-link-dup@test.dev");
+    mockExtractText.mockResolvedValue(VALID_ITAU_TEXT);
+
+    const cardRes = await createCard(token);
+    const cardId = cardRes.body.id;
+
+    const invRes = await uploadInvoice(token, cardId);
+    const invoiceId = invRes.body.id;
+
+    const billRes = await request(app)
+      .post("/bills")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ title: "Fatura março", amount: 1247.80, dueDate: "2026-03-15" });
+    await dbQuery(`UPDATE bills SET credit_card_id = $1 WHERE id = $2`, [cardId, billRes.body.id]);
+    const billId = billRes.body.id;
+
+    // First link
+    await request(app)
+      .post(`/credit-cards/${cardId}/invoices/${invoiceId}/link-bill`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ billId });
+
+    // Second link — should 409
+    const res = await request(app)
+      .post(`/credit-cards/${cardId}/invoices/${invoiceId}/link-bill`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ billId });
+
+    expect(res.status).toBe(409);
+  });
+
+  it("POST link-bill retorna 404 para fatura de outro usuario", async () => {
+    const token1 = await registerAndLogin("inv-link-iso-1@test.dev");
+    const token2 = await registerAndLogin("inv-link-iso-2@test.dev");
+    mockExtractText.mockResolvedValue(VALID_ITAU_TEXT);
+
+    const cardRes = await createCard(token1);
+    const cardId = cardRes.body.id;
+
+    const invRes = await uploadInvoice(token1, cardId);
+    const invoiceId = invRes.body.id;
+
+    const billRes = await request(app)
+      .post("/bills")
+      .set("Authorization", `Bearer ${token2}`)
+      .send({ title: "Minha conta", amount: 100, dueDate: "2026-03-15" });
+    const billId = billRes.body.id;
+
+    const res = await request(app)
+      .post(`/credit-cards/${cardId}/invoices/${invoiceId}/link-bill`)
+      .set("Authorization", `Bearer ${token2}`)
+      .send({ billId });
+
+    expect(res.status).toBe(404); // invoice not found for token2
+  });
+});

--- a/apps/api/src/credit-card-invoices.test.js
+++ b/apps/api/src/credit-card-invoices.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vites
 import request from "supertest";
 import app from "./app.js";
 import { clearDbClientForTests, dbQuery } from "./db/index.js";
-import { setupTestDb, registerAndLogin, expectErrorResponseWithRequestId } from "./test-helpers.js";
+import { setupTestDb, registerAndLogin } from "./test-helpers.js";
 import { resetLoginProtectionState } from "./middlewares/login-protection.middleware.js";
 import { resetImportRateLimiterState, resetWriteRateLimiterState } from "./middlewares/rate-limit.middleware.js";
 import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
@@ -32,6 +32,15 @@ const ITAU_TEXT_NO_PERIOD = `
 BANCO ITAÚ S.A.
 VENCIMENTO  15/03/2026
 TOTAL DA FATURA    R$ 850,00
+`.trim();
+
+const VALID_ITAU_TEXT_APRIL = `
+BANCO ITAÚ S.A.
+**** 1234
+PERÍODO DE 08/03/2026 A 07/04/2026
+VENCIMENTO  15/04/2026
+TOTAL DA FATURA    R$ 980,00
+PAGAMENTO MÍNIMO R$ 98,00
 `.trim();
 
 const INVALID_TEXT = `Este texto nao tem nenhum dado de fatura.`;
@@ -196,13 +205,16 @@ describe("credit-card-invoices", () => {
 
   it("GET /invoices retorna lista de faturas do cartao", async () => {
     const token = await registerAndLogin("inv-list@test.dev");
-    mockExtractText.mockResolvedValue(VALID_ITAU_TEXT);
 
     const cardRes = await createCard(token);
     const cardId = cardRes.body.id;
 
+    // Upload two invoices with different due_date+total_amount (unique constraint)
+    mockExtractText.mockResolvedValue(VALID_ITAU_TEXT);
     await uploadInvoice(token, cardId);
-    await uploadInvoice(token, cardId); // second upload same text (fine for test)
+
+    mockExtractText.mockResolvedValue(VALID_ITAU_TEXT_APRIL);
+    await uploadInvoice(token, cardId);
 
     const res = await request(app)
       .get(`/credit-cards/${cardId}/invoices`)

--- a/apps/api/src/db/migrations/110_create_credit_card_invoices.sql
+++ b/apps/api/src/db/migrations/110_create_credit_card_invoices.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS credit_card_invoices (
+  id                SERIAL PRIMARY KEY,
+  user_id           INTEGER        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  credit_card_id    INTEGER        NOT NULL REFERENCES credit_cards(id) ON DELETE CASCADE,
+  issuer            TEXT           NOT NULL,
+  card_last4        TEXT,
+  period_start      DATE           NOT NULL,
+  period_end        DATE           NOT NULL,
+  due_date          DATE           NOT NULL,
+  total_amount      NUMERIC(12,2)  NOT NULL CHECK (total_amount > 0),
+  minimum_payment   NUMERIC(12,2),
+  financed_balance  NUMERIC(12,2),
+  parse_confidence  TEXT           NOT NULL DEFAULT 'high'
+                                   CHECK (parse_confidence IN ('high', 'low')),
+  parse_metadata    JSONB          NOT NULL DEFAULT '{}'::jsonb,
+  linked_bill_id    INTEGER        REFERENCES bills(id) ON DELETE SET NULL,
+  created_at        TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ    NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_credit_card_invoices_user_card
+  ON credit_card_invoices (user_id, credit_card_id, period_start DESC);

--- a/apps/api/src/db/migrations/110_create_credit_card_invoices.sql
+++ b/apps/api/src/db/migrations/110_create_credit_card_invoices.sql
@@ -15,7 +15,8 @@ CREATE TABLE IF NOT EXISTS credit_card_invoices (
   parse_metadata    JSONB          NOT NULL DEFAULT '{}'::jsonb,
   linked_bill_id    INTEGER        REFERENCES bills(id) ON DELETE SET NULL,
   created_at        TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
-  updated_at        TIMESTAMPTZ    NOT NULL DEFAULT NOW()
+  updated_at        TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+  CONSTRAINT credit_card_invoices_unique_invoice UNIQUE (credit_card_id, due_date, total_amount)
 );
 
 CREATE INDEX IF NOT EXISTS idx_credit_card_invoices_user_card

--- a/apps/api/src/domain/imports/itau-invoice.parser.js
+++ b/apps/api/src/domain/imports/itau-invoice.parser.js
@@ -1,0 +1,203 @@
+/**
+ * Itaú credit card invoice PDF parser.
+ *
+ * Pure function — no I/O, no DB access, no AI.
+ * Input:  rawText (string from extractTextFromPdfWithOcr)
+ * Output: ParsedItauInvoice | null
+ *
+ * Returns null only when mandatory fields (totalAmount + dueDate) are missing.
+ * Period inference from closing_day is handled by the service layer, which has
+ * DB access. The parser signals missing period via periodStart/periodEnd = null.
+ */
+
+// ─── Currency normalisation ───────────────────────────────────────────────────
+
+/**
+ * Parse a Brazilian formatted number string to float.
+ * "1.247,80" → 1247.80    "247,80" → 247.80
+ */
+export const parseBRL = (str) => {
+  if (typeof str !== "string") return null;
+  const cleaned = str.trim().replace(/\./g, "").replace(",", ".");
+  const parsed = Number(cleaned);
+  return Number.isFinite(parsed) && parsed > 0 ? Number(parsed.toFixed(2)) : null;
+};
+
+// ─── Date helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Convert "DD/MM/YYYY" to "YYYY-MM-DD". Returns null on invalid input.
+ */
+export const parseDMY = (str) => {
+  if (typeof str !== "string") return null;
+  const m = str.trim().match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+  if (!m) return null;
+  const [, day, month, year] = m;
+  const d = new Date(`${year}-${month}-${day}T00:00:00`);
+  if (isNaN(d.getTime())) return null;
+  return `${year}-${month}-${day}`;
+};
+
+// ─── Field extractors ─────────────────────────────────────────────────────────
+
+const extractTotalAmount = (text) => {
+  // "TOTAL DA FATURA R$ 1.247,80" or "TOTAL DA FATURA 1.247,80"
+  const patterns = [
+    /TOTAL\s+DA\s+FATURA\s+R\$\s*([\d.,]+)/i,
+    /TOTAL\s+DA\s+FATURA\s+([\d.,]+)/i,
+    /VALOR\s+TOTAL\s+DA\s+FATURA\s+R\$\s*([\d.,]+)/i,
+    /FATURA\s+TOTAL\s+R\$\s*([\d.,]+)/i,
+  ];
+  for (const re of patterns) {
+    const m = text.match(re);
+    if (m) {
+      const val = parseBRL(m[1]);
+      if (val !== null) return { value: val, source: "regex:TOTAL_DA_FATURA" };
+    }
+  }
+  return null;
+};
+
+const extractDueDate = (text) => {
+  const patterns = [
+    /VENCIMENTO\s+(\d{2}\/\d{2}\/\d{4})/i,
+    /DATA\s+DE\s+VENCIMENTO\s+(\d{2}\/\d{2}\/\d{4})/i,
+    /PAGUE\s+AT[EÉ]\s+(\d{2}\/\d{2}\/\d{4})/i,
+    /VENCE\s+EM\s+(\d{2}\/\d{2}\/\d{4})/i,
+  ];
+  for (const re of patterns) {
+    const m = text.match(re);
+    if (m) {
+      const val = parseDMY(m[1]);
+      if (val !== null) return { value: val, source: "regex:VENCIMENTO" };
+    }
+  }
+  return null;
+};
+
+const extractPeriod = (text) => {
+  // "PERÍODO DE 08/02/2026 A 07/03/2026"
+  const patterns = [
+    /PER[IÍ]ODO\s+DE\s+(\d{2}\/\d{2}\/\d{4})\s+A\s+(\d{2}\/\d{2}\/\d{4})/i,
+    /DE\s+(\d{2}\/\d{2}\/\d{4})\s+A\s+(\d{2}\/\d{2}\/\d{4})/i,
+    /COMPETENCIA\s+(\d{2}\/\d{2}\/\d{4})\s+A\s+(\d{2}\/\d{2}\/\d{4})/i,
+  ];
+  for (const re of patterns) {
+    const m = text.match(re);
+    if (m) {
+      const start = parseDMY(m[1]);
+      const end = parseDMY(m[2]);
+      if (start && end && start <= end) {
+        return { start, end, source: "regex:PERIODO" };
+      }
+    }
+  }
+  return null;
+};
+
+const extractMinimumPayment = (text) => {
+  const patterns = [
+    /PAGAMENTO\s+M[IÍ]NIMO\s+R\$\s*([\d.,]+)/i,
+    /PAGAMENTO\s+M[IÍ]NIMO\s+([\d.,]+)/i,
+    /VALOR\s+M[IÍ]NIMO\s+R\$\s*([\d.,]+)/i,
+  ];
+  for (const re of patterns) {
+    const m = text.match(re);
+    if (m) {
+      const val = parseBRL(m[1]);
+      if (val !== null) return val;
+    }
+  }
+  return null;
+};
+
+const extractFinancedBalance = (text) => {
+  const patterns = [
+    /SALDO\s+FINANCIADO\s+R\$\s*([\d.,]+)/i,
+    /SALDO\s+A\s+FINANCIAR\s+R\$\s*([\d.,]+)/i,
+    /SALDO\s+FINANCIADO\s+([\d.,]+)/i,
+  ];
+  for (const re of patterns) {
+    const m = text.match(re);
+    if (m) {
+      const val = parseBRL(m[1]);
+      if (val !== null) return val;
+    }
+  }
+  return null;
+};
+
+const extractCardLast4 = (text) => {
+  const patterns = [
+    /\*{4}\s*(\d{4})/,
+    /final\s+(\d{4})/i,
+    /CART[AÃ]O\s+(?:FINAL|N[ÚU]MERO)?\s*\*+(\d{4})/i,
+  ];
+  for (const re of patterns) {
+    const m = text.match(re);
+    if (m) return m[1];
+  }
+  return null;
+};
+
+// ─── Raw excerpt (first 800 chars after normalisation) ────────────────────────
+
+const extractRawExcerpt = (text) =>
+  text.replace(/\s+/g, " ").trim().slice(0, 800);
+
+// ─── Main parser ─────────────────────────────────────────────────────────────
+
+/**
+ * @typedef {Object} ParsedItauInvoice
+ * @property {number}      totalAmount
+ * @property {string}      dueDate          - "YYYY-MM-DD"
+ * @property {string|null} periodStart      - null when not found in PDF
+ * @property {string|null} periodEnd        - null when not found in PDF
+ * @property {number|null} minimumPayment
+ * @property {number|null} financedBalance
+ * @property {string|null} cardLast4
+ * @property {string}      issuer           - always 'itau'
+ * @property {Object}      fieldsSources    - which regex matched each field
+ * @property {string}      rawExcerpt
+ */
+
+/**
+ * Parse raw text from an Itaú credit card invoice PDF.
+ * Returns null if mandatory fields (totalAmount OR dueDate) are missing.
+ */
+export const parseItauInvoice = (rawText) => {
+  if (typeof rawText !== "string" || !rawText.trim()) return null;
+
+  const text = rawText.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+
+  const totalResult = extractTotalAmount(text);
+  if (!totalResult) return null;
+
+  const dueDateResult = extractDueDate(text);
+  if (!dueDateResult) return null;
+
+  const periodResult = extractPeriod(text);
+  const minimumPayment = extractMinimumPayment(text);
+  const financedBalance = extractFinancedBalance(text);
+  const cardLast4 = extractCardLast4(text);
+
+  const fieldsSources = {
+    totalAmount: totalResult.source,
+    dueDate: dueDateResult.source,
+    periodStart: periodResult ? periodResult.source : null,
+    periodEnd: periodResult ? periodResult.source : null,
+  };
+
+  return {
+    totalAmount: totalResult.value,
+    dueDate: dueDateResult.value,
+    periodStart: periodResult ? periodResult.start : null,
+    periodEnd: periodResult ? periodResult.end : null,
+    minimumPayment,
+    financedBalance,
+    cardLast4,
+    issuer: "itau",
+    fieldsSources,
+    rawExcerpt: extractRawExcerpt(text),
+  };
+};

--- a/apps/api/src/domain/imports/itau-invoice.parser.test.js
+++ b/apps/api/src/domain/imports/itau-invoice.parser.test.js
@@ -1,0 +1,188 @@
+import { describe, it, expect } from "vitest";
+import { parseBRL, parseDMY, parseItauInvoice } from "./itau-invoice.parser.js";
+
+// ─── parseBRL ─────────────────────────────────────────────────────────────────
+
+describe("parseBRL", () => {
+  it("converte formato brasileiro com milhar e decimal", () => {
+    expect(parseBRL("1.247,80")).toBe(1247.80);
+  });
+
+  it("converte valor sem milhar", () => {
+    expect(parseBRL("247,80")).toBe(247.80);
+  });
+
+  it("converte valor sem centavos fracionados", () => {
+    expect(parseBRL("500,00")).toBe(500.00);
+  });
+
+  it("retorna null para string vazia", () => {
+    expect(parseBRL("")).toBeNull();
+  });
+
+  it("retorna null para valor zero", () => {
+    expect(parseBRL("0,00")).toBeNull();
+  });
+
+  it("retorna null para input nao string", () => {
+    expect(parseBRL(null)).toBeNull();
+    expect(parseBRL(undefined)).toBeNull();
+  });
+});
+
+// ─── parseDMY ─────────────────────────────────────────────────────────────────
+
+describe("parseDMY", () => {
+  it("converte DD/MM/YYYY para YYYY-MM-DD", () => {
+    expect(parseDMY("15/03/2026")).toBe("2026-03-15");
+  });
+
+  it("retorna null para formato errado", () => {
+    expect(parseDMY("2026-03-15")).toBeNull();
+    expect(parseDMY("15-03-2026")).toBeNull();
+  });
+
+  it("retorna null para data invalida", () => {
+    expect(parseDMY("32/13/2026")).toBeNull();
+  });
+
+  it("retorna null para input nao string", () => {
+    expect(parseDMY(null)).toBeNull();
+  });
+});
+
+// ─── parseItauInvoice ─────────────────────────────────────────────────────────
+
+// Helper to build a realistic Itaú invoice excerpt
+const buildItauText = (overrides = {}) => {
+  const defaults = {
+    total: "TOTAL DA FATURA    R$ 1.247,80",
+    vencimento: "VENCIMENTO  15/03/2026",
+    periodo: "PERÍODO DE 08/02/2026 A 07/03/2026",
+    minimo: "PAGAMENTO MÍNIMO R$ 124,78",
+    financiado: null,
+    last4: "**** 1234",
+  };
+  const config = { ...defaults, ...overrides };
+
+  return [
+    "BANCO ITAÚ S.A.",
+    config.last4,
+    config.periodo,
+    config.vencimento,
+    config.total,
+    config.minimo,
+    config.financiado,
+  ]
+    .filter(Boolean)
+    .join("\n");
+};
+
+describe("parseItauInvoice", () => {
+  it("parse completo — retorna todos os campos com alta confiança", () => {
+    const text = buildItauText();
+    const result = parseItauInvoice(text);
+
+    expect(result).not.toBeNull();
+    expect(result.totalAmount).toBe(1247.80);
+    expect(result.dueDate).toBe("2026-03-15");
+    expect(result.periodStart).toBe("2026-02-08");
+    expect(result.periodEnd).toBe("2026-03-07");
+    expect(result.minimumPayment).toBe(124.78);
+    expect(result.financedBalance).toBeNull();
+    expect(result.cardLast4).toBe("1234");
+    expect(result.issuer).toBe("itau");
+    expect(result.fieldsSources.totalAmount).toContain("regex:");
+    expect(result.fieldsSources.dueDate).toContain("regex:");
+    expect(result.fieldsSources.periodStart).toContain("regex:");
+  });
+
+  it("parse sem período — periodStart e periodEnd ficam null", () => {
+    const text = buildItauText({ periodo: null });
+    const result = parseItauInvoice(text);
+
+    expect(result).not.toBeNull();
+    expect(result.periodStart).toBeNull();
+    expect(result.periodEnd).toBeNull();
+    expect(result.fieldsSources.periodStart).toBeNull();
+  });
+
+  it("retorna null quando totalAmount nao encontrado", () => {
+    const text = buildItauText({ total: "INFORMACOES DA FATURA" });
+    expect(parseItauInvoice(text)).toBeNull();
+  });
+
+  it("retorna null quando dueDate nao encontrado", () => {
+    const text = buildItauText({ vencimento: "SEM DATA" });
+    expect(parseItauInvoice(text)).toBeNull();
+  });
+
+  it("retorna null para string vazia", () => {
+    expect(parseItauInvoice("")).toBeNull();
+  });
+
+  it("retorna null para input nao string", () => {
+    expect(parseItauInvoice(null)).toBeNull();
+    expect(parseItauInvoice(undefined)).toBeNull();
+  });
+
+  it("extrai SALDO FINANCIADO quando presente", () => {
+    const text = buildItauText({ financiado: "SALDO FINANCIADO R$ 623,90" });
+    const result = parseItauInvoice(text);
+
+    expect(result).not.toBeNull();
+    expect(result.financedBalance).toBe(623.90);
+  });
+
+  it("extrai SALDO A FINANCIAR como alternativa a SALDO FINANCIADO", () => {
+    const text = buildItauText({ financiado: "SALDO A FINANCIAR R$ 311,95" });
+    const result = parseItauInvoice(text);
+
+    expect(result).not.toBeNull();
+    expect(result.financedBalance).toBe(311.95);
+  });
+
+  it("extrai cardLast4 no formato 'final 5678'", () => {
+    const text = buildItauText({ last4: "Cartão final 5678" });
+    const result = parseItauInvoice(text);
+
+    expect(result).not.toBeNull();
+    expect(result.cardLast4).toBe("5678");
+  });
+
+  it("funciona sem cardLast4 no texto", () => {
+    const text = buildItauText({ last4: null });
+    const result = parseItauInvoice(text);
+
+    expect(result).not.toBeNull();
+    expect(result.cardLast4).toBeNull();
+  });
+
+  it("rawExcerpt contem os primeiros 800 chars do texto normalizado", () => {
+    const text = buildItauText();
+    const result = parseItauInvoice(text);
+
+    expect(result).not.toBeNull();
+    expect(typeof result.rawExcerpt).toBe("string");
+    expect(result.rawExcerpt.length).toBeLessThanOrEqual(800);
+    expect(result.rawExcerpt).toContain("ITAÚ");
+  });
+
+  it("aceita variacao 'VALOR TOTAL DA FATURA' para totalAmount", () => {
+    const text = buildItauText({
+      total: "VALOR TOTAL DA FATURA R$ 850,00",
+    });
+    const result = parseItauInvoice(text);
+
+    expect(result).not.toBeNull();
+    expect(result.totalAmount).toBe(850.00);
+  });
+
+  it("aceita variacao 'VENCE EM' para dueDate", () => {
+    const text = buildItauText({ vencimento: "VENCE EM 20/03/2026" });
+    const result = parseItauInvoice(text);
+
+    expect(result).not.toBeNull();
+    expect(result.dueDate).toBe("2026-03-20");
+  });
+});

--- a/apps/api/src/routes/credit-cards.routes.js
+++ b/apps/api/src/routes/credit-cards.routes.js
@@ -19,16 +19,17 @@ import {
   linkBillToInvoiceForUser,
 } from "../services/credit-card-invoices.service.js";
 
-const INVOICE_PDF_MAX_BYTES = Number(process.env.INVOICE_PDF_MAX_SIZE_BYTES || 10 * 1024 * 1024);
+const INVOICE_PDF_MAX_BYTES =
+  Number.isInteger(Number(process.env.INVOICE_PDF_MAX_SIZE_BYTES)) &&
+  Number(process.env.INVOICE_PDF_MAX_SIZE_BYTES) > 0
+    ? Number(process.env.INVOICE_PDF_MAX_SIZE_BYTES)
+    : 10 * 1024 * 1024;
+
+const INVOICE_PDF_MAX_MB = Math.round(INVOICE_PDF_MAX_BYTES / (1024 * 1024));
 
 const invoiceUpload = multer({
   storage: multer.memoryStorage(),
-  limits: {
-    fileSize:
-      Number.isInteger(INVOICE_PDF_MAX_BYTES) && INVOICE_PDF_MAX_BYTES > 0
-        ? INVOICE_PDF_MAX_BYTES
-        : 10 * 1024 * 1024,
-  },
+  limits: { fileSize: INVOICE_PDF_MAX_BYTES },
 });
 
 const ensureInvoicePdfFile = (file) => {
@@ -132,7 +133,7 @@ router.post("/:id/invoices/parse-pdf", creditCardsWriteRateLimiter, (req, res, n
   invoiceUpload.single("file")(req, res, async (uploadError) => {
     if (uploadError) {
       if (uploadError instanceof multer.MulterError && uploadError.code === "LIMIT_FILE_SIZE") {
-        const err = new Error("Arquivo muito grande. Limite: 10 MB.");
+        const err = new Error(`Arquivo muito grande. Limite: ${INVOICE_PDF_MAX_MB} MB.`);
         err.status = 413;
         return next(err);
       }

--- a/apps/api/src/routes/credit-cards.routes.js
+++ b/apps/api/src/routes/credit-cards.routes.js
@@ -1,4 +1,6 @@
+import path from "node:path";
 import { Router } from "express";
+import multer from "multer";
 import { authMiddleware } from "../middlewares/auth.middleware.js";
 import { creditCardsWriteRateLimiter } from "../middlewares/rate-limit.middleware.js";
 import {
@@ -11,6 +13,38 @@ import {
   closeCreditCardInvoiceForUser,
   reopenCreditCardInvoiceForUser,
 } from "../services/credit-cards.service.js";
+import {
+  parseCreditCardInvoicePdfForUser,
+  listCreditCardInvoicesForUser,
+  linkBillToInvoiceForUser,
+} from "../services/credit-card-invoices.service.js";
+
+const INVOICE_PDF_MAX_BYTES = Number(process.env.INVOICE_PDF_MAX_SIZE_BYTES || 10 * 1024 * 1024);
+
+const invoiceUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize:
+      Number.isInteger(INVOICE_PDF_MAX_BYTES) && INVOICE_PDF_MAX_BYTES > 0
+        ? INVOICE_PDF_MAX_BYTES
+        : 10 * 1024 * 1024,
+  },
+});
+
+const ensureInvoicePdfFile = (file) => {
+  if (!file || !file.buffer || file.buffer.length === 0) {
+    const err = new Error("Arquivo PDF (file) e obrigatorio.");
+    err.status = 400;
+    throw err;
+  }
+  const ext = path.extname(String(file.originalname || "")).toLowerCase();
+  const mime = String(file.mimetype || "").toLowerCase();
+  if (ext !== ".pdf" && mime !== "application/pdf") {
+    const err = new Error("Apenas arquivos PDF sao aceitos.");
+    err.status = 400;
+    throw err;
+  }
+};
 
 const router = Router();
 
@@ -87,6 +121,55 @@ router.post("/invoices/:invoiceId/reopen", creditCardsWriteRateLimiter, async (r
   try {
     const result = await reopenCreditCardInvoiceForUser(req.user.id, req.params.invoiceId);
     res.status(200).json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// ─── Credit card invoice PDF import ──────────────────────────────────────────
+
+router.post("/:id/invoices/parse-pdf", creditCardsWriteRateLimiter, (req, res, next) => {
+  invoiceUpload.single("file")(req, res, async (uploadError) => {
+    if (uploadError) {
+      if (uploadError instanceof multer.MulterError && uploadError.code === "LIMIT_FILE_SIZE") {
+        const err = new Error("Arquivo muito grande. Limite: 10 MB.");
+        err.status = 413;
+        return next(err);
+      }
+      return next(uploadError);
+    }
+    try {
+      ensureInvoicePdfFile(req.file);
+      const invoice = await parseCreditCardInvoicePdfForUser(
+        req.user.id,
+        req.params.id,
+        req.file.buffer
+      );
+      return res.status(201).json(invoice);
+    } catch (error) {
+      return next(error);
+    }
+  });
+});
+
+router.get("/:id/invoices", async (req, res, next) => {
+  try {
+    const invoices = await listCreditCardInvoicesForUser(req.user.id, req.params.id);
+    res.status(200).json(invoices);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post("/:id/invoices/:invoiceId/link-bill", creditCardsWriteRateLimiter, async (req, res, next) => {
+  try {
+    const invoice = await linkBillToInvoiceForUser(
+      req.user.id,
+      req.params.id,
+      req.params.invoiceId,
+      req.body || {}
+    );
+    res.status(200).json(invoice);
   } catch (error) {
     next(error);
   }

--- a/apps/api/src/services/credit-card-invoices.service.js
+++ b/apps/api/src/services/credit-card-invoices.service.js
@@ -1,0 +1,271 @@
+import { dbQuery } from "../db/index.js";
+import { extractTextFromPdfWithOcr } from "../domain/imports/pdf-ocr.js";
+import { parseItauInvoice } from "../domain/imports/itau-invoice.parser.js";
+
+const createError = (status, message, extra = {}) => {
+  const error = new Error(message);
+  error.status = status;
+  Object.assign(error, extra);
+  return error;
+};
+
+const normalizeUserId = (value) => {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw createError(401, "Usuario nao autenticado.");
+  }
+  return parsed;
+};
+
+const normalizeCardId = (value) => {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw createError(400, "ID de cartao invalido.");
+  }
+  return parsed;
+};
+
+const normalizeInvoiceId = (value) => {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw createError(400, "ID de fatura invalido.");
+  }
+  return parsed;
+};
+
+// ─── Period inference ─────────────────────────────────────────────────────────
+
+/**
+ * Infer period_start and period_end from dueDate and card's closing_day.
+ *
+ * Logic:
+ *   - period_end   = closing_day of the month BEFORE dueDate's month
+ *   - period_start = day after the previous closing (closing_day + 1 of month M-2)
+ *
+ * Example: closing_day=7, dueDate=2026-03-15
+ *   period_end   = 2026-03-07
+ *   period_start = 2026-02-08
+ */
+const inferPeriod = (dueDate, closingDay) => {
+  const due = new Date(`${dueDate}T00:00:00`);
+  if (isNaN(due.getTime())) return null;
+
+  // period_end: closing_day of the same month as dueDate
+  const endYear = due.getUTCFullYear();
+  const endMonth = due.getUTCMonth() + 1; // 1-based
+  const daysInEndMonth = new Date(Date.UTC(endYear, endMonth, 0)).getUTCDate();
+  const endDay = Math.min(closingDay, daysInEndMonth);
+
+  const periodEndDate = new Date(Date.UTC(endYear, endMonth - 1, endDay));
+
+  // If period_end >= due_date, use the previous month's closing
+  if (periodEndDate >= due) {
+    periodEndDate.setUTCMonth(periodEndDate.getUTCMonth() - 1);
+    const prevMonthDays = new Date(
+      Date.UTC(periodEndDate.getUTCFullYear(), periodEndDate.getUTCMonth() + 1, 0)
+    ).getUTCDate();
+    periodEndDate.setUTCDate(Math.min(closingDay, prevMonthDays));
+  }
+
+  // period_start: day after closing_day of the month before period_end
+  const periodStartDate = new Date(periodEndDate);
+  periodStartDate.setUTCMonth(periodStartDate.getUTCMonth() - 1);
+  const prevMonthDays = new Date(
+    Date.UTC(periodStartDate.getUTCFullYear(), periodStartDate.getUTCMonth() + 1, 0)
+  ).getUTCDate();
+  const startClosingDay = Math.min(closingDay, prevMonthDays);
+  periodStartDate.setUTCDate(startClosingDay + 1);
+
+  const toISO = (d) =>
+    `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}`;
+
+  const start = toISO(periodStartDate);
+  const end = toISO(periodEndDate);
+
+  // Sanity check
+  if (start >= end) return null;
+
+  return { start, end };
+};
+
+// ─── Formatters ───────────────────────────────────────────────────────────────
+
+const formatInvoice = (row) => ({
+  id: Number(row.id),
+  userId: Number(row.user_id),
+  creditCardId: Number(row.credit_card_id),
+  issuer: row.issuer,
+  cardLast4: row.card_last4 ?? null,
+  periodStart: typeof row.period_start === "string"
+    ? row.period_start
+    : row.period_start?.toISOString().slice(0, 10) ?? null,
+  periodEnd: typeof row.period_end === "string"
+    ? row.period_end
+    : row.period_end?.toISOString().slice(0, 10) ?? null,
+  dueDate: typeof row.due_date === "string"
+    ? row.due_date
+    : row.due_date?.toISOString().slice(0, 10) ?? null,
+  totalAmount: Number(row.total_amount),
+  minimumPayment: row.minimum_payment != null ? Number(row.minimum_payment) : null,
+  financedBalance: row.financed_balance != null ? Number(row.financed_balance) : null,
+  parseConfidence: row.parse_confidence,
+  parseMetadata: row.parse_metadata ?? {},
+  linkedBillId: row.linked_bill_id ? Number(row.linked_bill_id) : null,
+  createdAt: typeof row.created_at === "string" ? row.created_at : row.created_at?.toISOString(),
+  updatedAt: typeof row.updated_at === "string" ? row.updated_at : row.updated_at?.toISOString(),
+});
+
+// ─── Parse PDF ────────────────────────────────────────────────────────────────
+
+export const parseCreditCardInvoicePdfForUser = async (rawUserId, rawCardId, fileBuffer) => {
+  const userId = normalizeUserId(rawUserId);
+  const cardId = normalizeCardId(rawCardId);
+
+  // Ownership check
+  const { rows: cardRows } = await dbQuery(
+    `SELECT id, closing_day FROM credit_cards WHERE id = $1 AND user_id = $2 AND is_active = true`,
+    [cardId, userId]
+  );
+  if (!cardRows.length) throw createError(404, "Cartao nao encontrado.");
+  const card = cardRows[0];
+
+  // Extract text from PDF
+  let rawText;
+  try {
+    rawText = await extractTextFromPdfWithOcr(fileBuffer);
+  } catch {
+    throw createError(422, "Nao foi possivel ler o PDF. Verifique se o arquivo nao esta corrompido.");
+  }
+
+  // Parse
+  const parsed = parseItauInvoice(rawText);
+  if (!parsed) {
+    throw createError(422, "Nao foi possivel extrair dados da fatura. Verifique se o PDF e um extrato do Itau.", {
+      publicCode: "INVOICE_PARSE_FAILED",
+    });
+  }
+
+  // Resolve period
+  let periodStart = parsed.periodStart;
+  let periodEnd = parsed.periodEnd;
+  let parseConfidence = "high";
+  const fieldsSources = { ...parsed.fieldsSources };
+  const inferenceContext = {};
+
+  if (!periodStart || !periodEnd) {
+    const closingDay = Number(card.closing_day);
+    if (!Number.isInteger(closingDay) || closingDay < 1 || closingDay > 31) {
+      throw createError(422,
+        "Periodo da fatura nao encontrado no PDF e o cartao nao tem dia de fechamento cadastrado.",
+        { publicCode: "INVOICE_PERIOD_INFERENCE_FAILED" }
+      );
+    }
+    const inferred = inferPeriod(parsed.dueDate, closingDay);
+    if (!inferred) {
+      throw createError(422,
+        "Nao foi possivel inferir o periodo da fatura a partir do dia de fechamento do cartao.",
+        { publicCode: "INVOICE_PERIOD_INFERENCE_FAILED" }
+      );
+    }
+    periodStart = inferred.start;
+    periodEnd = inferred.end;
+    parseConfidence = "low";
+    fieldsSources.periodStart = "inference:closing_day";
+    fieldsSources.periodEnd = "inference:closing_day";
+    inferenceContext.closingDay = closingDay;
+  }
+
+  const parseMetadata = {
+    rawExcerpt: parsed.rawExcerpt,
+    fieldsSources,
+    ...(Object.keys(inferenceContext).length > 0 ? { inferenceContext } : {}),
+  };
+
+  const { rows } = await dbQuery(
+    `INSERT INTO credit_card_invoices
+       (user_id, credit_card_id, issuer, card_last4, period_start, period_end,
+        due_date, total_amount, minimum_payment, financed_balance,
+        parse_confidence, parse_metadata)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+     RETURNING *`,
+    [
+      userId, cardId, parsed.issuer, parsed.cardLast4 ?? null,
+      periodStart, periodEnd, parsed.dueDate,
+      parsed.totalAmount,
+      parsed.minimumPayment ?? null,
+      parsed.financedBalance ?? null,
+      parseConfidence,
+      JSON.stringify(parseMetadata),
+    ]
+  );
+
+  return formatInvoice(rows[0]);
+};
+
+// ─── List ─────────────────────────────────────────────────────────────────────
+
+export const listCreditCardInvoicesForUser = async (rawUserId, rawCardId) => {
+  const userId = normalizeUserId(rawUserId);
+  const cardId = normalizeCardId(rawCardId);
+
+  // Ownership check
+  const { rows: cardRows } = await dbQuery(
+    `SELECT id FROM credit_cards WHERE id = $1 AND user_id = $2 AND is_active = true`,
+    [cardId, userId]
+  );
+  if (!cardRows.length) throw createError(404, "Cartao nao encontrado.");
+
+  const { rows } = await dbQuery(
+    `SELECT * FROM credit_card_invoices
+      WHERE credit_card_id = $1 AND user_id = $2
+      ORDER BY period_start DESC
+      LIMIT 24`,
+    [cardId, userId]
+  );
+
+  return rows.map(formatInvoice);
+};
+
+// ─── Link bill ────────────────────────────────────────────────────────────────
+
+export const linkBillToInvoiceForUser = async (rawUserId, rawCardId, rawInvoiceId, input) => {
+  const userId = normalizeUserId(rawUserId);
+  const cardId = normalizeCardId(rawCardId);
+  const invoiceId = normalizeInvoiceId(rawInvoiceId);
+
+  const billId = Number(input.billId);
+  if (!Number.isInteger(billId) || billId <= 0) {
+    throw createError(400, "billId invalido.");
+  }
+
+  // Invoice ownership
+  const { rows: invRows } = await dbQuery(
+    `SELECT id, linked_bill_id FROM credit_card_invoices
+      WHERE id = $1 AND credit_card_id = $2 AND user_id = $3`,
+    [invoiceId, cardId, userId]
+  );
+  if (!invRows.length) throw createError(404, "Fatura nao encontrada.");
+  if (invRows[0].linked_bill_id) throw createError(409, "Fatura ja esta vinculada a uma pendencia.");
+
+  // Bill ownership + same card
+  const { rows: billRows } = await dbQuery(
+    `SELECT id, credit_card_id FROM bills WHERE id = $1 AND user_id = $2`,
+    [billId, userId]
+  );
+  if (!billRows.length) throw createError(404, "Pendencia nao encontrada.");
+
+  const billCardId = billRows[0].credit_card_id ? Number(billRows[0].credit_card_id) : null;
+  if (billCardId !== null && billCardId !== cardId) {
+    throw createError(422, "A pendencia pertence a outro cartao.");
+  }
+
+  const { rows: updated } = await dbQuery(
+    `UPDATE credit_card_invoices
+        SET linked_bill_id = $1, updated_at = NOW()
+      WHERE id = $2 AND user_id = $3
+      RETURNING *`,
+    [billId, invoiceId, userId]
+  );
+
+  return formatInvoice(updated[0]);
+};

--- a/apps/web/src/components/CreditCardsSummaryWidget.tsx
+++ b/apps/web/src/components/CreditCardsSummaryWidget.tsx
@@ -1,6 +1,10 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useMaskedCurrency } from "../context/DiscreetModeContext";
-import { creditCardsService, type CreditCardItem } from "../services/credit-cards.service";
+import {
+  creditCardsService,
+  type CreditCardItem,
+  type CreditCardInvoicePdf,
+} from "../services/credit-cards.service";
 
 interface CreditCardsSummaryWidgetProps {
   onOpenCreditCards?: () => void;
@@ -32,12 +36,161 @@ const buildAggregate = (items: CreditCardItem[]): CreditCardsAggregate =>
     },
   );
 
+const formatDMY = (iso: string): string => {
+  const [year, month, day] = iso.split("-");
+  return `${day}/${month}/${year}`;
+};
+
+// ─── Invoice PDF panel per card ───────────────────────────────────────────────
+
+type UploadPhase =
+  | { phase: "idle" }
+  | { phase: "uploading" }
+  | { phase: "done"; invoice: CreditCardInvoicePdf }
+  | { phase: "error"; message: string };
+
+const InvoicePdfPanel = ({
+  card,
+  money,
+}: {
+  card: CreditCardItem;
+  money: (v: number) => string;
+}) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploadPhase, setUploadPhase] = useState<UploadPhase>({ phase: "idle" });
+  const [recentInvoice, setRecentInvoice] = useState<CreditCardInvoicePdf | null>(null);
+  const [loadingInvoices, setLoadingInvoices] = useState(false);
+
+  // Load most recent invoice for this card on first open
+  useEffect(() => {
+    setLoadingInvoices(true);
+    creditCardsService
+      .listInvoicesPdf(card.id)
+      .then((invoices) => {
+        setRecentInvoice(invoices[0] ?? null);
+      })
+      .catch(() => {/* non-blocking */})
+      .finally(() => setLoadingInvoices(false));
+  }, [card.id]);
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    // Reset input so same file can be re-uploaded
+    if (fileInputRef.current) fileInputRef.current.value = "";
+
+    setUploadPhase({ phase: "uploading" });
+    try {
+      const invoice = await creditCardsService.parseInvoicePdf(card.id, file);
+      setUploadPhase({ phase: "done", invoice });
+      setRecentInvoice(invoice);
+    } catch (err: unknown) {
+      const apiMessage =
+        err instanceof Object && "response" in err
+          ? ((err as { response?: { data?: { message?: string } } }).response?.data?.message ?? null)
+          : null;
+      setUploadPhase({
+        phase: "error",
+        message: apiMessage ?? "Não foi possível processar a fatura. Verifique se é um PDF do Itaú.",
+      });
+    }
+  };
+
+  const displayInvoice =
+    uploadPhase.phase === "done" ? uploadPhase.invoice : recentInvoice;
+
+  return (
+    <div className="mt-2 rounded border border-cf-border bg-cf-bg-page px-3 py-2.5">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <p className="text-[10px] font-semibold uppercase tracking-wide text-cf-text-secondary">
+          Fatura PDF — {card.name}
+        </p>
+        <label className="cursor-pointer rounded border border-cf-border px-2 py-0.5 text-[10px] text-cf-text-secondary hover:border-brand-1 hover:text-brand-1">
+          {uploadPhase.phase === "uploading" ? "Processando..." : "+ Importar fatura"}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".pdf,application/pdf"
+            className="hidden"
+            disabled={uploadPhase.phase === "uploading"}
+            onChange={handleFileChange}
+          />
+        </label>
+      </div>
+
+      {uploadPhase.phase === "error" ? (
+        <p className="mb-2 text-[10px] text-red-600">{uploadPhase.message}</p>
+      ) : null}
+
+      {loadingInvoices && !displayInvoice ? (
+        <p className="text-[10px] text-cf-text-secondary">Carregando...</p>
+      ) : displayInvoice ? (
+        <div>
+          {displayInvoice.parseConfidence === "low" ? (
+            <p className="mb-1.5 rounded border border-amber-200 bg-amber-50 px-2 py-1 text-[10px] text-amber-700">
+              Período inferido pelo dia de fechamento do cartão — confirme os valores antes de usar.
+            </p>
+          ) : null}
+          <div className="grid grid-cols-2 gap-x-4 gap-y-0.5">
+            <div>
+              <p className="text-[10px] text-cf-text-secondary">Total da fatura</p>
+              <p className="text-xs font-semibold text-cf-text-primary">
+                {money(displayInvoice.totalAmount)}
+              </p>
+            </div>
+            <div>
+              <p className="text-[10px] text-cf-text-secondary">Vencimento</p>
+              <p className="text-xs font-semibold text-cf-text-primary">
+                {formatDMY(displayInvoice.dueDate)}
+              </p>
+            </div>
+            <div>
+              <p className="text-[10px] text-cf-text-secondary">Ciclo</p>
+              <p className="text-xs text-cf-text-primary">
+                {formatDMY(displayInvoice.periodStart)} – {formatDMY(displayInvoice.periodEnd)}
+              </p>
+            </div>
+            {displayInvoice.financedBalance ? (
+              <div>
+                <p className="text-[10px] text-cf-text-secondary">Saldo financiado</p>
+                <p className="text-xs font-semibold text-amber-700">
+                  {money(displayInvoice.financedBalance)}
+                </p>
+              </div>
+            ) : null}
+          </div>
+          {displayInvoice.cardLast4 ? (
+            <p className="mt-1 text-[10px] text-cf-text-secondary">
+              Cartão final {displayInvoice.cardLast4}
+              {" · "}
+              <span
+                className={`font-medium ${
+                  displayInvoice.parseConfidence === "high" ? "text-emerald-600" : "text-amber-600"
+                }`}
+              >
+                {displayInvoice.parseConfidence === "high" ? "Alta confiança" : "Baixa confiança"}
+              </span>
+            </p>
+          ) : null}
+        </div>
+      ) : (
+        <p className="text-[10px] text-cf-text-secondary">
+          Nenhuma fatura importada ainda para este cartão.
+        </p>
+      )}
+    </div>
+  );
+};
+
+// ─── Widget ───────────────────────────────────────────────────────────────────
+
 const CreditCardsSummaryWidget = ({
   onOpenCreditCards,
 }: CreditCardsSummaryWidgetProps): JSX.Element | null => {
   const [cards, setCards] = useState<CreditCardItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
+  const [expandedInvoiceCardId, setExpandedInvoiceCardId] = useState<number | null>(null);
   const money = useMaskedCurrency();
 
   useEffect(() => {
@@ -115,42 +268,67 @@ const CreditCardsSummaryWidget = ({
           Cadastre um cartão para acompanhar limite disponível, compras abertas e faturas pendentes.
         </div>
       ) : (
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-          <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
-            <p className="text-xs font-medium uppercase text-cf-text-secondary">Disponível</p>
-            <p className="text-sm font-semibold text-cf-text-primary">
-              {money(aggregate.availableTotal)}
-            </p>
-            <p className="text-xs text-cf-text-secondary">Soma dos limites livres</p>
+        <>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
+              <p className="text-xs font-medium uppercase text-cf-text-secondary">Disponível</p>
+              <p className="text-sm font-semibold text-cf-text-primary">
+                {money(aggregate.availableTotal)}
+              </p>
+              <p className="text-xs text-cf-text-secondary">Soma dos limites livres</p>
+            </div>
+
+            <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
+              <p className="text-xs font-medium uppercase text-cf-text-secondary">Compras abertas</p>
+              <p className="text-sm font-semibold text-cf-text-primary">
+                {money(aggregate.openPurchasesTotal)}
+              </p>
+              <p className="text-xs text-cf-text-secondary">Ainda não fechadas em fatura</p>
+            </div>
+
+            <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
+              <p className="text-xs font-medium uppercase text-cf-text-secondary">Faturas pendentes</p>
+              <p
+                className={`text-sm font-semibold ${
+                  aggregate.pendingInvoicesCount > 0 ? "text-amber-700" : "text-cf-text-primary"
+                }`}
+              >
+                {money(aggregate.pendingInvoicesTotal)}
+              </p>
+              <p
+                className={`text-xs ${
+                  aggregate.pendingInvoicesCount > 0 ? "text-amber-700" : "text-cf-text-secondary"
+                }`}
+              >
+                {aggregate.pendingInvoicesCount}{" "}
+                {aggregate.pendingInvoicesCount === 1 ? "fatura" : "faturas"}
+              </p>
+            </div>
           </div>
 
-          <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
-            <p className="text-xs font-medium uppercase text-cf-text-secondary">Compras abertas</p>
-            <p className="text-sm font-semibold text-cf-text-primary">
-              {money(aggregate.openPurchasesTotal)}
-            </p>
-            <p className="text-xs text-cf-text-secondary">Ainda não fechadas em fatura</p>
+          {/* Per-card invoice import — one panel per card, collapsible */}
+          <div className="mt-3 space-y-1">
+            {cards.map((card) => (
+              <div key={card.id}>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setExpandedInvoiceCardId(
+                      expandedInvoiceCardId === card.id ? null : card.id
+                    )
+                  }
+                  className="flex w-full items-center justify-between rounded px-2 py-1 text-[10px] text-cf-text-secondary hover:bg-cf-bg-subtle hover:text-cf-text-primary"
+                >
+                  <span>{card.name}</span>
+                  <span>{expandedInvoiceCardId === card.id ? "▲" : "▼ Fatura PDF"}</span>
+                </button>
+                {expandedInvoiceCardId === card.id ? (
+                  <InvoicePdfPanel card={card} money={money} />
+                ) : null}
+              </div>
+            ))}
           </div>
-
-          <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
-            <p className="text-xs font-medium uppercase text-cf-text-secondary">Faturas pendentes</p>
-            <p
-              className={`text-sm font-semibold ${
-                aggregate.pendingInvoicesCount > 0 ? "text-amber-700" : "text-cf-text-primary"
-              }`}
-            >
-              {money(aggregate.pendingInvoicesTotal)}
-            </p>
-            <p
-              className={`text-xs ${
-                aggregate.pendingInvoicesCount > 0 ? "text-amber-700" : "text-cf-text-secondary"
-              }`}
-            >
-              {aggregate.pendingInvoicesCount}{" "}
-              {aggregate.pendingInvoicesCount === 1 ? "fatura" : "faturas"}
-            </p>
-          </div>
-        </div>
+        </>
       )}
     </div>
   );

--- a/apps/web/src/services/credit-cards.service.ts
+++ b/apps/web/src/services/credit-cards.service.ts
@@ -97,6 +97,27 @@ export interface ReopenInvoiceResult {
   success: boolean;
 }
 
+export type InvoiceParseConfidence = "high" | "low";
+
+export interface CreditCardInvoicePdf {
+  id: number;
+  userId: number;
+  creditCardId: number;
+  issuer: string;
+  cardLast4: string | null;
+  periodStart: string;
+  periodEnd: string;
+  dueDate: string;
+  totalAmount: number;
+  minimumPayment: number | null;
+  financedBalance: number | null;
+  parseConfidence: InvoiceParseConfidence;
+  parseMetadata: Record<string, unknown>;
+  linkedBillId: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
 const normalizeString = (value: unknown) => (typeof value === "string" ? value.trim() : "");
 
 const normalizeStringOrNull = (value: unknown) => {
@@ -252,5 +273,31 @@ export const creditCardsService = {
       reopenedPurchasesCount: Number(raw.reopenedPurchasesCount) || 0,
       success: Boolean(raw.success),
     };
+  },
+
+  parseInvoicePdf: async (cardId: number, file: File): Promise<CreditCardInvoicePdf> => {
+    const form = new FormData();
+    form.append("file", file);
+    const { data } = await api.post(`/credit-cards/${cardId}/invoices/parse-pdf`, form, {
+      headers: { "Content-Type": "multipart/form-data" },
+    });
+    return data as CreditCardInvoicePdf;
+  },
+
+  listInvoicesPdf: async (cardId: number): Promise<CreditCardInvoicePdf[]> => {
+    const { data } = await api.get<CreditCardInvoicePdf[]>(`/credit-cards/${cardId}/invoices`);
+    return data;
+  },
+
+  linkBillToInvoicePdf: async (
+    cardId: number,
+    invoiceId: number,
+    billId: number
+  ): Promise<CreditCardInvoicePdf> => {
+    const { data } = await api.post<CreditCardInvoicePdf>(
+      `/credit-cards/${cardId}/invoices/${invoiceId}/link-bill`,
+      { billId }
+    );
+    return data;
   },
 };


### PR DESCRIPTION
## O que entra

Parser determinístico de PDF de fatura do Itaú, persistência do statement e UI de import no widget de cartões.

## Migration 110

Nova tabela `credit_card_invoices`:
- `period_start / period_end / due_date / total_amount`
- `minimum_payment / financed_balance` (opcionais)
- `parse_confidence`: `high` (todos os campos por regex) | `low` (período inferido)
- `parse_metadata`: JSONB com `fieldsSources`, `rawExcerpt`, `inferenceContext` para auditoria
- `linked_bill_id`: FK para reconciliação com bill

## Parser Itaú (`itau-invoice.parser.js`)

Função pura — sem I/O, sem IA, 100% testável em isolamento.

Campos extraídos por regex:
| Campo | Padrão principal |
|-------|-----------------|
| `totalAmount` | `TOTAL DA FATURA R$ X` |
| `dueDate` | `VENCIMENTO DD/MM/YYYY` |
| `periodStart/End` | `PERÍODO DE DD/MM/YYYY A DD/MM/YYYY` |
| `minimumPayment` | `PAGAMENTO MÍNIMO R$ X` |
| `financedBalance` | `SALDO FINANCIADO` / `SALDO A FINANCIAR` |
| `cardLast4` | `**** 1234` / `final 1234` |

Retorna `null` apenas se `totalAmount` ou `dueDate` ausentes.

## Inferência de período

Quando PDF não traz `period_start/end`:
- Infere a partir de `closing_day` do cartão + `dueDate`
- `period_end` = fechamento do ciclo que gera este vencimento
- `period_start` = dia após fechamento do ciclo anterior
- `parse_confidence = 'low'` + `fieldsSources = "inference:closing_day"`
- `422 INVOICE_PERIOD_INFERENCE_FAILED` se cartão não tem `closing_day`

## API

- `POST /credit-cards/:id/invoices/parse-pdf` — multipart PDF, 201 com invoice
- `GET /credit-cards/:id/invoices` — lista até 24 faturas, ordenadas por `period_start DESC`
- `POST /credit-cards/:id/invoices/:invoiceId/link-bill` — vincula fatura a uma bill

## Frontend

- `CreditCardInvoicePdf` type + 3 novos métodos em `creditCardsService`
- `CreditCardsSummaryWidget` estendido: painel colapsível por cartão com upload de PDF, preview dos campos e badge **Alta/Baixa confiança**; banner âmbar quando `parseConfidence = 'low'`

## Testes

- 23 unit (parser puro): scores exatos, variações de layout, campos opcionais, null guards
- 13 integration (mock pdf-ocr): upload válido, inferência de período, parse failure, isolamento por usuário, link-bill duplo (409)

## Fora de escopo

- Outros emissores (Bradesco, Nubank, XP)
- Criação automática de bill ao importar
- Importação da lista de lançamentos do PDF