### PR TITLE
feat(tax): CPF deep-link from tax warning

### DIFF
--- a/apps/web/src/AppRoutes.tsx
+++ b/apps/web/src/AppRoutes.tsx
@@ -187,7 +187,11 @@ const TaxRoute = () => {
     navigate("/app");
   };
 
-  return <TaxPage onBack={handleBack} />;
+  const handleOpenProfileSettings = () => {
+    navigate("/app/settings/profile?focus=taxpayer_cpf");
+  };
+
+  return <TaxPage onBack={handleBack} onOpenProfileSettings={handleOpenProfileSettings} />;
 };
 
 const RootRedirect = () => {

--- a/apps/web/src/pages/ProfileSettings.test.tsx
+++ b/apps/web/src/pages/ProfileSettings.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
 import ProfileSettings from "./ProfileSettings";
 import { profileService } from "../services/profile.service";
 import { DiscreetModeProvider } from "../context/DiscreetModeContext";
@@ -31,15 +32,20 @@ const buildMe = (overrides = {}) => ({
   ...overrides,
 });
 
-const renderPage = (props: {
-  onBack?: () => void;
-  onLogout?: () => void;
-  onOpenBilling?: () => void;
-} = {}) =>
+const renderPage = (
+  props: {
+    onBack?: () => void;
+    onLogout?: () => void;
+    onOpenBilling?: () => void;
+  } = {},
+  { initialEntries = ["/app/settings/profile"] } = {},
+) =>
   render(
-    <DiscreetModeProvider>
-      <ProfileSettings {...props} />
-    </DiscreetModeProvider>,
+    <MemoryRouter initialEntries={initialEntries}>
+      <DiscreetModeProvider>
+        <ProfileSettings {...props} />
+      </DiscreetModeProvider>
+    </MemoryRouter>,
   );
 
 describe("ProfileSettings — Dados da conta", () => {
@@ -338,5 +344,28 @@ describe("ProfileSettings — Assinatura", () => {
     renderPage();
     await waitFor(() => expect(screen.getByText("Acesso ativo")).toBeInTheDocument());
     expect(screen.getByText(/Consulte Faturamento para ver o que está liberado agora/)).toBeInTheDocument();
+  });
+});
+
+describe("ProfileSettings — CPF deep-link", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    vi.mocked(profileService.getMe).mockResolvedValue(buildMe());
+    vi.mocked(profileService.updateProfile).mockResolvedValue({} as ReturnType<typeof profileService.updateProfile> extends Promise<infer T> ? T : never);
+  });
+
+  it("renders CPF input regardless of ?focus param", async () => {
+    renderPage({}, { initialEntries: ["/app/settings/profile?focus=taxpayer_cpf"] });
+    await waitFor(() =>
+      expect(screen.getByLabelText(/CPF do titular/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("renders CPF input without ?focus param", async () => {
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByLabelText(/CPF do titular/i)).toBeInTheDocument(),
+    );
   });
 });

--- a/apps/web/src/pages/ProfileSettings.tsx
+++ b/apps/web/src/pages/ProfileSettings.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { FormEvent } from "react";
+import { useSearchParams } from "react-router-dom";
 import { profileService, type UserProfile } from "../services/profile.service";
 import { getApiErrorMessage } from "../utils/apiError";
 import { useDiscreetMode } from "../context/DiscreetModeContext";
@@ -74,6 +75,8 @@ const ProfileSettings = ({
   onOpenBilling = undefined,
 }: ProfileSettingsProps): JSX.Element => {
   const { isDiscreetMode, toggleDiscreetMode } = useDiscreetMode();
+  const [searchParams] = useSearchParams();
+  const cpfInputRef = useRef<HTMLInputElement>(null);
 
   // Account fields
   const [email, setEmail] = useState("");
@@ -146,6 +149,19 @@ const ProfileSettings = ({
       if (successTimerRef.current) clearTimeout(successTimerRef.current);
     };
   }, [loadProfile]);
+
+  useEffect(() => {
+    if (searchParams.get("focus") !== "taxpayer_cpf") return;
+    if (!cpfInputRef.current) return;
+    const el = cpfInputRef.current;
+    el.scrollIntoView({ behavior: "smooth", block: "center" });
+    el.focus();
+    el.classList.add("ring-2", "ring-amber-400");
+    const timer = setTimeout(() => {
+      el.classList.remove("ring-2", "ring-amber-400");
+    }, 2500);
+    return () => clearTimeout(timer);
+  }, [searchParams]);
 
   const handleAiPrefChange = useCallback(
     async (field: "ai_tone" | "ai_insight_frequency", value: string) => {
@@ -324,6 +340,7 @@ const ProfileSettings = ({
                     CPF do titular (IRPF)
                   </label>
                   <input
+                    ref={cpfInputRef}
                     id="taxpayer_cpf"
                     type="text"
                     inputMode="numeric"

--- a/apps/web/src/pages/TaxPage.test.tsx
+++ b/apps/web/src/pages/TaxPage.test.tsx
@@ -145,11 +145,11 @@ const buildDocumentDetail = (overrides: Partial<TaxDocumentDetail> = {}): TaxDoc
   ...overrides,
 });
 
-const renderPage = () =>
+const renderPage = (props: { onOpenProfileSettings?: () => void } = {}) =>
   render(
     <MemoryRouter initialEntries={["/app/tax/2026"]}>
       <Routes>
-        <Route path="/app/tax/:taxYear" element={<TaxPage onBack={vi.fn()} />} />
+        <Route path="/app/tax/:taxYear" element={<TaxPage onBack={vi.fn()} {...props} />} />
       </Routes>
     </MemoryRouter>,
   );
@@ -870,5 +870,57 @@ describe("TaxPage", () => {
     // Aguarda estabilização — não deve ter chamadas adicionais
     await new Promise((r) => setTimeout(r, 100));
     expect(taxService.syncAppData).toHaveBeenCalledTimes(1);
+  });
+
+  it("exibe botão 'Configurar CPF' no alerta de CPF não configurado e chama onOpenProfileSettings ao clicar", async () => {
+    const user = userEvent.setup();
+    const onOpenProfileSettings = vi.fn();
+
+    vi.mocked(profileService.getMe).mockResolvedValue({
+      id: 1,
+      name: "Test",
+      email: "test@example.com",
+      profile: {
+        salaryMonthly: null,
+        bankLimitTotal: null,
+        payday: null,
+        displayName: null,
+        avatarUrl: null,
+        taxpayerCpf: null, // sem CPF → warning TAXPAYER_CPF_NOT_CONFIGURED
+      },
+    });
+
+    renderPage({ onOpenProfileSettings });
+
+    await waitFor(() => {
+      expect(screen.getByText("Configurar CPF")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Configurar CPF" }));
+    expect(onOpenProfileSettings).toHaveBeenCalledOnce();
+  });
+
+  it("nao exibe botão 'Configurar CPF' quando CPF já está configurado", async () => {
+    vi.mocked(profileService.getMe).mockResolvedValue({
+      id: 1,
+      name: "Test",
+      email: "test@example.com",
+      profile: {
+        salaryMonthly: null,
+        bankLimitTotal: null,
+        payday: null,
+        displayName: null,
+        avatarUrl: null,
+        taxpayerCpf: "123.456.789-09",
+      },
+    });
+
+    renderPage({ onOpenProfileSettings: vi.fn() });
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Central do Leão" })).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole("button", { name: "Configurar CPF" })).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/TaxPage.test.tsx
+++ b/apps/web/src/pages/TaxPage.test.tsx
@@ -880,6 +880,8 @@ describe("TaxPage", () => {
       id: 1,
       name: "Test",
       email: "test@example.com",
+      trialEndsAt: null,
+      trialExpired: false,
       profile: {
         salaryMonthly: null,
         bankLimitTotal: null,
@@ -905,6 +907,8 @@ describe("TaxPage", () => {
       id: 1,
       name: "Test",
       email: "test@example.com",
+      trialEndsAt: null,
+      trialExpired: false,
       profile: {
         salaryMonthly: null,
         bankLimitTotal: null,

--- a/apps/web/src/pages/TaxPage.tsx
+++ b/apps/web/src/pages/TaxPage.tsx
@@ -17,6 +17,7 @@ import { formatCurrency } from "../utils/formatCurrency";
 
 interface TaxPageProps {
   onBack?: () => void;
+  onOpenProfileSettings?: () => void;
 }
 
 interface CorrectionDraft {
@@ -330,7 +331,7 @@ const FactSummaryCard = ({
   </div>
 );
 
-const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
+const TaxPage = ({ onBack = undefined, onOpenProfileSettings = undefined }: TaxPageProps): JSX.Element => {
   const params = useParams();
   const taxYear = useMemo(() => normalizeRouteTaxYear(params.taxYear), [params.taxYear]);
 
@@ -1228,10 +1229,23 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
                   key={warning.code}
                   className="rounded border border-amber-200 bg-white/60 px-3 py-2 text-sm text-amber-900"
                 >
-                  <span className="font-semibold" title={warning.code}>
-                    {formatFactWarningLabel(warning.code)}
-                  </span>
-                  : {warning.message}
+                  <div className="flex flex-wrap items-start justify-between gap-2">
+                    <span>
+                      <span className="font-semibold" title={warning.code}>
+                        {formatFactWarningLabel(warning.code)}
+                      </span>
+                      : {warning.message}
+                    </span>
+                    {warning.code === "TAXPAYER_CPF_NOT_CONFIGURED" && onOpenProfileSettings ? (
+                      <button
+                        type="button"
+                        onClick={onOpenProfileSettings}
+                        className="shrink-0 rounded border border-amber-400 bg-amber-100 px-2.5 py-1 text-xs font-semibold text-amber-900 hover:bg-amber-200"
+                      >
+                        Configurar CPF
+                      </button>
+                    ) : null}
+                  </div>
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Summary

- `TaxPage`: adds `onOpenProfileSettings` prop; the `TAXPAYER_CPF_NOT_CONFIGURED` warning now renders a **"Configurar CPF"** CTA button inline when the callback is provided
- `ProfileSettings`: adds `useSearchParams` + `cpfInputRef`; navigating to `/app/settings/profile?focus=taxpayer_cpf` scrolls to, focuses, and briefly highlights the CPF input with an amber ring for 2.5s
- `AppRoutes`: `TaxRoute` wires `handleOpenProfileSettings` → `navigate('/app/settings/profile?focus=taxpayer_cpf')`

## Test plan

- [x] `TAXPAYER_CPF_NOT_CONFIGURED` warning shows "Configurar CPF" button and calls callback on click (2 new tests)
- [x] CPF warning absent when `taxpayerCpf` is already set (1 new test)
- [x] `ProfileSettings` renders CPF input with and without `?focus` param (2 new tests — also fixes router context for all 18 existing tests)
- [x] 16/16 TaxPage tests passing; 20/20 ProfileSettings tests passing; 355/355 full suite passing