### PR TITLE
fix(summary): enforce realized-only month semantics

### DIFF
--- a/apps/api/src/summary.test.js
+++ b/apps/api/src/summary.test.js
@@ -93,6 +93,45 @@ describe("transaction summary", () => {
     });
   });
 
+  it("GET /transactions/summary ignora pendencias de contas e considera apenas transacoes realizadas", async () => {
+    const token = await registerAndLogin("summary-realizado-only@controlfinance.dev");
+
+    await request(app)
+      .post("/bills")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        title: "Conta de Internet",
+        amount: 180,
+        dueDate: "2026-02-12",
+      });
+
+    await request(app)
+      .post("/transactions")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        type: "Entrada",
+        value: 1200,
+        date: "2026-02-05",
+        description: "Receita liquidada",
+      });
+
+    const response = await request(app)
+      .get("/transactions/summary")
+      .query({
+        month: "2026-02",
+      })
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      month: "2026-02",
+      income: 1200,
+      expense: 0,
+      balance: 1200,
+      byCategory: [],
+    });
+  });
+
   it("GET /transactions/summary retorna totais do mes e breakdown por categoria", async () => {
     const token = await registerAndLogin("summary-mix@controlfinance.dev");
 

--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -500,6 +500,16 @@ describe("App", () => {
     expect(transactionsService.getMonthlySummary).toHaveBeenCalledWith(expect.any(String));
   });
 
+  it("explicita que a visao do mes considera apenas movimentacoes realizadas", async () => {
+    render(<App />);
+
+    expect(
+      await screen.findByText(
+        "Saldo, entradas e saídas de movimentações realizadas (sem pendências ou projeções).",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("exibe comparativo mensal (MoM) com direcao, percentual e delta absoluto", async () => {
     transactionsService.getMonthlySummary.mockResolvedValueOnce(
       buildSummaryResponse({

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -2338,7 +2338,7 @@ const App = ({
               <div>
                 <h3 className="text-sm font-medium text-cf-text-primary">Visão do mês</h3>
                 <p className="mt-1 text-xs text-cf-text-secondary">
-                  Saldo, entradas e saídas consolidados antes das análises detalhadas.
+                  Saldo, entradas e saídas de movimentações realizadas (sem pendências ou projeções).
                 </p>
               </div>
               <input


### PR DESCRIPTION
## Contexto
Aplica o contrato semântico do PR4 à superfície da Visão do mês, sem alterar a base de cálculo existente.

## Inclui
- teste de API garantindo que pendências não entram no resumo mensal
- cópia explícita na UI: "somente movimentações realizadas"
- teste de UI travando a comunicação semântica

## Não inclui
- mudança de projeção
- mudança de pensão/renda confirmada
- mudança de importadores
- mudança estrutural no cálculo do backend além da proteção por teste

## Evidência
- npm --prefix apps/api test -- src/summary.test.js -> 9/9
- npm --prefix apps/web test -- src/pages/App.test.jsx -> 81/81
