### PR TITLE
fix(web/lint): remover parametro nao usado no mock de auth service test

### DIFF
--- a/apps/web/src/services/auth.service.test.ts
+++ b/apps/web/src/services/auth.service.test.ts
@@ -7,7 +7,7 @@ vi.mock("./api", () => ({
     post: vi.fn(),
     delete: vi.fn(),
   },
-  withApiRequestContext: vi.fn((context) => ({ headers: {} })),
+  withApiRequestContext: vi.fn(() => ({ headers: {} })),
 }));
 
 const postMock = vi.mocked(api.post);


### PR DESCRIPTION
## Contexto
Após o merge da PR #352, o CI da main quebrou em Lint (web) por @typescript-eslint/no-unused-vars em pps/web/src/services/auth.service.test.ts.

## Correção
- Remove o parâmetro não utilizado no mock:
  - withApiRequestContext: vi.fn((context) => ({ headers: {} }))
  - para withApiRequestContext: vi.fn(() => ({ headers: {} }))

## Validação local
- 
pm -w apps/web run lint ✅
- 
pm -w apps/web run test:run -- src/services/auth.service.test.ts ✅

## Escopo
- Sem mudanças funcionais, apenas ajuste para cumprir lint estrito e destravar CI.
