### PR TITLE
docs(roadmap): S7.4 hardening e fechamento da Sprint 7

### DIFF
--- a/docs/roadmap-execution.md
+++ b/docs/roadmap-execution.md
@@ -388,7 +388,7 @@ Legenda de status:
 | Sprint | Foco | Status |
 |---|---|---|
 | Sprint 6 | Guard rails operacionais + parsers prioritários de documentos | ✅ |
-| Sprint 7 | Conta corrente operacional (saldo/limite/risco) | 🟡 |
+| Sprint 7 | Conta corrente operacional (saldo/limite/risco) | ✅ |
 | Sprint 8 | Cartão, ciclo de fatura e conciliação | ⚪ |
 
 ### Fase 3 - Expansão estratégica
@@ -404,12 +404,14 @@ Legenda de status:
 - Sprint 4 fechada.
 - Sprint 5 concluida.
 - Sprint 6 concluida.
-- Sprint 7 iniciada.
+- Sprint 7 concluida.
+- Sprint 8 passa a ser o proximo alvo operacional.
 - Documento operacional da Sprint 6: `docs/roadmaps/sprint-6-guard-rails-documentais.md`.
 - Documento operacional da Sprint 7: `docs/roadmaps/sprint-7-conta-corrente-operacional.md`.
 - Documento operacional da Sprint 5: `docs/roadmaps/sprint-5-renda-confirmada.md`.
 - Evidencias da Sprint 5: PR #355, PR #356, PR #357, PR #358.
 - Evidencias da Sprint 6: PR #359, PR #360, PR #361, PR #362.
+- Evidencias da Sprint 7: PR #364, PR #365, PR #366, PR #367.
 - Pendências manuais continuam rastreadas fora de CI (prova visual do PR #348 e validação E2E real do OAuth).
 
 ---

--- a/docs/roadmaps/sprint-7-conta-corrente-operacional.md
+++ b/docs/roadmaps/sprint-7-conta-corrente-operacional.md
@@ -2,7 +2,28 @@
 
 > Documento operacional para executar a Sprint 7 com foco em tornar conta corrente um modulo confiavel de operacao diaria, com leitura clara de saldo, uso de limite e risco real.
 
-Status: iniciada em 31/03/2026.
+Status: concluida em 31/03/2026.
+
+---
+
+## 0. Entregas executadas
+
+### PRs da Sprint 7
+
+1. PR #364 - kickoff documental da sprint
+2. PR #365 - S7.1 (fonte de verdade operacional para limite no forecast)
+3. PR #366 - S7.2 (leitura operacional de risco no frontend)
+4. PR #367 - S7.3 (guard rails de risco no insight de conta)
+5. PR final S7.4 (este PR) - hardening e fechamento executivo
+
+### Evidencia de validacao final (S7.4)
+
+- Lint monorepo: `npm run lint`
+- Typecheck web: `npm run typecheck`
+- API testes direcionados: `npm -w apps/api run test -- src/forecast.test.js src/ai.test.js`
+- Web testes direcionados: `npm -w apps/web run test:run -- src/components/BankAccountsWidget.test.tsx src/components/ForecastCard.test.tsx`
+
+Todos os comandos acima concluiram com sucesso.
 
 ---
 


### PR DESCRIPTION
Contexto: fechamento da Slice S7.4 da Sprint 7 (hardening, smoke e atualização executiva do roadmap). Entrega: marca Sprint 7 como concluída no roadmap executivo, registra Sprint 8 como próximo alvo operacional e atualiza documento operacional da Sprint 7 com PRs e evidências de validação final. Evidências S7.4: npm run lint; npm run typecheck; npm -w apps/api run test -- src/forecast.test.js src/ai.test.js; npm -w apps/web run test:run -- src/components/BankAccountsWidget.test.tsx src/components/ForecastCard.test.tsx. Todos concluíram com sucesso localmente.