### PR TITLE
feat(import): S6.1 guard rails operacionais

### DIFF
--- a/apps/api/src/import.test.js
+++ b/apps/api/src/import.test.js
@@ -273,6 +273,7 @@ describe("transaction imports", () => {
       committedAt: "2026-04-01T10:10:00.000Z",
       fileName: "newer.ofx",
       documentType: "bank_statement",
+      state: "imported",
       canUndo: true,
       undoBlockedReason: null,
       summary: {
@@ -293,6 +294,7 @@ describe("transaction imports", () => {
       committedAt: null,
       fileName: "older.csv",
       documentType: "bank_statement",
+      state: "pending_confirmation",
       canUndo: false,
       undoBlockedReason: null,
       summary: {
@@ -319,6 +321,101 @@ describe("transaction imports", () => {
     expect(pagedResponse.body.items).toHaveLength(1);
     expect(pagedResponse.body.items[0].id).toBe(olderImportId);
     expect(pagedResponse.body.items.map((item) => item.id)).not.toContain(otherUserImportId);
+  });
+
+  it("GET /transactions/imports retorna estados partial e conflict quando aplicavel", async () => {
+    const email = "imports-history-state@controlfinance.dev";
+    const token = await registerAndLogin(email);
+    const userId = await getUserIdByEmail(email);
+
+    const partialImportId = "44444444-4444-4444-8444-444444444444";
+    const conflictImportId = "55555555-5555-4555-8555-555555555555";
+
+    await dbQuery(
+      `
+        INSERT INTO transaction_import_sessions (
+          id,
+          user_id,
+          payload_json,
+          created_at,
+          expires_at,
+          committed_at
+        )
+        VALUES
+          ($1, $2, $3::jsonb, $4, $5, $6),
+          ($7, $8, $9::jsonb, $10, $11, $12)
+      `,
+      [
+        partialImportId,
+        userId,
+        JSON.stringify({
+          fileName: "partial.csv",
+          documentType: "bank_statement",
+          summary: {
+            totalRows: 3,
+            validRows: 3,
+            duplicateRows: 0,
+            conflictRows: 0,
+            invalidRows: 0,
+            income: 300,
+            expense: 0,
+          },
+        }),
+        "2026-04-02T09:00:00.000Z",
+        "2026-04-02T09:30:00.000Z",
+        "2026-04-02T09:05:00.000Z",
+        conflictImportId,
+        userId,
+        JSON.stringify({
+          fileName: "conflict.csv",
+          documentType: "bank_statement",
+          summary: {
+            totalRows: 4,
+            validRows: 1,
+            duplicateRows: 0,
+            conflictRows: 2,
+            invalidRows: 1,
+            income: 100,
+            expense: 0,
+          },
+        }),
+        "2026-04-02T10:00:00.000Z",
+        "2026-04-02T10:30:00.000Z",
+        "2026-04-02T10:05:00.000Z",
+      ],
+    );
+
+    await dbQuery(
+      `
+        INSERT INTO transactions (
+          user_id,
+          type,
+          value,
+          date,
+          description,
+          import_session_id,
+          imported_at
+        )
+        VALUES
+          ($1, 'Entrada', 100, '2026-04-02', 'Parcial ativa', $2, NOW()),
+          ($1, 'Entrada', 100, '2026-04-02', 'Conflito ativo', $3, NOW())
+      `,
+      [userId, partialImportId, conflictImportId],
+    );
+
+    const response = await request(app)
+      .get("/transactions/imports")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+
+    const partialItem = response.body.items.find((item) => item.id === partialImportId);
+    const conflictItem = response.body.items.find((item) => item.id === conflictImportId);
+
+    expect(partialItem).toBeTruthy();
+    expect(conflictItem).toBeTruthy();
+    expect(partialItem.state).toBe("partial");
+    expect(conflictItem.state).toBe("conflict");
   });
 
   it("POST /transactions/import/dry-run bloqueia sem token", async () => {
@@ -1430,6 +1527,7 @@ describe("transaction imports", () => {
 
     const undoResponse = await request(app)
       .delete(`/transactions/imports/${sessionId}`)
+      .send({ confirm: true })
       .set("Authorization", `Bearer ${token}`);
 
     expect(undoResponse.status).toBe(200);
@@ -1444,6 +1542,7 @@ describe("transaction imports", () => {
     expect(historyResponse.status).toBe(200);
     expect(historyResponse.body.items[0]).toMatchObject({
       id: sessionId,
+      state: "reverted",
       canUndo: false,
       summary: {
         imported: 0,
@@ -1504,6 +1603,7 @@ describe("transaction imports", () => {
     expect(historyResponse.status).toBe(200);
     expect(historyResponse.body.items[0]).toMatchObject({
       id: sessionId,
+      state: "imported",
       canUndo: true,
       undoBlockedReason: null,
     });
@@ -1568,6 +1668,7 @@ describe("transaction imports", () => {
     expect(historyResponse.status).toBe(200);
     expect(historyResponse.body.items[0]).toMatchObject({
       id: sessionId,
+      state: "imported",
       canUndo: false,
       undoBlockedReason:
         "Nao e possivel desfazer esta importacao porque existem derivados ativos vinculados a ela: 1 lancamento no historico de renda.",
@@ -1607,6 +1708,7 @@ describe("transaction imports", () => {
 
     const undoResponse = await request(app)
       .delete(`/transactions/imports/${sessionId}`)
+      .send({ confirm: true })
       .set("Authorization", `Bearer ${token}`);
 
     expect(undoResponse.status).toBe(200);
@@ -1683,6 +1785,7 @@ describe("transaction imports", () => {
 
     const undoResponse = await request(app)
       .delete(`/transactions/imports/${sessionId}`)
+      .send({ confirm: true })
       .set("Authorization", `Bearer ${token}`);
 
     expect(undoResponse.status).toBe(200);
@@ -1765,6 +1868,7 @@ describe("transaction imports", () => {
 
     const undoResponse = await request(app)
       .delete(`/transactions/imports/${sessionId}`)
+      .send({ confirm: true })
       .set("Authorization", `Bearer ${token}`);
 
     expectErrorResponseWithRequestId(
@@ -1821,6 +1925,7 @@ describe("transaction imports", () => {
 
     const undoResponse = await request(app)
       .delete(`/transactions/imports/${sessionId}`)
+      .send({ confirm: true })
       .set("Authorization", `Bearer ${token}`);
 
     expectErrorResponseWithRequestId(
@@ -1858,6 +1963,7 @@ describe("transaction imports", () => {
 
     const undoResponse = await request(app)
       .delete(`/transactions/imports/${sessionId}`)
+      .send({ confirm: true })
       .set("Authorization", `Bearer ${tokenB}`);
 
     expectErrorResponseWithRequestId(undoResponse, 404, "Sessao de importacao nao encontrada.");
@@ -1869,6 +1975,35 @@ describe("transaction imports", () => {
     );
 
     expect(response.status).toBe(401);
+  });
+
+  it("DELETE /transactions/imports/:sessionId exige confirmacao explicita", async () => {
+    const token = await registerAndLogin("import-undo-confirm-required@controlfinance.dev");
+    await makeProUser("import-undo-confirm-required@controlfinance.dev");
+
+    const csv = csvFile("date,type,value,description\n2026-03-01,Entrada,100,Teste");
+
+    const dryRunResponse = await request(app)
+      .post("/transactions/import/dry-run")
+      .set("Authorization", `Bearer ${token}`)
+      .attach("file", csv.buffer, { filename: csv.fileName, contentType: "text/csv" });
+
+    const commitResponse = await request(app)
+      .post("/transactions/import/commit")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ importId: dryRunResponse.body.importId });
+
+    const sessionId = commitResponse.body.importSessionId;
+
+    const undoResponse = await request(app)
+      .delete(`/transactions/imports/${sessionId}`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expectErrorResponseWithRequestId(
+      undoResponse,
+      400,
+      "Confirmacao explicita obrigatoria para esta acao destrutiva.",
+    );
   });
 
   it("POST /transactions/bulk-delete exclui transacoes selecionadas", async () => {
@@ -1894,7 +2029,7 @@ describe("transaction imports", () => {
     const bulkResponse = await request(app)
       .post("/transactions/bulk-delete")
       .set("Authorization", `Bearer ${token}`)
-      .send({ transactionIds: [t1.body.id, t2.body.id] });
+      .send({ transactionIds: [t1.body.id, t2.body.id], confirm: true });
 
     expect(bulkResponse.status).toBe(200);
     expect(bulkResponse.body.deletedCount).toBe(2);
@@ -1923,7 +2058,7 @@ describe("transaction imports", () => {
     const bulkResponse = await request(app)
       .post("/transactions/bulk-delete")
       .set("Authorization", `Bearer ${tokenB}`)
-      .send({ transactionIds: [tx.body.id] });
+      .send({ transactionIds: [tx.body.id], confirm: true });
 
     expect(bulkResponse.status).toBe(200);
     expect(bulkResponse.body.deletedCount).toBe(0);
@@ -1941,11 +2076,26 @@ describe("transaction imports", () => {
     const response = await request(app)
       .post("/transactions/bulk-delete")
       .set("Authorization", `Bearer ${token}`)
-      .send({ transactionIds: [] });
+      .send({ transactionIds: [], confirm: true });
 
     expect(response.status).toBe(200);
     expect(response.body.deletedCount).toBe(0);
     expect(response.body.success).toBe(true);
+  });
+
+  it("POST /transactions/bulk-delete exige confirmacao explicita", async () => {
+    const token = await registerAndLogin("bulk-delete-confirm-required@controlfinance.dev");
+
+    const response = await request(app)
+      .post("/transactions/bulk-delete")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ transactionIds: [1] });
+
+    expectErrorResponseWithRequestId(
+      response,
+      400,
+      "Confirmacao explicita obrigatoria para esta acao destrutiva.",
+    );
   });
 
   it("POST /transactions/bulk-delete bloqueia sem token", async () => {

--- a/apps/api/src/routes/transactions.routes.js
+++ b/apps/api/src/routes/transactions.routes.js
@@ -60,6 +60,18 @@ const createError = (status, message) => {
   return error;
 };
 
+const isExplicitConfirmation = (value) => {
+  const normalizedValue = String(value || "").trim().toLowerCase();
+
+  return ["true", "1", "yes", "confirm"].includes(normalizedValue);
+};
+
+const ensureDestructiveActionConfirmation = (value) => {
+  if (!isExplicitConfirmation(value)) {
+    throw createError(400, "Confirmacao explicita obrigatoria para esta acao destrutiva.");
+  }
+};
+
 const ensureValidImportFile = (file) => {
   if (!file) {
     throw createError(400, "Arquivo do extrato (file) e obrigatorio.");
@@ -258,6 +270,7 @@ router.post("/", transactionsWriteRateLimiter, async (req, res, next) => {
 
 router.delete("/imports/:sessionId", transactionsWriteRateLimiter, async (req, res, next) => {
   try {
+    ensureDestructiveActionConfirmation(req.body?.confirm ?? req.query?.confirm);
     const result = await deleteImportSessionForUser(req.user.id, req.params.sessionId);
     res.status(200).json(result);
   } catch (error) {
@@ -267,6 +280,7 @@ router.delete("/imports/:sessionId", transactionsWriteRateLimiter, async (req, r
 
 router.post("/bulk-delete", transactionsWriteRateLimiter, async (req, res, next) => {
   try {
+    ensureDestructiveActionConfirmation(req.body?.confirm ?? req.query?.confirm);
     const ids = Array.isArray(req.body?.transactionIds) ? req.body.transactionIds : [];
     const result = await bulkDeleteTransactionsForUser(req.user.id, ids);
     res.status(200).json(result);

--- a/apps/api/src/services/transactions-import.service.js
+++ b/apps/api/src/services/transactions-import.service.js
@@ -284,6 +284,40 @@ const normalizeSummaryInteger = (value, fallbackValue = 0) => {
   return parsedValue;
 };
 
+const resolveImportSessionState = ({
+  committedAt,
+  expiresAt,
+  imported,
+  summary,
+}) => {
+  if (committedAt) {
+    if (imported <= 0) {
+      return "reverted";
+    }
+
+    const validRows = normalizeSummaryInteger(summary?.validRows, 0);
+    const conflictRows = normalizeSummaryInteger(summary?.conflictRows, 0);
+
+    if (validRows > 0 && imported < validRows) {
+      return "partial";
+    }
+
+    if (conflictRows > 0) {
+      return "conflict";
+    }
+
+    return "imported";
+  }
+
+  const expiresAtTimestamp = Date.parse(String(expiresAt || ""));
+
+  if (Number.isFinite(expiresAtTimestamp) && expiresAtTimestamp <= Date.now()) {
+    return "expired";
+  }
+
+  return "pending_confirmation";
+};
+
 const toIsoDateString = (value) => {
   if (!value) {
     return null;
@@ -1098,6 +1132,8 @@ export const listTransactionsImportSessionsByUser = async (userId, filters = {})
     const summary = payload.summary || {};
     const imported = normalizeSummaryInteger(row.active_imported_count, 0);
     const committedAt = toIsoDateString(row.committed_at);
+    const createdAt = toIsoDateString(row.created_at);
+    const expiresAt = toIsoDateString(row.expires_at);
     const derivedIncomeStatements = normalizeSummaryInteger(
       row.active_income_statements_count,
       0,
@@ -1116,10 +1152,28 @@ export const listTransactionsImportSessionsByUser = async (userId, filters = {})
           )
         : { undoBlockedReason: null };
 
+    const normalizedSummary = {
+      totalRows: normalizeSummaryInteger(summary.totalRows, 0),
+      validRows: normalizeSummaryInteger(summary.validRows, 0),
+      duplicateRows: normalizeSummaryInteger(summary.duplicateRows, 0),
+      conflictRows: normalizeSummaryInteger(summary.conflictRows, 0),
+      invalidRows: normalizeSummaryInteger(summary.invalidRows, 0),
+      income: normalizeSummaryNumber(summary.income, 0),
+      expense: normalizeSummaryNumber(summary.expense, 0),
+      imported,
+    };
+
+    const state = resolveImportSessionState({
+      committedAt,
+      expiresAt,
+      imported,
+      summary: normalizedSummary,
+    });
+
     return {
       id: String(row.id),
-      createdAt: toIsoDateString(row.created_at),
-      expiresAt: toIsoDateString(row.expires_at),
+      createdAt,
+      expiresAt,
       committedAt,
       fileName:
         typeof payload.fileName === "string" && payload.fileName.trim()
@@ -1129,18 +1183,10 @@ export const listTransactionsImportSessionsByUser = async (userId, filters = {})
         typeof payload.documentType === "string" && payload.documentType.trim()
           ? payload.documentType.trim()
           : null,
+      state,
       canUndo: Boolean(committedAt) && imported > 0 && !undoPlan.undoBlockedReason,
       undoBlockedReason: undoPlan.undoBlockedReason,
-      summary: {
-        totalRows: normalizeSummaryInteger(summary.totalRows, 0),
-        validRows: normalizeSummaryInteger(summary.validRows, 0),
-        duplicateRows: normalizeSummaryInteger(summary.duplicateRows, 0),
-        conflictRows: normalizeSummaryInteger(summary.conflictRows, 0),
-        invalidRows: normalizeSummaryInteger(summary.invalidRows, 0),
-        income: normalizeSummaryNumber(summary.income, 0),
-        expense: normalizeSummaryNumber(summary.expense, 0),
-        imported,
-      },
+      summary: normalizedSummary,
     };
   }));
 

--- a/apps/web/src/components/ImportHistoryModal.jsx
+++ b/apps/web/src/components/ImportHistoryModal.jsx
@@ -22,29 +22,44 @@ const formatDateTime = (value) => {
 };
 
 const resolveImportStatus = (item) => {
-  if (item.committedAt) {
-    return {
-      label: item.summary.imported > 0 ? "Importada" : "Desfeita",
-      className:
-        item.summary.imported > 0
-          ? "bg-green-100 text-green-700"
-          : "bg-slate-100 text-slate-700",
-    };
+  switch (item.state) {
+    case "imported":
+      return {
+        label: "Importada",
+        className: "bg-green-100 text-green-700",
+        hint: "Sessao confirmada com efeitos ativos.",
+      };
+    case "reverted":
+      return {
+        label: "Revertida",
+        className: "bg-slate-100 text-slate-700",
+        hint: "Sessao desfeita com sucesso.",
+      };
+    case "partial":
+      return {
+        label: "Parcial",
+        className: "bg-amber-100 text-amber-700",
+        hint: `${item.summary.imported} de ${item.summary.validRows} linhas prontas seguem ativas.`,
+      };
+    case "conflict":
+      return {
+        label: "Com conflito",
+        className: "bg-orange-100 text-orange-700",
+        hint: `${item.summary.conflictRows} ${item.summary.conflictRows === 1 ? "linha ficou" : "linhas ficaram"} com conflito na revisao inicial.`,
+      };
+    case "expired":
+      return {
+        label: "Expirada",
+        className: "bg-red-100 text-red-700",
+        hint: "Sessao nao foi confirmada dentro do prazo.",
+      };
+    default:
+      return {
+        label: "Aguardando confirmacao",
+        className: "bg-yellow-100 text-yellow-700",
+        hint: "Sessao ainda sem confirmacao final.",
+      };
   }
-
-  const expiresAtTimestamp = Date.parse(item.expiresAt || "");
-
-  if (Number.isFinite(expiresAtTimestamp) && Date.now() > expiresAtTimestamp) {
-    return {
-      label: "Expirada",
-      className: "bg-red-100 text-red-700",
-    };
-  }
-
-  return {
-    label: "Aguardando confirmação",
-    className: "bg-yellow-100 text-yellow-700",
-  };
 };
 
 const humanizeUndoBlockedReason = (value) => {
@@ -322,6 +337,11 @@ const ImportHistoryModal = ({ isOpen, onClose, onImportSessionReverted = undefin
                             <span className={`rounded px-2 py-0.5 font-semibold ${item.status.className}`}>
                               {item.status.label}
                             </span>
+                            {item.status.hint ? (
+                              <p className="mt-1 max-w-52 text-[11px] text-cf-text-secondary">
+                                {item.status.hint}
+                              </p>
+                            ) : null}
                           </td>
                           <td className="border-b border-cf-border px-2 py-2 text-cf-text-primary">
                             <div className="space-y-1 text-[11px]">

--- a/apps/web/src/components/ImportHistoryModal.test.jsx
+++ b/apps/web/src/components/ImportHistoryModal.test.jsx
@@ -36,6 +36,7 @@ describe("ImportHistoryModal", () => {
             committedAt: "2026-04-01T10:10:00.000Z",
             fileName: "itau-90-dias.ofx",
             documentType: "bank_statement",
+            state: "reverted",
             canUndo: false,
             undoBlockedReason:
               "Nao e possivel desfazer esta importacao porque existem derivados ativos vinculados a ela: 1 conta derivada.",
@@ -56,7 +57,7 @@ describe("ImportHistoryModal", () => {
 
     render(<ImportHistoryModal isOpen onClose={vi.fn()} />);
 
-    expect(await screen.findByText("Desfeita")).toBeInTheDocument();
+    expect(await screen.findByText("Revertida")).toBeInTheDocument();
     expect(screen.getByText("itau-90-dias.ofx")).toBeInTheDocument();
     expect(screen.getByText("Extrato bancário")).toBeInTheDocument();
     expect(screen.getByText("Já existentes: 1")).toBeInTheDocument();
@@ -83,6 +84,7 @@ describe("ImportHistoryModal", () => {
               committedAt: "2026-04-01T10:10:00.000Z",
               fileName: "inss.pdf",
               documentType: "income_statement_inss",
+              state: "imported",
               canUndo: true,
               undoBlockedReason: null,
               summary: {
@@ -109,6 +111,7 @@ describe("ImportHistoryModal", () => {
               committedAt: "2026-04-01T10:10:00.000Z",
               fileName: "inss.pdf",
               documentType: "income_statement_inss",
+              state: "reverted",
               canUndo: false,
               undoBlockedReason: null,
               summary: {
@@ -154,6 +157,6 @@ describe("ImportHistoryModal", () => {
     });
 
     expect(await screen.findByText("Importação desfeita com sucesso.")).toBeInTheDocument();
-    expect(screen.getByText("Desfeita")).toBeInTheDocument();
+    expect(screen.getByText("Revertida")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -1933,6 +1933,7 @@ describe("App", () => {
             createdAt: "2026-04-01T10:00:00.000Z",
             expiresAt: "2026-04-01T10:30:00.000Z",
             committedAt: "2026-04-01T10:10:00.000Z",
+            state: "imported",
             summary: {
               totalRows: 2,
               validRows: 2,
@@ -1992,6 +1993,7 @@ describe("App", () => {
       createdAt: "2026-04-01T10:00:00.000Z",
       expiresAt: "2026-04-01T10:30:00.000Z",
       committedAt: null,
+      state: "pending_confirmation",
       summary: {
         totalRows: 1,
         validRows: 1,
@@ -2020,6 +2022,7 @@ describe("App", () => {
               createdAt: "2026-04-01T11:00:00.000Z",
               expiresAt: "2026-04-01T11:30:00.000Z",
               committedAt: null,
+              state: "pending_confirmation",
               summary: {
                 totalRows: 1,
                 validRows: 1,

--- a/apps/web/src/services/transactions.service.ts
+++ b/apps/web/src/services/transactions.service.ts
@@ -256,6 +256,14 @@ export interface ImportHistorySummary {
   imported: number;
 }
 
+export type ImportSessionState =
+  | "imported"
+  | "reverted"
+  | "partial"
+  | "conflict"
+  | "pending_confirmation"
+  | "expired";
+
 export interface ImportHistoryItem {
   id: string;
   createdAt: string;
@@ -263,6 +271,7 @@ export interface ImportHistoryItem {
   committedAt: string | null;
   fileName: string | null;
   documentType: string | null;
+  state: ImportSessionState;
   canUndo: boolean;
   undoBlockedReason: string | null;
   summary: ImportHistorySummary;
@@ -449,6 +458,7 @@ interface ImportHistoryApiResponse {
     committedAt?: unknown;
     fileName?: unknown;
     documentType?: unknown;
+    state?: unknown;
     canUndo?: unknown;
     undoBlockedReason?: unknown;
     summary?: {
@@ -467,6 +477,53 @@ interface ImportHistoryApiResponse {
     offset?: unknown;
   };
 }
+
+const normalizeImportSessionState = (value: unknown): ImportSessionState | null => {
+  const normalized = typeof value === "string" ? value.trim() : "";
+
+  if (
+    normalized === "imported" ||
+    normalized === "reverted" ||
+    normalized === "partial" ||
+    normalized === "conflict" ||
+    normalized === "pending_confirmation" ||
+    normalized === "expired"
+  ) {
+    return normalized;
+  }
+
+  return null;
+};
+
+const deriveLegacyImportSessionState = (
+  committedAt: string | null,
+  expiresAt: string,
+  summary: ImportHistorySummary,
+): ImportSessionState => {
+  if (committedAt) {
+    if (summary.imported <= 0) {
+      return "reverted";
+    }
+
+    if (summary.validRows > 0 && summary.imported < summary.validRows) {
+      return "partial";
+    }
+
+    if (summary.conflictRows > 0) {
+      return "conflict";
+    }
+
+    return "imported";
+  }
+
+  const expiresAtTimestamp = Date.parse(expiresAt);
+
+  if (Number.isFinite(expiresAtTimestamp) && Date.now() > expiresAtTimestamp) {
+    return "expired";
+  }
+
+  return "pending_confirmation";
+};
 
 const normalizeImportDryRunProfileDeduction = (
   raw: unknown,
@@ -1092,11 +1149,16 @@ export const transactionsService = {
     };
   },
   deleteImportSession: async (sessionId: string): Promise<{ importSessionId: string; deletedCount: number; success: boolean }> => {
-    const { data } = await api.delete(`/transactions/imports/${sessionId}`);
+    const { data } = await api.delete(`/transactions/imports/${sessionId}`, {
+      data: { confirm: true },
+    });
     return data as { importSessionId: string; deletedCount: number; success: boolean };
   },
   bulkDeleteTransactions: async (transactionIds: number[]): Promise<{ deletedCount: number; success: boolean }> => {
-    const { data } = await api.post("/transactions/bulk-delete", { transactionIds });
+    const { data } = await api.post("/transactions/bulk-delete", {
+      transactionIds,
+      confirm: true,
+    });
     return data as { deletedCount: number; success: boolean };
   },
   getImportHistory: async (options: ImportHistoryOptions = {}): Promise<ImportHistoryResponse> => {
@@ -1114,28 +1176,13 @@ export const transactionsService = {
     });
     const responseBody = data as ImportHistoryApiResponse;
     const items = Array.isArray(responseBody.items)
-      ? responseBody.items.map((item) => ({
-          id: String(item?.id || ""),
-          createdAt: String(item?.createdAt || ""),
-          expiresAt: String(item?.expiresAt || ""),
-          committedAt:
+      ? responseBody.items.map((item) => {
+          const committedAt =
             typeof item?.committedAt === "string" && item.committedAt.trim()
               ? item.committedAt
-              : null,
-          fileName:
-            typeof item?.fileName === "string" && item.fileName.trim()
-              ? item.fileName.trim()
-              : null,
-          documentType:
-            typeof item?.documentType === "string" && item.documentType.trim()
-              ? item.documentType.trim()
-              : null,
-          canUndo: Boolean(item?.canUndo),
-          undoBlockedReason:
-            typeof item?.undoBlockedReason === "string" && item.undoBlockedReason.trim()
-              ? item.undoBlockedReason.trim()
-              : null,
-          summary: {
+              : null;
+          const expiresAt = String(item?.expiresAt || "");
+          const summary: ImportHistorySummary = {
             totalRows: Number(item?.summary?.totalRows) || 0,
             validRows: Number(item?.summary?.validRows) || 0,
             duplicateRows: Number(item?.summary?.duplicateRows) || 0,
@@ -1144,8 +1191,32 @@ export const transactionsService = {
             income: Number(item?.summary?.income) || 0,
             expense: Number(item?.summary?.expense) || 0,
             imported: Number(item?.summary?.imported) || 0,
-          },
-        }))
+          };
+
+          return {
+            id: String(item?.id || ""),
+            createdAt: String(item?.createdAt || ""),
+            expiresAt,
+            committedAt,
+            fileName:
+              typeof item?.fileName === "string" && item.fileName.trim()
+                ? item.fileName.trim()
+                : null,
+            documentType:
+              typeof item?.documentType === "string" && item.documentType.trim()
+                ? item.documentType.trim()
+                : null,
+            state:
+              normalizeImportSessionState(item?.state) ||
+              deriveLegacyImportSessionState(committedAt, expiresAt, summary),
+            canUndo: Boolean(item?.canUndo),
+            undoBlockedReason:
+              typeof item?.undoBlockedReason === "string" && item.undoBlockedReason.trim()
+                ? item.undoBlockedReason.trim()
+                : null,
+            summary,
+          };
+        })
       : [];
     const responseLimit = Number(responseBody.pagination?.limit);
     const responseOffset = Number(responseBody.pagination?.offset);


### PR DESCRIPTION
## Contexto\nPrimeiro PR funcional da Sprint 6 (S6.1), focado em segurança operacional no ciclo de importação e undo.\n\n## Entregas\n- Confirmação explícita obrigatória para ações destrutivas:\n  - DELETE /transactions/imports/:sessionId\n  - POST /transactions/bulk-delete\n- Estado operacional canônico por sessão de importação no histórico:\n  - imported, everted, partial, conflict, pending_confirmation, xpired\n- UX do histórico sem ambiguidade com novos rótulos e contexto\n- Contrato do frontend atualizado para consumir state com fallback legado\n\n## Testes\n- 
pm -w apps/api run test -- src/import.test.js\n- 
pm -w apps/web run test:run -- src/components/ImportHistoryModal.test.jsx\n- 
pm -w apps/web run typecheck\n- 
pm -w apps/api run lint\n\n## Fora de escopo\n- Reaplicar sessão (fica para próximo slice)\n- Expansão de parser e entidade de bills (S6.2/S6.3)\n