### PR TITLE
fix(api): make bank-limit realtime test date-independent

### DIFF
--- a/apps/api/src/forecast.test.js
+++ b/apps/api/src/forecast.test.js
@@ -472,12 +472,20 @@ describe("forecast — bills integration", () => {
     const userId = await getUserIdByEmail("fc-bills-realtime@test.dev");
 
     await dbQuery(
-      `INSERT INTO user_profiles (user_id, salary_monthly, payday, bank_limit_total)
-       VALUES ($1, 100, 31, 800)`,
+      `INSERT INTO user_profiles (user_id, bank_limit_total)
+       VALUES ($1, 800)`,
       [userId],
     );
 
-    // Recompute without bills — stored projectedBalance has no bills
+    // Seed a known income transaction so projectedBalance is deterministic (100),
+    // regardless of the current date (avoids salary/payday timing sensitivity)
+    await dbQuery(
+      `INSERT INTO transactions (user_id, type, value, date, description)
+       VALUES ($1, 'Entrada', 100, $2, 'Renda')`,
+      [userId, CURRENT_MONTH_START],
+    );
+
+    // Recompute without bills — stored projectedBalance = 100 (netToDate=100, dailyAvg=0)
     await request(app)
       .post("/forecasts/recompute")
       .set("Authorization", `Bearer ${token}`);


### PR DESCRIPTION
## Summary

- The `GET /forecasts/current enriquece com bills em tempo real` test was broken on `main` after merging #342
- Root cause: test used `salary_monthly=100, payday=31`; when run at UTC midnight on March 31, `getUTCDate()=31` and `payday > todayDay` evaluates to `false`, setting `incomeAdjustment=0` → `projectedBalance=0` → `used=180` instead of expected `80`
- Fix: replaced salary/payday setup with a seeded `Entrada` transaction (value=100, date=CURRENT_MONTH_START), making `projectedBalance=100` deterministic regardless of the current UTC date

## Test plan

- [ ] `cd apps/api && npx vitest run src/forecast.test.js` — 30 tests green