### PR TITLE
feat(web): leitura operacional de ciclo, limite e pendencias em cartoes

### DIFF
--- a/apps/web/src/components/CreditCardsSummaryWidget.test.tsx
+++ b/apps/web/src/components/CreditCardsSummaryWidget.test.tsx
@@ -86,6 +86,9 @@ describe("CreditCardsSummaryWidget", () => {
     expect(screen.getByText(/680,00|680,00/)).toBeInTheDocument();
     expect(screen.getByText(/1\.900,00|1900,00/)).toBeInTheDocument();
     expect(screen.getByText("3 faturas")).toBeInTheDocument();
+    expect(screen.getByText("Limite em uso")).toBeInTheDocument();
+    expect(screen.getByText("Em uso")).toBeInTheDocument();
+    expect(screen.getByText("43.60% do limite total")).toBeInTheDocument();
   });
 
   it("mostra estado vazio amigável quando não há cartão cadastrado", async () => {

--- a/apps/web/src/components/CreditCardsSummaryWidget.tsx
+++ b/apps/web/src/components/CreditCardsSummaryWidget.tsx
@@ -12,29 +12,78 @@ interface CreditCardsSummaryWidgetProps {
 
 interface CreditCardsAggregate {
   cardsCount: number;
+  limitTotal: number;
+  limitUsed: number;
   availableTotal: number;
   openPurchasesTotal: number;
   pendingInvoicesTotal: number;
   pendingInvoicesCount: number;
+  usagePct: number;
+  usageStatus: "unused" | "using" | "exceeded";
 }
 
+const resolveAggregateUsageStatus = (
+  limitTotal: number,
+  limitUsed: number,
+): "unused" | "using" | "exceeded" => {
+  if (limitUsed > limitTotal && limitTotal > 0) return "exceeded";
+  if (limitUsed > 0) return "using";
+  return "unused";
+};
+
 const buildAggregate = (items: CreditCardItem[]): CreditCardsAggregate =>
-  items.reduce<CreditCardsAggregate>(
+  {
+    const aggregate = items.reduce<CreditCardsAggregate>(
     (aggregate, card) => ({
       cardsCount: aggregate.cardsCount + 1,
+      limitTotal: aggregate.limitTotal + card.usage.total,
+      limitUsed: aggregate.limitUsed + card.usage.used,
       availableTotal: aggregate.availableTotal + card.usage.available,
       openPurchasesTotal: aggregate.openPurchasesTotal + card.openPurchasesTotal,
       pendingInvoicesTotal: aggregate.pendingInvoicesTotal + card.pendingInvoicesTotal,
       pendingInvoicesCount: aggregate.pendingInvoicesCount + card.pendingInvoicesCount,
+      usagePct: 0,
+      usageStatus: "unused",
     }),
     {
       cardsCount: 0,
+      limitTotal: 0,
+      limitUsed: 0,
       availableTotal: 0,
       openPurchasesTotal: 0,
       pendingInvoicesTotal: 0,
       pendingInvoicesCount: 0,
+      usagePct: 0,
+      usageStatus: "unused",
     },
   );
+
+    const usagePct =
+      aggregate.limitTotal > 0 ? Number(((aggregate.limitUsed / aggregate.limitTotal) * 100).toFixed(2)) : 0;
+    return {
+      ...aggregate,
+      usagePct,
+      usageStatus: resolveAggregateUsageStatus(aggregate.limitTotal, aggregate.limitUsed),
+    };
+  };
+
+const USAGE_STATUS_LABELS = {
+  unused: "Sem uso",
+  using: "Em uso",
+  exceeded: "Excedido",
+} as const;
+
+const USAGE_STATUS_CLASSNAMES = {
+  unused: "border-cf-border bg-cf-bg-subtle text-cf-text-secondary",
+  using: "border-amber-200 bg-amber-50 text-amber-700",
+  exceeded: "border-red-200 bg-red-50 text-red-700",
+} as const;
+
+const USAGE_PROGRESS_CLASSNAMES = {
+  unused: "bg-cf-border",
+  using: "bg-amber-500",
+  exceeded: "bg-red-500",
+} as const;
 
 const formatDMY = (iso: string): string => {
   const [year, month, day] = iso.split("-");
@@ -208,6 +257,10 @@ const CreditCardsSummaryWidget = ({
   }, []);
 
   const aggregate = useMemo(() => buildAggregate(cards), [cards]);
+  const usageStatusLabel = USAGE_STATUS_LABELS[aggregate.usageStatus];
+  const usageStatusClassName = USAGE_STATUS_CLASSNAMES[aggregate.usageStatus];
+  const usageProgressClassName = USAGE_PROGRESS_CLASSNAMES[aggregate.usageStatus];
+  const usageProgressWidthPct = Math.min(100, aggregate.usagePct);
 
   if (isLoading) {
     return (
@@ -269,7 +322,28 @@ const CreditCardsSummaryWidget = ({
         </div>
       ) : (
         <>
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-xs font-medium uppercase text-cf-text-secondary">Limite em uso</p>
+                <span
+                  className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${usageStatusClassName}`}
+                >
+                  {usageStatusLabel}
+                </span>
+              </div>
+              <p className="mt-1 text-sm font-semibold text-cf-text-primary">
+                {money(aggregate.limitUsed)}
+              </p>
+              <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-cf-border/60">
+                <div
+                  className={`h-full rounded-full ${usageProgressClassName}`}
+                  style={{ width: `${usageProgressWidthPct}%` }}
+                />
+              </div>
+              <p className="mt-1 text-xs text-cf-text-secondary">{aggregate.usagePct.toFixed(2)}% do limite total</p>
+            </div>
+
             <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
               <p className="text-xs font-medium uppercase text-cf-text-secondary">Disponível</p>
               <p className="text-sm font-semibold text-cf-text-primary">

--- a/apps/web/src/pages/CreditCardsPage.test.tsx
+++ b/apps/web/src/pages/CreditCardsPage.test.tsx
@@ -165,8 +165,31 @@ describe("CreditCardsPage", () => {
     expect(screen.getByText("Fatura Nubank 2026-03")).toBeInTheDocument();
     expect(screen.getByText("24.00% do limite")).toBeInTheDocument();
     expect(screen.getAllByText("Com compras no ciclo").length).toBeGreaterThan(0);
+    expect(screen.getByText("Fatura pendente")).toBeInTheDocument();
+    expect(screen.getByText("Ação: registrar pagamento da fatura até o vencimento.")).toBeInTheDocument();
     expect(screen.getByText("Fatura do ciclo")).toBeInTheDocument();
     expect(screen.getByText("Pendente")).toBeInTheDocument();
+  });
+
+  it("destaca ciclo aberto quando há compras sem fatura pendente", async () => {
+    vi.mocked(creditCardsService.list).mockResolvedValueOnce({
+      items: [
+        buildCard({
+          pendingInvoicesCount: 0,
+          pendingInvoicesTotal: 0,
+          invoices: [],
+          openPurchasesCount: 2,
+          openPurchasesTotal: 280,
+        }),
+      ],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("Nubank")).toBeInTheDocument();
+    expect(screen.getByText("Ciclo aberto")).toBeInTheDocument();
+    expect(screen.getByText("Ação: fechar a fatura quando o dia de fechamento chegar.")).toBeInTheDocument();
+    expect(screen.getByText("Compras em ciclo aberto aguardando fechamento")).toBeInTheDocument();
   });
 
   it("desabilita fechar fatura quando nao ha compras abertas", async () => {
@@ -214,6 +237,8 @@ describe("CreditCardsPage", () => {
 
     expect(await screen.findByText("Nubank")).toBeInTheDocument();
     expect(screen.getByText("Atrasada")).toBeInTheDocument();
+    expect(screen.getByText("Fatura atrasada")).toBeInTheDocument();
+    expect(screen.getByText("Ação: regularize a fatura vencida para normalizar o ciclo.")).toBeInTheDocument();
   });
 
   it("cria cartão novo pelo modal", async () => {

--- a/apps/web/src/pages/CreditCardsPage.tsx
+++ b/apps/web/src/pages/CreditCardsPage.tsx
@@ -44,6 +44,48 @@ const INVOICE_STATUS_BADGE_CLASSNAMES = {
   overdue: "border-red-200 bg-red-50 text-red-700",
 } as const;
 
+type CardCycleStatus = "no_cycle" | "open_cycle" | "pending_invoice" | "overdue_invoice";
+
+const CYCLE_STATUS_LABELS: Record<CardCycleStatus, string> = {
+  no_cycle: "Sem ciclo aberto",
+  open_cycle: "Ciclo aberto",
+  pending_invoice: "Fatura pendente",
+  overdue_invoice: "Fatura atrasada",
+};
+
+const CYCLE_STATUS_BADGE_CLASSNAMES: Record<CardCycleStatus, string> = {
+  no_cycle: "border-cf-border bg-cf-bg-subtle text-cf-text-secondary",
+  open_cycle: "border-blue-200 bg-blue-50 text-blue-700",
+  pending_invoice: "border-amber-200 bg-amber-50 text-amber-700",
+  overdue_invoice: "border-red-200 bg-red-50 text-red-700",
+};
+
+const getCardCycleStatus = (card: CreditCardItem): CardCycleStatus => {
+  const hasOverdueInvoice = card.invoices.some(
+    (invoice) => invoice.status === "pending" && invoice.isOverdue,
+  );
+  if (hasOverdueInvoice) return "overdue_invoice";
+
+  const hasPendingInvoice = card.invoices.some((invoice) => invoice.status === "pending");
+  if (hasPendingInvoice) return "pending_invoice";
+
+  if (card.openPurchasesCount > 0) return "open_cycle";
+  return "no_cycle";
+};
+
+const getCardCycleActionLabel = (cycleStatus: CardCycleStatus): string => {
+  if (cycleStatus === "overdue_invoice") {
+    return "Ação: regularize a fatura vencida para normalizar o ciclo.";
+  }
+  if (cycleStatus === "pending_invoice") {
+    return "Ação: registrar pagamento da fatura até o vencimento.";
+  }
+  if (cycleStatus === "open_cycle") {
+    return "Ação: fechar a fatura quando o dia de fechamento chegar.";
+  }
+  return "Sem pendências operacionais no cartão neste momento.";
+};
+
 const getInvoiceBadge = (invoice: CreditCardItem["invoices"][number]) => {
   if (invoice.status === "paid") {
     return {
@@ -263,6 +305,10 @@ const CreditCardsPage = ({
                 card.invoices.find((invoice) => invoice.status === "pending") ?? null;
               const usageStatusLabel = USAGE_STATUS_LABELS[card.usage.status];
               const usageStatusClassName = USAGE_STATUS_BADGE_CLASSNAMES[card.usage.status];
+              const cycleStatus = getCardCycleStatus(card);
+              const cycleStatusLabel = CYCLE_STATUS_LABELS[cycleStatus];
+              const cycleStatusClassName = CYCLE_STATUS_BADGE_CLASSNAMES[cycleStatus];
+              const cycleActionLabel = getCardCycleActionLabel(cycleStatus);
 
               return (
                 <section key={card.id} className="rounded border border-cf-border bg-cf-surface p-4">
@@ -275,6 +321,11 @@ const CreditCardsPage = ({
                       >
                         {usageStatusLabel}
                       </span>
+                      <span
+                        className={`rounded-full border px-2 py-0.5 text-xs font-semibold ${cycleStatusClassName}`}
+                      >
+                        {cycleStatusLabel}
+                      </span>
                     </div>
                     <p className="mt-1 text-xs text-cf-text-secondary">
                       Fecha no dia {card.closingDay} e vence no dia {card.dueDay}
@@ -283,6 +334,9 @@ const CreditCardsPage = ({
                       {card.openPurchasesCount} compra{card.openPurchasesCount === 1 ? "" : "s"} em aberto
                       {card.openPurchasesCount === 1 ? "" : "s"} · {card.pendingInvoicesCount} fatura
                       {card.pendingInvoicesCount === 1 ? "" : "s"} pendente{card.pendingInvoicesCount === 1 ? "" : "s"}
+                    </p>
+                    <p className={`mt-1 text-xs ${cycleStatus === "overdue_invoice" ? "text-red-600" : cycleStatus === "pending_invoice" ? "text-amber-700" : "text-cf-text-secondary"}`}>
+                      {cycleActionLabel}
                     </p>
                   </div>
                   <div className="flex flex-wrap gap-2">
@@ -351,15 +405,15 @@ const CreditCardsPage = ({
                           : formatCurrency(0)}
                     </p>
                     {pendingInvoice ? (
-                      <p className="text-xs text-cf-text-secondary">
+                      <p className={`text-xs ${pendingInvoice.isOverdue ? "text-red-600" : "text-amber-700"}`}>
                         {pendingInvoice.isOverdue
-                          ? `Atrasada desde ${formatDate(pendingInvoice.dueDate)}`
-                          : `Vence em ${formatDate(pendingInvoice.dueDate)}`}
+                          ? `Obrigação atrasada desde ${formatDate(pendingInvoice.dueDate)}`
+                          : `Obrigação pendente com vencimento em ${formatDate(pendingInvoice.dueDate)}`}
                       </p>
                     ) : card.openPurchasesCount > 0 ? (
-                      <p className="text-xs text-cf-text-secondary">Compras deste ciclo aguardando fechamento</p>
+                      <p className="text-xs text-blue-700">Compras em ciclo aberto aguardando fechamento</p>
                     ) : (
-                      <p className="text-xs text-cf-text-secondary">Sem fatura pendente no momento</p>
+                      <p className="text-xs text-cf-text-secondary">Ciclo sem compras e sem faturas pendentes</p>
                     )}
                   </div>
                 </div>


### PR DESCRIPTION
## Contexto\nS8.2 da Sprint 8: tornar leitura operacional de cartão mais explícita no frontend para decisão rápida de ciclo, limite e pendências.\n\n## O que mudou\n- CreditCardsPage: novo status de ciclo por cartão (sem ciclo, ciclo aberto, fatura pendente, fatura atrasada) com badge e mensagem de ação\n- CreditCardsPage: card de fatura do ciclo com mensagem operacional explícita por estado\n- CreditCardsSummaryWidget: agregado com limite em uso, status (sem uso/em uso/excedido) e barra de consumo\n- testes atualizados para garantir os novos estados e mensagens operacionais\n\n## Arquivos\n- apps/web/src/pages/CreditCardsPage.tsx\n- apps/web/src/pages/CreditCardsPage.test.tsx\n- apps/web/src/components/CreditCardsSummaryWidget.tsx\n- apps/web/src/components/CreditCardsSummaryWidget.test.tsx\n\n## Validação local\n- npm -w apps/web run test:run -- src/pages/CreditCardsPage.test.tsx src/components/CreditCardsSummaryWidget.test.tsx\n- npm -w apps/web run typecheck\n- npm -w apps/web run lint\n\n## Resultado\n- 14 testes verdes nas suítes focadas\n- typecheck e lint OK\n