### PR TITLE
feat(bills): S6.3 buckets operacionais explícitos

### DIFF
--- a/apps/api/src/bills.test.js
+++ b/apps/api/src/bills.test.js
@@ -27,6 +27,7 @@ const toLocalDate = (offsetDays) => {
 
 const FUTURE_DATE = toLocalDate(30);   // 30 days from now — never overdue
 const PAST_DATE = toLocalDate(-30);    // 30 days ago — always overdue
+const DUE_SOON_DATE = toLocalDate(3);  // within due-soon window
 
 describe("bills", () => {
   beforeAll(async () => {
@@ -76,12 +77,15 @@ describe("bills", () => {
       dueDate: FUTURE_DATE,
       status: "pending",
       isOverdue: false,
+      operationalBucket: "future",
       categoryId: null,
       paidAt: null,
       notes: null,
       provider: null,
       referenceMonth: null,
     });
+    expect(typeof res.body.daysUntilDue).toBe("number");
+    expect(res.body.daysUntilDue).toBeGreaterThan(7);
     expect(Number.isInteger(res.body.id)).toBe(true);
     expect(typeof res.body.createdAt).toBe("string");
   });
@@ -247,6 +251,71 @@ describe("bills", () => {
     expect(res.body.items).toHaveLength(1);
     expect(res.body.items[0].title).toBe("Atrasada");
     expect(res.body.items[0].isOverdue).toBe(true);
+    expect(res.body.items[0].operationalBucket).toBe("overdue");
+  });
+
+  it("GET /bills?bucket=due_soon retorna apenas pendentes a vencer", async () => {
+    const token = await registerAndLogin("bills-bucket-due-soon@test.dev");
+    const userId = await getUserIdByEmail("bills-bucket-due-soon@test.dev");
+
+    await request(app)
+      .post("/bills")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ title: "A vencer", amount: 70, dueDate: DUE_SOON_DATE });
+
+    await dbQuery(
+      `INSERT INTO bills (user_id, title, amount, due_date) VALUES ($1, $2, $3, $4)`,
+      [userId, "Futura", 200, FUTURE_DATE],
+    );
+
+    const res = await request(app)
+      .get("/bills?bucket=due_soon")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0]).toMatchObject({
+      title: "A vencer",
+      operationalBucket: "due_soon",
+      status: "pending",
+    });
+  });
+
+  it("GET /bills?bucket=future retorna apenas pendentes futuras", async () => {
+    const token = await registerAndLogin("bills-bucket-future@test.dev");
+    const userId = await getUserIdByEmail("bills-bucket-future@test.dev");
+
+    await request(app)
+      .post("/bills")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ title: "A vencer", amount: 70, dueDate: DUE_SOON_DATE });
+
+    await dbQuery(
+      `INSERT INTO bills (user_id, title, amount, due_date) VALUES ($1, $2, $3, $4)`,
+      [userId, "Futura", 200, FUTURE_DATE],
+    );
+
+    const res = await request(app)
+      .get("/bills?bucket=future")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0]).toMatchObject({
+      title: "Futura",
+      operationalBucket: "future",
+      status: "pending",
+    });
+  });
+
+  it("GET /bills retorna 400 quando status e bucket sao enviados juntos", async () => {
+    const token = await registerAndLogin("bills-filter-ambiguous@test.dev");
+
+    const res = await request(app)
+      .get("/bills?status=pending&bucket=future")
+      .set("Authorization", `Bearer ${token}`);
+
+    expectErrorResponseWithRequestId(res, 400, "Use apenas um filtro: status ou bucket.");
   });
 
   // ─── Summary ─────────────────────────────────────────────────────────────────
@@ -378,6 +447,8 @@ describe("bills", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.bill).toMatchObject({ id: billId, status: "paid", isOverdue: false });
+    expect(res.body.bill.operationalBucket).toBe("paid");
+    expect(res.body.bill.daysUntilDue).toBeNull();
     expect(typeof res.body.bill.paidAt).toBe("string");
 
     // Transaction created

--- a/apps/api/src/routes/bills.routes.js
+++ b/apps/api/src/routes/bills.routes.js
@@ -43,6 +43,7 @@ router.get("/", async (req, res, next) => {
   try {
     const result = await listBillsByUser(req.user.id, {
       status: req.query.status,
+      bucket: req.query.bucket,
       limit: req.query.limit,
       offset: req.query.offset,
     });

--- a/apps/api/src/services/bills.service.js
+++ b/apps/api/src/services/bills.service.js
@@ -7,7 +7,9 @@ const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
 const TITLE_MAX_LENGTH = 200;
 const VALID_STATUS_FILTERS = new Set(["pending", "paid", "overdue"]);
+const VALID_BUCKET_FILTERS = new Set(["paid", "overdue", "due_soon", "future"]);
 const VALID_BILL_TYPES = new Set(["energy", "water", "rent", "internet", "phone", "gas", "other"]);
+const DUE_SOON_DAYS = 7;
 
 const createError = (status, message) => {
   const error = new Error(message);
@@ -151,6 +153,13 @@ const normalizeStatusFilter = (value) => {
   return lower;
 };
 
+const normalizeBucketFilter = (value) => {
+  if (typeof value === "undefined" || value === null || value === "") return undefined;
+  const lower = String(value).toLowerCase().trim();
+  if (!VALID_BUCKET_FILTERS.has(lower)) return undefined;
+  return lower;
+};
+
 const normalizePaidAt = (value) => {
   if (typeof value === "undefined" || value === null || value === "") return new Date();
   const parsed = new Date(value);
@@ -173,9 +182,67 @@ const normalizeOptionalImportSessionId = (value) => {
   return s || null;
 };
 
+const toDayStart = (value) => {
+  if (!value) return null;
+  if (typeof value === "string") {
+    if (ISO_DATE_REGEX.test(value)) {
+      const [year, month, day] = value.split("-").map(Number);
+      return new Date(year, month - 1, day);
+    }
+    const parsedDate = new Date(value);
+    if (Number.isNaN(parsedDate.getTime())) return null;
+    return new Date(parsedDate.getFullYear(), parsedDate.getMonth(), parsedDate.getDate());
+  }
+  const parsedDate = new Date(value);
+  if (Number.isNaN(parsedDate.getTime())) return null;
+  return new Date(parsedDate.getFullYear(), parsedDate.getMonth(), parsedDate.getDate());
+};
+
+const calculateDaysUntilDue = (dueDateValue, today = startOfToday()) => {
+  const dueDateStart = toDayStart(dueDateValue);
+  if (!dueDateStart) return null;
+  const millisecondsPerDay = 24 * 60 * 60 * 1000;
+  return Math.round((dueDateStart.getTime() - today.getTime()) / millisecondsPerDay);
+};
+
+const resolveOperationalBucket = ({ status, dueDateValue, today = startOfToday() }) => {
+  if (status === "paid") {
+    return "paid";
+  }
+
+  const daysUntilDue = calculateDaysUntilDue(dueDateValue, today);
+  if (daysUntilDue == null) {
+    return "future";
+  }
+
+  if (daysUntilDue < 0) {
+    return "overdue";
+  }
+
+  if (daysUntilDue <= DUE_SOON_DAYS) {
+    return "due_soon";
+  }
+
+  return "future";
+};
+
 // ─── Row mapping ──────────────────────────────────────────────────────────────
 
 const mapBillRow = (row) => ({
+  ...(() => {
+    const dueDateRaw = row.due_date;
+    const status = row.status;
+    const daysUntilDue = status === "pending" ? calculateDaysUntilDue(dueDateRaw) : null;
+    const operationalBucket = resolveOperationalBucket({
+      status,
+      dueDateValue: dueDateRaw,
+    });
+
+    return {
+      operationalBucket,
+      daysUntilDue,
+    };
+  })(),
   id: Number(row.id),
   userId: Number(row.user_id),
   title: row.title,
@@ -234,14 +301,31 @@ export const createBillForUser = async (userId, payload = {}) => {
 export const listBillsByUser = async (userId, filters = {}) => {
   const normalizedUserId = normalizeUserId(userId);
   const status = normalizeStatusFilter(filters.status);
+  const bucket = normalizeBucketFilter(filters.bucket);
   const limit = normalizePaginationLimit(filters.limit);
   const offset = normalizePaginationOffset(filters.offset);
+
+  if (status && bucket) {
+    throw createError(400, "Use apenas um filtro: status ou bucket.");
+  }
 
   const whereConditions = ["user_id = $1"];
   const params = [normalizedUserId];
   let paramIndex = 2;
 
-  if (status === "overdue") {
+  if (bucket === "paid") {
+    whereConditions.push(`status = 'paid'`);
+  } else if (bucket === "overdue") {
+    whereConditions.push(`status = 'pending'`);
+    whereConditions.push(`due_date < CURRENT_DATE`);
+  } else if (bucket === "due_soon") {
+    whereConditions.push(`status = 'pending'`);
+    whereConditions.push(`due_date >= CURRENT_DATE`);
+    whereConditions.push(`due_date <= CURRENT_DATE + INTERVAL '${DUE_SOON_DAYS} day'`);
+  } else if (bucket === "future") {
+    whereConditions.push(`status = 'pending'`);
+    whereConditions.push(`due_date > CURRENT_DATE + INTERVAL '${DUE_SOON_DAYS} day'`);
+  } else if (status === "overdue") {
     whereConditions.push(`status = 'pending'`);
     whereConditions.push(`due_date < CURRENT_DATE`);
   } else if (status === "pending" || status === "paid") {

--- a/apps/web/src/pages/BillsPage.test.tsx
+++ b/apps/web/src/pages/BillsPage.test.tsx
@@ -36,6 +36,8 @@ const buildBill = (overrides: Partial<Bill> = {}): Bill => ({
   dueDate: "2026-03-25",
   status: "pending",
   isOverdue: false,
+  operationalBucket: "future",
+  daysUntilDue: 20,
   categoryId: null,
   paidAt: null,
   notes: null,
@@ -108,7 +110,7 @@ describe("BillsPage", () => {
 
   it("exibe badge Vencida para bill com isOverdue true", async () => {
     vi.mocked(billsService.list).mockResolvedValue(
-      buildListResult([buildBill({ isOverdue: true })]),
+      buildListResult([buildBill({ isOverdue: true, operationalBucket: "overdue", daysUntilDue: -1 })]),
     );
 
     renderPage();
@@ -120,7 +122,14 @@ describe("BillsPage", () => {
 
   it("exibe badge Paga para bill com status paid", async () => {
     vi.mocked(billsService.list).mockResolvedValue(
-      buildListResult([buildBill({ status: "paid", paidAt: "2026-02-15T10:00:00.000Z" })]),
+      buildListResult([
+        buildBill({
+          status: "paid",
+          paidAt: "2026-02-15T10:00:00.000Z",
+          operationalBucket: "paid",
+          daysUntilDue: null,
+        }),
+      ]),
     );
 
     renderPage();
@@ -182,6 +191,35 @@ describe("BillsPage", () => {
     await waitFor(() => {
       expect(billsService.list).toHaveBeenCalledWith(
         expect.objectContaining({ status: "overdue" }),
+      );
+    });
+  });
+
+  it("exibe badge A vencer para bill com bucket due_soon", async () => {
+    vi.mocked(billsService.list).mockResolvedValue(
+      buildListResult([buildBill({ operationalBucket: "due_soon", daysUntilDue: 3 })]),
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("A vencer")).toBeInTheDocument();
+    });
+  });
+
+  it("clicar filtro A vencer chama list com status due_soon", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Conta de Agua")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "A vencer" }));
+
+    await waitFor(() => {
+      expect(billsService.list).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "due_soon" }),
       );
     });
   });

--- a/apps/web/src/pages/BillsPage.tsx
+++ b/apps/web/src/pages/BillsPage.tsx
@@ -39,23 +39,30 @@ const isCreditCardInvoice = (bill: Bill) => bill.billType === "credit_card_invoi
 // ─── Status badge ─────────────────────────────────────────────────────────────
 
 const BillStatusBadge = ({ bill }: { bill: Bill }): JSX.Element => {
-  if (bill.status === "paid") {
+  if (bill.operationalBucket === "paid") {
     return (
       <span className="whitespace-nowrap rounded px-2 py-0.5 text-xs font-semibold bg-green-100 text-green-700">
         Paga
       </span>
     );
   }
-  if (bill.isOverdue) {
+  if (bill.operationalBucket === "overdue") {
     return (
       <span className="whitespace-nowrap rounded border border-amber-200 bg-amber-50 px-2 py-0.5 text-xs font-semibold text-amber-700">
         Vencida
       </span>
     );
   }
+  if (bill.operationalBucket === "due_soon") {
+    return (
+      <span className="whitespace-nowrap rounded border border-blue-200 bg-blue-50 px-2 py-0.5 text-xs font-semibold text-blue-700">
+        A vencer
+      </span>
+    );
+  }
   return (
-    <span className="whitespace-nowrap rounded px-2 py-0.5 text-xs font-semibold bg-blue-100 text-blue-700">
-      Pendente
+    <span className="whitespace-nowrap rounded border border-slate-200 bg-slate-50 px-2 py-0.5 text-xs font-semibold text-slate-700">
+      Futura
     </span>
   );
 };
@@ -247,6 +254,8 @@ const BillsPage = ({
     { label: "Todos", value: undefined },
     { label: "Pendentes", value: "pending" },
     { label: "Vencidas", value: "overdue" },
+    { label: "A vencer", value: "due_soon" },
+    { label: "Futuras", value: "future" },
     { label: "Pagas", value: "paid" },
   ];
 

--- a/apps/web/src/services/bills.service.ts
+++ b/apps/web/src/services/bills.service.ts
@@ -3,7 +3,8 @@ import { api } from "./api";
 // ─── Public types ─────────────────────────────────────────────────────────────
 
 export type BillStatus = "pending" | "paid";
-export type BillStatusFilter = "pending" | "paid" | "overdue" | undefined;
+export type BillOperationalBucket = "paid" | "overdue" | "due_soon" | "future";
+export type BillStatusFilter = "pending" | "paid" | "overdue" | "due_soon" | "future" | undefined;
 export type MatchStatus = "unmatched" | "matched";
 
 export interface Bill {
@@ -14,6 +15,8 @@ export interface Bill {
   dueDate: string;
   status: BillStatus;
   isOverdue: boolean;
+  operationalBucket: BillOperationalBucket;
+  daysUntilDue: number | null;
   categoryId: number | null;
   paidAt: string | null;
   notes: string | null;
@@ -144,6 +147,10 @@ interface BillApiPayload {
   status?: unknown;
   isOverdue?: unknown;
   is_overdue?: unknown;
+  operationalBucket?: unknown;
+  operational_bucket?: unknown;
+  daysUntilDue?: unknown;
+  days_until_due?: unknown;
   categoryId?: unknown;
   category_id?: unknown;
   paidAt?: unknown;
@@ -178,21 +185,76 @@ const normalizeISOString = (value: unknown): string => {
   return "";
 };
 
+const toDayStart = (value: string): Date | null => {
+  if (!value) return null;
+  const [year, month, day] = value.split("-").map(Number);
+  if (!year || !month || !day) return null;
+  return new Date(year, month - 1, day);
+};
+
+const fallbackDaysUntilDue = (dueDate: string): number | null => {
+  const dueDateStart = toDayStart(dueDate);
+  if (!dueDateStart) return null;
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const millisecondsPerDay = 24 * 60 * 60 * 1000;
+  return Math.round((dueDateStart.getTime() - today.getTime()) / millisecondsPerDay);
+};
+
+const normalizeOperationalBucket = (
+  value: unknown,
+  fallback: BillOperationalBucket,
+): BillOperationalBucket => {
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
+  if (
+    normalized === "paid" ||
+    normalized === "overdue" ||
+    normalized === "due_soon" ||
+    normalized === "future"
+  ) {
+    return normalized;
+  }
+  return fallback;
+};
+
 const normalizeBill = (raw: BillApiPayload): Bill => {
   const id = Number(raw.id);
   const userId = Number(raw.userId ?? raw.user_id);
   const amount = Number(raw.amount);
   const categoryId = raw.categoryId ?? raw.category_id;
   const categoryIdNum = categoryId != null && categoryId !== "" ? Number(categoryId) : null;
+  const dueDate = normalizeISOString(raw.dueDate ?? raw.due_date);
+  const isOverdue = Boolean(raw.isOverdue ?? raw.is_overdue);
+  const status: BillStatus = raw.status === "paid" ? "paid" : "pending";
+  const normalizedDaysUntilDueRaw = Number(raw.daysUntilDue ?? raw.days_until_due);
+  const daysUntilDue =
+    status === "pending"
+      ? Number.isInteger(normalizedDaysUntilDueRaw)
+        ? normalizedDaysUntilDueRaw
+        : fallbackDaysUntilDue(dueDate)
+      : null;
+  const fallbackBucket: BillOperationalBucket =
+    status === "paid"
+      ? "paid"
+      : isOverdue
+        ? "overdue"
+        : daysUntilDue != null && daysUntilDue <= 7
+          ? "due_soon"
+          : "future";
 
   return {
     id: Number.isInteger(id) && id > 0 ? id : 0,
     userId: Number.isInteger(userId) && userId > 0 ? userId : 0,
     title: typeof raw.title === "string" ? raw.title.trim() : "",
     amount: Number.isFinite(amount) ? amount : 0,
-    dueDate: normalizeISOString(raw.dueDate ?? raw.due_date),
-    status: raw.status === "paid" ? "paid" : "pending",
-    isOverdue: Boolean(raw.isOverdue ?? raw.is_overdue),
+    dueDate,
+    status,
+    isOverdue,
+    operationalBucket: normalizeOperationalBucket(
+      raw.operationalBucket ?? raw.operational_bucket,
+      fallbackBucket,
+    ),
+    daysUntilDue,
     categoryId:
       categoryIdNum != null && Number.isInteger(categoryIdNum) && categoryIdNum > 0
         ? categoryIdNum
@@ -237,7 +299,13 @@ export const billsService = {
     offset?: number;
   } = {}): Promise<BillsListResult> => {
     const params: Record<string, string | number> = {};
-    if (opts.status) params.status = opts.status;
+    if (opts.status) {
+      if (opts.status === "due_soon" || opts.status === "future") {
+        params.bucket = opts.status;
+      } else {
+        params.status = opts.status;
+      }
+    }
     if (opts.limit != null) params.limit = opts.limit;
     if (opts.offset != null) params.offset = opts.offset;
 


### PR DESCRIPTION
## Contexto\nS6.3 da Sprint 6: consolidar bills como entidade operacional com buckets explícitos e leitura sem ambiguidade entre pendência e caixa liquidado.\n\n## Entregas\n- Bucket operacional em bills (API):\n  - paid, overdue, due_soon, uture\n- Campo daysUntilDue para pendências ativas\n- Filtro por ucket no endpoint GET /bills\n- Guard rail: retorna 400 se status e ucket forem enviados juntos\n- UI de bills com badge explícita:\n  - Paga, Vencida, A vencer, Futura\n- Novos filtros na página: A vencer e Futuras\n\n## Arquivos\n- pps/api/src/services/bills.service.js\n- pps/api/src/routes/bills.routes.js\n- pps/api/src/bills.test.js\n- pps/web/src/services/bills.service.ts\n- pps/web/src/pages/BillsPage.tsx\n- pps/web/src/pages/BillsPage.test.tsx\n\n## Validação local\n- 
pm -w apps/api run test -- src/bills.test.js\n- 
pm -w apps/web run test:run -- src/pages/BillsPage.test.tsx\n- 
pm -w apps/web run typecheck\n- 
pm -w apps/api run lint\n