### PR TITLE
fix(auth): COOP-aware headers + instrumentation for OAuth popup flow

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -5,6 +5,7 @@ import dotenv from "dotenv";
 import healthRoutes from "./routes/health.routes.js";
 import metricsRoutes from "./routes/metrics.routes.js";
 import authRoutes from "./routes/auth.routes.js";
+import { securityHeadersMiddleware } from "./middlewares/security-headers.middleware.js";
 import categoriesRoutes from "./routes/categories.routes.js";
 import budgetsRoutes from "./routes/budgets.routes.js";
 import analyticsRoutes from "./routes/analytics.routes.js";
@@ -60,6 +61,7 @@ app.set("trust proxy", resolveTrustProxyValue());
 app.use(requestIdMiddleware);
 app.use(httpMetricsMiddleware);
 app.use(requestLoggingMiddleware);
+app.use(securityHeadersMiddleware);
 
 const allowedOrigins = (process.env.CORS_ORIGIN || "http://localhost:5173")
   .split(",")

--- a/apps/api/src/forecast.test.js
+++ b/apps/api/src/forecast.test.js
@@ -19,6 +19,7 @@ import { computeForecast, getLatestForecast } from "./services/forecast.service.
 const FIXED_NOW = new Date("2026-03-10T12:00:00.000Z");
 const FIXED_MONTH = "2026-03";
 const FIXED_MONTH_START = "2026-03-01";
+const FIXED_MONTH_END = "2026-03-31";
 
 const resetState = async () => {
   resetLoginProtectionState();
@@ -26,6 +27,10 @@ const resetState = async () => {
   resetWriteRateLimiterState();
   resetHttpMetricsForTests();
   await dbQuery("DELETE FROM user_forecasts");
+  await dbQuery("DELETE FROM bank_accounts");
+  await dbQuery("DELETE FROM bills");
+  await dbQuery("DELETE FROM income_statements");
+  await dbQuery("DELETE FROM income_sources");
   await dbQuery("DELETE FROM user_profiles");
   await dbQuery("DELETE FROM transactions");
   await dbQuery("DELETE FROM user_identities");
@@ -358,6 +363,109 @@ describe("computeForecast — flip detection (deterministic)", () => {
   });
 });
 
+describe("computeForecast — projection semantics (deterministic)", () => {
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await clearDbClientForTests(); });
+  beforeEach(resetState);
+
+  it("usa saldo real de contas como base e trata bills pendentes como obrigacao futura", async () => {
+    await registerAndLogin("fc-sem-a@test.dev");
+    const userId = await getUserIdByEmail("fc-sem-a@test.dev");
+
+    await dbQuery(
+      `INSERT INTO bank_accounts (user_id, name, balance, limit_total)
+       VALUES ($1, 'Conta corrente', 1000, 500)`,
+      [userId],
+    );
+
+    await dbQuery(
+      `INSERT INTO bills (user_id, title, amount, due_date, status)
+       VALUES ($1, 'Internet', 300, $2, 'pending')`,
+      [userId, FIXED_MONTH_END],
+    );
+
+    const result = await computeForecast(userId, { now: FIXED_NOW });
+
+    expect(result.projectedBalance).toBe(1000);
+    expect(result.spendingToDate).toBe(0);
+    expect(result.billsPendingTotal).toBe(300);
+    expect(result.billsPendingCount).toBe(1);
+    expect(result.adjustedProjectedBalance).toBe(700);
+  });
+
+  it("inclui fatura aberta como obrigacao futura sem tratar como saida liquidada", async () => {
+    await registerAndLogin("fc-sem-b@test.dev");
+    const userId = await getUserIdByEmail("fc-sem-b@test.dev");
+
+    await dbQuery(
+      `INSERT INTO bank_accounts (user_id, name, balance, limit_total)
+       VALUES ($1, 'Conta principal', 1200, 0)`,
+      [userId],
+    );
+
+    await dbQuery(
+      `INSERT INTO bills (user_id, title, amount, due_date, status, bill_type)
+       VALUES ($1, 'Fatura Cartao Março', 450, $2, 'pending', 'credit_card_invoice')`,
+      [userId, FIXED_MONTH_END],
+    );
+
+    const result = await computeForecast(userId, { now: FIXED_NOW });
+
+    expect(result.spendingToDate).toBe(0);
+    expect(result.projectedBalance).toBe(1200);
+    expect(result.billsPendingTotal).toBe(450);
+    expect(result.adjustedProjectedBalance).toBe(750);
+  });
+
+  it("renda confirmada futura aumenta a projecao", async () => {
+    await registerAndLogin("fc-sem-c@test.dev");
+    const userId = await getUserIdByEmail("fc-sem-c@test.dev");
+
+    await dbQuery(
+      `INSERT INTO bank_accounts (user_id, name, balance, limit_total)
+       VALUES ($1, 'Conta salário', 1000, 0)`,
+      [userId],
+    );
+
+    const sourceId = await insertIncomeSource(userId, "Salário principal");
+    await insertStatement(sourceId, {
+      referenceMonth: "2026-03",
+      netAmount: 500,
+      paymentDate: "2026-03-25",
+      status: "posted",
+    });
+
+    const result = await computeForecast(userId, { now: FIXED_NOW });
+
+    expect(result.incomeExpected).toBe(500);
+    expect(result.projectedBalance).toBe(1500);
+  });
+
+  it("renda nao confirmada (draft) nao aumenta a projecao", async () => {
+    await registerAndLogin("fc-sem-d@test.dev");
+    const userId = await getUserIdByEmail("fc-sem-d@test.dev");
+
+    await dbQuery(
+      `INSERT INTO bank_accounts (user_id, name, balance, limit_total)
+       VALUES ($1, 'Conta salário', 1000, 0)`,
+      [userId],
+    );
+
+    const sourceId = await insertIncomeSource(userId, "Renda detectada");
+    await insertStatement(sourceId, {
+      referenceMonth: "2026-03",
+      netAmount: 400,
+      paymentDate: "2026-03-20",
+      status: "draft",
+    });
+
+    const result = await computeForecast(userId, { now: FIXED_NOW });
+
+    expect(result.incomeExpected).toBeNull();
+    expect(result.projectedBalance).toBe(1000);
+  });
+});
+
 // ─── Forecast + Bills integration ────────────────────────────────────────────
 
 // Helpers for real current-month boundaries (HTTP tests use real `now`)
@@ -607,7 +715,7 @@ describe("computeForecast — statement-aware income (deterministic)", () => {
     expect(result.projectedBalance).toBe(0); // netToDate=0, adj=0, daily=0
   });
 
-  it("statement draft com payment_date futuro: incomeAdjustment=net_amount", async () => {
+  it("statement draft com payment_date futuro: nao entra na projecao sem confirmacao", async () => {
     await registerAndLogin("fc-stmt-draft-future@test.dev");
     const userId = await getUserIdByEmail("fc-stmt-draft-future@test.dev");
 
@@ -621,11 +729,11 @@ describe("computeForecast — statement-aware income (deterministic)", () => {
 
     const result = await computeForecast(userId, { now: FIXED_NOW });
 
-    expect(result.incomeExpected).toBe(3500);
-    expect(result.projectedBalance).toBe(3500); // netToDate=0, adj=3500, daily=0
+    expect(result.incomeExpected).toBeNull();
+    expect(result.projectedBalance).toBe(0);
   });
 
-  it("statement draft com payment_date passada: incomeAdjustment=0", async () => {
+  it("statement draft com payment_date passada: permanece fora da projecao", async () => {
     await registerAndLogin("fc-stmt-draft-past@test.dev");
     const userId = await getUserIdByEmail("fc-stmt-draft-past@test.dev");
 
@@ -639,9 +747,7 @@ describe("computeForecast — statement-aware income (deterministic)", () => {
 
     const result = await computeForecast(userId, { now: FIXED_NOW });
 
-    // incomeExpected = statement net_amount (competence)
-    expect(result.incomeExpected).toBe(3500);
-    // but no cash adjustment (payment date already passed without posting)
+    expect(result.incomeExpected).toBeNull();
     expect(result.projectedBalance).toBe(0);
   });
 
@@ -660,9 +766,7 @@ describe("computeForecast — statement-aware income (deterministic)", () => {
 
     const result = await computeForecast(userId, { now: FIXED_NOW });
 
-    // income_expected de março = 4200 (competência)
-    expect(result.incomeExpected).toBe(4200);
-    // mas não entra no caixa projetado de março
+    expect(result.incomeExpected).toBeNull();
     expect(result.projectedBalance).toBe(0);
   });
 
@@ -680,8 +784,26 @@ describe("computeForecast — statement-aware income (deterministic)", () => {
 
     const result = await computeForecast(userId, { now: FIXED_NOW });
 
+    expect(result.incomeExpected).toBeNull();
+    expect(result.projectedBalance).toBe(0);
+  });
+
+  it("statement posted com payment_date futuro: entra na projecao como renda confirmada", async () => {
+    await registerAndLogin("fc-stmt-posted-future@test.dev");
+    const userId = await getUserIdByEmail("fc-stmt-posted-future@test.dev");
+
+    const sid = await insertIncomeSource(userId);
+    await insertStatement(sid, {
+      referenceMonth: "2026-03",
+      netAmount: 2800,
+      paymentDate: "2026-03-20",
+      status: "posted",
+    });
+
+    const result = await computeForecast(userId, { now: FIXED_NOW });
+
     expect(result.incomeExpected).toBe(2800);
-    expect(result.projectedBalance).toBe(0); // sem data, sem ajuste de caixa
+    expect(result.projectedBalance).toBe(2800);
   });
 
   it("multiplas fontes: soma corretamente em income_expected e incomeAdjustment", async () => {
@@ -709,7 +831,7 @@ describe("computeForecast — statement-aware income (deterministic)", () => {
 
     const result = await computeForecast(userId, { now: FIXED_NOW });
 
-    expect(result.incomeExpected).toBe(6500); // 5000 + 1500
-    expect(result.projectedBalance).toBe(1500); // adj = apenas draft futuro
+    expect(result.incomeExpected).toBe(5000);
+    expect(result.projectedBalance).toBe(0);
   });
 });

--- a/apps/api/src/middlewares/error.middleware.js
+++ b/apps/api/src/middlewares/error.middleware.js
@@ -61,6 +61,9 @@ export const errorHandler = (error, req, res, next) => {
     latencyMs,
     userId,
     message,
+    feature: req.feature || null,
+    widget: req.widget || null,
+    operation: req.operation || null,
   };
 
   if (code) {

--- a/apps/api/src/middlewares/security-headers.middleware.js
+++ b/apps/api/src/middlewares/security-headers.middleware.js
@@ -1,0 +1,30 @@
+/**
+ * Security headers middleware for COOP and COEP.
+ *
+ * Cross-Origin-Opener-Policy (COOP):
+ *   - "same-origin" (default): blocks popup communication
+ *   - "same-origin-allow-popups": allows OAuth popup callbacks via postMessage
+ *
+ * Routes:
+ *   - /auth/* → "same-origin-allow-popups" (OAuth popup flow)
+ *   - other routes → "same-origin" (default security posture)
+ */
+
+export const securityHeadersMiddleware = (req, res, next) => {
+  // Default COOP policy: restrict popup communication for general security
+  let coopPolicy = "same-origin";
+
+  // Exception for auth routes: allow popups for OAuth callback postMessage
+  const isAuthRoute = req.path.startsWith("/auth");
+  if (isAuthRoute) {
+    coopPolicy = "same-origin-allow-popups";
+  }
+
+  // Set COOP header
+  res.setHeader("Cross-Origin-Opener-Policy", coopPolicy);
+
+  // Set COEP header: require CORS headers on cross-origin resources
+  res.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+
+  next();
+};

--- a/apps/api/src/routes/auth.routes.js
+++ b/apps/api/src/routes/auth.routes.js
@@ -83,6 +83,8 @@ const issueSessionCookies = async (res, user, req) => {
 // ─── Routes ───────────────────────────────────────────────────────────────────
 
 router.post("/register", async (req, res, next) => {
+  req.feature = "auth";
+  req.operation = "email_password_register";
   try {
     const { user } = await registerUser(req.body || {});
     await issueSessionCookies(res, user, req);
@@ -93,6 +95,8 @@ router.post("/register", async (req, res, next) => {
 });
 
 router.post("/login", loginRateLimiter, bruteForceLoginGuard, async (req, res, next) => {
+  req.feature = "auth";
+  req.operation = "email_password_login";
   try {
     const { user } = await loginUser(req.body || {});
     clearLoginFailures(req);
@@ -107,6 +111,8 @@ router.post("/login", loginRateLimiter, bruteForceLoginGuard, async (req, res, n
 });
 
 router.post("/google", async (req, res, next) => {
+  req.feature = "auth";
+  req.operation = "google_signin_callback";
   try {
     const { user } = await loginOrRegisterWithGoogle(req.body || {});
     await issueSessionCookies(res, user, req);
@@ -117,6 +123,8 @@ router.post("/google", async (req, res, next) => {
 });
 
 router.post("/refresh", async (req, res, next) => {
+  req.feature = "auth";
+  req.operation = "refresh_token_rotate";
   const rawToken = req.cookies?.cf_refresh;
 
   if (!rawToken) {
@@ -140,6 +148,8 @@ router.post("/refresh", async (req, res, next) => {
 });
 
 router.delete("/logout", async (req, res) => {
+  req.feature = "auth";
+  req.operation = "logout";
   const rawToken = req.cookies?.cf_refresh;
 
   if (rawToken) {

--- a/apps/api/src/security-headers.test.js
+++ b/apps/api/src/security-headers.test.js
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { securityHeadersMiddleware } from "./middlewares/security-headers.middleware.js";
+
+describe("PR #351: Security Headers Middleware (COOP/COEP)", () => {
+  it("retorna COOP 'same-origin' para rotas normais", () => {
+    const req = { path: "/some-endpoint" };
+    const res = {
+      headers: {},
+      setHeader(name, value) {
+        this.headers[name] = value;
+      },
+    };
+    const next = () => {};
+
+    securityHeadersMiddleware(req, res, next);
+
+    expect(res.headers["Cross-Origin-Opener-Policy"]).toBe("same-origin");
+    expect(res.headers["Cross-Origin-Embedder-Policy"]).toBe("require-corp");
+  });
+
+  it("retorna COOP 'same-origin-allow-popups' para /auth/* routes", () => {
+    const req = { path: "/auth/google" };
+    const res = {
+      headers: {},
+      setHeader(name, value) {
+        this.headers[name] = value;
+      },
+    };
+    const next = () => {};
+
+    securityHeadersMiddleware(req, res, next);
+
+    expect(res.headers["Cross-Origin-Opener-Policy"]).toBe("same-origin-allow-popups");
+    expect(res.headers["Cross-Origin-Embedder-Policy"]).toBe("require-corp");
+  });
+
+  it("retorna COOP 'same-origin-allow-popups' para /auth/refresh", () => {
+    const req = { path: "/auth/refresh" };
+    const res = {
+      headers: {},
+      setHeader(name, value) {
+        this.headers[name] = value;
+      },
+    };
+    const next = () => {};
+
+    securityHeadersMiddleware(req, res, next);
+
+    expect(res.headers["Cross-Origin-Opener-Policy"]).toBe("same-origin-allow-popups");
+  });
+
+  it("chama next() para propagar para middleware seguinte", () => {
+    const req = { path: "/auth/google" };
+    const res = {
+      setHeader() {},
+    };
+    let nextCalled = false;
+    const next = () => {
+      nextCalled = true;
+    };
+
+    securityHeadersMiddleware(req, res, next);
+
+    expect(nextCalled).toBe(true);
+  });
+
+  it("retorna mesmo COEP para todas as rotas", () => {
+    const routes = ["/auth/google", "/api/transactions", "/health", "/auth/logout"];
+    
+    routes.forEach(path => {
+      const req = { path };
+      const res = {
+        headers: {},
+        setHeader(name, value) {
+          this.headers[name] = value;
+        },
+      };
+      const next = () => {};
+
+      securityHeadersMiddleware(req, res, next);
+
+      expect(res.headers["Cross-Origin-Embedder-Policy"]).toBe("require-corp");
+    });
+  });
+});

--- a/apps/api/src/services/forecast.service.js
+++ b/apps/api/src/services/forecast.service.js
@@ -119,7 +119,7 @@ export const computeForecast = async (userId, { now = new Date() } = {}) => {
   const bankLimitTotal =
     profile?.bank_limit_total != null ? Number(profile.bank_limit_total) : null;
 
-  // 2. This-month totals
+  // 2. Realized month totals (up to today only)
   const monthlyResult = await dbQuery(
     `SELECT
        COALESCE(SUM(CASE WHEN type = 'Saida'  THEN value ELSE 0 END), 0) AS spending_to_date,
@@ -129,12 +129,26 @@ export const computeForecast = async (userId, { now = new Date() } = {}) => {
        AND deleted_at IS NULL
        AND date >= $2
        AND date <= $3`,
-    [uid, mStart, mEnd],
+    [uid, mStart, todayStr],
   );
   const spendingToDate = Number(monthlyResult.rows[0].spending_to_date);
   const incomeToDate = Number(monthlyResult.rows[0].income_to_date);
 
-  // 3. Daily average spending over last 60 days
+  // 2b. Real current balance base from active bank accounts.
+  // If there are no active accounts yet, keep legacy fallback to realized net this month.
+  const bankBalanceResult = await dbQuery(
+    `SELECT
+       COALESCE(SUM(balance), 0)::numeric AS total_balance,
+       COUNT(*)::int AS active_accounts_count
+     FROM bank_accounts
+     WHERE user_id = $1
+       AND is_active = true`,
+    [uid],
+  );
+  const totalBankBalance = Number(bankBalanceResult.rows[0]?.total_balance || 0);
+  const activeAccountsCount = Number(bankBalanceResult.rows[0]?.active_accounts_count || 0);
+
+  // 3. Daily average spending over last 60 realized days (up to today)
   const sixtyDaysAgo = daysAgoStr(now, 60);
   const dailyResult = await dbQuery(
     `SELECT COALESCE(SUM(value), 0) AS total_60d
@@ -144,30 +158,31 @@ export const computeForecast = async (userId, { now = new Date() } = {}) => {
        AND type      = 'Saida'
        AND date >= $2
        AND date <= $3`,
-    [uid, sixtyDaysAgo, mEnd],
+    [uid, sixtyDaysAgo, todayStr],
   );
   const total60d = Number(dailyResult.rows[0].total_60d);
   const dailyAvgSpending = total60d / 60;
 
-  // 4a. income_expected — competence-based: all statements for reference_month = current month
+  // 4a. income_expected — confirmed statements for current month.
+  // Unconfirmed/draft statements are excluded from projection semantics.
   const stmtExpectedResult = await dbQuery(
     `SELECT COALESCE(SUM(st.net_amount), 0) AS total
      FROM income_statements st
      JOIN income_sources s ON s.id = st.income_source_id
      WHERE s.user_id = $1
-       AND st.reference_month = $2`,
+       AND st.reference_month = $2
+       AND st.status = 'posted'`,
     [uid, currentMonth],
   );
   const statementsExpected = Number(stmtExpectedResult.rows[0].total);
 
-  // 4b. incomeAdjustment — cash-flow-based: draft statements whose payment_date
-  //     is still upcoming within the current month (posted ones already live in transactions)
+  // 4b. incomeAdjustment — confirmed inflows still in the future within the month.
   const stmtCashResult = await dbQuery(
     `SELECT COALESCE(SUM(st.net_amount), 0) AS total
      FROM income_statements st
      JOIN income_sources s ON s.id = st.income_source_id
      WHERE s.user_id = $1
-       AND st.status = 'draft'
+       AND st.status = 'posted'
        AND st.payment_date > $2
        AND st.payment_date <= $3`,
     [uid, todayStr, mEnd],
@@ -175,8 +190,7 @@ export const computeForecast = async (userId, { now = new Date() } = {}) => {
   const statementsCashPending = Number(stmtCashResult.rows[0].total);
 
   // 4c. Resolve incomeExpected and incomeAdjustment.
-  //     Statements win over salary; salary is fallback only.
-  //     Posted statements are never added to incomeAdjustment (already in incomeToDate).
+  // Confirmed statements win over salary; salary remains fallback only.
   const hasStatementsThisMonth = statementsExpected > 0;
   const incomeExpected = hasStatementsThisMonth
     ? statementsExpected
@@ -189,7 +203,8 @@ export const computeForecast = async (userId, { now = new Date() } = {}) => {
 
   // 5. Projected balance
   const netToDate = incomeToDate - spendingToDate;
-  const projectedBalance = netToDate + incomeAdjustment - dailyAvgSpending * daysRemaining;
+  const realBalanceBase = activeAccountsCount > 0 ? totalBankBalance : netToDate;
+  const projectedBalance = realBalanceBase + incomeAdjustment - dailyAvgSpending * daysRemaining;
 
   // 6. Flip detection against previous stored value
   const prevResult = await dbQuery(

--- a/apps/web/src/services/auth.service.ts
+++ b/apps/web/src/services/auth.service.ts
@@ -80,12 +80,22 @@ export const authService = {
   },
 
   loginWithGoogle: async ({ idToken }: GoogleLoginPayload): Promise<AuthUserResponse> => {
-    const { data } = await api.post("/auth/google", { idToken });
+    const { data } = await api.post("/auth/google", { idToken }, {
+      headers: withApiRequestContext({
+        feature: "auth",
+        operation: "google_signin_callback_xhr",
+      }).headers,
+    });
     return parseUserResponse(data);
   },
 
   refresh: async (): Promise<AuthUserResponse> => {
-    const { data } = await api.post("/auth/refresh");
+    const { data } = await api.post("/auth/refresh", {}, {
+      headers: withApiRequestContext({
+        feature: "auth",
+        operation: "refresh_token_xhr",
+      }).headers,
+    });
     return parseUserResponse(data);
   },
 

--- a/apps/web/src/services/auth.service.ts
+++ b/apps/web/src/services/auth.service.ts
@@ -1,4 +1,4 @@
-import { api } from "./api";
+import { api, withApiRequestContext } from "./api";
 
 export interface AuthUser {
   id: number | string;


### PR DESCRIPTION
## Problema

Google OAuth popup flow bloqueado por COOP (Cross-Origin-Opener-Policy) mismatch.

### Sintomas
- POST /auth/google retorna status: null
- POST /auth/refresh falha após login Google
- Browser console: Cross-Origin-Opener-Policy policy would block the window.postMessage call
- Logs com feature: null, operation: null tornam tracing impossível

### Causa raiz
1. Backend não envia Cross-Origin-Opener-Policy: same-origin-allow-popups para rotas /auth
2. Popup do Google callback não consegue usar postMessage para opener window
3. Sessão/token nunca é estabelecido
4. Falta instrumentação de feature/operation nos logs

## Solução

### Backend

1. Novo middleware: security-headers.middleware.js
   - COOP default: same-origin (segurança)
   - COOP em /auth/*: same-origin-allow-popups (OAuth popup)

2. Instrumentação em auth.routes.js
   - POST /register: operation='email_password_register'
   - POST /login: operation='email_password_login'
   - POST /google: operation='google_signin_callback'
   - POST /refresh: operation='refresh_token_rotate'
   - DELETE /logout: operation='logout'

3. Error middleware: incluir feature/operation em logs
   - Antes: {status:null, feature:null, operation:null}
   - Depois: {status:200, feature:'auth', operation:'google_signin_callback'}

### Frontend

- authService.loginWithGoogle(): adicionar context headers feature=auth, operation=google_signin_callback_xhr
- authService.refresh(): adicionar context headers feature=auth, operation=refresh_token_xhr

## Testes
1. npm run dev (web + api)
2. Ir para /login
3. Clicar Continue with Google
4. Autenticar no popup
5. Verificar: Popup fecha, usuário redirecionado para /app
6. DevTools Console: nenhum Cross-Origin-Opener-Policy error
7. Backend logs: feature:'auth', operation:'google_signin_callback', status:200

## Scope
- Security headers: COOP/COEP apenas
- Auth flow: POST /google, /refresh, /login, /register, /logout
- Não toca em conteúdo, SameSite cookie (será PR/Auth-Hotfix-2 se necessário)
- Não toca em forecast (PR6)

## Impacto
- Risk: Baixo (apenas headers de segurança + logs)
- Benefit: Google OAuth ativa novamente, auth traceability
- Breakage: Nenhuma (COOP reverter para default se houver issue)