### PR TITLE
fix(web): isolamento de falha por widget na home

### DIFF
--- a/apps/web/src/components/FinancialAlertBanner.tsx
+++ b/apps/web/src/components/FinancialAlertBanner.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { forecastService } from "../services/forecast.service";
 import { formatCurrency } from "../utils/formatCurrency";
+import { logWidgetFallbackError } from "../utils/widgetFallbackTelemetry";
 
 const DISMISS_KEY = "cf.forecast_alert.dismissed_v1";
 
@@ -16,12 +17,22 @@ const FinancialAlertBanner = (): JSX.Element | null => {
   });
 
   useEffect(() => {
-    void forecastService.getCurrent({ feature: "forecast", widget: "financial-alert-banner", operation: "load" }).then((forecast) => {
-      if (forecast !== null) {
-        setProjectedBalance(forecast.adjustedProjectedBalance);
-        setMonth(forecast.month);
-      }
-    });
+    void forecastService
+      .getCurrent({ feature: "forecast", widget: "financial-alert-banner", operation: "load" })
+      .then((forecast) => {
+        if (forecast !== null) {
+          setProjectedBalance(forecast.adjustedProjectedBalance);
+          setMonth(forecast.month);
+        }
+      })
+      .catch((error) => {
+        logWidgetFallbackError({
+          widget: "financial-alert-banner",
+          operation: "load",
+          error,
+          fallbackRendered: true,
+        });
+      });
   }, []);
 
   if (dismissed || projectedBalance === null || projectedBalance >= 0) {

--- a/apps/web/src/components/ForecastCard.tsx
+++ b/apps/web/src/components/ForecastCard.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { forecastService, type Forecast } from "../services/forecast.service";
 import { profileService } from "../services/profile.service";
 import { useMaskedCurrency } from "../context/DiscreetModeContext";
+import { logWidgetFallbackError } from "../utils/widgetFallbackTelemetry";
 
 interface ForecastCardProps {
   onOpenProfileSettings?: () => void;
@@ -98,10 +99,13 @@ const ForecastCard = ({
   const [forecast, setForecast] = useState<Forecast | null>(null);
   const [isRecomputing, setIsRecomputing] = useState(false);
   const [error, setError] = useState("");
+  const [hasLoadError, setHasLoadError] = useState(false);
+  const [hasRetriedLoad, setHasRetriedLoad] = useState(false);
 
-  const loadForecast = useCallback(async () => {
+  const loadForecast = useCallback(async (retryAttempt = false) => {
     try {
       setError("");
+      setHasLoadError(false);
       const me = await profileService.getMe();
 
       const hasProfile =
@@ -143,8 +147,14 @@ const ForecastCard = ({
       setForecast(computed);
       persistForecast(computed);
       setCardState("active");
-    } catch {
-      setError("Não foi possível carregar a projeção.");
+    } catch (loadError) {
+      setHasLoadError(true);
+      logWidgetFallbackError({
+        widget: "forecast-card",
+        operation: retryAttempt ? "retry-load" : "load",
+        error: loadError,
+        fallbackRendered: true,
+      });
       setCardState("active");
     }
   }, [trialExpired]);
@@ -152,6 +162,16 @@ const ForecastCard = ({
   useEffect(() => {
     void loadForecast();
   }, [loadForecast]);
+
+  const handleRetryLoad = useCallback(() => {
+    if (hasRetriedLoad) {
+      return;
+    }
+
+    setHasRetriedLoad(true);
+    setCardState("loading");
+    void loadForecast(true);
+  }, [hasRetriedLoad, loadForecast]);
 
   const handleRecompute = useCallback(async () => {
     if (isRecomputing) return;
@@ -165,7 +185,13 @@ const ForecastCard = ({
       });
       setForecast(updated);
       persistForecast(updated);
-    } catch {
+    } catch (recomputeError) {
+      logWidgetFallbackError({
+        widget: "forecast-card",
+        operation: "manual-recompute",
+        error: recomputeError,
+        fallbackRendered: true,
+      });
       setError("Erro ao atualizar projeção.");
     } finally {
       setIsRecomputing(false);
@@ -266,7 +292,24 @@ const ForecastCard = ({
         </button>
       </div>
 
-      {error ? (
+      {hasLoadError ? (
+        <div className="mt-3 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700" role="alert">
+          <p>Não foi possível carregar a projeção deste widget.</p>
+          <div className="mt-2 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleRetryLoad}
+              disabled={hasRetriedLoad}
+              className="rounded border border-red-300 bg-white px-2 py-1 text-xs font-semibold text-red-700 hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {hasRetriedLoad ? "Nova tentativa indisponível" : "Tentar novamente"}
+            </button>
+            {hasRetriedLoad ? (
+              <span className="text-xs text-red-600">Limite de 1 nova tentativa atingido.</span>
+            ) : null}
+          </div>
+        </div>
+      ) : error ? (
         <p className="mt-2 text-xs text-red-600">{error}</p>
       ) : forecast !== null ? (
         <>
@@ -336,7 +379,9 @@ const ForecastCard = ({
 
           <BankLimitPanel forecast={forecast} money={money} />
         </>
-      ) : null}
+      ) : (
+        <p className="mt-3 text-xs text-cf-text-secondary">Sem dados de projeção para exibir neste momento.</p>
+      )}
     </div>
   );
 };

--- a/apps/web/src/components/GoalsSection.tsx
+++ b/apps/web/src/components/GoalsSection.tsx
@@ -6,6 +6,7 @@ import { GOAL_ICONS, goalsService } from "../services/goals.service";
 import { forecastService } from "../services/forecast.service";
 import GoalFormModal from "./GoalFormModal";
 import ConfirmDialog from "./ConfirmDialog";
+import { logWidgetFallbackError } from "../utils/widgetFallbackTelemetry";
 
 // ── Goal Card ────────────────────────────────────────────────────────────────
 
@@ -211,22 +212,37 @@ export default function GoalsSection() {
   const [projectedBalance, setProjectedBalance] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [hasRetriedFetch, setHasRetriedFetch] = useState(false);
   const [modal, setModal] = useState<ModalMode | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Goal | null>(null);
   const [deleting, setDeleting] = useState(false);
 
-  const fetchData = async () => {
+  const fetchData = async (retryAttempt = false) => {
     setError(null);
     try {
       const [goalsData, forecast] = await Promise.all([
         goalsService.list(),
         forecastService
-          .getCurrent({ feature: "forecast", widget: "goals-section", operation: "load" })
-          .catch(() => null),
+          .getCurrent({ feature: "forecast", widget: "goals-section", operation: retryAttempt ? "retry-load" : "load" })
+          .catch((forecastError) => {
+            logWidgetFallbackError({
+              widget: "goals-section",
+              operation: retryAttempt ? "retry-load" : "load",
+              error: forecastError,
+              fallbackRendered: true,
+            });
+            return null;
+          }),
       ]);
       setGoals(goalsData);
       setProjectedBalance(forecast?.adjustedProjectedBalance ?? null);
     } catch (err) {
+      logWidgetFallbackError({
+        widget: "goals-section",
+        operation: retryAttempt ? "retry-load" : "load",
+        error: err,
+        fallbackRendered: true,
+      });
       setError(getApiErrorMessage(err, "Erro ao carregar metas."));
     } finally {
       setLoading(false);
@@ -331,10 +347,19 @@ export default function GoalsSection() {
             <span>{error}</span>
             <button
               type="button"
-              onClick={() => { setLoading(true); void fetchData(); }}
+              onClick={() => {
+                if (hasRetriedFetch) {
+                  return;
+                }
+
+                setHasRetriedFetch(true);
+                setLoading(true);
+                void fetchData(true);
+              }}
+              disabled={hasRetriedFetch}
               className="shrink-0 text-xs font-semibold underline"
             >
-              Tentar novamente
+              {hasRetriedFetch ? "Nova tentativa indisponível" : "Tentar novamente"}
             </button>
           </div>
         ) : goals.length === 0 ? (

--- a/apps/web/src/components/HealthOverview.test.tsx
+++ b/apps/web/src/components/HealthOverview.test.tsx
@@ -72,22 +72,24 @@ describe("HealthOverview", () => {
     vi.resetAllMocks();
   });
 
-  it("retorna null quando forecast e null", async () => {
+  it("renderiza estado vazio quando forecast e null", async () => {
     (forecastService.getCurrent as ReturnType<typeof vi.fn>).mockResolvedValue(null);
     await act(async () => {
       render(<HealthOverview />);
     });
-    expect(screen.queryByText("Saúde Financeira do Mês")).toBeNull();
+    expect(screen.getByText("Saúde Financeira do Mês")).toBeInTheDocument();
+    expect(screen.getByText("Sem dados suficientes para exibir este widget.")).toBeInTheDocument();
   });
 
-  it("retorna null quando daysRemaining e zero", async () => {
+  it("renderiza estado vazio quando daysRemaining e zero", async () => {
     (forecastService.getCurrent as ReturnType<typeof vi.fn>).mockResolvedValue(
       buildForecast({ daysRemaining: 0 }),
     );
     await act(async () => {
       render(<HealthOverview />);
     });
-    expect(screen.queryByText("Saúde Financeira do Mês")).toBeNull();
+    expect(screen.getByText("Saúde Financeira do Mês")).toBeInTheDocument();
+    expect(screen.getByText("Sem dados suficientes para exibir este widget.")).toBeInTheDocument();
   });
 
   it("renderiza titulo e paineis quando forecast e valido", async () => {

--- a/apps/web/src/components/HealthOverview.tsx
+++ b/apps/web/src/components/HealthOverview.tsx
@@ -11,6 +11,8 @@ import { forecastService, type Forecast } from "../services/forecast.service";
 import { aiService, type AiInsight } from "../services/ai.service";
 import AIInsightPanel from "./AIInsightPanel";
 import { formatCurrency } from "../utils/formatCurrency";
+import { getApiErrorMessage } from "../utils/apiError";
+import { logWidgetFallbackError } from "../utils/widgetFallbackTelemetry";
 
 interface TrajectoryPoint {
   day: string;
@@ -98,13 +100,35 @@ const TrajectoryTooltip = ({
 const HealthOverview = (): JSX.Element | null => {
   const [forecast, setForecast] = useState<Forecast | null>(null);
   const [insight, setInsight] = useState<AiInsight | null>(null);
+  const [isLoadingForecast, setIsLoadingForecast] = useState(true);
+  const [forecastError, setForecastError] = useState<string | null>(null);
+  const [hasRetriedForecastLoad, setHasRetriedForecastLoad] = useState(false);
   const [isLoadingInsight, setIsLoadingInsight] = useState(true);
 
+  const loadForecast = async (retryAttempt = false) => {
+    setIsLoadingForecast(true);
+    setForecastError(null);
+
+    try {
+      const loadedForecast = await forecastService
+        .getCurrent({ feature: "forecast", widget: "health-overview", operation: retryAttempt ? "retry-load" : "load" });
+      setForecast(loadedForecast);
+    } catch (error) {
+      setForecast(null);
+      setForecastError(getApiErrorMessage(error, "Não foi possível carregar a saúde financeira do mês."));
+      logWidgetFallbackError({
+        widget: "health-overview",
+        operation: retryAttempt ? "retry-load" : "load",
+        error,
+        fallbackRendered: true,
+      });
+    } finally {
+      setIsLoadingForecast(false);
+    }
+  };
+
   useEffect(() => {
-    void forecastService
-      .getCurrent({ feature: "forecast", widget: "health-overview", operation: "load" })
-      .then(setForecast)
-      .catch(() => undefined);
+    void loadForecast();
   }, []);
 
   useEffect(() => {
@@ -116,7 +140,52 @@ const HealthOverview = (): JSX.Element | null => {
       .finally(() => setIsLoadingInsight(false));
   }, []);
 
-  if (forecast === null || forecast.daysRemaining <= 0) return null;
+  const handleRetryForecastLoad = () => {
+    if (hasRetriedForecastLoad) {
+      return;
+    }
+
+    setHasRetriedForecastLoad(true);
+    void loadForecast(true);
+  };
+
+  if (isLoadingForecast) {
+    return (
+      <div className="rounded border border-cf-border bg-cf-surface p-4">
+        <p className="text-xs text-cf-text-secondary">Carregando saúde financeira...</p>
+      </div>
+    );
+  }
+
+  if (forecastError) {
+    return (
+      <div className="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
+        <p>{forecastError}</p>
+        <div className="mt-2 flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleRetryForecastLoad}
+            disabled={hasRetriedForecastLoad}
+            className="rounded border border-red-300 bg-white px-2 py-1 text-xs font-semibold text-red-700 hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {hasRetriedForecastLoad ? "Nova tentativa indisponível" : "Tentar novamente"}
+          </button>
+          {hasRetriedForecastLoad ? (
+            <span className="text-xs text-red-600">Limite de 1 nova tentativa atingido.</span>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+
+  if (forecast === null || forecast.daysRemaining <= 0) {
+    return (
+      <div className="rounded border border-cf-border bg-cf-surface p-4">
+        <h3 className="text-sm font-semibold text-cf-text-primary">Saúde Financeira do Mês</h3>
+        <p className="mt-2 text-xs text-cf-text-secondary">Sem dados suficientes para exibir este widget.</p>
+      </div>
+    );
+  }
 
   const trajectory = generateTrajectory(forecast);
   const { adjustedProjectedBalance, incomeExpected } = forecast;

--- a/apps/web/src/components/OperationalSummaryPanel.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { useMaskedCurrency } from "../context/DiscreetModeContext";
 import { dashboardService, type DashboardSnapshot } from "../services/dashboard.service";
+import { getApiErrorMessage } from "../utils/apiError";
+import { logWidgetFallbackError } from "../utils/widgetFallbackTelemetry";
 
 // ─── Tile ─────────────────────────────────────────────────────────────────────
 
@@ -50,15 +52,44 @@ const SkeletonTile = () => (
 const OperationalSummaryPanel = (): JSX.Element | null => {
   const [snapshot, setSnapshot] = useState<DashboardSnapshot | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [hasRetriedLoad, setHasRetriedLoad] = useState(false);
   const money = useMaskedCurrency();
 
+  const loadSnapshot = async (retryAttempt = false) => {
+    setIsLoading(true);
+    setLoadError(null);
+
+    try {
+      const data = await dashboardService
+        .getSnapshot({ feature: "dashboard", widget: "operational-summary-panel", operation: retryAttempt ? "retry-load" : "load" });
+      setSnapshot(data);
+    } catch (error) {
+      setSnapshot(null);
+      setLoadError(getApiErrorMessage(error, "Não foi possível carregar o resumo operacional."));
+      logWidgetFallbackError({
+        widget: "operational-summary-panel",
+        operation: retryAttempt ? "retry-load" : "load",
+        error,
+        fallbackRendered: true,
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   useEffect(() => {
-    dashboardService
-      .getSnapshot({ feature: "dashboard", widget: "operational-summary-panel", operation: "load" })
-      .then(setSnapshot)
-      .catch(() => {/* non-blocking — panel just won't render */})
-      .finally(() => setIsLoading(false));
+    void loadSnapshot();
   }, []);
+
+  const handleRetry = () => {
+    if (hasRetriedLoad) {
+      return;
+    }
+
+    setHasRetriedLoad(true);
+    void loadSnapshot(true);
+  };
 
   if (isLoading) {
     return (
@@ -70,7 +101,34 @@ const OperationalSummaryPanel = (): JSX.Element | null => {
     );
   }
 
-  if (!snapshot) return null;
+  if (loadError) {
+    return (
+      <div className="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
+        <p>{loadError}</p>
+        <div className="mt-2 flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleRetry}
+            disabled={hasRetriedLoad}
+            className="rounded border border-red-300 bg-white px-2 py-1 text-xs font-semibold text-red-700 hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {hasRetriedLoad ? "Nova tentativa indisponível" : "Tentar novamente"}
+          </button>
+          {hasRetriedLoad ? (
+            <span className="text-xs text-red-600">Limite de 1 nova tentativa atingido.</span>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+
+  if (!snapshot) {
+    return (
+      <div className="rounded border border-cf-border bg-cf-surface px-4 py-3 text-sm text-cf-text-secondary">
+        Resumo operacional indisponível no momento.
+      </div>
+    );
+  }
 
   const { bankBalance, bills, cards, income, forecast, consignado } = snapshot;
 

--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -1023,8 +1023,10 @@ describe("App", () => {
 
     render(<App />);
 
-    expect(await screen.findByText("Não foi possível carregar as metas mensais.")).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Tentar novamente" }));
+    const budgetsErrorMessage = await screen.findByText("Não foi possível carregar as metas mensais.");
+    const budgetsErrorAlert = budgetsErrorMessage.closest("[role='alert']") ?? budgetsErrorMessage.parentElement;
+    expect(budgetsErrorAlert).toBeTruthy();
+    await user.click(within(budgetsErrorAlert).getByRole("button", { name: "Tentar novamente" }));
     expect(await screen.findByText("Transporte")).toBeInTheDocument();
     expect(screen.queryByText("Não foi possível carregar as metas mensais.")).not.toBeInTheDocument();
   });
@@ -1887,11 +1889,11 @@ describe("App", () => {
 
     render(<App />);
 
-    expect(
-      await screen.findByText("Não foi possível carregar o resumo mensal."),
-    ).toBeInTheDocument();
+    const summaryErrorMessage = await screen.findByText("Não foi possível carregar o resumo mensal.");
+    const summaryErrorAlert = summaryErrorMessage.closest("[role='alert']") ?? summaryErrorMessage.parentElement;
+    expect(summaryErrorAlert).toBeTruthy();
 
-    await user.click(screen.getByRole("button", { name: "Tentar novamente" }));
+    await user.click(within(summaryErrorAlert).getByRole("button", { name: "Tentar novamente" }));
 
     expect(await screen.findByTestId("mom-balance")).toBeInTheDocument();
     expect(screen.getByText("R$ 700,00")).toBeInTheDocument();

--- a/apps/web/src/utils/widgetFallbackTelemetry.ts
+++ b/apps/web/src/utils/widgetFallbackTelemetry.ts
@@ -1,0 +1,82 @@
+type ApiErrorLike = {
+  message?: string;
+  response?: {
+    status?: number;
+    headers?: Record<string, unknown>;
+    data?: {
+      message?: string;
+      requestId?: unknown;
+    };
+  };
+  config?: {
+    headers?: Record<string, unknown>;
+  };
+};
+
+const REQUEST_ID_HEADER_NAME = "x-request-id";
+
+const readHeaderValue = (headers: Record<string, unknown> | undefined, headerName: string): string => {
+  if (!headers || typeof headers !== "object") {
+    return "";
+  }
+
+  const directValue = headers[headerName] ?? headers[headerName.toLowerCase()] ?? "";
+  return typeof directValue === "string" ? directValue.trim() : "";
+};
+
+export const resolveApiRequestId = (error: unknown): string | null => {
+  const apiError = error as ApiErrorLike;
+
+  const responseHeaderRequestId = readHeaderValue(apiError?.response?.headers, REQUEST_ID_HEADER_NAME);
+  if (responseHeaderRequestId) {
+    return responseHeaderRequestId;
+  }
+
+  const bodyRequestId =
+    typeof apiError?.response?.data?.requestId === "string"
+      ? apiError.response.data.requestId.trim()
+      : "";
+  if (bodyRequestId) {
+    return bodyRequestId;
+  }
+
+  const requestHeaderRequestId = readHeaderValue(apiError?.config?.headers, REQUEST_ID_HEADER_NAME);
+  if (requestHeaderRequestId) {
+    return requestHeaderRequestId;
+  }
+
+  return null;
+};
+
+export const logWidgetFallbackError = ({
+  widget,
+  operation,
+  error,
+  fallbackRendered,
+}: {
+  widget: string;
+  operation: string;
+  error: unknown;
+  fallbackRendered: boolean;
+}) => {
+  const apiError = error as ApiErrorLike;
+
+  console.error(
+    JSON.stringify({
+      level: "error",
+      event: "web.widget.fallback",
+      page: "home",
+      widget,
+      operation,
+      requestId: resolveApiRequestId(error),
+      status: Number(apiError?.response?.status) || null,
+      message:
+        (typeof apiError?.response?.data?.message === "string" &&
+          apiError.response.data.message.trim()) ||
+        (typeof apiError?.message === "string" && apiError.message.trim()) ||
+        "Unexpected widget error.",
+      outcome: "error",
+      fallbackRendered,
+    }),
+  );
+};


### PR DESCRIPTION
## Contexto\nEste PR implementa isolamento local de falhas por widget na Home, evitando efeito cascata quando endpoints individuais falham.\n\n## Escopo\n- Sem alteração de regra de negócio\n- Sem alteração de semântica de mês/projeção\n- Sem tocar parser/importação IRPF\n- Sem incluir .env\n\n## Mudanças\n- Adiciona telemetry util para fallback por widget com correlação de requestId\n- Adiciona fallback local + retry único em widgets críticos\n- Substitui falhas silenciosas por estados explícitos (erro/empty/loading)\n\n## Arquivos\n- apps/web/src/utils/widgetFallbackTelemetry.ts\n- apps/web/src/components/ForecastCard.tsx\n- apps/web/src/components/OperationalSummaryPanel.tsx\n- apps/web/src/components/HealthOverview.tsx\n- apps/web/src/components/GoalsSection.tsx\n- apps/web/src/components/FinancialAlertBanner.tsx\n\n## Telemetria\nEventos de fallback com campos:\n- page, widget, operation, equestId, outcome=error, allbackRendered=true\n\n## Evidência de validação\n- Typecheck: ✅ (
pm run typecheck)\n\n## Matriz de evidências (execução)\n| Widget | Endpoint(s) | Falha simulada | Resultado esperado | Resultado obtido |\n|---|---|---|---|---|\n| ForecastCard | /forecast/* | 500/timeout | Fallback local + retry único | Pendente execução manual |\n| OperationalSummaryPanel | /dashboard/* | 500/timeout | Fallback local + retry único | Pendente execução manual |\n| HealthOverview | /forecast/* | 500/timeout | Loading/empty/error local sem cascade | Pendente execução manual |\n| GoalsSection | /goals/* + /forecast/* | forecast falha parcial | Degradação local sem quebrar goals | Pendente execução manual |\n| FinancialAlertBanner | /forecast/alerts | erro fetch | Banner falha isolado sem quebrar página | Pendente execução manual |\n