### PR TITLE
feat(web): Sprint 5.3 status explícito de renda confirmada

### DIFF
--- a/apps/web/src/pages/IncomeSourcesPage.test.tsx
+++ b/apps/web/src/pages/IncomeSourcesPage.test.tsx
@@ -295,6 +295,39 @@ describe("IncomeSourcesPage", () => {
     });
   });
 
+  it("exibe badges de status do extrato (rascunho e confirmada)", async () => {
+    vi.mocked(incomeSourcesService.listStatements).mockResolvedValueOnce([
+      buildListedStatement({ id: 10, status: "draft" }),
+      buildListedStatement({
+        id: 11,
+        status: "posted",
+        postedTransactionId: 900,
+        reconciliation: {
+          status: "manual_entry",
+          summary: "Extrato lancado como entrada manual no app.",
+          linkedTransaction: {
+            id: 900,
+            type: "Entrada",
+            value: 2803.52,
+            date: "2026-02-23",
+            description: "INSS Credito",
+            importSessionId: null,
+            importDocumentType: null,
+            deletedAt: null,
+          },
+          candidates: [],
+        },
+      }),
+    ]);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Rascunho")).toBeInTheDocument();
+      expect(screen.getByText("Confirmada")).toBeInTheDocument();
+    });
+  });
+
   it("Salvar rascunho chama createStatement sem postStatement", async () => {
     const user = userEvent.setup();
     vi.mocked(incomeSourcesService.createStatement).mockResolvedValue(buildStatementResult());

--- a/apps/web/src/pages/IncomeSourcesPage.tsx
+++ b/apps/web/src/pages/IncomeSourcesPage.tsx
@@ -53,6 +53,20 @@ const getReconciliationBadge = (status: IncomeStatementReconciliation["status"])
   }
 };
 
+const getStatementStatusBadge = (status: "draft" | "posted") => {
+  if (status === "posted") {
+    return {
+      label: "Confirmada",
+      className: "border-green-200 bg-green-50 text-green-700",
+    };
+  }
+
+  return {
+    label: "Rascunho",
+    className: "border-amber-200 bg-amber-50 text-amber-700",
+  };
+};
+
 const IncomeSourcesPage = ({
   onBack = undefined,
 }: IncomeSourcesPageProps): JSX.Element => {
@@ -476,6 +490,7 @@ const IncomeSourcesPage = ({
                       {(statementsBySource[source.id] ?? []).slice(0, 3).map((statement) => {
                         const reconciliation = statement.reconciliation;
                         const badge = getReconciliationBadge(reconciliation?.status ?? "pending");
+                        const statementStatusBadge = getStatementStatusBadge(statement.status);
 
                         return (
                           <div
@@ -492,11 +507,18 @@ const IncomeSourcesPage = ({
                                   {statement.paymentDate ? ` · Pago em ${statement.paymentDate}` : ""}
                                 </p>
                               </div>
-                              <span
-                                className={`rounded border px-2 py-0.5 text-xs font-semibold ${badge.className}`}
-                              >
-                                {badge.label}
-                              </span>
+                              <div className="flex items-center gap-1">
+                                <span
+                                  className={`rounded border px-2 py-0.5 text-xs font-semibold ${statementStatusBadge.className}`}
+                                >
+                                  {statementStatusBadge.label}
+                                </span>
+                                <span
+                                  className={`rounded border px-2 py-0.5 text-xs font-semibold ${badge.className}`}
+                                >
+                                  {badge.label}
+                                </span>
+                              </div>
                             </div>
 
                             {reconciliation ? (


### PR DESCRIPTION
## Sprint 5.3\nAlinhamento de consumo no frontend para tornar a semântica de renda visível na UI.\n\n## O que entra\n- Badge explícito de status do extrato:\n  - Confirmada para posted\n  - Rascunho para draft\n- Badge de reconciliação mantido em paralelo (conciliado/candidato/conflito/etc.)\n- Teste da página cobrindo exibição dos dois estados\n\n## Arquivos\n- apps/web/src/pages/IncomeSourcesPage.tsx\n- apps/web/src/pages/IncomeSourcesPage.test.tsx\n\n## Validação local\n- 
pm -w apps/web run test:run -- src/pages/IncomeSourcesPage.test.tsx\n- 
pm -w apps/web run lint\n- 
pm -w apps/web run typecheck\n