### PR TITLE
feat(dashboard): operational summary panel — 6-tile financial snapshot

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -22,6 +22,7 @@ import opsRoutes from "./routes/ops.routes.js";
 import aiRoutes from "./routes/ai.routes.js";
 import goalsRoutes from "./routes/goals.routes.js";
 import bankAccountsRoutes from "./routes/bank-accounts.routes.js";
+import dashboardRoutes from "./routes/dashboard.routes.js";
 import { notFoundHandler, errorHandler } from "./middlewares/error.middleware.js";
 import { requestIdMiddleware } from "./middlewares/request-id.middleware.js";
 import { requestLoggingMiddleware } from "./middlewares/request-logging.middleware.js";
@@ -114,6 +115,7 @@ app.use("/ops", opsRoutes);
 app.use("/ai", aiRoutes);
 app.use("/goals", goalsRoutes);
 app.use("/bank-accounts", bankAccountsRoutes);
+app.use("/dashboard", dashboardRoutes);
 
 app.use(notFoundHandler);
 app.use(errorHandler);

--- a/apps/api/src/dashboard.test.js
+++ b/apps/api/src/dashboard.test.js
@@ -1,0 +1,373 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import request from "supertest";
+import app from "./app.js";
+import { clearDbClientForTests, dbQuery } from "./db/index.js";
+import { setupTestDb, registerAndLogin } from "./test-helpers.js";
+import { resetLoginProtectionState } from "./middlewares/login-protection.middleware.js";
+import { resetWriteRateLimiterState } from "./middlewares/rate-limit.middleware.js";
+import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
+
+// ─── Date helpers (UTC-safe) ──────────────────────────────────────────────────
+
+const isoDate = (offsetDays = 0) => {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + offsetDays);
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}`;
+};
+
+const currentMonth = () => isoDate(0).slice(0, 7);
+
+// ─── State reset ──────────────────────────────────────────────────────────────
+
+const resetState = async () => {
+  resetLoginProtectionState();
+  resetWriteRateLimiterState();
+  resetHttpMetricsForTests();
+  await dbQuery("DELETE FROM salary_consignacoes");
+  await dbQuery("DELETE FROM salary_profiles");
+  await dbQuery("DELETE FROM income_statements");
+  await dbQuery("DELETE FROM income_sources");
+  await dbQuery("DELETE FROM user_forecasts");
+  await dbQuery("DELETE FROM credit_card_purchases");
+  await dbQuery("DELETE FROM bills");
+  await dbQuery("DELETE FROM credit_cards");
+  await dbQuery("DELETE FROM bank_accounts");
+  await dbQuery("DELETE FROM users");
+};
+
+// ─── API helpers ──────────────────────────────────────────────────────────────
+
+const getSnapshot = (token) =>
+  request(app)
+    .get("/dashboard/snapshot")
+    .set("Authorization", `Bearer ${token}`);
+
+const createBankAccount = (token, overrides = {}) =>
+  request(app)
+    .post("/bank-accounts")
+    .set("Authorization", `Bearer ${token}`)
+    .send({ name: "Conta Corrente", balance: 1000, accountType: "checking", ...overrides });
+
+const createBill = (token, overrides = {}) =>
+  request(app)
+    .post("/bills")
+    .set("Authorization", `Bearer ${token}`)
+    .send({ title: "Energia", amount: 200, dueDate: isoDate(0), ...overrides });
+
+const createCreditCard = (token, overrides = {}) =>
+  request(app)
+    .post("/credit-cards")
+    .set("Authorization", `Bearer ${token}`)
+    .send({ name: "Itaú", limitTotal: 5000, closingDay: 7, dueDay: 15, ...overrides });
+
+const createPurchase = (token, cardId, overrides = {}) =>
+  request(app)
+    .post(`/credit-cards/${cardId}/purchases`)
+    .set("Authorization", `Bearer ${token}`)
+    .send({ title: "Supermercado", amount: 300, purchaseDate: isoDate(0), ...overrides });
+
+const createIncomeSource = (token) =>
+  request(app)
+    .post("/income-sources")
+    .set("Authorization", `Bearer ${token}`)
+    .send({ name: "INSS Aposentadoria", sourceType: "inss_benefit" });
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("dashboard snapshot", () => {
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  afterAll(async () => {
+    await clearDbClientForTests();
+  });
+
+  beforeEach(resetState);
+
+  // ─── Auth ─────────────────────────────────────────────────────────────────
+
+  it("GET /dashboard/snapshot bloqueia sem token", async () => {
+    const res = await request(app).get("/dashboard/snapshot");
+    expect(res.status).toBe(401);
+  });
+
+  // ─── Empty state ──────────────────────────────────────────────────────────
+
+  it("retorna zeros para usuario sem dados", async () => {
+    const token = await registerAndLogin("dash-empty@test.dev");
+
+    const res = await getSnapshot(token);
+
+    expect(res.status).toBe(200);
+    expect(res.body.bankBalance).toBe(0);
+    expect(res.body.bills.overdueCount).toBe(0);
+    expect(res.body.bills.overdueTotal).toBe(0);
+    expect(res.body.bills.dueSoonCount).toBe(0);
+    expect(res.body.bills.dueSoonTotal).toBe(0);
+    expect(res.body.cards.openPurchasesTotal).toBe(0);
+    expect(res.body.cards.pendingInvoicesTotal).toBe(0);
+    expect(res.body.income.receivedThisMonth).toBe(0);
+    expect(res.body.income.pendingThisMonth).toBe(0);
+    expect(res.body.income.referenceMonth).toBe(currentMonth());
+    expect(res.body.forecast).toBeNull();
+    expect(res.body.consignado.monthlyTotal).toBe(0);
+  });
+
+  // ─── Bank balance ─────────────────────────────────────────────────────────
+
+  it("bankBalance agrega saldo de todas as contas ativas", async () => {
+    const token = await registerAndLogin("dash-bank@test.dev");
+
+    await createBankAccount(token, { balance: 1500 });
+    await createBankAccount(token, { name: "Poupança", balance: 800, accountType: "savings" });
+
+    const res = await getSnapshot(token);
+
+    expect(res.status).toBe(200);
+    expect(res.body.bankBalance).toBe(2300);
+  });
+
+  it("bankBalance exclui contas inativas", async () => {
+    const token = await registerAndLogin("dash-bank-inactive@test.dev");
+
+    await createBankAccount(token, { balance: 1000 });
+    const toDelete = await createBankAccount(token, { name: "Encerrada", balance: 500 });
+    // Soft-delete via DELETE endpoint
+    await request(app)
+      .delete(`/bank-accounts/${toDelete.body.id}`)
+      .set("Authorization", `Bearer ${token}`);
+
+    const res = await getSnapshot(token);
+
+    expect(res.status).toBe(200);
+    expect(res.body.bankBalance).toBe(1000);
+  });
+
+  // ─── Bills ────────────────────────────────────────────────────────────────
+
+  it("bills.overdueCount conta faturas vencidas", async () => {
+    const token = await registerAndLogin("dash-bills-overdue@test.dev");
+
+    await createBill(token, { dueDate: isoDate(-5), amount: 150 });
+    await createBill(token, { dueDate: isoDate(-1), amount: 80 });
+    await createBill(token, { dueDate: isoDate(2), amount: 200 }); // due soon, not overdue
+
+    const res = await getSnapshot(token);
+
+    expect(res.status).toBe(200);
+    expect(res.body.bills.overdueCount).toBe(2);
+    expect(res.body.bills.overdueTotal).toBe(230);
+  });
+
+  it("bills.dueSoonCount conta faturas que vencem em 7 dias", async () => {
+    const token = await registerAndLogin("dash-bills-soon@test.dev");
+
+    await createBill(token, { dueDate: isoDate(0), amount: 100 });  // today
+    await createBill(token, { dueDate: isoDate(3), amount: 200 });  // in 3 days
+    await createBill(token, { dueDate: isoDate(10), amount: 999 }); // beyond 7 days
+
+    const res = await getSnapshot(token);
+
+    expect(res.status).toBe(200);
+    expect(res.body.bills.dueSoonCount).toBe(2);
+    expect(res.body.bills.dueSoonTotal).toBe(300);
+  });
+
+  it("bills nao conta faturas pagas", async () => {
+    const token = await registerAndLogin("dash-bills-paid@test.dev");
+
+    await createBill(token, { dueDate: isoDate(-3), amount: 200 }); // overdue pending
+    const b2 = await createBill(token, { dueDate: isoDate(-1), amount: 100 });
+    // Mark as paid via the dedicated endpoint
+    await request(app)
+      .patch(`/bills/${b2.body.id}/mark-paid`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ paidAt: isoDate(-1) });
+
+    const res = await getSnapshot(token);
+
+    expect(res.body.bills.overdueCount).toBe(1);
+    expect(res.body.bills.overdueTotal).toBe(200);
+  });
+
+  // ─── Cards ────────────────────────────────────────────────────────────────
+
+  it("cards.openPurchasesTotal soma compras abertas", async () => {
+    const token = await registerAndLogin("dash-cards@test.dev");
+
+    const cardRes = await createCreditCard(token);
+    const cardId = cardRes.body.id;
+
+    await createPurchase(token, cardId, { amount: 500 });
+    await createPurchase(token, cardId, { amount: 300 });
+
+    const res = await getSnapshot(token);
+
+    expect(res.status).toBe(200);
+    expect(res.body.cards.openPurchasesTotal).toBe(800);
+  });
+
+  it("cards.pendingInvoicesTotal soma faturas de cartão pendentes", async () => {
+    const token = await registerAndLogin("dash-card-inv@test.dev");
+
+    const cardRes = await createCreditCard(token);
+    const cardId = cardRes.body.id;
+
+    // Insert a credit card invoice bill directly with the correct bill_type and credit_card_id
+    const userRes = await dbQuery(
+      "SELECT id FROM users WHERE email = $1 LIMIT 1",
+      ["dash-card-inv@test.dev"],
+    );
+    const userId = Number(userRes.rows[0].id);
+    await dbQuery(
+      `INSERT INTO bills (user_id, title, amount, due_date, bill_type, credit_card_id)
+       VALUES ($1, 'Fatura Itaú', 1247.80, $2, 'credit_card_invoice', $3)`,
+      [userId, isoDate(5), cardId],
+    );
+
+    const res = await getSnapshot(token);
+
+    expect(res.status).toBe(200);
+    expect(res.body.cards.pendingInvoicesTotal).toBeCloseTo(1247.80, 2);
+  });
+
+  // ─── Income ───────────────────────────────────────────────────────────────
+
+  it("income.receivedThisMonth soma statements posted no mes corrente", async () => {
+    const token = await registerAndLogin("dash-income@test.dev");
+
+    const srcRes = await createIncomeSource(token);
+    const sourceId = srcRes.body.id;
+
+    // Create a draft statement this month
+    await request(app)
+      .post(`/income-sources/${sourceId}/statements`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        referenceMonth: currentMonth(),
+        netAmount: 1902.31,
+        paymentDate: isoDate(-5),
+      });
+    // Mark as posted via direct DB update
+    await dbQuery(
+      `UPDATE income_statements SET status = 'posted'
+       WHERE income_source_id = $1 AND reference_month = $2`,
+      [sourceId, currentMonth()],
+    );
+
+    const res = await getSnapshot(token);
+
+    expect(res.status).toBe(200);
+    expect(res.body.income.receivedThisMonth).toBeCloseTo(1902.31, 2);
+    expect(res.body.income.pendingThisMonth).toBe(0);
+    expect(res.body.income.referenceMonth).toBe(currentMonth());
+  });
+
+  it("income.pendingThisMonth soma statements draft no mes corrente", async () => {
+    const token = await registerAndLogin("dash-income-draft@test.dev");
+
+    const srcRes = await createIncomeSource(token);
+    const sourceId = srcRes.body.id;
+
+    await request(app)
+      .post(`/income-sources/${sourceId}/statements`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        referenceMonth: currentMonth(),
+        netAmount: 1902.31,
+        paymentDate: isoDate(5),
+      });
+
+    const res = await getSnapshot(token);
+
+    // Draft statement → pending
+    expect(res.body.income.pendingThisMonth).toBeCloseTo(1902.31, 2);
+    expect(res.body.income.receivedThisMonth).toBe(0);
+  });
+
+  // ─── Forecast ─────────────────────────────────────────────────────────────
+
+  it("forecast e null quando nao ha previsao computada", async () => {
+    const token = await registerAndLogin("dash-fc-null@test.dev");
+
+    const res = await getSnapshot(token);
+
+    expect(res.status).toBe(200);
+    expect(res.body.forecast).toBeNull();
+  });
+
+  it("forecast retorna projected_balance do forecast mais recente", async () => {
+    const token = await registerAndLogin("dash-fc-val@test.dev");
+
+    // Trigger forecast recompute via the forecasts endpoint
+    await request(app)
+      .post("/forecasts/recompute")
+      .set("Authorization", `Bearer ${token}`);
+
+    const res = await getSnapshot(token);
+
+    expect(res.status).toBe(200);
+    // Forecast may or may not produce a value depending on transaction data; just check shape
+    if (res.body.forecast) {
+      expect(typeof res.body.forecast.projectedBalance).toBe("number");
+      expect(typeof res.body.forecast.month).toBe("string");
+    }
+  });
+
+  // ─── Consignado ───────────────────────────────────────────────────────────
+
+  it("consignado.monthlyTotal e zero quando nao ha perfil salarial", async () => {
+    const token = await registerAndLogin("dash-consig-none@test.dev");
+
+    const res = await getSnapshot(token);
+
+    expect(res.status).toBe(200);
+    expect(res.body.consignado.monthlyTotal).toBe(0);
+  });
+
+  it("consignado.monthlyTotal soma consignacoes do perfil salarial", async () => {
+    const token = await registerAndLogin("dash-consig@test.dev");
+
+    // Insert salary profile and consignacoes directly (bypasses entitlement middleware)
+    const userRes = await dbQuery(
+      "SELECT id FROM users WHERE email = $1 LIMIT 1",
+      ["dash-consig@test.dev"],
+    );
+    const userId = Number(userRes.rows[0].id);
+
+    const profileRes = await dbQuery(
+      `INSERT INTO salary_profiles (user_id, gross_salary, dependents, payment_day, profile_type)
+       VALUES ($1, 3000, 0, 5, 'clt') RETURNING id`,
+      [userId],
+    );
+    const profileId = Number(profileRes.rows[0].id);
+
+    await dbQuery(
+      `INSERT INTO salary_consignacoes (salary_profile_id, description, amount, consignacao_type)
+       VALUES ($1, 'Empréstimo Caixa', 300, 'loan'), ($1, 'Cartão Consignado', 150, 'card')`,
+      [profileId],
+    );
+
+    const res = await getSnapshot(token);
+
+    expect(res.status).toBe(200);
+    expect(res.body.consignado.monthlyTotal).toBe(450);
+  });
+
+  // ─── User isolation ───────────────────────────────────────────────────────
+
+  it("snapshot retorna apenas dados do usuario autenticado", async () => {
+    const token1 = await registerAndLogin("dash-iso-1@test.dev");
+    const token2 = await registerAndLogin("dash-iso-2@test.dev");
+
+    // User 1 has bank balance
+    await createBankAccount(token1, { balance: 5000 });
+
+    // User 2 has nothing
+    const res = await getSnapshot(token2);
+
+    expect(res.status).toBe(200);
+    expect(res.body.bankBalance).toBe(0);
+  });
+});

--- a/apps/api/src/routes/dashboard.routes.js
+++ b/apps/api/src/routes/dashboard.routes.js
@@ -1,0 +1,18 @@
+import { Router } from "express";
+import { authMiddleware } from "../middlewares/auth.middleware.js";
+import { getDashboardSnapshot } from "../services/dashboard.service.js";
+
+const router = Router();
+
+router.use(authMiddleware);
+
+router.get("/snapshot", async (req, res, next) => {
+  try {
+    const snapshot = await getDashboardSnapshot(req.user.id);
+    res.status(200).json(snapshot);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/apps/api/src/services/dashboard.service.js
+++ b/apps/api/src/services/dashboard.service.js
@@ -38,15 +38,15 @@ export const getDashboardSnapshot = async (userId) => {
       [uid],
     ),
 
-    // 2. Bills: overdue + due in the next 7 days
+    // 2. Bills: overdue + due in the next 7 days (status filter in WHERE to leverage index)
     dbQuery(
       `SELECT
-         COUNT(CASE WHEN status = 'pending' AND due_date < $2 THEN 1 END) AS overdue_count,
-         COALESCE(SUM(CASE WHEN status = 'pending' AND due_date < $2 THEN amount ELSE 0 END), 0) AS overdue_total,
-         COUNT(CASE WHEN status = 'pending' AND due_date >= $2 AND due_date < $3 THEN 1 END) AS due_soon_count,
-         COALESCE(SUM(CASE WHEN status = 'pending' AND due_date >= $2 AND due_date < $3 THEN amount ELSE 0 END), 0) AS due_soon_total
+         COUNT(CASE WHEN due_date < $2 THEN 1 END) AS overdue_count,
+         COALESCE(SUM(CASE WHEN due_date < $2 THEN amount ELSE 0 END), 0) AS overdue_total,
+         COUNT(CASE WHEN due_date >= $2 AND due_date < $3 THEN 1 END) AS due_soon_count,
+         COALESCE(SUM(CASE WHEN due_date >= $2 AND due_date < $3 THEN amount ELSE 0 END), 0) AS due_soon_total
        FROM bills
-       WHERE user_id = $1`,
+       WHERE user_id = $1 AND status = 'pending'`,
       [uid, today, in7Days],
     ),
 

--- a/apps/api/src/services/dashboard.service.js
+++ b/apps/api/src/services/dashboard.service.js
@@ -1,0 +1,132 @@
+import { dbQuery } from "../db/index.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const toNum = (v) => Number(v) || 0;
+const toInt = (v) => Math.round(toNum(v));
+
+// Returns YYYY-MM-DD from a Date
+const toISODate = (d) => d.toISOString().slice(0, 10);
+
+// Returns YYYY-MM from a Date
+const toYearMonth = (d) => d.toISOString().slice(0, 7);
+
+// ─── Snapshot ─────────────────────────────────────────────────────────────────
+
+export const getDashboardSnapshot = async (userId) => {
+  const uid = Number(userId);
+
+  const now = new Date();
+  const today = toISODate(now);
+  const in7Days = toISODate(new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000));
+  const currentMonth = toYearMonth(now);
+
+  const [
+    bankRes,
+    billsRes,
+    cardPurchasesRes,
+    cardInvoicesRes,
+    incomeRes,
+    forecastRes,
+    consignadoRes,
+  ] = await Promise.all([
+    // 1. Total bank balance across active accounts
+    dbQuery(
+      `SELECT COALESCE(SUM(balance), 0) AS total
+       FROM bank_accounts
+       WHERE user_id = $1 AND is_active = true`,
+      [uid],
+    ),
+
+    // 2. Bills: overdue + due in the next 7 days
+    dbQuery(
+      `SELECT
+         COUNT(CASE WHEN status = 'pending' AND due_date < $2 THEN 1 END) AS overdue_count,
+         COALESCE(SUM(CASE WHEN status = 'pending' AND due_date < $2 THEN amount ELSE 0 END), 0) AS overdue_total,
+         COUNT(CASE WHEN status = 'pending' AND due_date >= $2 AND due_date < $3 THEN 1 END) AS due_soon_count,
+         COALESCE(SUM(CASE WHEN status = 'pending' AND due_date >= $2 AND due_date < $3 THEN amount ELSE 0 END), 0) AS due_soon_total
+       FROM bills
+       WHERE user_id = $1`,
+      [uid, today, in7Days],
+    ),
+
+    // 3a. Credit card open purchases (not yet billed)
+    dbQuery(
+      `SELECT COALESCE(SUM(p.amount), 0) AS total
+       FROM credit_card_purchases p
+       JOIN credit_cards cc ON cc.id = p.credit_card_id
+       WHERE cc.user_id = $1 AND p.status = 'open'`,
+      [uid],
+    ),
+
+    // 3b. Pending credit card invoice bills
+    dbQuery(
+      `SELECT COALESCE(SUM(amount), 0) AS total
+       FROM bills
+       WHERE user_id = $1 AND status = 'pending' AND bill_type = 'credit_card_invoice'`,
+      [uid],
+    ),
+
+    // 4. Income statements this month: received (posted) + pending (draft)
+    dbQuery(
+      `SELECT
+         COALESCE(SUM(CASE WHEN st.status = 'posted' THEN st.net_amount ELSE 0 END), 0) AS received,
+         COALESCE(SUM(CASE WHEN st.status = 'draft'  THEN st.net_amount ELSE 0 END), 0) AS pending
+       FROM income_statements st
+       JOIN income_sources src ON src.id = st.income_source_id
+       WHERE src.user_id = $1 AND st.reference_month = $2`,
+      [uid, currentMonth],
+    ),
+
+    // 5. Latest forecast
+    dbQuery(
+      `SELECT projected_balance, month
+       FROM user_forecasts
+       WHERE user_id = $1
+       ORDER BY generated_at DESC
+       LIMIT 1`,
+      [uid],
+    ),
+
+    // 6. Consignado: sum of all monthly consignação amounts for this user
+    dbQuery(
+      `SELECT COALESCE(SUM(sc.amount), 0) AS total
+       FROM salary_consignacoes sc
+       JOIN salary_profiles sp ON sp.id = sc.salary_profile_id
+       WHERE sp.user_id = $1`,
+      [uid],
+    ),
+  ]);
+
+  const bills = billsRes.rows[0] ?? {};
+  const income = incomeRes.rows[0] ?? {};
+  const forecastRow = forecastRes.rows[0] ?? null;
+
+  return {
+    bankBalance: toNum(bankRes.rows[0]?.total),
+    bills: {
+      overdueCount: toInt(bills.overdue_count),
+      overdueTotal: toNum(bills.overdue_total),
+      dueSoonCount: toInt(bills.due_soon_count),
+      dueSoonTotal: toNum(bills.due_soon_total),
+    },
+    cards: {
+      openPurchasesTotal: toNum(cardPurchasesRes.rows[0]?.total),
+      pendingInvoicesTotal: toNum(cardInvoicesRes.rows[0]?.total),
+    },
+    income: {
+      receivedThisMonth: toNum(income.received),
+      pendingThisMonth: toNum(income.pending),
+      referenceMonth: currentMonth,
+    },
+    forecast: forecastRow
+      ? {
+          projectedBalance: toNum(forecastRow.projected_balance),
+          month: String(forecastRow.month),
+        }
+      : null,
+    consignado: {
+      monthlyTotal: toNum(consignadoRes.rows[0]?.total),
+    },
+  };
+};

--- a/apps/web/src/components/OperationalSummaryPanel.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.tsx
@@ -1,0 +1,186 @@
+import { useEffect, useState } from "react";
+import { useMaskedCurrency } from "../context/DiscreetModeContext";
+import { dashboardService, type DashboardSnapshot } from "../services/dashboard.service";
+
+// ─── Tile ─────────────────────────────────────────────────────────────────────
+
+interface TileProps {
+  label: string;
+  primary: string;
+  secondary?: string;
+  tertiary?: string;
+  accent?: "default" | "warning" | "danger" | "success" | "muted";
+}
+
+const ACCENT_CLASSES: Record<NonNullable<TileProps["accent"]>, string> = {
+  default: "text-cf-text-primary",
+  warning: "text-amber-600",
+  danger: "text-red-600",
+  success: "text-emerald-600",
+  muted: "text-cf-text-secondary",
+};
+
+const Tile = ({ label, primary, secondary, tertiary, accent = "default" }: TileProps) => (
+  <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
+    <p className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-cf-text-secondary">
+      {label}
+    </p>
+    <p className={`text-sm font-semibold leading-tight ${ACCENT_CLASSES[accent]}`}>{primary}</p>
+    {secondary ? (
+      <p className="mt-0.5 text-xs text-cf-text-secondary">{secondary}</p>
+    ) : null}
+    {tertiary ? (
+      <p className="text-xs text-cf-text-secondary">{tertiary}</p>
+    ) : null}
+  </div>
+);
+
+// ─── Loading skeleton ─────────────────────────────────────────────────────────
+
+const SkeletonTile = () => (
+  <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5 animate-pulse">
+    <div className="mb-1.5 h-2 w-16 rounded bg-cf-border" />
+    <div className="h-4 w-24 rounded bg-cf-border" />
+    <div className="mt-1 h-3 w-20 rounded bg-cf-border" />
+  </div>
+);
+
+// ─── Panel ────────────────────────────────────────────────────────────────────
+
+const OperationalSummaryPanel = (): JSX.Element | null => {
+  const [snapshot, setSnapshot] = useState<DashboardSnapshot | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const money = useMaskedCurrency();
+
+  useEffect(() => {
+    dashboardService
+      .getSnapshot()
+      .then(setSnapshot)
+      .catch(() => {/* non-blocking — panel just won't render */})
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-6">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <SkeletonTile key={i} />
+        ))}
+      </div>
+    );
+  }
+
+  if (!snapshot) return null;
+
+  const { bankBalance, bills, cards, income, forecast, consignado } = snapshot;
+
+  // ── Tile 1: Bank balance ──────────────────────────────────────────────────
+  const bankTile: TileProps = {
+    label: "Conta",
+    primary: money(bankBalance),
+    secondary: "Saldo disponível",
+    accent: bankBalance < 0 ? "danger" : "default",
+  };
+
+  // ── Tile 2: Bills ─────────────────────────────────────────────────────────
+  const totalBillsCount = bills.overdueCount + bills.dueSoonCount;
+  const totalBillsAmount = bills.overdueTotal + bills.dueSoonTotal;
+  const billsAccent: TileProps["accent"] =
+    bills.overdueCount > 0 ? "danger" : bills.dueSoonCount > 0 ? "warning" : "muted";
+  const billsTile: TileProps = {
+    label: "Contas a pagar",
+    primary: totalBillsCount > 0 ? money(totalBillsAmount) : "—",
+    secondary:
+      bills.overdueCount > 0
+        ? `${bills.overdueCount} vencida${bills.overdueCount > 1 ? "s" : ""}`
+        : bills.dueSoonCount > 0
+          ? `${bills.dueSoonCount} em 7 dias`
+          : "Nenhuma pendente",
+    tertiary:
+      bills.overdueCount > 0 && bills.dueSoonCount > 0
+        ? `+ ${bills.dueSoonCount} a vencer`
+        : undefined,
+    accent: billsAccent,
+  };
+
+  // ── Tile 3: Credit card ───────────────────────────────────────────────────
+  const cardTotal = cards.openPurchasesTotal + cards.pendingInvoicesTotal;
+  const cardTile: TileProps = {
+    label: "Cartão",
+    primary: cardTotal > 0 ? money(cardTotal) : "—",
+    secondary:
+      cards.openPurchasesTotal > 0 ? `${money(cards.openPurchasesTotal)} em aberto` : undefined,
+    tertiary:
+      cards.pendingInvoicesTotal > 0
+        ? `${money(cards.pendingInvoicesTotal)} fatura`
+        : undefined,
+    accent: cards.pendingInvoicesTotal > 0 ? "warning" : "default",
+  };
+
+  // ── Tile 4: Income ────────────────────────────────────────────────────────
+  const hasIncome = income.receivedThisMonth > 0 || income.pendingThisMonth > 0;
+  const incomeTile: TileProps = {
+    label: "Renda do mês",
+    primary: hasIncome ? money(income.receivedThisMonth + income.pendingThisMonth) : "—",
+    secondary:
+      income.receivedThisMonth > 0
+        ? `${money(income.receivedThisMonth)} recebido`
+        : income.pendingThisMonth > 0
+          ? "Ainda não recebido"
+          : "Sem lançamento",
+    tertiary:
+      income.pendingThisMonth > 0 && income.receivedThisMonth > 0
+        ? `${money(income.pendingThisMonth)} pendente`
+        : undefined,
+    accent:
+      income.receivedThisMonth > 0
+        ? "success"
+        : income.pendingThisMonth > 0
+          ? "warning"
+          : "muted",
+  };
+
+  // ── Tile 5: Forecast ──────────────────────────────────────────────────────
+  const forecastTile: TileProps = forecast
+    ? {
+        label: "Projeção",
+        primary: money(forecast.projectedBalance),
+        secondary: "Fechamento do mês",
+        accent: forecast.projectedBalance < 0 ? "danger" : forecast.projectedBalance < 200 ? "warning" : "default",
+      }
+    : {
+        label: "Projeção",
+        primary: "—",
+        secondary: "Sem dados suficientes",
+        accent: "muted",
+      };
+
+  // ── Tile 6: Consignado ────────────────────────────────────────────────────
+  const consignadoTile: TileProps =
+    consignado.monthlyTotal > 0
+      ? {
+          label: "Consignado",
+          primary: money(consignado.monthlyTotal),
+          secondary: "Desconto mensal",
+          accent: "warning",
+        }
+      : {
+          label: "Consignado",
+          primary: "—",
+          secondary: "Sem descontos",
+          accent: "muted",
+        };
+
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-6">
+      <Tile {...bankTile} />
+      <Tile {...billsTile} />
+      <Tile {...cardTile} />
+      <Tile {...incomeTile} />
+      <Tile {...forecastTile} />
+      <Tile {...consignadoTile} />
+    </div>
+  );
+};
+
+export default OperationalSummaryPanel;

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -13,6 +13,7 @@ import BillsSummaryWidget from "../components/BillsSummaryWidget";
 import UtilityBillsWidget from "../components/UtilityBillsWidget";
 import CreditCardsSummaryWidget from "../components/CreditCardsSummaryWidget";
 import SalaryWidget from "../components/SalaryWidget";
+import OperationalSummaryPanel from "../components/OperationalSummaryPanel";
 import TransactionList from "../components/TransactionList";
 import {
   transactionsService,
@@ -2448,6 +2449,8 @@ const App = ({
                 O que pede ação agora: projeção, pendências, cartões, renda principal e sinais de risco.
               </p>
             </div>
+
+            <OperationalSummaryPanel />
 
             <div className="grid gap-4 xl:grid-cols-3">
               <ForecastCard onOpenProfileSettings={onOpenProfileSettings} />

--- a/apps/web/src/services/dashboard.service.ts
+++ b/apps/web/src/services/dashboard.service.ts
@@ -1,0 +1,85 @@
+import { api } from "./api";
+
+export interface DashboardBills {
+  overdueCount: number;
+  overdueTotal: number;
+  dueSoonCount: number;
+  dueSoonTotal: number;
+}
+
+export interface DashboardCards {
+  openPurchasesTotal: number;
+  pendingInvoicesTotal: number;
+}
+
+export interface DashboardIncome {
+  receivedThisMonth: number;
+  pendingThisMonth: number;
+  referenceMonth: string;
+}
+
+export interface DashboardForecast {
+  projectedBalance: number;
+  month: string;
+}
+
+export interface DashboardConsignado {
+  monthlyTotal: number;
+}
+
+export interface DashboardSnapshot {
+  bankBalance: number;
+  bills: DashboardBills;
+  cards: DashboardCards;
+  income: DashboardIncome;
+  forecast: DashboardForecast | null;
+  consignado: DashboardConsignado;
+}
+
+const normalizeBills = (raw: Record<string, unknown>): DashboardBills => ({
+  overdueCount: Number(raw.overdueCount) || 0,
+  overdueTotal: Number(raw.overdueTotal) || 0,
+  dueSoonCount: Number(raw.dueSoonCount) || 0,
+  dueSoonTotal: Number(raw.dueSoonTotal) || 0,
+});
+
+const normalizeCards = (raw: Record<string, unknown>): DashboardCards => ({
+  openPurchasesTotal: Number(raw.openPurchasesTotal) || 0,
+  pendingInvoicesTotal: Number(raw.pendingInvoicesTotal) || 0,
+});
+
+const normalizeIncome = (raw: Record<string, unknown>): DashboardIncome => ({
+  receivedThisMonth: Number(raw.receivedThisMonth) || 0,
+  pendingThisMonth: Number(raw.pendingThisMonth) || 0,
+  referenceMonth: String(raw.referenceMonth ?? ""),
+});
+
+const normalizeForecast = (raw: Record<string, unknown> | null): DashboardForecast | null => {
+  if (!raw) return null;
+  return {
+    projectedBalance: Number(raw.projectedBalance) || 0,
+    month: String(raw.month ?? ""),
+  };
+};
+
+const normalizeConsignado = (raw: Record<string, unknown>): DashboardConsignado => ({
+  monthlyTotal: Number(raw.monthlyTotal) || 0,
+});
+
+const normalizeSnapshot = (raw: Record<string, unknown>): DashboardSnapshot => ({
+  bankBalance: Number(raw.bankBalance) || 0,
+  bills: normalizeBills((raw.bills as Record<string, unknown>) ?? {}),
+  cards: normalizeCards((raw.cards as Record<string, unknown>) ?? {}),
+  income: normalizeIncome((raw.income as Record<string, unknown>) ?? {}),
+  forecast: normalizeForecast(
+    raw.forecast != null ? (raw.forecast as Record<string, unknown>) : null,
+  ),
+  consignado: normalizeConsignado((raw.consignado as Record<string, unknown>) ?? {}),
+});
+
+export const dashboardService = {
+  getSnapshot: async (): Promise<DashboardSnapshot> => {
+    const { data } = await api.get("/dashboard/snapshot");
+    return normalizeSnapshot(data as Record<string, unknown>);
+  },
+};


### PR DESCRIPTION
## Summary

- **`GET /dashboard/snapshot`** — single endpoint aggregating 6 data points in parallel (bank balance, bills overdue/due-soon, card totals, income this month, forecast, consignado monthly) in one round trip
- **`OperationalSummaryPanel`** — 2×3 tile grid placed at the top of the "Painel operacional" section, answering the 6 ICP questions in under 10 seconds; tiles use semantic accent colors (danger/warning/success/muted) based on the actual financial state
- **16 integration tests** covering auth, empty state, each data dimension individually, and user isolation

## Tile breakdown

| Tile | Source | Accent |
|---|---|---|
| Conta | `bank_accounts` (active only) | danger if negative |
| Contas a pagar | `bills` overdue + 7-day window | danger if overdue, warning if due soon |
| Cartão | `credit_card_purchases` (open) + `bills` (credit_card_invoice) | warning if pending invoice |
| Renda do mês | `income_statements` posted/draft for current month | success if received, warning if pending |
| Projeção | `user_forecasts` latest row | danger/warning/default by amount |
| Consignado | `salary_consignacoes` sum | warning if any, muted if none |

## Test plan

- [ ] `GET /dashboard/snapshot` returns 401 without token
- [ ] Empty state returns all zeros and null forecast
- [ ] Bank balance aggregates active accounts, excludes deleted
- [ ] Bills counts respect overdue vs due-soon boundary and exclude paid
- [ ] Card totals cover open purchases + pending invoices separately
- [ ] Income separates posted vs draft statements
- [ ] Forecast is null when no recompute has run
- [ ] Consignado sums salary_consignacoes for the user's profile
- [ ] User isolation: snapshot only returns data for authenticated user