### PR TITLE
feat(web): S7.2 leitura operacional de conta corrente

### DIFF
--- a/apps/web/src/components/BankAccountsWidget.test.tsx
+++ b/apps/web/src/components/BankAccountsWidget.test.tsx
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import BankAccountsWidget from "./BankAccountsWidget";
+import { DiscreetModeProvider } from "../context/DiscreetModeContext";
+import {
+  bankAccountsService,
+  type BankAccountItem,
+  type BankAccountsSummary,
+} from "../services/bank-accounts.service";
+import { aiService } from "../services/ai.service";
+
+vi.mock("../services/bank-accounts.service", () => ({
+  bankAccountsService: {
+    list: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("../services/ai.service", () => ({
+  aiService: {
+    getBankAccountInsight: vi.fn(),
+  },
+}));
+
+const buildAccount = (overrides: Partial<BankAccountItem> = {}): BankAccountItem => ({
+  id: 1,
+  userId: 1,
+  name: "Conta principal",
+  bankName: "Banco A",
+  balance: 100,
+  limitTotal: 1000,
+  limitUsed: 0,
+  limitAvailable: 1000,
+  isActive: true,
+  createdAt: "2026-03-31T00:00:00.000Z",
+  updatedAt: "2026-03-31T00:00:00.000Z",
+  ...overrides,
+});
+
+const buildSummary = (overrides: Partial<BankAccountsSummary> = {}): BankAccountsSummary => ({
+  totalBalance: 100,
+  totalLimitTotal: 1000,
+  totalLimitUsed: 0,
+  totalLimitAvailable: 1000,
+  accountsCount: 1,
+  ...overrides,
+});
+
+const renderWidget = () =>
+  render(
+    <DiscreetModeProvider>
+      <BankAccountsWidget />
+    </DiscreetModeProvider>,
+  );
+
+describe("BankAccountsWidget", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(aiService.getBankAccountInsight).mockResolvedValue(null);
+    vi.mocked(bankAccountsService.list).mockResolvedValue({
+      accounts: [buildAccount()],
+      summary: buildSummary(),
+    });
+  });
+
+  it("exibe status operacional por conta (Sem uso, Em uso, Excedido)", async () => {
+    vi.mocked(bankAccountsService.list).mockResolvedValue({
+      accounts: [
+        buildAccount({ id: 1, name: "Conta 1", balance: 400, limitTotal: 1000, limitUsed: 0, limitAvailable: 1000 }),
+        buildAccount({ id: 2, name: "Conta 2", balance: -200, limitTotal: 1000, limitUsed: 200, limitAvailable: 800 }),
+        buildAccount({ id: 3, name: "Conta 3", balance: -1200, limitTotal: 1000, limitUsed: 1000, limitAvailable: 0 }),
+      ],
+      summary: buildSummary({
+        totalBalance: -1000,
+        totalLimitTotal: 3000,
+        totalLimitUsed: 1200,
+        totalLimitAvailable: 1800,
+        accountsCount: 3,
+      }),
+    });
+
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText("3 contas cadastradas")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Sem uso")).toBeInTheDocument();
+    expect(screen.getByText("Em uso")).toBeInTheDocument();
+    expect(screen.getByText("Excedido")).toBeInTheDocument();
+  });
+
+  it("resume limite como esgotado quando uso total atinge o limite", async () => {
+    vi.mocked(bankAccountsService.list).mockResolvedValue({
+      accounts: [
+        buildAccount({ id: 1, balance: -1000, limitTotal: 1000, limitUsed: 1000, limitAvailable: 0 }),
+      ],
+      summary: buildSummary({
+        totalBalance: -1000,
+        totalLimitTotal: 1000,
+        totalLimitUsed: 1000,
+        totalLimitAvailable: 0,
+        accountsCount: 1,
+      }),
+    });
+
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText("Limite esgotado")).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/BankAccountsWidget.tsx
+++ b/apps/web/src/components/BankAccountsWidget.tsx
@@ -29,12 +29,32 @@ interface ModalState {
   editing: BankAccountItem | null;
 }
 
-const statusOf = (account: BankAccountItem) => {
-  if (account.limitUsed > 0 && account.limitUsed >= account.limitTotal && account.limitTotal > 0) {
-    return "critical";
+type OperationalLimitStatus = "unused" | "using" | "exceeded";
+
+const resolveAccountLimitStatus = (account: BankAccountItem): OperationalLimitStatus => {
+  if (account.limitTotal <= 0) {
+    return account.balance < 0 ? "exceeded" : "unused";
   }
-  if (account.balance < 0) return "limit_in_use";
-  return "healthy";
+  if (account.limitUsed >= account.limitTotal && account.limitUsed > 0) {
+    return "exceeded";
+  }
+  if (account.limitUsed > 0) {
+    return "using";
+  }
+  return "unused";
+};
+
+const resolveSummaryLimitStatus = (summary: BankAccountsSummary): OperationalLimitStatus => {
+  if (summary.totalLimitTotal <= 0) {
+    return summary.totalBalance < 0 ? "exceeded" : "unused";
+  }
+  if (summary.totalLimitUsed >= summary.totalLimitTotal && summary.totalLimitUsed > 0) {
+    return "exceeded";
+  }
+  if (summary.totalLimitUsed > 0) {
+    return "using";
+  }
+  return "unused";
 };
 
 const BankAccountsWidget = (): JSX.Element => {
@@ -171,7 +191,19 @@ const BankAccountsWidget = (): JSX.Element => {
   }
 
   const hasAccounts = summary.accountsCount > 0;
-  const usingLimit = summary.totalLimitUsed > 0;
+  const limitStatus = resolveSummaryLimitStatus(summary);
+  const isLimitUsing = limitStatus === "using";
+  const isLimitExceeded = limitStatus === "exceeded";
+  const limitTone = isLimitExceeded
+    ? "text-red-600"
+    : isLimitUsing
+      ? "text-amber-700"
+      : "text-cf-text-primary";
+  const limitSupportTone = isLimitExceeded
+    ? "text-red-600"
+    : isLimitUsing
+      ? "text-amber-700"
+      : "text-cf-text-secondary";
 
   return (
     <>
@@ -224,19 +256,17 @@ const BankAccountsWidget = (): JSX.Element => {
                 <p className="text-xs font-medium uppercase text-cf-text-secondary">
                   Limite disponível
                 </p>
-                <p
-                  className={`text-sm font-semibold ${
-                    usingLimit ? "text-amber-700" : "text-cf-text-primary"
-                  }`}
-                >
+                <p className={`text-sm font-semibold ${limitTone}`}>
                   {money(summary.totalLimitAvailable)}
                 </p>
-                <p
-                  className={`text-xs ${usingLimit ? "text-amber-700" : "text-cf-text-secondary"}`}
-                >
-                  {usingLimit
-                    ? `${money(summary.totalLimitUsed)} em uso`
-                    : `de ${money(summary.totalLimitTotal)} total`}
+                <p className={`text-xs ${limitSupportTone}`}>
+                  {isLimitExceeded
+                    ? "Limite esgotado"
+                    : isLimitUsing
+                      ? `${money(summary.totalLimitUsed)} em uso`
+                      : summary.totalLimitTotal > 0
+                        ? `de ${money(summary.totalLimitTotal)} total`
+                        : "Sem limite configurado"}
                 </p>
               </div>
 
@@ -282,7 +312,15 @@ const BankAccountsWidget = (): JSX.Element => {
             {/* Account list */}
             <div className="space-y-2">
               {accounts.map((account) => {
-                const status = statusOf(account);
+                const status = resolveAccountLimitStatus(account);
+                const statusLabel =
+                  status === "exceeded"
+                    ? "Excedido"
+                    : status === "using"
+                      ? "Em uso"
+                      : account.limitTotal > 0
+                        ? "Sem uso"
+                        : "Sem limite";
                 return (
                   <div
                     key={account.id}
@@ -292,9 +330,9 @@ const BankAccountsWidget = (): JSX.Element => {
                       <div className="flex items-center gap-1.5">
                         <span
                           className={`inline-block h-2 w-2 rounded-full flex-shrink-0 ${
-                            status === "critical"
+                            status === "exceeded"
                               ? "bg-red-500"
-                              : status === "limit_in_use"
+                              : status === "using"
                                 ? "bg-amber-500"
                                 : "bg-emerald-500"
                           }`}
@@ -307,6 +345,17 @@ const BankAccountsWidget = (): JSX.Element => {
                             · {account.bankName}
                           </p>
                         ) : null}
+                        <span
+                          className={`rounded border px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide ${
+                            status === "exceeded"
+                              ? "border-red-200 bg-red-50 text-red-700"
+                              : status === "using"
+                                ? "border-amber-200 bg-amber-50 text-amber-700"
+                                : "border-emerald-200 bg-emerald-50 text-emerald-700"
+                          }`}
+                        >
+                          {statusLabel}
+                        </span>
                       </div>
                       <p
                         className={`mt-0.5 text-xs ${


### PR DESCRIPTION
Contexto: Slice S7.2 da Sprint 7 para alinhar leitura de risco de limite entre superfícies de conta corrente e projeção. Entrega: BankAccountsWidget agora usa semântica operacional padronizada (unused, using, exceeded), destaca limite esgotado com tom crítico, explicita status por conta (Sem uso, Em uso, Excedido/Sem limite) e mantém mensagem de resumo coerente com ForecastCard. Testes: novo arquivo BankAccountsWidget.test.tsx cobrindo status por conta e resumo de limite esgotado. Validação local: npm -w apps/web run test:run -- src/components/BankAccountsWidget.test.tsx src/components/ForecastCard.test.tsx; npm -w apps/web run typecheck; npm -w apps/web run lint.