### PR TITLE
fix(api): guard rails de conciliacao invoice-bill

### DIFF
--- a/apps/api/src/credit-card-invoices.test.js
+++ b/apps/api/src/credit-card-invoices.test.js
@@ -43,6 +43,15 @@ TOTAL DA FATURA    R$ 980,00
 PAGAMENTO MÍNIMO R$ 98,00
 `.trim();
 
+const VALID_ITAU_TEXT_APRIL_SAME_TOTAL = `
+BANCO ITAÚ S.A.
+**** 1234
+PERÍODO DE 08/03/2026 A 07/04/2026
+VENCIMENTO  15/04/2026
+TOTAL DA FATURA    R$ 1.247,80
+PAGAMENTO MÍNIMO R$ 124,78
+`.trim();
+
 const INVALID_TEXT = `Este texto nao tem nenhum dado de fatura.`;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -264,7 +273,7 @@ describe("credit-card-invoices", () => {
       });
     // Manually set credit_card_id on the bill since the API doesn't expose it directly
     await dbQuery(
-      `UPDATE bills SET credit_card_id = $1 WHERE id = $2`,
+      `UPDATE bills SET credit_card_id = $1, bill_type = 'credit_card_invoice' WHERE id = $2`,
       [cardId, billRes.body.id]
     );
     const billId = billRes.body.id;
@@ -291,8 +300,16 @@ describe("credit-card-invoices", () => {
     const billRes = await request(app)
       .post("/bills")
       .set("Authorization", `Bearer ${token}`)
-      .send({ title: "Fatura março", amount: 1247.80, dueDate: "2026-03-15" });
-    await dbQuery(`UPDATE bills SET credit_card_id = $1 WHERE id = $2`, [cardId, billRes.body.id]);
+      .send({
+        title: "Fatura março",
+        amount: 1247.80,
+        dueDate: "2026-03-15",
+        billType: "credit_card_invoice",
+      });
+    await dbQuery(
+      `UPDATE bills SET credit_card_id = $1, bill_type = 'credit_card_invoice' WHERE id = $2`,
+      [cardId, billRes.body.id],
+    );
     const billId = billRes.body.id;
 
     // First link
@@ -308,6 +325,81 @@ describe("credit-card-invoices", () => {
       .send({ billId });
 
     expect(res.status).toBe(409);
+  });
+
+  it("POST link-bill retorna 422 quando valor da pendencia difere do total da fatura", async () => {
+    const token = await registerAndLogin("inv-link-amount-mismatch@test.dev");
+    mockExtractText.mockResolvedValue(VALID_ITAU_TEXT);
+
+    const cardRes = await createCard(token);
+    const cardId = cardRes.body.id;
+
+    const invRes = await uploadInvoice(token, cardId);
+    const invoiceId = invRes.body.id;
+
+    const billRes = await request(app)
+      .post("/bills")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        title: "Fatura Itaú com valor divergente",
+        amount: 1000,
+        dueDate: "2026-03-15",
+        billType: "credit_card_invoice",
+      });
+
+    await dbQuery(
+      `UPDATE bills SET credit_card_id = $1, bill_type = 'credit_card_invoice' WHERE id = $2`,
+      [cardId, billRes.body.id],
+    );
+
+    const res = await request(app)
+      .post(`/credit-cards/${cardId}/invoices/${invoiceId}/link-bill`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ billId: billRes.body.id });
+
+    expect(res.status).toBe(422);
+    expect(res.body.message).toBe("Valor da pendencia difere do total da fatura.");
+  });
+
+  it("POST link-bill retorna 409 quando a mesma pendencia ja esta vinculada a outra fatura", async () => {
+    const token = await registerAndLogin("inv-link-bill-already-linked@test.dev");
+    const cardRes = await createCard(token);
+    const cardId = cardRes.body.id;
+
+    mockExtractText.mockResolvedValue(VALID_ITAU_TEXT);
+    const firstInvoiceRes = await uploadInvoice(token, cardId);
+
+    mockExtractText.mockResolvedValue(VALID_ITAU_TEXT_APRIL_SAME_TOTAL);
+    const secondInvoiceRes = await uploadInvoice(token, cardId);
+
+    const billRes = await request(app)
+      .post("/bills")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        title: "Fatura Itaú março",
+        amount: 1247.80,
+        dueDate: "2026-03-15",
+        billType: "credit_card_invoice",
+      });
+    await dbQuery(
+      `UPDATE bills SET credit_card_id = $1, bill_type = 'credit_card_invoice' WHERE id = $2`,
+      [cardId, billRes.body.id],
+    );
+    const billId = billRes.body.id;
+
+    const firstLinkRes = await request(app)
+      .post(`/credit-cards/${cardId}/invoices/${firstInvoiceRes.body.id}/link-bill`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ billId });
+    expect(firstLinkRes.status).toBe(200);
+
+    const secondLinkRes = await request(app)
+      .post(`/credit-cards/${cardId}/invoices/${secondInvoiceRes.body.id}/link-bill`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ billId });
+
+    expect(secondLinkRes.status).toBe(409);
+    expect(secondLinkRes.body.message).toBe("Pendencia ja esta vinculada a outra fatura.");
   });
 
   it("POST link-bill retorna 404 para fatura de outro usuario", async () => {

--- a/apps/api/src/services/credit-card-invoices.service.js
+++ b/apps/api/src/services/credit-card-invoices.service.js
@@ -2,6 +2,8 @@ import { dbQuery } from "../db/index.js";
 import { extractTextFromPdfWithOcr } from "../domain/imports/pdf-ocr.js";
 import { parseItauInvoice } from "../domain/imports/itau-invoice.parser.js";
 
+const CREDIT_CARD_INVOICE_BILL_TYPE = "credit_card_invoice";
+
 const createError = (status, message, extra = {}) => {
   const error = new Error(message);
   error.status = status;
@@ -32,6 +34,8 @@ const normalizeInvoiceId = (value) => {
   }
   return parsed;
 };
+
+const toMoney = (value) => Number(Number(value || 0).toFixed(2));
 
 // ─── Period inference ─────────────────────────────────────────────────────────
 
@@ -240,7 +244,7 @@ export const linkBillToInvoiceForUser = async (rawUserId, rawCardId, rawInvoiceI
 
   // Invoice ownership
   const { rows: invRows } = await dbQuery(
-    `SELECT id, linked_bill_id FROM credit_card_invoices
+    `SELECT id, linked_bill_id, total_amount FROM credit_card_invoices
       WHERE id = $1 AND credit_card_id = $2 AND user_id = $3`,
     [invoiceId, cardId, userId]
   );
@@ -249,14 +253,40 @@ export const linkBillToInvoiceForUser = async (rawUserId, rawCardId, rawInvoiceI
 
   // Bill ownership + same card
   const { rows: billRows } = await dbQuery(
-    `SELECT id, credit_card_id FROM bills WHERE id = $1 AND user_id = $2`,
+    `SELECT id, credit_card_id, bill_type, status, amount FROM bills WHERE id = $1 AND user_id = $2`,
     [billId, userId]
   );
   if (!billRows.length) throw createError(404, "Pendencia nao encontrada.");
 
+  if (billRows[0].bill_type !== CREDIT_CARD_INVOICE_BILL_TYPE) {
+    throw createError(422, "A pendencia informada nao e do tipo fatura de cartao.");
+  }
+
+  if (billRows[0].status !== "pending") {
+    throw createError(409, "Apenas pendencias pendentes podem ser vinculadas a fatura.");
+  }
+
   const billCardId = billRows[0].credit_card_id ? Number(billRows[0].credit_card_id) : null;
-  if (billCardId !== null && billCardId !== cardId) {
-    throw createError(422, "A pendencia pertence a outro cartao.");
+  if (billCardId !== cardId) {
+    throw createError(422, "A pendencia deve pertencer ao mesmo cartao da fatura.");
+  }
+
+  const invoiceAmount = toMoney(invRows[0].total_amount);
+  const billAmount = toMoney(billRows[0].amount);
+  if (billAmount !== invoiceAmount) {
+    throw createError(422, "Valor da pendencia difere do total da fatura.");
+  }
+
+  const { rows: existingLinkRows } = await dbQuery(
+    `SELECT id
+      FROM credit_card_invoices
+      WHERE user_id = $1
+        AND linked_bill_id = $2
+      LIMIT 1`,
+    [userId, billId],
+  );
+  if (existingLinkRows.length > 0) {
+    throw createError(409, "Pendencia ja esta vinculada a outra fatura.");
   }
 
   const { rows: updated } = await dbQuery(


### PR DESCRIPTION
## Contexto\nS8.3 (guard rails de conciliacao): reforcar vinculo entre invoice, bill e fluxo operacional para evitar divergencia financeira e duplicidade de vinculo.\n\n## O que mudou\n- linkBillToInvoiceForUser agora valida:\n  - bill_type obrigatoriamente credit_card_invoice\n  - status da pendencia obrigatoriamente pending\n  - pendencia deve pertencer ao mesmo cartao da fatura\n  - valor da pendencia deve ser igual ao total da fatura\n  - mesma pendencia nao pode ser vinculada a outra fatura\n- regressoes adicionadas em credit-card-invoices.test.js para valor divergente e reutilizacao da mesma pendencia em outra fatura\n\n## Arquivos\n- apps/api/src/services/credit-card-invoices.service.js\n- apps/api/src/credit-card-invoices.test.js\n\n## Validacao local\n- npm -w apps/api run test -- src/credit-card-invoices.test.js\n- npm -w apps/api run test -- src/credit-cards.test.js src/credit-card-invoices.test.js\n- npm -w apps/api run lint\n\n## Resultado\n- 27 testes verdes nas suites focadas\n- lint API OK\n