### PR TITLE
fix(ai): S7.3 guard rails de risco de conta corrente

### DIFF
--- a/apps/api/src/ai.test.js
+++ b/apps/api/src/ai.test.js
@@ -321,6 +321,27 @@ describe("GET /ai/bank-account-insight", () => {
     expect(mockCreate).toHaveBeenCalledOnce();
   });
 
+  it("retorna type success quando conta esta positiva e sem limite configurado", async () => {
+    const token = await registerAndLogin("bank-insight-no-limit-positive@test.dev");
+
+    await request(app)
+      .post("/bank-accounts")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Conta", balance: 300, limitTotal: 0 });
+
+    mockCreate.mockResolvedValueOnce(
+      buildMockAnthropicResponse("Conta positiva e sem uso de limite. Cenário estável no momento.")
+    );
+
+    const res = await request(app)
+      .get("/ai/bank-account-insight")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.type).toBe("success");
+    expect(res.body.riskLabel).toBe("saudável");
+  });
+
   it("retorna type warning e riskLabel pressionada quando conta usa limite", async () => {
     const token = await registerAndLogin("bank-insight-warning@test.dev");
 
@@ -354,6 +375,27 @@ describe("GET /ai/bank-account-insight", () => {
 
     mockCreate.mockResolvedValueOnce(
       buildMockAnthropicResponse("Limite esgotado. Priorize quitar o saldo negativo antes de qualquer gasto.")
+    );
+
+    const res = await request(app)
+      .get("/ai/bank-account-insight")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.type).toBe("critical");
+    expect(res.body.riskLabel).toBe("no limite");
+  });
+
+  it("retorna type critical quando saldo fica negativo sem limite configurado", async () => {
+    const token = await registerAndLogin("bank-insight-no-limit-negative@test.dev");
+
+    await request(app)
+      .post("/bank-accounts")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Conta", balance: -120, limitTotal: 0 });
+
+    mockCreate.mockResolvedValueOnce(
+      buildMockAnthropicResponse("Saldo negativo sem limite configurado. Priorize recompor caixa imediatamente.")
     );
 
     const res = await request(app)

--- a/apps/api/src/services/ai.service.js
+++ b/apps/api/src/services/ai.service.js
@@ -158,6 +158,7 @@ const BANK_INSIGHT_SYSTEM =
   "Você é o Especialista Financeiro do app Control Finance. Analise a situação da conta corrente e retorne UMA frase de no máximo 160 caracteres explicando o que o usuário deve saber agora. Seja direto e prático, sem jargão. Retorne APENAS o texto, sem formatação, sem aspas, sem JSON.";
 
 const classifyBankRisk = (summary, accounts) => {
+  if (summary.totalLimitTotal <= 0 && summary.totalBalance < 0) return "critical";
   if (accounts.some((a) => a.limitTotal > 0 && a.limitUsed >= a.limitTotal)) return "critical";
   if (summary.totalLimitUsed > 0 || summary.totalBalance < 0) return "warning";
   return "success";


### PR DESCRIPTION
Contexto: Slice S7.3 da Sprint 7 para eliminar divergência de risco em cenários de borda no insight de conta corrente. Entrega: classificação de risco bancário agora trata saldo negativo sem limite configurado como crítico; mantidos comportamentos para limite em uso/esgotado e conta saudável. Testes: adicionados casos de regressão para sem limite com saldo positivo (success) e sem limite com saldo negativo (critical). Validação local: npm -w apps/api run test -- src/ai.test.js; npm -w apps/api run lint.