### PR TITLE
docs(roadmap): iniciar Sprint 8 de cartao e ciclo

### DIFF
--- a/docs/roadmap-execution.md
+++ b/docs/roadmap-execution.md
@@ -389,7 +389,7 @@ Legenda de status:
 |---|---|---|
 | Sprint 6 | Guard rails operacionais + parsers prioritários de documentos | ✅ |
 | Sprint 7 | Conta corrente operacional (saldo/limite/risco) | ✅ |
-| Sprint 8 | Cartão, ciclo de fatura e conciliação | ⚪ |
+| Sprint 8 | Cartão, ciclo de fatura e conciliação | 🟡 |
 
 ### Fase 3 - Expansão estratégica
 
@@ -405,9 +405,10 @@ Legenda de status:
 - Sprint 5 concluida.
 - Sprint 6 concluida.
 - Sprint 7 concluida.
-- Sprint 8 passa a ser o proximo alvo operacional.
+- Sprint 8 iniciada.
 - Documento operacional da Sprint 6: `docs/roadmaps/sprint-6-guard-rails-documentais.md`.
 - Documento operacional da Sprint 7: `docs/roadmaps/sprint-7-conta-corrente-operacional.md`.
+- Documento operacional da Sprint 8: `docs/roadmaps/sprint-8-cartao-ciclo-conciliacao.md`.
 - Documento operacional da Sprint 5: `docs/roadmaps/sprint-5-renda-confirmada.md`.
 - Evidencias da Sprint 5: PR #355, PR #356, PR #357, PR #358.
 - Evidencias da Sprint 6: PR #359, PR #360, PR #361, PR #362.

--- a/docs/roadmaps/sprint-8-cartao-ciclo-conciliacao.md
+++ b/docs/roadmaps/sprint-8-cartao-ciclo-conciliacao.md
@@ -1,0 +1,113 @@
+# Sprint 8 - Cartao, Ciclo de Fatura e Conciliacao
+
+> Documento operacional para executar a Sprint 8 com foco em tornar o dominio de cartao totalmente confiavel no ciclo de fatura, no caixa e na conciliacao com pendencias.
+
+Status: iniciada em 31/03/2026.
+
+---
+
+## 1. Objetivo
+
+Fechar o modulo de cartao como operacao financeira real na Fase 2:
+
+- consolidar semantica unica para compra aberta, fatura pendente e fatura paga
+- garantir fechamento/reabertura de ciclo sem efeitos duplicados no caixa
+- reforcar conciliacao entre fatura, bill e movimentos derivados
+- manter API e UI com leitura operacional clara de limite, ciclo e risco
+
+---
+
+## 2. Escopo
+
+### Em escopo
+
+- Fortalecer regras de ciclo de fatura (close/reopen) e seus guard rails.
+- Consolidar uso de `credit_card_invoice` como entidade operacional no fluxo de bills.
+- Melhorar leitura de cartao no frontend para ciclo, limite e pendencias.
+- Cobrir cenarios criticos de conciliacao com testes direcionados de API e Web.
+
+### Fora de escopo
+
+- Reabrir semantica da Sprint 7.
+- Expandir funcionalidades fiscais da Central do Leao.
+- Redesign amplo de dashboard fora do necessario para cartao/ciclo.
+- Novas frentes estrategicas da Fase 3 durante a Sprint 8.
+
+---
+
+## 3. Contrato funcional de aceite
+
+A Sprint 8 so fecha quando:
+
+1. Compra em cartao nao vira saida de caixa imediata antes da fatura.
+2. Fatura pendente vira obrigacao operacional explicita e auditavel.
+3. Pagamento de fatura liquida obrigacao sem duplicar efeito financeiro.
+4. Fechamento/reabertura de fatura respeita guard rails e ownership do usuario.
+5. API e UI mantem leitura coerente de limite, ciclo e status sem ambiguidades.
+
+---
+
+## 4. Mapa tecnico inicial
+
+### Backend
+
+- apps/api/src/services/credit-cards.service.js
+- apps/api/src/services/credit-card-invoices.service.js
+- apps/api/src/routes/credit-cards.routes.js
+- apps/api/src/services/bills.service.js
+- apps/api/src/credit-cards.test.js
+- apps/api/src/credit-card-invoices.test.js
+
+### Frontend
+
+- apps/web/src/pages/CreditCardsPage.tsx
+- apps/web/src/pages/CreditCardsPage.test.tsx
+- apps/web/src/components/CreditCardsSummaryWidget.tsx
+- apps/web/src/components/CreditCardsSummaryWidget.test.tsx
+- apps/web/src/components/CreditCardPurchaseModal.tsx
+- apps/web/src/services/credit-cards.service.ts
+
+---
+
+## 5. Plano de execucao em slices
+
+### Slice S8.1 - Contrato de ciclo e fatura
+
+- Revisar regras de fechamento/reabertura e consistencia de status de fatura.
+- Endurecer cenarios de ownership e conflito de ciclo.
+- Resultado esperado: ciclo deterministico e sem efeitos ambiguos.
+
+### Slice S8.2 - Leitura operacional no frontend de cartao
+
+- Tornar status de ciclo, limite e pendencias mais explicitos.
+- Alinhar resumo de cartao com leitura de decisao operacional.
+- Resultado esperado: UX de cartao confiavel e acionavel.
+
+### Slice S8.3 - Guard rails de conciliacao
+
+- Reforcar vinculo entre invoice, bill e compras abertas.
+- Cobrir bordas de duplicidade/sumico no fluxo de conciliacao.
+- Resultado esperado: conciliacao segura ponta a ponta.
+
+### Slice S8.4 - Hardening, smoke e fechamento executivo
+
+- Rodar lint, typecheck e suites direcionadas.
+- Atualizar roadmap para status de conclusao quando criterios forem cumpridos.
+- Resultado esperado: PR final da Sprint 8 pronto para merge com CI verde.
+
+---
+
+## 6. Dependencias e riscos
+
+- Pendencias manuais externas continuam rastreadas (PR #348 visual e OAuth E2E).
+- Mudancas devem respeitar contrato semantico de `docs/architecture/v1.6.12-financial-semantics-contract.md`.
+- Evitar acoplamento com Sprint 9 durante a Sprint 8.
+
+---
+
+## 7. Definition of Done da Sprint 8
+
+- Criterios funcionais da secao 3 cumpridos.
+- CI dos PRs da Sprint 8 fechado em verde.
+- Evidencias de testes e smoke anexadas nos PRs.
+- Roadmap executivo atualizado movendo Sprint 8 para concluida e Sprint 9 para proximo alvo.


### PR DESCRIPTION
Contexto: kickoff da Sprint 8 apos fechamento completo da Sprint 7. Entrega: cria documento operacional da Sprint 8 e atualiza roadmap executivo para marcar Sprint 8 como iniciada. Arquivos: docs/roadmaps/sprint-8-cartao-ciclo-conciliacao.md e docs/roadmap-execution.md.