### PR TITLE
fix/p0-home-observability

### DIFF
--- a/apps/api/src/middlewares/request-logging.middleware.js
+++ b/apps/api/src/middlewares/request-logging.middleware.js
@@ -20,6 +20,25 @@ const resolveUserId = (req) => {
   return Number.isInteger(parsedUserId) && parsedUserId > 0 ? parsedUserId : null;
 };
 
+const normalizeContextValue = (value) => {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim();
+  if (!normalized) {
+    return null;
+  }
+
+  return normalized.slice(0, 80);
+};
+
+const resolveClientContext = (req) => ({
+  feature: normalizeContextValue(req.headers?.["x-cf-feature"]),
+  widget: normalizeContextValue(req.headers?.["x-cf-widget"]),
+  operation: normalizeContextValue(req.headers?.["x-cf-operation"]),
+});
+
 export const requestLoggingMiddleware = (req, res, next) => {
   const startedAt = Date.now();
 
@@ -34,6 +53,7 @@ export const requestLoggingMiddleware = (req, res, next) => {
       status: res.statusCode,
       latencyMs: resolveLatencyMs(startedAt),
       userId: resolveUserId(req),
+      ...resolveClientContext(req),
     });
   });
 

--- a/apps/api/src/routes/forecast.routes.js
+++ b/apps/api/src/routes/forecast.routes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { authMiddleware } from "../middlewares/auth.middleware.js";
 import { requireActiveTrialOrPaidPlan } from "../middlewares/entitlement.middleware.js";
+import { logWarn } from "../observability/logger.js";
 import {
   maybeSendFlipNotification,
   maybeSendPaydayReminder,
@@ -11,9 +12,10 @@ const router = Router();
 
 router.use(authMiddleware, requireActiveTrialOrPaidPlan);
 
-const logNotificationError = (userId, notificationType, error) => {
-  console.error({
+const logNotificationError = (requestId, userId, notificationType, error) => {
+  logWarn({
     event: "forecast.notification.failed",
+    requestId: requestId || null,
     userId,
     notificationType,
     error: error?.message || "Unknown error",
@@ -34,14 +36,15 @@ router.get("/current", async (req, res, next) => {
 router.post("/recompute", async (req, res, next) => {
   try {
     const userId = req.user.id;
+    const requestId = req.requestId || null;
     const forecast = await computeForecast(userId);
 
     // Notifications are best-effort and must not break recompute responses.
     void maybeSendFlipNotification(userId, forecast).catch((error) => {
-      logNotificationError(userId, "flip_neg", error);
+      logNotificationError(requestId, userId, "flip_neg", error);
     });
     void maybeSendPaydayReminder(userId, forecast).catch((error) => {
-      logNotificationError(userId, "payday_reminder", error);
+      logNotificationError(requestId, userId, "payday_reminder", error);
     });
 
     res.status(200).json(forecast);

--- a/apps/web/src/components/FinancialAlertBanner.tsx
+++ b/apps/web/src/components/FinancialAlertBanner.tsx
@@ -16,7 +16,7 @@ const FinancialAlertBanner = (): JSX.Element | null => {
   });
 
   useEffect(() => {
-    void forecastService.getCurrent().then((forecast) => {
+    void forecastService.getCurrent({ feature: "forecast", widget: "financial-alert-banner", operation: "load" }).then((forecast) => {
       if (forecast !== null) {
         setProjectedBalance(forecast.adjustedProjectedBalance);
         setMonth(forecast.month);

--- a/apps/web/src/components/ForecastCard.tsx
+++ b/apps/web/src/components/ForecastCard.tsx
@@ -121,7 +121,11 @@ const ForecastCard = ({
         return;
       }
 
-      const current = await forecastService.getCurrent();
+      const current = await forecastService.getCurrent({
+        feature: "forecast",
+        widget: "forecast-card",
+        operation: "load",
+      });
 
       if (current !== null) {
         setForecast(current);
@@ -131,7 +135,11 @@ const ForecastCard = ({
       }
 
       // No forecast yet - trigger initial compute
-      const computed = await forecastService.recompute();
+      const computed = await forecastService.recompute({
+        feature: "forecast",
+        widget: "forecast-card",
+        operation: "initial-recompute",
+      });
       setForecast(computed);
       persistForecast(computed);
       setCardState("active");
@@ -150,7 +158,11 @@ const ForecastCard = ({
     setIsRecomputing(true);
     setError("");
     try {
-      const updated = await forecastService.recompute();
+      const updated = await forecastService.recompute({
+        feature: "forecast",
+        widget: "forecast-card",
+        operation: "manual-recompute",
+      });
       setForecast(updated);
       persistForecast(updated);
     } catch {

--- a/apps/web/src/components/GoalsSection.tsx
+++ b/apps/web/src/components/GoalsSection.tsx
@@ -220,7 +220,9 @@ export default function GoalsSection() {
     try {
       const [goalsData, forecast] = await Promise.all([
         goalsService.list(),
-        forecastService.getCurrent().catch(() => null),
+        forecastService
+          .getCurrent({ feature: "forecast", widget: "goals-section", operation: "load" })
+          .catch(() => null),
       ]);
       setGoals(goalsData);
       setProjectedBalance(forecast?.adjustedProjectedBalance ?? null);

--- a/apps/web/src/components/HealthOverview.tsx
+++ b/apps/web/src/components/HealthOverview.tsx
@@ -101,7 +101,10 @@ const HealthOverview = (): JSX.Element | null => {
   const [isLoadingInsight, setIsLoadingInsight] = useState(true);
 
   useEffect(() => {
-    void forecastService.getCurrent().then(setForecast).catch(() => undefined);
+    void forecastService
+      .getCurrent({ feature: "forecast", widget: "health-overview", operation: "load" })
+      .then(setForecast)
+      .catch(() => undefined);
   }, []);
 
   useEffect(() => {

--- a/apps/web/src/components/OperationalSummaryPanel.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.tsx
@@ -54,7 +54,7 @@ const OperationalSummaryPanel = (): JSX.Element | null => {
 
   useEffect(() => {
     dashboardService
-      .getSnapshot()
+      .getSnapshot({ feature: "dashboard", widget: "operational-summary-panel", operation: "load" })
       .then(setSnapshot)
       .catch(() => {/* non-blocking — panel just won't render */})
       .finally(() => setIsLoading(false));

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -21,6 +21,12 @@ type ApiConfigurationError = Error & {
   code: "API_URL_NOT_CONFIGURED";
 };
 
+export type ApiRequestContext = {
+  feature?: string;
+  widget?: string;
+  operation?: string;
+};
+
 type QueueEntry = { resolve: () => void; reject: (err: unknown) => void };
 
 export const resolveApiUrl = (env: EnvConfig = import.meta.env) => {
@@ -39,6 +45,10 @@ export const resolveApiUrl = (env: EnvConfig = import.meta.env) => {
 
 const API_URL = resolveApiUrl();
 const REQUEST_ID_HEADER_NAME = "x-request-id";
+const FEATURE_HEADER_NAME = "x-cf-feature";
+const WIDGET_HEADER_NAME = "x-cf-widget";
+const OPERATION_HEADER_NAME = "x-cf-operation";
+const REQUEST_STARTED_AT = "_requestStartedAt";
 const isApiConfigured = Boolean(API_URL);
 let unauthorizedHandler: UnauthorizedHandler = undefined;
 let paymentRequiredHandler: PaymentRequiredHandler = undefined;
@@ -130,6 +140,57 @@ const resolveErrorRequestId = (error: unknown) => {
 
 const shouldLogApiErrors = () => import.meta.env?.MODE !== "test";
 
+const shouldLogApiCompleted = (url: string) =>
+  /(^\/dashboard\/snapshot$)|(^\/forecasts\/current$)|(^\/forecasts\/recompute$)/.test(url);
+
+const normalizeContextValue = (value: unknown) =>
+  typeof value === "string" && value.trim() ? value.trim().slice(0, 80) : "";
+
+const getHeaderValue = (
+  headers: InternalAxiosRequestConfig["headers"] | Record<string, unknown> | undefined,
+  headerName: string,
+) => {
+  if (!headers || typeof headers !== "object") {
+    return "";
+  }
+
+  const mutableHeaders = headers as { set?: (name: string, value: string) => void } & Record<
+    string,
+    unknown
+  >;
+
+  const directValue =
+    mutableHeaders[headerName] ?? mutableHeaders[headerName.toLowerCase()] ?? "";
+
+  return normalizeContextValue(directValue);
+};
+
+const resolveRequestRoute = (urlValue: unknown) => {
+  if (typeof urlValue !== "string" || !urlValue.trim()) {
+    return "";
+  }
+
+  return urlValue.split("?")[0] || "";
+};
+
+const resolveDurationMs = (startedAt: unknown) => {
+  const parsed = Number(startedAt);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+
+  return Math.max(0, Date.now() - parsed);
+};
+
+const resolveRequestContext = (headers: InternalAxiosRequestConfig["headers"] | undefined) => ({
+  feature: getHeaderValue(headers, FEATURE_HEADER_NAME) || null,
+  widget: getHeaderValue(headers, WIDGET_HEADER_NAME) || null,
+  operation: getHeaderValue(headers, OPERATION_HEADER_NAME) || null,
+});
+
+const resolveMethod = (method: unknown) =>
+  typeof method === "string" && method.trim() ? method.toUpperCase() : "GET";
+
 const drainQueue = (error?: unknown) => {
   pendingQueue.forEach(({ resolve, reject }) => {
     if (error) {
@@ -149,6 +210,27 @@ export const setPaymentRequiredHandler = (handler: PaymentRequiredHandler) => {
   paymentRequiredHandler = typeof handler === "function" ? handler : undefined;
 };
 
+export const withApiRequestContext = (context: ApiRequestContext = {}) => {
+  const feature = normalizeContextValue(context.feature);
+  const widget = normalizeContextValue(context.widget);
+  const operation = normalizeContextValue(context.operation);
+  const headers: Record<string, string> = {};
+
+  if (feature) {
+    headers[FEATURE_HEADER_NAME] = feature;
+  }
+
+  if (widget) {
+    headers[WIDGET_HEADER_NAME] = widget;
+  }
+
+  if (operation) {
+    headers[OPERATION_HEADER_NAME] = operation;
+  }
+
+  return { headers };
+};
+
 export const api = axios.create({
   baseURL: API_URL || undefined,
   timeout: 8000,
@@ -161,6 +243,7 @@ api.interceptors.request.use((config: InternalAxiosRequestConfig) => {
   }
 
   setRequestHeader(config, REQUEST_ID_HEADER_NAME, createRequestId());
+  (config as InternalAxiosRequestConfig & Record<string, unknown>)[REQUEST_STARTED_AT] = Date.now();
 
   return config;
 });
@@ -222,16 +305,50 @@ const resolvePaywallPayload = (
 };
 
 api.interceptors.response.use(
-  (response) => response,
+  (response) => {
+    const requestConfig = response.config as InternalAxiosRequestConfig & Record<string, unknown>;
+    const requestRoute = resolveRequestRoute(requestConfig?.url);
+
+    if (shouldLogApiErrors() && shouldLogApiCompleted(requestRoute)) {
+      const requestId =
+        getHeaderValue(response.headers as Record<string, unknown>, REQUEST_ID_HEADER_NAME) ||
+        getHeaderValue(requestConfig.headers, REQUEST_ID_HEADER_NAME) ||
+        null;
+
+      console.log(
+        JSON.stringify({
+          level: "info",
+          event: "web.api.request.completed",
+          requestId,
+          method: resolveMethod(requestConfig?.method),
+          route: requestRoute,
+          status: response.status,
+          latencyMs: resolveDurationMs(requestConfig?.[REQUEST_STARTED_AT]),
+          ...resolveRequestContext(requestConfig.headers),
+        }),
+      );
+    }
+
+    return response;
+  },
   async (error) => {
     const requestId = resolveErrorRequestId(error);
+    const config = error?.config as (InternalAxiosRequestConfig & Record<string, unknown>) | undefined;
+    const requestRoute = resolveRequestRoute(config?.url);
 
-    if (requestId && shouldLogApiErrors()) {
+    if (shouldLogApiErrors()) {
       console.error(
         JSON.stringify({
           level: "error",
           event: "web.api.request.error",
-          requestId,
+          requestId: requestId || null,
+          method: resolveMethod(config?.method),
+          route: requestRoute || null,
+          status: Number(error?.response?.status) || null,
+          latencyMs: resolveDurationMs(config?.[REQUEST_STARTED_AT]),
+          timeoutMs: Number(config?.timeout) || null,
+          timeout: error?.code === "ECONNABORTED",
+          ...resolveRequestContext(config?.headers),
         }),
       );
     }

--- a/apps/web/src/services/dashboard.service.ts
+++ b/apps/web/src/services/dashboard.service.ts
@@ -1,4 +1,4 @@
-import { api } from "./api";
+import { api, withApiRequestContext, type ApiRequestContext } from "./api";
 
 export interface DashboardBills {
   overdueCount: number;
@@ -82,8 +82,8 @@ const normalizeSnapshot = (raw: Record<string, unknown>): DashboardSnapshot => (
 });
 
 export const dashboardService = {
-  getSnapshot: async (): Promise<DashboardSnapshot> => {
-    const { data } = await api.get("/dashboard/snapshot");
+  getSnapshot: async (context?: ApiRequestContext): Promise<DashboardSnapshot> => {
+    const { data } = await api.get("/dashboard/snapshot", withApiRequestContext(context));
     return normalizeSnapshot(data as Record<string, unknown>);
   },
 };

--- a/apps/web/src/services/forecast.service.ts
+++ b/apps/web/src/services/forecast.service.ts
@@ -1,4 +1,4 @@
-import { api } from "./api";
+import { api, withApiRequestContext, type ApiRequestContext } from "./api";
 
 export interface ForecastBankLimit {
   total: number;
@@ -27,13 +27,13 @@ export interface Forecast {
 }
 
 export const forecastService = {
-  getCurrent: async (): Promise<Forecast | null> => {
-    const { data } = await api.get<Forecast | null>("/forecasts/current");
+  getCurrent: async (context?: ApiRequestContext): Promise<Forecast | null> => {
+    const { data } = await api.get<Forecast | null>("/forecasts/current", withApiRequestContext(context));
     return data;
   },
 
-  recompute: async (): Promise<Forecast> => {
-    const { data } = await api.post<Forecast>("/forecasts/recompute");
+  recompute: async (context?: ApiRequestContext): Promise<Forecast> => {
+    const { data } = await api.post<Forecast>("/forecasts/recompute", undefined, withApiRequestContext(context));
     return data;
   },
 };


### PR DESCRIPTION
## Objetivo
Instrumentar home/forecast para mapear fan-out, latência, timeout e correlação por widget sem alterar regra de negócio.

## Inclui
- metadados `feature/widget/operation` no cliente HTTP
- logs estruturados no frontend com duração/status/requestId
- propagação do contexto para widgets críticos
- enriquecimento dos logs HTTP no backend

## Não inclui
- deduplicação de chamadas
- alteração de cálculo
- alteração de timeout como solução
- mudança de `.env`

## Checklist
- [x] Diff limpo sem `.env` no commit
- [x] Nome do PR coerente com observabilidade
- [x] Evidência de log web
- [x] Evidência de log API
- [x] Evidência de correlação por `requestId`
- [x] Lista de widgets instrumentados

## Evidência
### Exemplo de log web (sucesso)
```json
{
  "level": "info",
  "event": "web.api.request.completed",
  "requestId": "<id>",
  "method": "GET",
  "route": "/forecasts/current",
  "status": 200,
  "latencyMs": 123,
  "feature": "forecast",
  "widget": "forecast-card",
  "operation": "load"
}
```

### Exemplo de log web (erro/timeout)
```json
{
  "level": "error",
  "event": "web.api.request.error",
  "requestId": "<id>",
  "method": "GET",
  "route": "/dashboard/snapshot",
  "status": 504,
  "latencyMs": 8004,
  "timeoutMs": 8000,
  "timeout": true,
  "feature": "dashboard",
  "widget": "operational-summary-panel",
  "operation": "load"
}
```

### Exemplo de log API correlacionado
```json
{
  "level": "info",
  "event": "http.request.completed",
  "requestId": "<id>",
  "method": "GET",
  "route": "/forecasts/current",
  "status": 200,
  "latencyMs": 87,
  "feature": "forecast",
  "widget": "health-overview",
  "operation": "load"
}
```

### Prova de correlação por requestId
Mesmo `requestId` trafega web -> API via header `x-request-id` e aparece nos eventos `web.api.request.*` e `http.request.completed`.

### Widgets instrumentados
- financial-alert-banner
- forecast-card (load, initial-recompute, manual-recompute)
- goals-section
- health-overview
- operational-summary-panel

## Baseline para PR2 (fan-out/dedup)
Com esta instrumentação já é possível levantar:
- chamadas por mount por widget
- duplicidade de `/forecasts/current`
- antes/depois de redução por requestId+widget+operation