### PR TITLE
docs(roadmap): Sprint 5.4 hardening e fechamento da Sprint 5

### DIFF
--- a/docs/roadmap-execution.md
+++ b/docs/roadmap-execution.md
@@ -381,7 +381,7 @@ Legenda de status:
 | Sprint | Foco | Escopo de fechamento | Status |
 |---|---|---|---|
 | Sprint 4 | Forecast semantics (projeção confiável) | saldo real como base, obrigações futuras sem abatimento duplo, trilha de home/auth estabilizada e CI verde em main | ✅ |
-| Sprint 5 | Renda confirmada ponta a ponta (pensão/INSS) | documento -> entidade -> agregado mensal -> projeção sem sumir/duplicar | 🟡 |
+| Sprint 5 | Renda confirmada ponta a ponta (pensão/INSS) | documento -> entidade -> agregado mensal -> projeção sem sumir/duplicar | ✅ |
 
 ### Fase 2 - Operação financeira real
 
@@ -402,8 +402,10 @@ Legenda de status:
 ### Decisão executiva atual
 
 - Sprint 4 fechada.
-- Sprint 5 iniciada.
+- Sprint 5 concluida.
+- Sprint 6 e o proximo alvo.
 - Documento operacional da Sprint 5: `docs/roadmaps/sprint-5-renda-confirmada.md`.
+- Evidencias da Sprint 5: PR #355, PR #356, PR #357, PR #358.
 - Pendências manuais continuam rastreadas fora de CI (prova visual do PR #348 e validação E2E real do OAuth).
 
 ---

--- a/docs/roadmaps/sprint-5-renda-confirmada.md
+++ b/docs/roadmaps/sprint-5-renda-confirmada.md
@@ -2,6 +2,29 @@
 
 > Documento operacional para executar a Sprint 5 com foco em verdade financeira: renda reconhecida corretamente no dominio, no agregado mensal e na projecao.
 
+Status: concluida em 31/03/2026.
+
+---
+
+## 0. Entregas executadas
+
+### PRs da Sprint 5
+
+1. PR #355 - S5.1 (testes de semantica e guard rails)
+2. PR #356 - S5.2 (integridade backend no vinculo de extrato)
+3. PR #357 - S5.3 (status explicito de renda confirmada no frontend)
+4. PR #358 - S5.4 (hardening final e fechamento executivo)
+
+### Evidencia de validacao final (S5.4)
+
+- API lint: `npm -w apps/api run lint`
+- API testes direcionados: `npm -w apps/api run test -- src/forecast.test.js src/income-sources.test.js src/transactions.test.js`
+- Web lint: `npm -w apps/web run lint`
+- Web typecheck: `npm -w apps/web run typecheck`
+- Web testes direcionados: `npm -w apps/web run test:run -- src/pages/IncomeSourcesPage.test.tsx src/services/auth.service.test.ts`
+
+Todos os comandos acima concluiram com sucesso.
+
 ---
 
 ## 1. Objetivo


### PR DESCRIPTION
## Sprint 5.4\nFechamento executivo da Sprint 5 com evidencias de validacao.\n\n## O que entra\n- Marca Sprint 5 como concluida no roadmap executivo\n- Define Sprint 6 como proximo alvo\n- Registra PRs executados da Sprint 5\n- Registra evidencias dos comandos de hardening (lint/typecheck/testes direcionados)\n\n## Arquivos\n- docs/roadmap-execution.md\n- docs/roadmaps/sprint-5-renda-confirmada.md\n\n## Validacao final executada\n- 
pm -w apps/api run lint\n- 
pm -w apps/api run test -- src/forecast.test.js src/income-sources.test.js src/transactions.test.js\n- 
pm -w apps/web run lint\n- 
pm -w apps/web run typecheck\n- 
pm -w apps/web run test:run -- src/pages/IncomeSourcesPage.test.tsx src/services/auth.service.test.ts\n