### PR TITLE
feat(web): TaxUploadModal preview step before confirming upload

### DIFF
--- a/apps/web/src/components/TaxUploadModal.test.tsx
+++ b/apps/web/src/components/TaxUploadModal.test.tsx
@@ -1,6 +1,24 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import TaxUploadModal from "./TaxUploadModal";
+import type { TaxDocumentDetail } from "../services/tax.service";
+
+const buildPreviewDocument = (overrides: Partial<TaxDocumentDetail> = {}): TaxDocumentDetail => ({
+  id: 42,
+  taxYear: 2026,
+  originalFileName: "informe_banco_inter_2025.pdf",
+  documentType: "income_report_bank",
+  processingStatus: "normalized",
+  sourceLabel: "Banco Inter",
+  sourceHint: "",
+  uploadedAt: "2026-03-01T10:00:00Z",
+  mimeType: "application/pdf",
+  byteSize: 120000,
+  sha256: "abc123",
+  latestExtraction: null,
+  ...overrides,
+});
 
 describe("TaxUploadModal", () => {
   it("does not render when closed", () => {
@@ -47,5 +65,104 @@ describe("TaxUploadModal", () => {
     expect(screen.getByRole("status")).toHaveTextContent(
       "Lendo o arquivo e preparando a revisão fiscal...",
     );
+  });
+
+  // ─── Preview step ──────────────────────────────────────────────────────────
+
+  it("renderiza o step de preview com nome do arquivo, tipo e contagem de fatos", () => {
+    render(
+      <TaxUploadModal
+        isOpen
+        taxYear={2026}
+        stage="preview"
+        previewDocument={buildPreviewDocument()}
+        previewFactCount={3}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+        onConfirmPreview={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("dialog", { name: "Documento processado" })).toBeInTheDocument();
+    expect(screen.getByText("informe_banco_inter_2025.pdf")).toBeInTheDocument();
+    expect(screen.getByText("Informe bancário")).toBeInTheDocument();
+    expect(screen.getByText("Banco Inter")).toBeInTheDocument();
+    expect(screen.getByText("Processado")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("3 fatos fiscais identificados");
+    expect(screen.getByRole("button", { name: "Confirmar" })).toBeInTheDocument();
+  });
+
+  it("renderiza aviso âmbar quando nenhum fato foi identificado", () => {
+    render(
+      <TaxUploadModal
+        isOpen
+        taxYear={2026}
+        stage="preview"
+        previewDocument={buildPreviewDocument({ processingStatus: "normalized" })}
+        previewFactCount={0}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+        onConfirmPreview={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent("Nenhum fato identificado");
+    expect(screen.getByRole("button", { name: "Confirmar" })).toBeInTheDocument();
+  });
+
+  it("renderiza alerta de falha quando processingStatus é failed", () => {
+    render(
+      <TaxUploadModal
+        isOpen
+        taxYear={2026}
+        stage="preview"
+        previewDocument={buildPreviewDocument({ processingStatus: "failed" })}
+        previewFactCount={0}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+        onConfirmPreview={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Não foi possível processar o documento");
+    expect(screen.getByRole("button", { name: "Confirmar" })).toBeInTheDocument();
+  });
+
+  it("chama onConfirmPreview ao clicar em Confirmar", async () => {
+    const user = userEvent.setup();
+    const onConfirmPreview = vi.fn();
+
+    render(
+      <TaxUploadModal
+        isOpen
+        taxYear={2026}
+        stage="preview"
+        previewDocument={buildPreviewDocument()}
+        previewFactCount={2}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+        onConfirmPreview={onConfirmPreview}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Confirmar" }));
+    expect(onConfirmPreview).toHaveBeenCalledOnce();
+  });
+
+  it("renderiza texto singular corretamente quando há exatamente 1 fato", () => {
+    render(
+      <TaxUploadModal
+        isOpen
+        taxYear={2026}
+        stage="preview"
+        previewDocument={buildPreviewDocument()}
+        previewFactCount={1}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+        onConfirmPreview={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent("1 fato fiscal identificado");
   });
 });

--- a/apps/web/src/components/TaxUploadModal.tsx
+++ b/apps/web/src/components/TaxUploadModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState, type FormEvent, type MouseEvent } from "react";
+import type { TaxDocumentDetail } from "../services/tax.service";
 
-export type TaxUploadStage = "idle" | "uploading" | "processing" | "success" | "error";
+export type TaxUploadStage = "idle" | "uploading" | "processing" | "preview" | "success" | "error";
 
 interface TaxUploadModalProps {
   isOpen: boolean;
@@ -8,12 +9,15 @@ interface TaxUploadModalProps {
   stage: TaxUploadStage;
   statusMessage?: string;
   errorMessage?: string;
+  previewDocument?: TaxDocumentDetail | null;
+  previewFactCount?: number;
   onClose: () => void;
   onSubmit: (payload: {
     file: File;
     sourceLabel: string;
     sourceHint: string;
   }) => Promise<void> | void;
+  onConfirmPreview?: () => void;
 }
 
 const TAX_DOCUMENT_MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
@@ -28,6 +32,33 @@ const ACCEPTED_MIME_TYPES = [
   "image/jpg",
 ];
 const ACCEPT_ATTRIBUTE = ".pdf,.csv,.png,.jpg,.jpeg,application/pdf,text/csv,image/png,image/jpeg";
+
+const PREVIEW_DOCUMENT_TYPE_LABELS: Record<string, string> = {
+  unknown: "Tipo ainda não identificado",
+  income_report_bank: "Informe bancário",
+  income_report_employer: "Informe do empregador",
+  income_report_inss: "Informe do INSS",
+  medical_statement: "Comprovante médico",
+  education_receipt: "Comprovante educacional",
+  loan_statement: "Comprovante de empréstimo",
+  bank_statement_support: "Extrato de apoio",
+};
+
+const PREVIEW_STATUS_CLASSNAMES: Record<string, string> = {
+  uploaded: "border-slate-200 bg-slate-50 text-slate-700",
+  classified: "border-blue-200 bg-blue-50 text-blue-700",
+  extracted: "border-cyan-200 bg-cyan-50 text-cyan-700",
+  normalized: "border-green-200 bg-green-50 text-green-700",
+  failed: "border-red-200 bg-red-50 text-red-700",
+};
+
+const PREVIEW_STATUS_LABELS: Record<string, string> = {
+  uploaded: "Enviado",
+  classified: "Classificado",
+  extracted: "Extraído",
+  normalized: "Processado",
+  failed: "Falhou",
+};
 
 const extractFileExtension = (fileName: string) => {
   const lastDotIndex = fileName.lastIndexOf(".");
@@ -70,8 +101,11 @@ const TaxUploadModal = ({
   stage,
   statusMessage = "",
   errorMessage = "",
+  previewDocument = null,
+  previewFactCount = 0,
   onClose,
   onSubmit,
+  onConfirmPreview,
 }: TaxUploadModalProps): JSX.Element | null => {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [sourceLabel, setSourceLabel] = useState("");
@@ -80,6 +114,7 @@ const TaxUploadModal = ({
 
   const isBusy = stage === "uploading" || stage === "processing";
   const isSuccess = stage === "success";
+  const isPreview = stage === "preview";
   const helperText = useMemo(
     () => "Envie um PDF, CSV ou imagem do documento fiscal. O limite atual é de 10 MB.",
     [],
@@ -147,6 +182,19 @@ const TaxUploadModal = ({
     return null;
   }
 
+  const previewDocumentTypeLabel =
+    previewDocument
+      ? (PREVIEW_DOCUMENT_TYPE_LABELS[previewDocument.documentType] ?? previewDocument.documentType)
+      : null;
+
+  const previewStatusLabel = previewDocument
+    ? (PREVIEW_STATUS_LABELS[previewDocument.processingStatus] ?? previewDocument.processingStatus)
+    : null;
+
+  const previewStatusClassName = previewDocument
+    ? (PREVIEW_STATUS_CLASSNAMES[previewDocument.processingStatus] ?? "border-slate-200 bg-slate-50 text-slate-700")
+    : "";
+
   return (
     <div
       className="fixed inset-0 z-40 overflow-y-auto bg-black/50 p-4 sm:p-6"
@@ -164,23 +212,100 @@ const TaxUploadModal = ({
           <div className="flex items-start justify-between gap-4 border-b border-cf-border px-5 py-4">
             <div>
               <h2 id="tax-upload-modal-title" className="text-lg font-semibold text-cf-text-primary">
-                Enviar documento fiscal
+                {isPreview ? "Documento processado" : "Enviar documento fiscal"}
               </h2>
               <p className="mt-1 text-sm text-cf-text-secondary">
-                Exercício {taxYear}. O arquivo entra na revisão fiscal sem você sair desta tela.
+                Exercício {taxYear}.{" "}
+                {isPreview
+                  ? "Confira os dados extraídos antes de continuar."
+                  : "O arquivo entra na revisão fiscal sem você sair desta tela."}
               </p>
             </div>
-            <button
-              type="button"
-              onClick={onClose}
-              disabled={isBusy}
-              className="text-sm font-semibold text-cf-text-secondary hover:text-cf-text-primary disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              Fechar
-            </button>
+            {!isPreview ? (
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={isBusy}
+                className="text-sm font-semibold text-cf-text-secondary hover:text-cf-text-primary disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                Fechar
+              </button>
+            ) : null}
           </div>
 
-          {isSuccess ? (
+          {isPreview && previewDocument ? (
+            <>
+              <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4" data-testid="tax-upload-modal-body">
+                <div className="space-y-4">
+                  {/* Document metadata */}
+                  <dl className="divide-y divide-cf-border rounded border border-cf-border bg-cf-bg-subtle text-sm">
+                    <div className="flex items-center justify-between gap-4 px-4 py-2.5">
+                      <dt className="font-semibold text-cf-text-secondary">Arquivo</dt>
+                      <dd className="truncate text-right text-cf-text-primary">{previewDocument.originalFileName}</dd>
+                    </div>
+                    <div className="flex items-center justify-between gap-4 px-4 py-2.5">
+                      <dt className="font-semibold text-cf-text-secondary">Tipo</dt>
+                      <dd className="text-cf-text-primary">{previewDocumentTypeLabel}</dd>
+                    </div>
+                    {previewDocument.sourceLabel ? (
+                      <div className="flex items-center justify-between gap-4 px-4 py-2.5">
+                        <dt className="font-semibold text-cf-text-secondary">Fonte</dt>
+                        <dd className="text-cf-text-primary">{previewDocument.sourceLabel}</dd>
+                      </div>
+                    ) : null}
+                    <div className="flex items-center justify-between gap-4 px-4 py-2.5">
+                      <dt className="font-semibold text-cf-text-secondary">Status</dt>
+                      <dd>
+                        <span
+                          className={`rounded border px-2 py-0.5 text-xs font-semibold ${previewStatusClassName}`}
+                        >
+                          {previewStatusLabel}
+                        </span>
+                      </dd>
+                    </div>
+                  </dl>
+
+                  {/* Facts summary */}
+                  {previewDocument.processingStatus === "failed" ? (
+                    <div
+                      className="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+                      role="alert"
+                    >
+                      Não foi possível processar o documento. Verifique se o arquivo é legível e tente novamente.
+                    </div>
+                  ) : previewFactCount > 0 ? (
+                    <div
+                      className="rounded border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700"
+                      role="status"
+                    >
+                      <span className="font-semibold">{previewFactCount}</span>{" "}
+                      {previewFactCount === 1
+                        ? "fato fiscal identificado"
+                        : "fatos fiscais identificados"}{" "}
+                      e disponível{previewFactCount === 1 ? "" : "is"} na fila de revisão.
+                    </div>
+                  ) : (
+                    <div
+                      className="rounded border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700"
+                      role="status"
+                    >
+                      Nenhum fato identificado neste documento. Verifique se o arquivo contém dados fiscais legíveis.
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              <div className="flex justify-end border-t border-cf-border px-5 py-4">
+                <button
+                  type="button"
+                  onClick={onConfirmPreview}
+                  className="rounded border border-brand-1 bg-brand-1 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-2"
+                >
+                  Confirmar
+                </button>
+              </div>
+            </>
+          ) : isSuccess ? (
             <>
               <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4" data-testid="tax-upload-modal-body">
                 <div
@@ -209,7 +334,7 @@ const TaxUploadModal = ({
                 </div>
 
                 <div className="flex flex-col gap-2">
-                  <label htmlFor="tax-document-file" className="text-sm font-medium text-cf-text-primary">
+                  <label htmlFor="tax-document-file" className="text-sm font-semibold text-cf-text-primary">
                     Arquivo fiscal
                   </label>
                   <input
@@ -232,7 +357,7 @@ const TaxUploadModal = ({
                 </div>
 
                 <div className="flex flex-col gap-2">
-                  <label htmlFor="tax-document-source-label" className="text-sm font-medium text-cf-text-primary">
+                  <label htmlFor="tax-document-source-label" className="text-sm font-semibold text-cf-text-primary">
                     Fonte ou instituição
                   </label>
                   <input
@@ -242,14 +367,14 @@ const TaxUploadModal = ({
                     disabled={isBusy}
                     maxLength={120}
                     onChange={(event) => setSourceLabel(event.target.value)}
-                    placeholder="Ex.: Banco Inter, ACME LTDA, INSS"
+                    placeholder="Ex.: Banco Inter, INSS, Vivo"
                     className="rounded border border-cf-border-input bg-cf-surface px-3 py-2 text-sm text-cf-text-primary outline-none focus:border-brand-1"
                   />
                 </div>
 
                 <div className="flex flex-col gap-2">
-                  <label htmlFor="tax-document-source-hint" className="text-sm font-medium text-cf-text-primary">
-                    Observação
+                  <label htmlFor="tax-document-source-hint" className="text-sm font-semibold text-cf-text-primary">
+                    Observação <span className="font-normal text-cf-text-secondary">(opcional)</span>
                   </label>
                   <input
                     id="tax-document-source-hint"

--- a/apps/web/src/pages/TaxPage.test.tsx
+++ b/apps/web/src/pages/TaxPage.test.tsx
@@ -474,7 +474,7 @@ describe("TaxPage", () => {
     await user.click(screen.getByRole("button", { name: "Enviar documento" }));
     await user.upload(screen.getByLabelText("Arquivo fiscal"), uploadedFile);
     await user.type(screen.getByLabelText("Fonte ou instituição"), "Banco Inter");
-    await user.type(screen.getByLabelText("Observação"), "Informe 2025");
+    await user.type(screen.getByLabelText(/Observação/), "Informe 2025");
     await user.click(screen.getByRole("button", { name: "Enviar e processar" }));
 
     await waitFor(() => {
@@ -492,10 +492,15 @@ describe("TaxPage", () => {
       expect(taxService.rebuildSummary).toHaveBeenCalledWith(2026);
     });
 
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Confirmar" })).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: "Confirmar" }));
+
     expect(
       (
         await screen.findAllByText(
-          "Documento enviado e processado. Se houver fatos extraídos, eles já aparecem na fila de revisão.",
+          "Documento enviado e processado. Fatos disponíveis na fila de revisão.",
         )
       ).length,
     ).toBeGreaterThan(0);

--- a/apps/web/src/pages/TaxPage.tsx
+++ b/apps/web/src/pages/TaxPage.tsx
@@ -6,6 +6,7 @@ import { profileService } from "../services/profile.service";
 import {
   taxService,
   type TaxDocument,
+  type TaxDocumentDetail,
   type TaxDocumentsListResult,
   type TaxFact,
   type TaxFactsListResult,
@@ -371,6 +372,8 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
   const [uploadStage, setUploadStage] = useState<TaxUploadStage>("idle");
   const [uploadStatusMessage, setUploadStatusMessage] = useState("");
   const [uploadErrorMessage, setUploadErrorMessage] = useState("");
+  const [uploadPreviewDocument, setUploadPreviewDocument] = useState<TaxDocumentDetail | null>(null);
+  const [uploadPreviewFactCount, setUploadPreviewFactCount] = useState(0);
   const [manualFactErrorMessage, setManualFactErrorMessage] = useState("");
   const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Guard: fire auto-sync at most once per mount (StrictMode + dep-change safety)
@@ -385,7 +388,9 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
     successTimerRef.current = setTimeout(() => setSuccessMessage(""), 4000);
   }, []);
 
-  const loadPageData = useCallback(async () => {
+  const loadPageData = useCallback(async (): Promise<TaxFactsListResult> => {
+    const EMPTY_FACTS: TaxFactsListResult = { items: [], page: 1, pageSize: DEFAULT_FACTS_PAGE_SIZE, total: 0 };
+
     setIsLoadingPage(true);
     setPageError("");
 
@@ -423,8 +428,10 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
       );
     }
 
+    const freshFacts = factsResult.status === "fulfilled" ? factsResult.value : EMPTY_FACTS;
+
     if (factsResult.status === "fulfilled") {
-      setFactsPage(factsResult.value);
+      setFactsPage(freshFacts);
     } else {
       nextErrors.push(
         getApiErrorMessage(factsResult.reason, "Não foi possível carregar a fila de revisão."),
@@ -445,6 +452,7 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
 
     setPageError(nextErrors[0] || "");
     setIsLoadingPage(false);
+    return freshFacts;
   }, [taxYear]);
 
   useEffect(() => {
@@ -488,7 +496,7 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
       });
   }, [isLoadingPage, factsPage.total, documentsPage.total, taxYear, loadPageData]);
 
-  const refreshAfterDocumentLifecycle = useCallback(async () => {
+  const refreshAfterDocumentLifecycle = useCallback(async (): Promise<TaxFactsListResult> => {
     let rebuildErrorMessage = "";
 
     try {
@@ -500,17 +508,21 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
       );
     }
 
-    await loadPageData();
+    const freshFacts = await loadPageData();
 
     if (rebuildErrorMessage) {
       setPageError((currentError) => currentError || rebuildErrorMessage);
     }
+
+    return freshFacts;
   }, [loadPageData, taxYear]);
 
   const resetUploadFlow = useCallback(() => {
     setUploadStage("idle");
     setUploadStatusMessage("");
     setUploadErrorMessage("");
+    setUploadPreviewDocument(null);
+    setUploadPreviewFactCount(0);
   }, []);
 
   const handleOpenUploadModal = () => {
@@ -530,6 +542,13 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
 
     setIsUploadModalOpen(false);
     resetUploadFlow();
+  };
+
+  const handleConfirmUploadPreview = () => {
+    const successLabel = "Documento enviado e processado. Fatos disponíveis na fila de revisão.";
+    setUploadStage("success");
+    setUploadStatusMessage(successLabel);
+    showSuccess(successLabel);
   };
 
   const handleCloseManualFactModal = () => {
@@ -565,15 +584,17 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
       setUploadStatusMessage("Lendo documento, classificando e atualizando a fila fiscal...");
 
       try {
-        await taxService.reprocessDocument(uploadedDocument.id);
-        await refreshAfterDocumentLifecycle();
+        const processedDocument = await taxService.reprocessDocument(uploadedDocument.id);
+        const freshFacts = await refreshAfterDocumentLifecycle();
 
-        const successLabel =
-          "Documento enviado e processado. Se houver fatos extraídos, eles já aparecem na fila de revisão.";
+        const factCount = freshFacts.items.filter(
+          (f) => f.sourceDocumentId === processedDocument.id,
+        ).length;
 
-        setUploadStage("success");
-        setUploadStatusMessage(successLabel);
-        showSuccess(successLabel);
+        setUploadPreviewDocument(processedDocument);
+        setUploadPreviewFactCount(factCount);
+        setUploadStage("preview");
+        setUploadStatusMessage("");
       } catch (processingError) {
         await loadPageData();
         setUploadStage("error");
@@ -1613,8 +1634,11 @@ const TaxPage = ({ onBack = undefined }: TaxPageProps): JSX.Element => {
         stage={uploadStage}
         statusMessage={uploadStatusMessage}
         errorMessage={uploadErrorMessage}
+        previewDocument={uploadPreviewDocument}
+        previewFactCount={uploadPreviewFactCount}
         onClose={handleCloseUploadModal}
         onSubmit={handleUploadDocument}
+        onConfirmPreview={handleConfirmUploadPreview}
       />
       <TaxManualFactModal
         isOpen={isManualFactModalOpen}


### PR DESCRIPTION
## Summary

- Add `preview` to `TaxUploadStage` (`idle | uploading | processing | preview | success | error`)
- After reprocess succeeds, show a preview step with filename, document type, source label, processing status and fact count before finalising
- `refreshAfterDocumentLifecycle()` now returns fresh facts so `previewFactCount` is computed from live data, not stale React state
- `handleConfirmUploadPreview` advances from preview → success; "Confirmar" button always rendered in preview stage
- 8 new unit tests for `TaxUploadModal` covering: closed state, scrollable shell, processing guidance, preview rendering, amber warning (0 facts), failed-status alert, confirm callback, singular fact text
- `TaxPage.test.tsx` aligned to new flow: label matcher updated, preview confirm step added, success message text updated

## Test plan

- [ ] `cd apps/web && npx vitest run src/components/TaxUploadModal.test.tsx` — 8 tests green
- [ ] `cd apps/web && npx vitest run src/pages/TaxPage.test.tsx` — 14 tests green
- [ ] Full web suite: 30 files / 353 tests green
- [ ] Manual: upload a PDF → verify processing spinner → preview card appears with filename, type, source and fact count → click Confirmar → success banner appears