### PR TITLE
docs(roadmap): iniciar Sprint 5 - renda confirmada ponta a ponta

### DIFF
--- a/docs/roadmap-execution.md
+++ b/docs/roadmap-execution.md
@@ -357,6 +357,57 @@ Essa frente deve fechar antes de qualquer reposicionamento forte de preço ou de
 
 ---
 
+## 10.2 Fechamento operacional por fases e sprints (status executivo)
+
+Data de atualização: 31/03/2026.
+
+Legenda de status:
+
+- ✅ realizado
+- 🟡 em andamento
+- ⚪ próximo
+- 🔵 futuro estratégico
+
+### Fase 0 - Fundação e estabilização
+
+| Sprint | Foco | Evidências | Status |
+|---|---|---|---|
+| Sprint 1 | Contenção da home e redução de fan-out | PR #347 | ✅ |
+| Sprint 2 | Isolamento de falha por widget + contrato semântico + visão do mês realizado-only | PR #348, PR #349, PR #350 | ✅ |
+| Sprint 3 | Estabilização de auth Google OAuth + integridade da main | PR #351, PR #352, PR #353 | ✅ |
+
+### Fase 1 - Precisão financeira core
+
+| Sprint | Foco | Escopo de fechamento | Status |
+|---|---|---|---|
+| Sprint 4 | Forecast semantics (projeção confiável) | saldo real como base, obrigações futuras sem abatimento duplo, trilha de home/auth estabilizada e CI verde em main | ✅ |
+| Sprint 5 | Renda confirmada ponta a ponta (pensão/INSS) | documento -> entidade -> agregado mensal -> projeção sem sumir/duplicar | 🟡 |
+
+### Fase 2 - Operação financeira real
+
+| Sprint | Foco | Status |
+|---|---|---|
+| Sprint 6 | Guard rails operacionais + parsers prioritários de documentos | ⚪ |
+| Sprint 7 | Conta corrente operacional (saldo/limite/risco) | ⚪ |
+| Sprint 8 | Cartão, ciclo de fatura e conciliação | ⚪ |
+
+### Fase 3 - Expansão estratégica
+
+| Sprint | Foco | Status |
+|---|---|---|
+| Sprint 9 | Central do Leão (IRPF MVP) | 🔵 |
+| Sprint 10 | IA operacional por camadas | 🔵 |
+| Sprint 11 | Copiloto contextual ampliado | 🔵 |
+
+### Decisão executiva atual
+
+- Sprint 4 fechada.
+- Sprint 5 iniciada.
+- Documento operacional da Sprint 5: `docs/roadmaps/sprint-5-renda-confirmada.md`.
+- Pendências manuais continuam rastreadas fora de CI (prova visual do PR #348 e validação E2E real do OAuth).
+
+---
+
 ## 11. Frase-guia para não perder o trilho
 
 > **O Control Finance já pensa como copiloto.**

--- a/docs/roadmaps/sprint-5-renda-confirmada.md
+++ b/docs/roadmaps/sprint-5-renda-confirmada.md
@@ -1,0 +1,112 @@
+# Sprint 5 - Renda Confirmada Ponta a Ponta
+
+> Documento operacional para executar a Sprint 5 com foco em verdade financeira: renda reconhecida corretamente no dominio, no agregado mensal e na projecao.
+
+---
+
+## 1. Objetivo
+
+Fechar o ciclo completo de renda confirmada para os cenarios de pensao/INSS:
+
+- documento reconhecido
+- entidade correta
+- agregado mensal correto
+- projecao correta
+- sem sumir
+- sem duplicar
+
+---
+
+## 2. Escopo
+
+### Em escopo
+
+- Regras deterministicas de classificacao/confirmacao para renda documental relevante.
+- Persistencia e reconciliacao sem criar dupla contagem.
+- Consumo consistente por:
+  - resumo mensal
+  - forecast/projecao
+  - superficies de renda no frontend
+- Cobertura de testes para evitar regressao de semantica.
+
+### Fora de escopo
+
+- Redesign amplo de dashboard.
+- Novos modulos de cartao/conta corrente/bills (Sprint 6+).
+- Mudancas fiscais da Central do Leao fora do necessario para o caso de renda confirmada.
+
+---
+
+## 3. Contrato funcional de aceite
+
+A Sprint 5 so fecha quando, para o mesmo usuario e mesmo mes de referencia:
+
+1. Documento validado gera renda em entidade correta (source/statement).
+2. Agregado mensal inclui somente o que esta confirmado.
+3. Forecast usa a renda confirmada sem inflar nem omitir valor.
+4. Nenhum fluxo gera renda duplicada entre importacao e reconciliacao manual.
+5. Nenhum fluxo "some" com renda confirmada apos refresh/recompute.
+
+---
+
+## 4. Mapa tecnico inicial
+
+### Backend
+
+- apps/api/src/services/forecast.service.js
+- apps/api/src/services/transactions.service.js
+- apps/api/src/domain/imports/document-classifier.js
+- apps/api/src/forecast.test.js
+
+### Frontend
+
+- apps/web/src/pages/IncomeSourcesPage.tsx
+- apps/web/src/components/IncomeStatementModal.tsx
+- apps/web/src/services/transactions.service.ts
+
+---
+
+## 5. Plano de execucao em slices
+
+### Slice S5.1 - Testes de semantica e guard rails
+
+- Adicionar/ajustar cenarios de teste para:
+  - renda confirmada entra no forecast
+  - renda nao confirmada nao entra como confirmada
+  - sem dupla contagem no mesmo mes
+- Resultado esperado: baseline de seguranca para evolucao.
+
+### Slice S5.2 - Consolidacao backend de renda confirmada
+
+- Ajustar regras e queries de renda confirmada para manter semantica unica.
+- Garantir coerencia entre servico de forecast e resumo mensal.
+- Resultado esperado: API com comportamento deterministico.
+
+### Slice S5.3 - Consumo consistente no frontend
+
+- Alinhar exibicao e estado de renda em telas/modais relevantes.
+- Garantir que usuario veja status coerente (confirmada, pendente, conciliada).
+- Resultado esperado: mesma verdade no backend e na UI.
+
+### Slice S5.4 - Hardening e smoke final
+
+- Rodar lint, typecheck e suites direcionadas.
+- Validar cenarios de regressao de sumir/duplicar renda.
+- Resultado esperado: PR final da Sprint 5 pronto para merge com CI verde.
+
+---
+
+## 6. Dependencias e riscos
+
+- Pendencias manuais externas continuam rastreadas: prova visual do PR #348 e E2E real de OAuth.
+- Mudancas de semantica devem respeitar o contrato em docs/architecture/v1.6.12-financial-semantics-contract.md.
+- Evitar acoplamento com backlog de Sprint 6+ durante a Sprint 5.
+
+---
+
+## 7. Definition of Done da Sprint 5
+
+- Criterios funcionais da secao 3 cumpridos.
+- CI do PR da Sprint 5 fechado em verde.
+- Evidencia de testes anexada no corpo do PR.
+- Atualizacao do roadmap executivo movendo Sprint 5 para concluida e Sprint 6 para proximo alvo.


### PR DESCRIPTION
## Contexto\nInicio oficial da Sprint 5 apos fechamento da Sprint 4.\n\n## O que muda\n- Atualiza status executivo no roadmap para Sprint 5 em andamento\n- Registra decisao executiva de kickoff\n- Cria documento operacional da Sprint 5 com:\n  - objetivo\n  - escopo/foco\n  - criterios de aceite\n  - mapa tecnico inicial\n  - plano em slices\n  - Definition of Done\n\n## Arquivos\n- docs/roadmap-execution.md\n- docs/roadmaps/sprint-5-renda-confirmada.md\n\n## Fora de escopo\n- Sem alteracao funcional de backend/frontend\n- Sem fechamento de pendencias manuais externas (PR3 visual e OAuth E2E)\n