### PR TITLE
fix(api): Sprint 5.2 integridade no vínculo de renda confirmada

### DIFF
--- a/apps/api/src/income-sources.test.js
+++ b/apps/api/src/income-sources.test.js
@@ -1110,6 +1110,34 @@ describe("income-sources", () => {
     expect(res.status).toBe(404);
   });
 
+  it("POST .../link-transaction retorna 404 para transacao removida (soft delete)", async () => {
+    const { token, statementId, transactionId } = await setupStatementAndTransaction(
+      "inss-link-deleted-tx@test.dev",
+    );
+
+    await dbQuery(
+      `UPDATE transactions
+          SET deleted_at = NOW()
+        WHERE id = $1`,
+      [transactionId],
+    );
+
+    const res = await request(app)
+      .post(`/income-sources/statements/${statementId}/link-transaction`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionId });
+
+    expectErrorResponseWithRequestId(res, 404, "Transacao nao encontrada.");
+
+    const statementRes = await request(app)
+      .get(`/income-sources/statements/${statementId}`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(statementRes.status).toBe(200);
+    expect(statementRes.body.statement.status).toBe("draft");
+    expect(statementRes.body.statement.postedTransactionId).toBeNull();
+  });
+
   it("POST .../link-transaction retorna 422 para transacao tipo Saida", async () => {
     const { token, statementId } = await setupStatementAndTransaction(
       "inss-link-exit@test.dev",

--- a/apps/api/src/services/income-sources.service.js
+++ b/apps/api/src/services/income-sources.service.js
@@ -1081,7 +1081,11 @@ export const linkStatementToTransaction = async (userId, statementId, transactio
 
   // Fetch transaction (ownership)
   const { rows: txRows } = await dbQuery(
-    `SELECT * FROM transactions WHERE id = $1 AND user_id = $2`,
+    `SELECT *
+       FROM transactions
+      WHERE id = $1
+        AND user_id = $2
+        AND deleted_at IS NULL`,
     [txid, uid],
   );
   if (!txRows[0]) throw createError(404, "Transacao nao encontrada.");


### PR DESCRIPTION
## Sprint 5.2\nConsolidação backend para evitar inconsistência de renda confirmada.\n\n## Problema\nEra possível vincular extrato a transação soft-deletada, o que podia marcar extrato como posted sem transação ativa de suporte.\n\n## Correção\n- linkStatementToTransaction agora só aceita transação ativa (deleted_at IS NULL)\n- teste de regressão cobrindo o cenário de soft delete\n\n## Arquivos\n- apps/api/src/services/income-sources.service.js\n- apps/api/src/income-sources.test.js\n\n## Validação local\n- 
pm -w apps/api run test -- src/income-sources.test.js src/transactions.test.js\n- 
pm -w apps/api run lint\n