### PR TITLE
docs(architecture): contrato semântico financeiro único (v1)

### DIFF
--- a/docs/architecture/v1.6.12-financial-semantics-contract.md
+++ b/docs/architecture/v1.6.12-financial-semantics-contract.md
@@ -1,0 +1,88 @@
+# Financial Semantics Contract (v1)
+
+## Goal
+- Establish a single, explicit semantic contract for financial terms shared by backend, frontend, and dashboards.
+- Eliminate interpretation drift before implementing month view/projection fixes.
+
+## Scope (This PR)
+- Definitions only (contract).
+- Truth table for minimum shared scenarios.
+- Explicit rules for ambiguous terms (`renda_detectada`).
+
+## Out Of Scope (This PR)
+- No month-view calculation changes.
+- No projection engine changes.
+- No pension-specific handling.
+- No importer/parser changes.
+- No dashboard redesign.
+
+## Canonical Terms
+
+### liquidado
+- Confirmed transaction effectively settled in account/card statement period.
+- Counts in `saldo_real` and month realized view.
+
+### pendente
+- Obligation or movement not yet settled at reference date.
+- Does not count as realized cash movement.
+
+### projetado
+- Future effect expected by rules of obligations and expected inflows/outflows.
+- Includes open bills and open invoices under `obrigacao_futura`.
+
+### renda_confirmada
+- Inflow with explicit confirmation (settled or operationally confirmed).
+- Counts in realized month and projection.
+
+### renda_detectada
+- Inflow inferred by heuristics/import detection without explicit confirmation.
+- Default rule in v1: excluded from `saldo_real`; may appear in projection as separate inferred component.
+- Must always be flagged as inferred (`source=inferred`).
+
+### fatura_aberta
+- Credit card statement open and not fully paid.
+- Classified as `obrigacao_futura`; not realized until payment settlement.
+
+### bill_aberta
+- Open bill (non-card) not yet paid.
+- Classified as `obrigacao_futura`; not realized until settlement.
+
+### saldo_real
+- Realized net balance at reference period:
+- `saldo_real = soma(liquidado_entradas_confirmadas) - soma(liquidado_saidas)`
+- Excludes open obligations and inferred-only income.
+
+### obrigacao_futura
+- Future payable obligations (`bill_aberta`, `fatura_aberta`) considered in projection/pendências.
+
+## Truth Table (Minimum)
+
+| Situação | Visão do mês | Projeção | Pendências |
+|---|---:|---:|---:|
+| Transação liquidada | Sim | Sim | Não |
+| Bill aberta | Não | Sim | Sim |
+| Fatura aberta | Não | Sim | Sim |
+| Renda confirmada | Sim | Sim | Não |
+| Renda detectada não confirmada | Não (padrão v1) | Sim (como inferida) | Não |
+| Limite bancário/cartão | Não | Não como saldo | Não |
+
+## Deterministic Rules
+1. No item `pendente` can enter `saldo_real`.
+2. `fatura_aberta` and `bill_aberta` must remain in `obrigacao_futura` until settlement event.
+3. `renda_detectada` without confirmation cannot promote itself to `renda_confirmada`.
+4. Dashboards and widgets must use the same semantics labels from this contract.
+
+## Data Contract Notes
+- Recommended flags in APIs/events:
+  - `status`: `liquidado | pendente`
+  - `incomeType`: `confirmada | detectada`
+  - `isInferred`: `true | false`
+  - `obligationType`: `bill_aberta | fatura_aberta | none`
+- Frontend and analytics should not infer semantics outside these fields.
+
+## Governance
+- This contract is the prerequisite for:
+  - PR5: month-view implementation.
+  - PR6: projection implementation.
+  - PR7: pension/confirmed-income edge cases.
+- Any divergence must be proposed as a versioned change to this file.


### PR DESCRIPTION
## Contexto\nPR4 de contrato semântico único para alinhar frontend/backend/dashboard antes das correções de visão do mês e projeção.\n\n## Escopo\n- Documento versionado com definições canônicas\n- Tabela de verdade mínima\n- Regras determinísticas para casos ambíguos (ex.: renda_detectada)\n\n## Arquivo\n- docs/architecture/v1.6.12-financial-semantics-contract.md\n\n## Fora de escopo\n- Sem mudanças de implementação (mês/projeção/pensão/importadores/painéis)\n\n## Ordem de execução\n- PR5: visão do mês\n- PR6: projeção\n- PR7: pensão/renda confirmada\n\n## Governança\n- Pendência manual visual de PR3 permanece rastreada no comentário: https://github.com/JrValerio/Control-Finance/pull/348#issuecomment-4160111434\n