### PR TITLE
fix/p0-home-fanout-dedup

### DIFF
--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -469,7 +469,11 @@ const ImportCsvModal = ({
 
       await profileService.updateProfile(profilePatch);
       try {
-        await forecastService.recompute();
+        await forecastService.recompute({
+          feature: "forecast",
+          widget: "import-csv-modal",
+          operation: "apply-profile-recompute",
+        });
       } catch (forecastError) {
         setPlanningUpdateError(
           getApiErrorMessage(

--- a/apps/web/src/services/dashboard.service.ts
+++ b/apps/web/src/services/dashboard.service.ts
@@ -81,9 +81,24 @@ const normalizeSnapshot = (raw: Record<string, unknown>): DashboardSnapshot => (
   consignado: normalizeConsignado((raw.consignado as Record<string, unknown>) ?? {}),
 });
 
+let snapshotInFlightRequest: Promise<DashboardSnapshot> | null = null;
+
 export const dashboardService = {
   getSnapshot: async (context?: ApiRequestContext): Promise<DashboardSnapshot> => {
-    const { data } = await api.get("/dashboard/snapshot", withApiRequestContext(context));
-    return normalizeSnapshot(data as Record<string, unknown>);
+    if (snapshotInFlightRequest) {
+      return snapshotInFlightRequest;
+    }
+
+    const requestPromise = api
+      .get("/dashboard/snapshot", withApiRequestContext(context))
+      .then(({ data }) => normalizeSnapshot(data as Record<string, unknown>))
+      .finally(() => {
+        if (snapshotInFlightRequest === requestPromise) {
+          snapshotInFlightRequest = null;
+        }
+      });
+
+    snapshotInFlightRequest = requestPromise;
+    return requestPromise;
   },
 };

--- a/apps/web/src/services/forecast.service.ts
+++ b/apps/web/src/services/forecast.service.ts
@@ -26,14 +26,43 @@ export interface Forecast {
   bankLimit?: ForecastBankLimit | null;
 }
 
+let getCurrentInFlightRequest: Promise<Forecast | null> | null = null;
+let recomputeInFlightRequest: Promise<Forecast> | null = null;
+
 export const forecastService = {
   getCurrent: async (context?: ApiRequestContext): Promise<Forecast | null> => {
-    const { data } = await api.get<Forecast | null>("/forecasts/current", withApiRequestContext(context));
-    return data;
+    if (getCurrentInFlightRequest) {
+      return getCurrentInFlightRequest;
+    }
+
+    const requestPromise = api
+      .get<Forecast | null>("/forecasts/current", withApiRequestContext(context))
+      .then(({ data }) => data)
+      .finally(() => {
+        if (getCurrentInFlightRequest === requestPromise) {
+          getCurrentInFlightRequest = null;
+        }
+      });
+
+    getCurrentInFlightRequest = requestPromise;
+    return requestPromise;
   },
 
   recompute: async (context?: ApiRequestContext): Promise<Forecast> => {
-    const { data } = await api.post<Forecast>("/forecasts/recompute", undefined, withApiRequestContext(context));
-    return data;
+    if (recomputeInFlightRequest) {
+      return recomputeInFlightRequest;
+    }
+
+    const requestPromise = api
+      .post<Forecast>("/forecasts/recompute", undefined, withApiRequestContext(context))
+      .then(({ data }) => data)
+      .finally(() => {
+        if (recomputeInFlightRequest === requestPromise) {
+          recomputeInFlightRequest = null;
+        }
+      });
+
+    recomputeInFlightRequest = requestPromise;
+    return requestPromise;
   },
 };


### PR DESCRIPTION
## Objetivo
Reduzir fan-out e chamadas duplicadas da Home, com foco em tráfego HTTP (sem alterar regra de negócio).

## Escopo deste PR2
- deduplicação de requests concorrentes para `GET /forecasts/current`
- deduplicação de requests concorrentes para `POST /forecasts/recompute`
- deduplicação de requests concorrentes para `GET /dashboard/snapshot`
- ajuste de contexto observável no fluxo de recompute do modal de importação/perfil

## Fora de escopo (mantido)
- cálculo da visão do mês
- projeção semântica
- pensão/renda
- IRPF
- parser/importação de documentos

## Matriz real (antes)
### Home mount
- `financial-alert-banner` -> `GET /forecasts/current` -> 1 chamada
- `forecast-card` -> `GET /forecasts/current` -> 1 chamada
- `goals-section` -> `GET /forecasts/current` -> 1 chamada
- `health-overview` -> `GET /forecasts/current` -> 1 chamada
- `operational-summary-panel` -> `GET /dashboard/snapshot` -> 1 chamada

Total esperado em mount: `4x /forecasts/current` + `1x /dashboard/snapshot`.

## Matriz após PR2
### Home mount (com in-flight dedup)
- `financial-alert-banner` + `forecast-card` + `goals-section` + `health-overview`
  compartilham a mesma Promise em voo para `GET /forecasts/current`
- `operational-summary-panel` mantém `GET /dashboard/snapshot` (agora também deduplicável)

Total esperado em mount: `1x /forecasts/current` + `1x /dashboard/snapshot`.

## Evidência técnica
- Dedup implementado em:
  - `apps/web/src/services/forecast.service.ts`
  - `apps/web/src/services/dashboard.service.ts`
- Contexto de observabilidade no recompute do modal:
  - `apps/web/src/components/ImportCsvModal.jsx`
- Tipagem validada:
  - `npm run typecheck:web` (ok)

## Critério de aceite
- [x] redução mensurável de requests por mount
- [x] duplicidade de `/forecasts/current` removida por compartilhamento de in-flight request
- [x] sem mudança de regra de negócio
- [x] documentação before/after baseada na instrumentação do PR1