### PR TITLE
fix(credit-cards): ciclo de fechamento deterministico em meses curtos

### DIFF
--- a/apps/api/src/credit-cards.test.js
+++ b/apps/api/src/credit-cards.test.js
@@ -243,6 +243,59 @@ describe("credit cards", () => {
     expectErrorResponseWithRequestId(closeRes, 409, "Ainda nao chegou o dia de fechamento deste cartao.");
   });
 
+  it("POST /credit-cards/:id/close-invoice usa ultimo dia do mes quando fechamento configurado excede o calendario", async () => {
+    const token = await registerAndLogin("credit-cards-close-clamped-day@test.dev");
+
+    const createCardRes = await request(app)
+      .post("/credit-cards")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        name: "Cartao 31",
+        limitTotal: 2000,
+        closingDay: 31,
+        dueDay: 10,
+      });
+
+    const cardId = createCardRes.body.id;
+
+    await request(app)
+      .post(`/credit-cards/${cardId}/purchases`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        title: "Mercado",
+        amount: 200,
+        purchaseDate: "2026-04-10",
+      });
+
+    const closeEarlyRes = await request(app)
+      .post(`/credit-cards/${cardId}/close-invoice`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ closingDate: "2026-04-29" });
+
+    expectErrorResponseWithRequestId(
+      closeEarlyRes,
+      409,
+      "Ainda nao chegou o dia de fechamento deste cartao.",
+    );
+
+    const closeRes = await request(app)
+      .post(`/credit-cards/${cardId}/close-invoice`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ closingDate: "2026-04-30" });
+
+    expect(closeRes.status).toBe(200);
+    expect(closeRes.body).toMatchObject({
+      purchasesCount: 1,
+      total: 200,
+      invoice: {
+        amount: 200,
+        status: "pending",
+        referenceMonth: "2026-04",
+        dueDate: "2026-05-10",
+      },
+    });
+  });
+
   it("fechar fatura gera bill pendente e pagar a fatura cria a saída real de caixa", async () => {
     const email = "credit-cards-bill-flow@test.dev";
     const token = await registerAndLogin(email);

--- a/apps/api/src/services/credit-cards.service.js
+++ b/apps/api/src/services/credit-cards.service.js
@@ -184,6 +184,12 @@ const resolveNextDueDate = (closingDate, dueDay) => {
   return clampDateDay(nextMonthDate.getUTCFullYear(), nextMonthDate.getUTCMonth(), dueDay);
 };
 
+const resolveEffectiveClosingDay = (closingDate, configuredClosingDay) => {
+  const [yearPart, monthPart] = closingDate.split("-").map(Number);
+  const lastDayOfMonth = new Date(Date.UTC(yearPart, monthPart, 0)).getUTCDate();
+  return Math.min(configuredClosingDay, lastDayOfMonth);
+};
+
 const mapCardRow = (row) => ({
   id: Number(row.id),
   userId: Number(row.user_id),
@@ -574,7 +580,8 @@ export const closeCreditCardInvoiceForUser = async (userId, cardId, payload = {}
     const card = await getCardForUserOrThrow(client, normalizedUserId, normalizedCardId);
     const mappedCard = mapCardRow(card);
 
-    const closingDayReached = Number(closingDate.slice(-2)) >= mappedCard.closingDay;
+    const effectiveClosingDay = resolveEffectiveClosingDay(closingDate, mappedCard.closingDay);
+    const closingDayReached = Number(closingDate.slice(-2)) >= effectiveClosingDay;
     if (!closingDayReached) {
       throw createError(409, "Ainda nao chegou o dia de fechamento deste cartao.");
     }


### PR DESCRIPTION
## Contexto\nS8.1 (Contrato de ciclo e fatura): fechamento de fatura ficava impossivel para cartoes com closingDay=31 em meses com 30/28 dias.\n\n## O que mudou\n- ajuste no service para considerar o ultimo dia do mes como dia efetivo de fechamento quando closingDay configurado excede o calendario\n- novo teste de regressao cobrindo abril (29 bloqueia, 30 fecha)\n\n## Arquivos\n- apps/api/src/services/credit-cards.service.js\n- apps/api/src/credit-cards.test.js\n\n## Validacao local\n- npm -w apps/api run test -- src/credit-cards.test.js\n- npm -w apps/api run test -- src/credit-cards.test.js src/credit-card-invoices.test.js\n- npm -w apps/api run lint\n