### PR TITLE
feat(salary): consignado overview — contracts list, margin gauge, end_date

### DIFF
--- a/apps/api/src/db/migrations/111_add_end_date_to_salary_consignacoes.sql
+++ b/apps/api/src/db/migrations/111_add_end_date_to_salary_consignacoes.sql
@@ -1,0 +1,2 @@
+ALTER TABLE salary_consignacoes
+  ADD COLUMN IF NOT EXISTS end_date DATE;

--- a/apps/api/src/routes/salary.routes.js
+++ b/apps/api/src/routes/salary.routes.js
@@ -4,6 +4,7 @@ import { attachEntitlements } from "../middlewares/entitlement.middleware.js";
 import {
   addConsignacaoForUser,
   deleteConsignacaoForUser,
+  getConsignadoOverviewForUser,
   getSalaryProfileForUser,
   syncImportedBenefitProfileForUser,
   upsertSalaryProfileForUser,
@@ -52,6 +53,15 @@ router.put("/profile/imported-benefit", attachEntitlements, async (req, res, nex
     const profile = await syncImportedBenefitProfileForUser(req.user.id, req.body || {});
     const hasAnnual = req.entitlements?.salary_annual !== false;
     res.status(200).json(applyAnnualGate(profile, hasAnnual));
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get("/consignado-overview", async (req, res, next) => {
+  try {
+    const overview = await getConsignadoOverviewForUser(req.user.id);
+    res.status(200).json(overview);
   } catch (error) {
     next(error);
   }

--- a/apps/api/src/salary-profile.test.js
+++ b/apps/api/src/salary-profile.test.js
@@ -810,4 +810,181 @@ describe("salary-profile", () => {
 
     expect(res.status).toBe(404);
   });
+
+  // ─── Consignações — end_date ──────────────────────────────────────────────
+
+  it("POST /salary/consignacoes aceita end_date opcional e retorna no shape", async () => {
+    const token = await registerAndLogin("sal-consig-enddate@test.dev");
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 4000, profile_type: "inss_beneficiary" });
+
+    const res = await request(app)
+      .post("/salary/consignacoes")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ description: "BMG 48x", amount: 300, consignacao_type: "loan", end_date: "2028-12-01" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.endDate).toBe("2028-12-01");
+  });
+
+  it("POST /salary/consignacoes sem end_date retorna endDate null", async () => {
+    const token = await registerAndLogin("sal-consig-enddate-null@test.dev");
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 4000, profile_type: "inss_beneficiary" });
+
+    const res = await request(app)
+      .post("/salary/consignacoes")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ description: "BMG 24x", amount: 200, consignacao_type: "loan" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.endDate).toBeNull();
+  });
+
+  // ─── GET /salary/consignado-overview ─────────────────────────────────────
+
+  it("GET /salary/consignado-overview bloqueia sem token", async () => {
+    const res = await request(app).get("/salary/consignado-overview");
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /salary/consignado-overview retorna overview vazio quando usuario nao tem perfil", async () => {
+    const token = await registerAndLogin("sal-ov-noprofile@test.dev");
+    const res = await request(app)
+      .get("/salary/consignado-overview")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      contracts:          [],
+      monthlyTotal:       0,
+      comprometimentoPct: null,
+      netAfterConsignado: null,
+      marginStatus:       null,
+    });
+  });
+
+  it("GET /salary/consignado-overview retorna contracts e null para perfil CLT sem consignacoes", async () => {
+    const token = await registerAndLogin("sal-ov-clt@test.dev");
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000, profile_type: "clt" });
+
+    const res = await request(app)
+      .get("/salary/consignado-overview")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.contracts).toHaveLength(0);
+    expect(res.body.comprometimentoPct).toBeNull();
+    expect(res.body.marginStatus).toBeNull();
+  });
+
+  it("GET /salary/consignado-overview retorna margem safe para INSS beneficiario dentro do limite", async () => {
+    const token = await registerAndLogin("sal-ov-safe@test.dev");
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000, profile_type: "inss_beneficiary", birth_year: 1960 });
+
+    // 500 / 5000 = 10% → safe
+    await request(app)
+      .post("/salary/consignacoes")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ description: "Empréstimo BMG", amount: 500, consignacao_type: "loan" });
+
+    const res = await request(app)
+      .get("/salary/consignado-overview")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.marginStatus).toBe("safe");
+    expect(res.body.comprometimentoPct).toBe(10);
+    expect(typeof res.body.netAfterConsignado).toBe("number");
+    expect(res.body.netAfterConsignado).toBeGreaterThan(0);
+    expect(res.body.contracts).toHaveLength(1);
+    expect(res.body.contracts[0]).toMatchObject({
+      description:     "Empréstimo BMG",
+      amount:          500,
+      consignacaoType: "loan",
+      endDate:         null,
+    });
+  });
+
+  it("GET /salary/consignado-overview retorna margem warning quando comprometimento entre 30 e 35%", async () => {
+    const token = await registerAndLogin("sal-ov-warning@test.dev");
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000, profile_type: "inss_beneficiary", birth_year: 1960 });
+
+    // 1600 / 5000 = 32% → warning
+    await request(app)
+      .post("/salary/consignacoes")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ description: "Empréstimo A", amount: 1000, consignacao_type: "loan" });
+
+    await request(app)
+      .post("/salary/consignacoes")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ description: "Cartão B", amount: 600, consignacao_type: "card" });
+
+    const res = await request(app)
+      .get("/salary/consignado-overview")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.marginStatus).toBe("warning");
+    expect(res.body.comprometimentoPct).toBe(32);
+  });
+
+  it("GET /salary/consignado-overview retorna margem exceeded quando comprometimento acima de 35%", async () => {
+    const token = await registerAndLogin("sal-ov-exceeded@test.dev");
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ gross_salary: 5000, profile_type: "inss_beneficiary", birth_year: 1960 });
+
+    // 2000 / 5000 = 40% → exceeded
+    await request(app)
+      .post("/salary/consignacoes")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ description: "Empréstimo alto", amount: 2000, consignacao_type: "loan" });
+
+    const res = await request(app)
+      .get("/salary/consignado-overview")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.marginStatus).toBe("exceeded");
+    expect(res.body.comprometimentoPct).toBe(40);
+  });
+
+  it("GET /salary/consignado-overview isolado por usuario", async () => {
+    const tokenA = await registerAndLogin("sal-ov-owner-a@test.dev");
+    const tokenB = await registerAndLogin("sal-ov-owner-b@test.dev");
+
+    await request(app)
+      .put("/salary/profile")
+      .set("Authorization", `Bearer ${tokenA}`)
+      .send({ gross_salary: 5000, profile_type: "inss_beneficiary" });
+
+    await request(app)
+      .post("/salary/consignacoes")
+      .set("Authorization", `Bearer ${tokenA}`)
+      .send({ description: "Empréstimo A", amount: 300, consignacao_type: "loan" });
+
+    const resB = await request(app)
+      .get("/salary/consignado-overview")
+      .set("Authorization", `Bearer ${tokenB}`);
+
+    expect(resB.status).toBe(200);
+    expect(resB.body.contracts).toHaveLength(0);
+    expect(resB.body.monthlyTotal).toBe(0);
+  });
 });

--- a/apps/api/src/services/dashboard.service.js
+++ b/apps/api/src/services/dashboard.service.js
@@ -88,12 +88,16 @@ export const getDashboardSnapshot = async (userId) => {
       [uid],
     ),
 
-    // 6. Consignado: sum of all monthly consignação amounts for this user
+    // 6. Consignado: monthly total, contract count, gross salary for margin %
     dbQuery(
-      `SELECT COALESCE(SUM(sc.amount), 0) AS total
-       FROM salary_consignacoes sc
-       JOIN salary_profiles sp ON sp.id = sc.salary_profile_id
-       WHERE sp.user_id = $1`,
+      `SELECT
+         COALESCE(SUM(sc.amount), 0) AS monthly_total,
+         COUNT(sc.id) AS contracts_count,
+         sp.gross_salary
+       FROM salary_profiles sp
+       LEFT JOIN salary_consignacoes sc ON sc.salary_profile_id = sp.id
+       WHERE sp.user_id = $1
+       GROUP BY sp.gross_salary`,
       [uid],
     ),
   ]);
@@ -125,8 +129,16 @@ export const getDashboardSnapshot = async (userId) => {
           month: String(forecastRow.month),
         }
       : null,
-    consignado: {
-      monthlyTotal: toNum(consignadoRes.rows[0]?.total),
-    },
+    consignado: (() => {
+      const row = consignadoRes.rows[0];
+      const monthlyTotal = toNum(row?.monthly_total);
+      const contractsCount = toInt(row?.contracts_count);
+      const grossSalary = toNum(row?.gross_salary);
+      const comprometimentoPct =
+        grossSalary > 0 && monthlyTotal > 0
+          ? Number(((monthlyTotal / grossSalary) * 100).toFixed(1))
+          : null;
+      return { monthlyTotal, contractsCount, comprometimentoPct };
+    })(),
   };
 };

--- a/apps/api/src/services/salary-profile.service.js
+++ b/apps/api/src/services/salary-profile.service.js
@@ -358,8 +358,8 @@ export const addConsignacaoForUser = async (userId, body = {}) => {
 
 // ─── Consignado overview ──────────────────────────────────────────────────────
 
-const MARGIN_SAFE_THRESHOLD    = 30; // up to 30%: safe
-const MARGIN_WARNING_THRESHOLD = 35; // 30–35%: approaching legal limit
+const MARGIN_SAFE_THRESHOLD    = 25; // up to 25%: safe
+const MARGIN_WARNING_THRESHOLD = 35; // 25–35%: approaching legal limit
 // > 35%: exceeded
 
 const marginStatus = (pct) => {

--- a/apps/api/src/services/salary-profile.service.js
+++ b/apps/api/src/services/salary-profile.service.js
@@ -171,6 +171,7 @@ const toConsignacao = (row) => ({
   description:      row.description,
   amount:           toMoney(row.amount),
   consignacaoType:  row.consignacao_type,
+  endDate:          row.end_date != null ? toISODateOnly(row.end_date) : null,
   createdAt:        row.created_at,
 });
 
@@ -215,7 +216,7 @@ const FIND_SQL = `
 `;
 
 const FIND_CONSIGNACOES_SQL = `
-  SELECT id, salary_profile_id, description, amount, consignacao_type, created_at
+  SELECT id, salary_profile_id, description, amount, consignacao_type, end_date, created_at
   FROM   salary_consignacoes
   WHERE  salary_profile_id = $1
   ORDER  BY created_at ASC
@@ -249,9 +250,9 @@ const UPDATE_SQL = `
 
 const INSERT_CONSIGNACAO_SQL = `
   INSERT INTO salary_consignacoes
-    (salary_profile_id, description, amount, consignacao_type)
-  VALUES ($1, $2, $3, $4)
-  RETURNING id, salary_profile_id, description, amount, consignacao_type, created_at
+    (salary_profile_id, description, amount, consignacao_type, end_date)
+  VALUES ($1, $2, $3, $4, $5)
+  RETURNING id, salary_profile_id, description, amount, consignacao_type, end_date, created_at
 `;
 
 // ─── Public API ───────────────────────────────────────────────────────────────
@@ -328,6 +329,7 @@ export const addConsignacaoForUser = async (userId, body = {}) => {
     description,
     amount,
     consignacao_type: consignacaoType,
+    end_date: endDateRaw = null,
   } = body;
 
   validateConsignacaoInput({ description, amount, consignacaoType });
@@ -341,14 +343,81 @@ export const addConsignacaoForUser = async (userId, body = {}) => {
   assertBeneficiaryProfile(profile);
   const profileId = profile.id;
 
+  const endDate = endDateRaw != null ? toISODateOnly(endDateRaw) : null;
+
   const result = await dbQuery(INSERT_CONSIGNACAO_SQL, [
     profileId,
     String(description).trim(),
     Number(amount),
     consignacaoType,
+    endDate,
   ]);
 
   return toConsignacao(result.rows[0]);
+};
+
+// ─── Consignado overview ──────────────────────────────────────────────────────
+
+const MARGIN_SAFE_THRESHOLD    = 30; // up to 30%: safe
+const MARGIN_WARNING_THRESHOLD = 35; // 30–35%: approaching legal limit
+// > 35%: exceeded
+
+const marginStatus = (pct) => {
+  if (pct <= MARGIN_SAFE_THRESHOLD) return "safe";
+  if (pct <= MARGIN_WARNING_THRESHOLD) return "warning";
+  return "exceeded";
+};
+
+export const getConsignadoOverviewForUser = async (userId) => {
+  const profileResult = await dbQuery(FIND_SQL, [userId]);
+
+  if (!profileResult.rows[0]) {
+    return {
+      contracts: [],
+      monthlyTotal: 0,
+      comprometimentoPct: null,
+      netAfterConsignado: null,
+      marginStatus: null,
+    };
+  }
+
+  const profile = toProfile(profileResult.rows[0]);
+  const consigRows = await dbQuery(FIND_CONSIGNACOES_SQL, [profile.id]);
+  const contracts = consigRows.rows.map(toConsignacao);
+
+  const monthlyTotal = Number(
+    contracts.reduce((sum, c) => sum + c.amount, 0).toFixed(2),
+  );
+
+  if (profile.profileType !== "inss_beneficiary" || contracts.length === 0) {
+    return {
+      contracts,
+      monthlyTotal,
+      comprometimentoPct: contracts.length > 0 ? null : null,
+      netAfterConsignado: null,
+      marginStatus: null,
+    };
+  }
+
+  // For INSS beneficiaries, compute margin against gross benefit
+  const calculation = calculateNetBenefit({
+    grossBenefit: profile.grossSalary,
+    birthYear:    profile.birthYear,
+    dependents:   profile.dependents,
+    consignacoes: contracts,
+  });
+
+  const pct = Number(
+    ((monthlyTotal / profile.grossSalary) * 100).toFixed(1),
+  );
+
+  return {
+    contracts,
+    monthlyTotal,
+    comprometimentoPct: pct,
+    netAfterConsignado: calculation.netMonthly,
+    marginStatus: marginStatus(pct),
+  };
 };
 
 export const syncImportedBenefitProfileForUser = async (userId, body = {}) =>
@@ -423,6 +492,7 @@ export const syncImportedBenefitProfileForUser = async (userId, body = {}) =>
         consignacao.description,
         consignacao.amount,
         consignacao.consignacaoType,
+        null, // end_date not available from imported benefit data
       ]);
       insertedConsignacoes.push(toConsignacao(result.rows[0]));
     }

--- a/apps/web/src/components/ConsignadoOverviewWidget.tsx
+++ b/apps/web/src/components/ConsignadoOverviewWidget.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useState } from "react";
+import {
+  salaryService,
+  type ConsignadoOverview,
+  type ConsignacaoType,
+  type MarginStatus,
+} from "../services/salary.service";
+import { formatCurrency } from "../utils/formatCurrency";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const CONSIGNACAO_TYPE_LABEL: Record<ConsignacaoType, string> = {
+  loan:  "Empréstimo",
+  card:  "Cartão",
+  other: "Outro",
+};
+
+const MARGIN_COLORS: Record<MarginStatus, string> = {
+  safe:     "bg-emerald-500",
+  warning:  "bg-amber-500",
+  exceeded: "bg-red-500",
+};
+
+const MARGIN_TEXT: Record<MarginStatus, string> = {
+  safe:     "text-emerald-600",
+  warning:  "text-amber-600",
+  exceeded: "text-red-600",
+};
+
+const MARGIN_LABEL: Record<MarginStatus, string> = {
+  safe:     "Dentro do limite",
+  warning:  "Próximo do limite",
+  exceeded: "Limite ultrapassado",
+};
+
+const formatEndDate = (value: string | null): string | null => {
+  if (!value) return null;
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return value;
+  return `${match[3]}/${match[2]}/${match[1]}`;
+};
+
+// ─── Widget ───────────────────────────────────────────────────────────────────
+
+const ConsignadoOverviewWidget = (): JSX.Element | null => {
+  const [overview, setOverview] = useState<ConsignadoOverview | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    salaryService
+      .getConsignadoOverview()
+      .then(setOverview)
+      .catch(() => {/* non-blocking */})
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  // Don't render if no consignações
+  if (!isLoading && (overview === null || overview.contracts.length === 0)) return null;
+
+  const hasMargin = overview?.comprometimentoPct != null && overview?.marginStatus != null;
+  const pct = overview?.comprometimentoPct ?? 0;
+  const status = overview?.marginStatus ?? "safe";
+
+  return (
+    <section className="rounded border border-cf-border bg-cf-surface p-4">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <div>
+          <h3 className="text-sm font-medium text-cf-text-primary">Consignado</h3>
+          <p className="text-xs text-cf-text-secondary">Descontos em folha / benefício</p>
+        </div>
+
+        {!isLoading && overview && (
+          <div className="text-right">
+            <p className="text-base font-semibold text-cf-text-primary">
+              {formatCurrency(overview.monthlyTotal)}
+            </p>
+            <p className="text-xs text-cf-text-secondary">
+              /mês · {overview.contracts.length} contrato{overview.contracts.length !== 1 ? "s" : ""}
+            </p>
+          </div>
+        )}
+
+        {isLoading && (
+          <div className="animate-pulse text-right">
+            <div className="mb-1 h-5 w-24 rounded bg-cf-border" />
+            <div className="h-3 w-16 rounded bg-cf-border" />
+          </div>
+        )}
+      </div>
+
+      {/* Margin bar (INSS beneficiary only) */}
+      {!isLoading && hasMargin && (
+        <div className="mb-3">
+          <div className="mb-1 flex items-center justify-between">
+            <span className={`text-xs font-medium ${MARGIN_TEXT[status]}`}>
+              {MARGIN_LABEL[status]}
+            </span>
+            <span className={`text-xs font-semibold ${MARGIN_TEXT[status]}`}>
+              {pct.toFixed(1)}%
+            </span>
+          </div>
+          <div className="h-1.5 w-full overflow-hidden rounded-full bg-cf-border">
+            <div
+              className={`h-full rounded-full transition-all ${MARGIN_COLORS[status]}`}
+              style={{ width: `${Math.min(pct, 100)}%` }}
+            />
+          </div>
+          <div className="mt-0.5 flex justify-between">
+            <span className="text-[10px] text-cf-text-secondary">0%</span>
+            <span className="text-[10px] text-amber-500">30%</span>
+            <span className="text-[10px] text-red-500">35%</span>
+            <span className="text-[10px] text-cf-text-secondary">100%</span>
+          </div>
+        </div>
+      )}
+
+      {/* Net after consignado */}
+      {!isLoading && overview?.netAfterConsignado != null && (
+        <p className="mb-3 text-xs text-cf-text-secondary">
+          Líquido após descontos:{" "}
+          <span className="font-medium text-cf-text-primary">
+            {formatCurrency(overview.netAfterConsignado)}
+          </span>
+        </p>
+      )}
+
+      {/* Contract list */}
+      {isLoading ? (
+        <div className="space-y-2 animate-pulse">
+          {[1, 2].map((i) => (
+            <div key={i} className="flex items-center justify-between rounded bg-cf-bg-subtle px-3 py-2">
+              <div className="space-y-1">
+                <div className="h-3 w-32 rounded bg-cf-border" />
+                <div className="h-2.5 w-20 rounded bg-cf-border" />
+              </div>
+              <div className="h-4 w-16 rounded bg-cf-border" />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <ul className="space-y-1.5">
+          {(overview?.contracts ?? []).map((c) => {
+            const endLabel = formatEndDate(c.endDate);
+            return (
+              <li
+                key={c.id}
+                className="flex items-center justify-between rounded bg-cf-bg-subtle px-3 py-2"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-xs font-medium text-cf-text-primary">
+                    {c.description}
+                  </p>
+                  <p className="text-[10px] text-cf-text-secondary">
+                    {CONSIGNACAO_TYPE_LABEL[c.consignacaoType]}
+                    {endLabel ? ` · até ${endLabel}` : ""}
+                  </p>
+                </div>
+                <span className="ml-3 shrink-0 text-xs font-semibold text-cf-text-primary">
+                  {formatCurrency(c.amount)}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+};
+
+export default ConsignadoOverviewWidget;

--- a/apps/web/src/components/ConsignadoOverviewWidget.tsx
+++ b/apps/web/src/components/ConsignadoOverviewWidget.tsx
@@ -107,7 +107,7 @@ const ConsignadoOverviewWidget = (): JSX.Element | null => {
           </div>
           <div className="mt-0.5 flex justify-between">
             <span className="text-[10px] text-cf-text-secondary">0%</span>
-            <span className="text-[10px] text-amber-500">30%</span>
+            <span className="text-[10px] text-amber-500">25%</span>
             <span className="text-[10px] text-red-500">35%</span>
             <span className="text-[10px] text-cf-text-secondary">100%</span>
           </div>

--- a/apps/web/src/components/OperationalSummaryPanel.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.tsx
@@ -156,13 +156,28 @@ const OperationalSummaryPanel = (): JSX.Element | null => {
       };
 
   // ── Tile 6: Consignado ────────────────────────────────────────────────────
+  const consignadoAccent: TileProps["accent"] =
+    consignado.comprometimentoPct != null && consignado.comprometimentoPct > 35
+      ? "danger"
+      : consignado.comprometimentoPct != null && consignado.comprometimentoPct > 30
+        ? "warning"
+        : consignado.monthlyTotal > 0
+          ? "default"
+          : "muted";
   const consignadoTile: TileProps =
     consignado.monthlyTotal > 0
       ? {
           label: "Consignado",
           primary: money(consignado.monthlyTotal),
-          secondary: "Desconto mensal",
-          accent: "warning",
+          secondary:
+            consignado.contractsCount > 0
+              ? `${consignado.contractsCount} contrato${consignado.contractsCount > 1 ? "s" : ""}`
+              : "Desconto mensal",
+          tertiary:
+            consignado.comprometimentoPct != null
+              ? `${consignado.comprometimentoPct}% da margem`
+              : undefined,
+          accent: consignadoAccent,
         }
       : {
           label: "Consignado",

--- a/apps/web/src/components/OperationalSummaryPanel.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.tsx
@@ -159,7 +159,7 @@ const OperationalSummaryPanel = (): JSX.Element | null => {
   const consignadoAccent: TileProps["accent"] =
     consignado.comprometimentoPct != null && consignado.comprometimentoPct > 35
       ? "danger"
-      : consignado.comprometimentoPct != null && consignado.comprometimentoPct > 30
+      : consignado.comprometimentoPct != null && consignado.comprometimentoPct > 25
         ? "warning"
         : consignado.monthlyTotal > 0
           ? "default"

--- a/apps/web/src/components/SalaryWidget.test.tsx
+++ b/apps/web/src/components/SalaryWidget.test.tsx
@@ -433,8 +433,8 @@ describe("SalaryWidget — perfil beneficiário INSS", () => {
 describe("SalaryWidget — beneficiário com consignações", () => {
   const profileWithConsig = buildBenefitProfile({
     consignacoes: [
-      { id: 1, salaryProfileId: 2, description: "BMG Empréstimo", amount: 456.78, consignacaoType: "loan", createdAt: "2026-01-01T00:00:00Z" },
-      { id: 2, salaryProfileId: 2, description: "Cartão Banco X",  amount: 100.00, consignacaoType: "card", createdAt: "2026-01-02T00:00:00Z" },
+      { id: 1, salaryProfileId: 2, description: "BMG Empréstimo", amount: 456.78, consignacaoType: "loan", endDate: null, createdAt: "2026-01-01T00:00:00Z" },
+      { id: 2, salaryProfileId: 2, description: "Cartão Banco X",  amount: 100.00, consignacaoType: "card", endDate: null, createdAt: "2026-01-02T00:00:00Z" },
     ],
     calculation: {
       ...buildBenefitProfile().calculation,
@@ -480,6 +480,7 @@ describe("SalaryWidget — beneficiário com consignações", () => {
           description: "216 CONSIGNACAO EMPRESTIMO BANCARIO",
           amount: 156,
           consignacaoType: "loan",
+          endDate: null,
           createdAt: "2026-04-07T00:00:00Z",
         },
         {
@@ -488,6 +489,7 @@ describe("SalaryWidget — beneficiário com consignações", () => {
           description: "217 EMPRESTIMO SOBRE A RMC",
           amount: 238,
           consignacaoType: "loan",
+          endDate: null,
           createdAt: "2026-04-07T00:00:00Z",
         },
       ],
@@ -586,12 +588,12 @@ describe("SalaryWidget — adicionar consignação", () => {
   it("salva consignação e atualiza perfil", async () => {
     const updatedProfile = buildBenefitProfile({
       consignacoes: [
-        { id: 10, salaryProfileId: 2, description: "BMG", amount: 300, consignacaoType: "loan", createdAt: "2026-01-01T00:00:00Z" },
+        { id: 10, salaryProfileId: 2, description: "BMG", amount: 300, consignacaoType: "loan", endDate: null, createdAt: "2026-01-01T00:00:00Z" },
       ],
       calculation: { ...buildBenefitProfile().calculation, loanTotal: 300, consignacoesMonthly: 300 },
     });
     vi.mocked(salaryService.addConsignacao).mockResolvedValue({
-      id: 10, salaryProfileId: 2, description: "BMG", amount: 300, consignacaoType: "loan", createdAt: "2026-01-01T00:00:00Z",
+      id: 10, salaryProfileId: 2, description: "BMG", amount: 300, consignacaoType: "loan", endDate: null, createdAt: "2026-01-01T00:00:00Z",
     });
     vi.mocked(salaryService.getProfile).mockResolvedValueOnce(buildBenefitProfile()).mockResolvedValue(updatedProfile);
 

--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -114,6 +114,7 @@ vi.mock("../services/salary.service", () => ({
     getProfile: vi.fn(),
     upsertProfile: vi.fn(),
     syncImportedBenefitProfile: vi.fn(),
+    getConsignadoOverview: vi.fn(),
   },
 }));
 
@@ -372,6 +373,7 @@ describe("App", () => {
       items: [],
     });
     salaryService.getProfile.mockResolvedValue(null);
+    salaryService.getConsignadoOverview.mockResolvedValue({ contracts: [], monthlyTotal: 0, comprometimentoPct: null, netAfterConsignado: null, marginStatus: null });
     transactionsService.exportCsv.mockResolvedValue({
       blob: new Blob(["id,type\n1,Entrada"], { type: "text/csv;charset=utf-8" }),
       fileName: "transacoes.csv",

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -13,6 +13,7 @@ import BillsSummaryWidget from "../components/BillsSummaryWidget";
 import UtilityBillsWidget from "../components/UtilityBillsWidget";
 import CreditCardsSummaryWidget from "../components/CreditCardsSummaryWidget";
 import SalaryWidget from "../components/SalaryWidget";
+import ConsignadoOverviewWidget from "../components/ConsignadoOverviewWidget";
 import OperationalSummaryPanel from "../components/OperationalSummaryPanel";
 import TransactionList from "../components/TransactionList";
 import {
@@ -2464,6 +2465,8 @@ const App = ({
           <UtilityBillsWidget />
 
           <SalaryWidget />
+
+          <ConsignadoOverviewWidget />
 
           <Suspense fallback={null}>
             <HealthOverview />

--- a/apps/web/src/services/dashboard.service.ts
+++ b/apps/web/src/services/dashboard.service.ts
@@ -25,6 +25,8 @@ export interface DashboardForecast {
 
 export interface DashboardConsignado {
   monthlyTotal: number;
+  contractsCount: number;
+  comprometimentoPct: number | null;
 }
 
 export interface DashboardSnapshot {
@@ -63,7 +65,9 @@ const normalizeForecast = (raw: Record<string, unknown> | null): DashboardForeca
 };
 
 const normalizeConsignado = (raw: Record<string, unknown>): DashboardConsignado => ({
-  monthlyTotal: Number(raw.monthlyTotal) || 0,
+  monthlyTotal:       Number(raw.monthlyTotal) || 0,
+  contractsCount:     Number(raw.contractsCount) || 0,
+  comprometimentoPct: raw.comprometimentoPct != null ? Number(raw.comprometimentoPct) : null,
 });
 
 const normalizeSnapshot = (raw: Record<string, unknown>): DashboardSnapshot => ({

--- a/apps/web/src/services/salary.service.ts
+++ b/apps/web/src/services/salary.service.ts
@@ -28,7 +28,18 @@ export interface Consignacao {
   description: string;
   amount: number;
   consignacaoType: ConsignacaoType;
+  endDate: string | null;
   createdAt: string;
+}
+
+export type MarginStatus = "safe" | "warning" | "exceeded";
+
+export interface ConsignadoOverview {
+  contracts: Consignacao[];
+  monthlyTotal: number;
+  comprometimentoPct: number | null;
+  netAfterConsignado: number | null;
+  marginStatus: MarginStatus | null;
 }
 
 export interface ActiveBenefitStatement {
@@ -98,6 +109,7 @@ const normalizeConsignacao = (raw: Record<string, unknown>): Consignacao => ({
   description:     typeof raw.description === "string" ? raw.description : "",
   amount:          Number(raw.amount)          || 0,
   consignacaoType: (raw.consignacaoType as ConsignacaoType) ?? "other",
+  endDate:         typeof raw.endDate === "string" ? raw.endDate : null,
   createdAt:       typeof raw.createdAt === "string" ? raw.createdAt : "",
 });
 
@@ -165,5 +177,19 @@ export const salaryService = {
 
   deleteConsignacao: async (id: number): Promise<void> => {
     await api.delete(`/salary/consignacoes/${id}`);
+  },
+
+  getConsignadoOverview: async (): Promise<ConsignadoOverview> => {
+    const { data } = await api.get("/salary/consignado-overview");
+    const raw = data as Record<string, unknown>;
+    return {
+      contracts: Array.isArray(raw.contracts)
+        ? (raw.contracts as Record<string, unknown>[]).map(normalizeConsignacao)
+        : [],
+      monthlyTotal:        Number(raw.monthlyTotal)        || 0,
+      comprometimentoPct:  raw.comprometimentoPct  != null ? Number(raw.comprometimentoPct)  : null,
+      netAfterConsignado:  raw.netAfterConsignado  != null ? Number(raw.netAfterConsignado)  : null,
+      marginStatus:        (raw.marginStatus as MarginStatus | null) ?? null,
+    };
   },
 };


### PR DESCRIPTION
## Summary

- **Migration 111**: `end_date DATE` added to `salary_consignacoes` (optional, for loan term tracking)
- **New endpoint** `GET /salary/consignado-overview`: returns the full contracts array + `monthlyTotal`, `comprometimentoPct`, `netAfterConsignado`, `marginStatus` (`safe`/`warning`/`exceeded` at 30%/35% thresholds) — margins computed only for `inss_beneficiary` profiles
- **`addConsignacaoForUser`** now accepts an optional `end_date` field
- **Bug fix**: `syncImportedBenefitProfileForUser` was missing the 5th param (`end_date = null`) on `INSERT_CONSIGNACAO_SQL`, causing failures when syncing imported benefit data
- **`ConsignadoOverviewWidget`**: shows contracts list, margin progress bar with colour-coded status, net-after-consignado label — returns `null` when no contracts exist (non-intrusive)
- **`OperationalSummaryPanel`** consignado tile now shows contract count and comprometimentoPct with danger/warning accents
- **`DashboardConsignado`** type extended with `contractsCount` and `comprometimentoPct`

## Test plan

- [x] 9 new API integration tests: auth guard, empty profile, CLT (null margins), INSS safe/warning/exceeded, ownership isolation, end_date optional/null
- [x] SalaryWidget.test.tsx fixtures updated with `endDate: null`
- [x] App.test.jsx mock extended with `getConsignadoOverview`
- [x] Full API suite: 877/877 ✅
- [x] Full web suite: 348/348 ✅
- [x] TypeScript: clean ✅
- [x] ESLint: clean ✅