### PR TITLE
feat(tax): auto-sync app data on first empty fiscal visit

### DIFF
--- a/apps/web/src/pages/TaxPage.test.tsx
+++ b/apps/web/src/pages/TaxPage.test.tsx
@@ -785,4 +785,90 @@ describe("TaxPage", () => {
 
     confirmSpy.mockRestore();
   });
+
+  // ─── Auto-sync ────────────────────────────────────────────────────────────
+
+  it("auto-sync dispara quando nao ha fatos nem documentos ao carregar", async () => {
+    vi.mocked(taxService.listDocuments).mockResolvedValue({
+      items: [],
+      page: 1,
+      pageSize: 6,
+      total: 0,
+    });
+    vi.mocked(taxService.listFacts).mockResolvedValue({
+      items: [],
+      page: 1,
+      pageSize: 25,
+      total: 0,
+    });
+    vi.mocked(taxService.syncAppData).mockResolvedValue({
+      taxYear: 2026,
+      exerciseYear: 2026,
+      calendarYear: 2025,
+      sourceOrigin: "app",
+      processedStatements: 2,
+      processedTransactions: 0,
+      totalFactsGenerated: 2,
+      preservedReviewedFactsCount: 0,
+      summariesRebuilt: 1,
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(taxService.syncAppData).toHaveBeenCalledWith(2026);
+    });
+
+    // loadPageData re-executado após sync bem-sucedido com fatos gerados
+    await waitFor(() => {
+      expect(taxService.getSummary).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("auto-sync nao dispara quando ja existem fatos", async () => {
+    // beforeEach já configura listFacts com total: 1 e listDocuments com total: 1
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Central do Leão" })).toBeInTheDocument();
+    });
+
+    expect(taxService.syncAppData).not.toHaveBeenCalled();
+  });
+
+  it("auto-sync nao dispara mais de uma vez no mesmo mount", async () => {
+    vi.mocked(taxService.listDocuments).mockResolvedValue({
+      items: [],
+      page: 1,
+      pageSize: 6,
+      total: 0,
+    });
+    vi.mocked(taxService.listFacts).mockResolvedValue({
+      items: [],
+      page: 1,
+      pageSize: 25,
+      total: 0,
+    });
+    vi.mocked(taxService.syncAppData).mockResolvedValue({
+      taxYear: 2026,
+      exerciseYear: 2026,
+      calendarYear: 2025,
+      sourceOrigin: "app",
+      processedStatements: 0,
+      processedTransactions: 0,
+      totalFactsGenerated: 0,
+      preservedReviewedFactsCount: 0,
+      summariesRebuilt: 0,
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(taxService.syncAppData).toHaveBeenCalledTimes(1);
+    });
+
+    // Aguarda estabilização — não deve ter chamadas adicionais
+    await new Promise((r) => setTimeout(r, 100));
+    expect(taxService.syncAppData).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/web/src/pages/TaxPage.tsx
+++ b/apps/web/src/pages/TaxPage.tsx
@@ -373,6 +373,8 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
   const [uploadErrorMessage, setUploadErrorMessage] = useState("");
   const [manualFactErrorMessage, setManualFactErrorMessage] = useState("");
   const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Guard: fire auto-sync at most once per mount (StrictMode + dep-change safety)
+  const hasAutoSyncedRef = useRef(false);
 
   const showSuccess = useCallback((message: string) => {
     if (successTimerRef.current) {
@@ -454,6 +456,37 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
       }
     };
   }, [loadPageData]);
+
+  // Auto-sync: when the page finishes loading with zero facts and zero documents,
+  // silently pull income_statements + transactions into tax_facts for this year.
+  // The ref prevents re-triggering on subsequent renders or StrictMode double-mounts.
+  useEffect(() => {
+    if (
+      isLoadingPage ||
+      hasAutoSyncedRef.current ||
+      factsPage.total > 0 ||
+      documentsPage.total > 0
+    ) {
+      return;
+    }
+
+    hasAutoSyncedRef.current = true;
+    setIsSyncingAppData(true);
+
+    void taxService
+      .syncAppData(taxYear)
+      .then((result) => {
+        if (result.totalFactsGenerated > 0) {
+          void loadPageData();
+        }
+      })
+      .catch(() => {
+        // Silent — auto-sync failure is non-blocking; user can still sync manually.
+      })
+      .finally(() => {
+        setIsSyncingAppData(false);
+      });
+  }, [isLoadingPage, factsPage.total, documentsPage.total, taxYear, loadPageData]);
 
   const refreshAfterDocumentLifecycle = useCallback(async () => {
     let rebuildErrorMessage = "";


### PR DESCRIPTION
## Summary

- When TaxPage loads with zero facts **and** zero documents for the exercise year, automatically triggers `POST /tax/app-sync/:year` without user action
- `hasAutoSyncedRef` (useRef) guards against StrictMode double-mount and re-renders — sync fires exactly once per mount
- Failure is silent and non-blocking; the manual "Sincronizar do app" button remains available
- `loadPageData` re-runs only when `totalFactsGenerated > 0`, avoiding a redundant reload on empty sync results

## Test plan

- [x] `auto-sync dispara quando não há fatos nem documentos` — verifies `syncAppData` called and `loadPageData` re-runs after facts generated
- [x] `auto-sync não dispara quando já existem fatos` — beforeEach has total: 1; verifies `syncAppData` not called
- [x] `auto-sync não dispara mais de uma vez no mesmo mount` — verifies exactly 1 call after 100ms settle
- [x] All 17 TaxPage tests passing ✅
- [x] TypeScript clean ✅