### PR TITLE
fix(forecast): S7.1 fonte unica de limite operacional

### DIFF
--- a/apps/api/src/forecast.test.js
+++ b/apps/api/src/forecast.test.js
@@ -342,6 +342,35 @@ describe("computeForecast — flip detection (deterministic)", () => {
     expect(result.bankLimit.alertTriggered).toBe(true);
   });
 
+  it("prioriza limite de bank_accounts sobre bank_limit_total legado quando ha contas ativas", async () => {
+    await registerAndLogin("fc-bank-limit-priority@test.dev");
+    const userId = await getUserIdByEmail("fc-bank-limit-priority@test.dev");
+
+    await dbQuery(
+      `INSERT INTO user_profiles (user_id, bank_limit_total)
+       VALUES ($1, 5000)`,
+      [userId],
+    );
+
+    await dbQuery(
+      `INSERT INTO bank_accounts (user_id, name, balance, limit_total)
+       VALUES ($1, 'Conta principal', 0, 1000)`,
+      [userId],
+    );
+
+    await dbQuery(
+      `INSERT INTO transactions (user_id, type, value, date)
+       VALUES ($1, 'Saida', 500, $2)`,
+      [userId, FIXED_MONTH_START],
+    );
+
+    const result = await computeForecast(userId, { now: FIXED_NOW });
+
+    expect(result.bankLimit).toMatchObject({
+      total: 1000,
+    });
+  });
+
   it("getLatestForecast retorna null antes do primeiro compute", async () => {
     await registerAndLogin("fc-get-null-svc@test.dev");
     const userId = await getUserIdByEmail("fc-get-null-svc@test.dev");
@@ -360,6 +389,31 @@ describe("computeForecast — flip detection (deterministic)", () => {
     expect(result).not.toBeNull();
     expect(result.month).toBe(FIXED_MONTH);
     expect(typeof result.projectedBalance).toBe("number");
+  });
+
+  it("getLatestForecast prioriza limite de contas ativas sobre valor legado do perfil", async () => {
+    await registerAndLogin("fc-get-bank-limit-priority@test.dev");
+    const userId = await getUserIdByEmail("fc-get-bank-limit-priority@test.dev");
+
+    await dbQuery(
+      `INSERT INTO user_profiles (user_id, bank_limit_total)
+       VALUES ($1, 900)`,
+      [userId],
+    );
+
+    await dbQuery(
+      `INSERT INTO bank_accounts (user_id, name, balance, limit_total)
+       VALUES ($1, 'Conta operacional', 100, 250)`,
+      [userId],
+    );
+
+    await computeForecast(userId, { now: FIXED_NOW });
+
+    const result = await getLatestForecast(userId, { now: FIXED_NOW });
+
+    expect(result.bankLimit).toMatchObject({
+      total: 250,
+    });
   });
 });
 

--- a/apps/api/src/services/forecast.service.js
+++ b/apps/api/src/services/forecast.service.js
@@ -116,7 +116,7 @@ export const computeForecast = async (userId, { now = new Date() } = {}) => {
   const salaryMonthly =
     profile?.salary_monthly != null ? Number(profile.salary_monthly) : null;
   const payday = profile?.payday != null ? Number(profile.payday) : null;
-  const bankLimitTotal =
+  const profileBankLimitTotal =
     profile?.bank_limit_total != null ? Number(profile.bank_limit_total) : null;
 
   // 2. Realized month totals (up to today only)
@@ -139,6 +139,7 @@ export const computeForecast = async (userId, { now = new Date() } = {}) => {
   const bankBalanceResult = await dbQuery(
     `SELECT
        COALESCE(SUM(balance), 0)::numeric AS total_balance,
+       COALESCE(SUM(limit_total), 0)::numeric AS total_limit_total,
        COUNT(*)::int AS active_accounts_count
      FROM bank_accounts
      WHERE user_id = $1
@@ -146,7 +147,10 @@ export const computeForecast = async (userId, { now = new Date() } = {}) => {
     [uid],
   );
   const totalBankBalance = Number(bankBalanceResult.rows[0]?.total_balance || 0);
+  const totalBankLimitTotal = Number(bankBalanceResult.rows[0]?.total_limit_total || 0);
   const activeAccountsCount = Number(bankBalanceResult.rows[0]?.active_accounts_count || 0);
+  const effectiveBankLimitTotal =
+    activeAccountsCount > 0 ? totalBankLimitTotal : profileBankLimitTotal;
 
   // 3. Daily average spending over last 60 realized days (up to today)
   const sixtyDaysAgo = daysAgoStr(now, 60);
@@ -267,7 +271,7 @@ export const computeForecast = async (userId, { now = new Date() } = {}) => {
     billsPendingTotal: Number(billsTotal.toFixed(2)),
     billsPendingCount: billsCount,
     adjustedProjectedBalance,
-    bankLimit: buildBankLimitProjection(bankLimitTotal, adjustedProjectedBalance),
+    bankLimit: buildBankLimitProjection(effectiveBankLimitTotal, adjustedProjectedBalance),
   };
 };
 
@@ -295,12 +299,27 @@ export const getLatestForecast = async (userId, { now = new Date() } = {}) => {
     `SELECT bank_limit_total FROM user_profiles WHERE user_id = $1 LIMIT 1`,
     [uid],
   );
-  const bankLimitTotal =
+  const profileBankLimitTotal =
     profileResult.rows[0]?.bank_limit_total != null
       ? Number(profileResult.rows[0].bank_limit_total)
       : null;
+
+  const bankLimitResult = await dbQuery(
+    `SELECT
+       COALESCE(SUM(limit_total), 0)::numeric AS total_limit_total,
+       COUNT(*)::int AS active_accounts_count
+     FROM bank_accounts
+     WHERE user_id = $1
+       AND is_active = true`,
+    [uid],
+  );
+  const totalBankLimitTotal = Number(bankLimitResult.rows[0]?.total_limit_total || 0);
+  const activeAccountsCount = Number(bankLimitResult.rows[0]?.active_accounts_count || 0);
+  const effectiveBankLimitTotal =
+    activeAccountsCount > 0 ? totalBankLimitTotal : profileBankLimitTotal;
+
   forecast.bankLimit = buildBankLimitProjection(
-    bankLimitTotal,
+    effectiveBankLimitTotal,
     forecast.adjustedProjectedBalance,
   );
   return forecast;


### PR DESCRIPTION
Contexto: Slice S7.1 da Sprint 7 (conta corrente operacional). Problema: forecast usava bank_limit_total do perfil mesmo com contas ativas em bank_accounts. Entrega: prioriza soma de limit_total das contas ativas e usa valor do perfil apenas como fallback legado; aplica regra em computeForecast e getLatestForecast; adiciona testes de precedencia. Validacao local: npm -w apps/api run test -- src/forecast.test.js; npm -w apps/api run lint.