### PR TITLE
docs(roadmap): iniciar Sprint 7 de conta corrente operacional

### DIFF
--- a/docs/roadmap-execution.md
+++ b/docs/roadmap-execution.md
@@ -388,7 +388,7 @@ Legenda de status:
 | Sprint | Foco | Status |
 |---|---|---|
 | Sprint 6 | Guard rails operacionais + parsers prioritários de documentos | ✅ |
-| Sprint 7 | Conta corrente operacional (saldo/limite/risco) | ⚪ |
+| Sprint 7 | Conta corrente operacional (saldo/limite/risco) | 🟡 |
 | Sprint 8 | Cartão, ciclo de fatura e conciliação | ⚪ |
 
 ### Fase 3 - Expansão estratégica
@@ -404,8 +404,9 @@ Legenda de status:
 - Sprint 4 fechada.
 - Sprint 5 concluida.
 - Sprint 6 concluida.
-- Sprint 7 passa a ser o proximo alvo operacional.
+- Sprint 7 iniciada.
 - Documento operacional da Sprint 6: `docs/roadmaps/sprint-6-guard-rails-documentais.md`.
+- Documento operacional da Sprint 7: `docs/roadmaps/sprint-7-conta-corrente-operacional.md`.
 - Documento operacional da Sprint 5: `docs/roadmaps/sprint-5-renda-confirmada.md`.
 - Evidencias da Sprint 5: PR #355, PR #356, PR #357, PR #358.
 - Evidencias da Sprint 6: PR #359, PR #360, PR #361, PR #362.

--- a/docs/roadmaps/sprint-7-conta-corrente-operacional.md
+++ b/docs/roadmaps/sprint-7-conta-corrente-operacional.md
@@ -1,0 +1,112 @@
+# Sprint 7 - Conta Corrente Operacional (Saldo, Limite e Risco)
+
+> Documento operacional para executar a Sprint 7 com foco em tornar conta corrente um modulo confiavel de operacao diaria, com leitura clara de saldo, uso de limite e risco real.
+
+Status: iniciada em 31/03/2026.
+
+---
+
+## 1. Objetivo
+
+Consolidar conta corrente como dominio operacional na Fase 2:
+
+- leitura consistente de saldo real e limite por conta
+- risco de uso de limite sem ambiguidade entre API, dashboard e insights
+- fluxo confiavel de cadastro, edicao e exclusao de contas
+- base pronta para acoplamento seguro com Sprint 8 (cartao/fatura), sem misturar escopo agora
+
+---
+
+## 2. Escopo
+
+### Em escopo
+
+- Fortalecer contrato de `bank_accounts` como fonte operacional de saldo e limite.
+- Alinhar resumo de conta corrente e sinal de risco entre `bank-accounts`, `forecast` e `ai`.
+- Melhorar consistencia de UX na leitura de posicao real e uso de limite.
+- Cobrir cenarios criticos com testes direcionados de API e Web.
+
+### Fora de escopo
+
+- Reabrir semantica da Sprint 6.
+- Expandir dominio de cartao/ciclo de fatura (Sprint 8).
+- Redesign amplo de dashboard fora do necessario para conta corrente operacional.
+- Mudancas fiscais da Central do Leao fora do recorte desta sprint.
+
+---
+
+## 3. Contrato funcional de aceite
+
+A Sprint 7 so fecha quando:
+
+1. Conta corrente apresenta saldo, limite total, limite usado e limite disponivel com semantica unica.
+2. Sinal de risco de limite e coerente entre API, widgets e painel de projecao.
+3. Operacoes de criar/editar/excluir conta funcionam com validacoes e mensagens operacionais claras.
+4. Nao ha dupla contagem ou conflito de leitura entre configuracao legada de limite e contas bancarias.
+5. API e UI mantem leitura coerente do estado operacional sem ambiguidades.
+
+---
+
+## 4. Mapa tecnico inicial
+
+### Backend
+
+- apps/api/src/services/bank-accounts.service.js
+- apps/api/src/routes/bank-accounts.routes.js
+- apps/api/src/services/forecast.service.js
+- apps/api/src/services/ai.service.js
+- apps/api/src/forecast.test.js
+- apps/api/src/ai.test.js
+
+### Frontend
+
+- apps/web/src/components/BankAccountsWidget.tsx
+- apps/web/src/services/bank-accounts.service.ts
+- apps/web/src/components/ForecastCard.tsx
+- apps/web/src/pages/ProfileSettings.tsx
+- apps/web/src/services/forecast.service.ts
+
+---
+
+## 5. Plano de execucao em slices
+
+### Slice S7.1 - Contrato operacional de conta corrente
+
+- Definir e reforcar fonte de verdade para saldo/limite por conta.
+- Tratar convivencia com sinal legado de limite sem quebrar compatibilidade.
+- Resultado esperado: contrato semantico unico para conta corrente.
+
+### Slice S7.2 - Leitura operacional no frontend
+
+- Ajustar superficies de conta corrente e projecao para mensagem consistente de risco.
+- Tornar status de uso de limite evidente para tomada de decisao.
+- Resultado esperado: UX de conta corrente confiavel e acionavel.
+
+### Slice S7.3 - Guard rails e consistencia de risco
+
+- Cobrir cenarios de borda (limite em uso, limite esgotado, sem limite, saldo positivo).
+- Garantir coerencia entre calculo de risco em forecast e insight de IA.
+- Resultado esperado: sem divergencia entre servicos e widgets.
+
+### Slice S7.4 - Hardening, smoke e fechamento executivo
+
+- Rodar lint, typecheck e suites direcionadas.
+- Atualizar roadmap para status de conclusao quando criterios forem cumpridos.
+- Resultado esperado: PR final da Sprint 7 pronto para merge com CI verde.
+
+---
+
+## 6. Dependencias e riscos
+
+- Pendencias manuais externas continuam rastreadas (PR #348 visual e OAuth E2E).
+- Mudancas devem respeitar contrato semantico de `docs/architecture/v1.6.12-financial-semantics-contract.md`.
+- Evitar acoplamento com Sprint 8 durante a Sprint 7.
+
+---
+
+## 7. Definition of Done da Sprint 7
+
+- Criterios funcionais da secao 3 cumpridos.
+- CI dos PRs da Sprint 7 fechado em verde.
+- Evidencias de testes e smoke anexadas nos PRs.
+- Roadmap executivo atualizado movendo Sprint 7 para concluida e Sprint 8 para proximo alvo.


### PR DESCRIPTION
## Contexto\nKickoff documental da Sprint 7 apos fechamento completo da Sprint 6.\n\n## O que entra\n- cria documento operacional da Sprint 7\n- atualiza roadmap executivo para marcar Sprint 7 como iniciada\n- registra referencia ao novo documento no bloco de decisao executiva\n\n## Arquivos\n- docs/roadmaps/sprint-7-conta-corrente-operacional.md\n- docs/roadmap-execution.md\n\n## Escopo da Sprint 7\nConta corrente operacional (saldo/limite/risco) em slices S7.1-S7.4, sem acoplamento com Sprint 8.\n