### PR TITLE
fix(tax): contrato anual consistente em bootstrap e summary

### DIFF
--- a/apps/api/src/domain/tax/tax-rules.engine.js
+++ b/apps/api/src/domain/tax/tax-rules.engine.js
@@ -117,6 +117,12 @@ export const getTaxRuleSeedDefinitionsForYear = (taxYear) => {
   }));
 };
 
+export const listTaxRuleSeedYears = () =>
+  Object.keys(TAX_RULE_SEED_BY_YEAR)
+    .map((yearValue) => Number(yearValue))
+    .filter((yearValue) => Number.isInteger(yearValue))
+    .sort((leftYear, rightYear) => leftYear - rightYear);
+
 export const calculateSimplifiedDiscount = ({
   annualTaxableIncome,
   comparisonRules = {},

--- a/apps/api/src/services/tax-bootstrap.service.js
+++ b/apps/api/src/services/tax-bootstrap.service.js
@@ -6,15 +6,18 @@ import {
   TAX_FACT_TYPES,
   TAX_RULE_FAMILIES,
 } from "../domain/tax/tax.constants.js";
+import { listTaxRuleSeedYears } from "../domain/tax/tax-rules.engine.js";
 import { normalizeTaxUserId } from "../domain/tax/tax.validation.js";
 
 export const getTaxBootstrapByUser = async (userId) => {
   normalizeTaxUserId(userId);
+  const supportedTaxYears = listTaxRuleSeedYears();
 
   return {
     module: "tax",
     scope: "irpf_mvp",
     apiVersion: resolveApiVersion(),
+    supportedTaxYears,
     documentTypes: [...TAX_DOCUMENT_TYPES],
     documentProcessingStatuses: [...TAX_DOCUMENT_PROCESSING_STATUSES],
     factTypes: [...TAX_FACT_TYPES],

--- a/apps/api/src/services/tax-summary.service.js
+++ b/apps/api/src/services/tax-summary.service.js
@@ -180,6 +180,7 @@ const getLatestStoredSummaryRow = async (userId, taxYear) => {
 export const getTaxSummaryByYear = async (userId, taxYearValue) => {
   const normalizedUserId = normalizeTaxUserId(userId);
   const taxYear = normalizeTaxYear(taxYearValue);
+  const activeRuleConfig = await requireActiveTaxRuleConfigByYear(taxYear);
   const sourceCounts = await getSourceCountsByUserAndYear(normalizedUserId, taxYear);
   const latestSummary = await getLatestStoredSummaryRow(normalizedUserId, taxYear);
   const summaryPayload = {
@@ -189,8 +190,8 @@ export const getTaxSummaryByYear = async (userId, taxYearValue) => {
 
   return {
     taxYear,
-    exerciseYear: taxYear,
-    calendarYear: taxYear - 1,
+    exerciseYear: activeRuleConfig.exerciseYear,
+    calendarYear: activeRuleConfig.calendarYear,
     status: latestSummary ? "generated" : "not_generated",
     snapshotVersion: latestSummary ? Number(latestSummary.snapshot_version) : null,
     ...summaryPayload,

--- a/apps/api/src/tax.test.js
+++ b/apps/api/src/tax.test.js
@@ -467,6 +467,8 @@ describe("Tax API foundation", () => {
     expect(response.body.documentTypes).toContain("income_report_bank");
     expect(Array.isArray(response.body.ruleFamilies)).toBe(true);
     expect(response.body.ruleFamilies).toContain("obligation");
+    expect(Array.isArray(response.body.supportedTaxYears)).toBe(true);
+    expect(response.body.supportedTaxYears).toContain(2026);
     expect(typeof response.body.apiVersion).toBe("string");
     expect(response.body.apiVersion.length).toBeGreaterThan(0);
   });
@@ -1920,6 +1922,19 @@ describe("Tax API foundation", () => {
       },
       generatedAt: null,
     });
+  });
+
+  it("GET /tax/summary/:taxYear retorna 404 quando nao ha regras fiscais ativas para o exercicio", async () => {
+    const token = await registerAndLogin("tax-summary-rules-missing@test.dev");
+    const response = await request(app)
+      .get("/tax/summary/2030")
+      .set("Authorization", `Bearer ${token}`);
+
+    expectErrorResponseWithRequestId(
+      response,
+      404,
+      "Regras fiscais ativas indisponiveis para o exercicio informado.",
+    );
   });
 
   it("POST /tax/summary/:taxYear/rebuild gera snapshot versionado com fatos revisados", async () => {


### PR DESCRIPTION
## Contexto
S9.1 (contrato fiscal anual e bootstrap): alinhar fonte de verdade anual entre bootstrap e summary da Central do Leao.

## O que mudou
- bootstrap (GET /tax) agora expõe supportedTaxYears a partir dos anos seedados no motor fiscal
- summary (GET /tax/summary/:taxYear) agora usa equireActiveTaxRuleConfigByYear para metadata anual (exerciseYear/calendarYear) consistente com rules engine
- novo teste para garantir 404 em summary quando não há regras ativas para o exercício
- teste de bootstrap atualizado para validar supportedTaxYears

## Arquivos
- apps/api/src/domain/tax/tax-rules.engine.js
- apps/api/src/services/tax-bootstrap.service.js
- apps/api/src/services/tax-summary.service.js
- apps/api/src/tax.test.js

## Validação local
- npm -w apps/api run test -- src/tax.test.js
- npm -w apps/api run lint

## Resultado
- 54 testes verdes em 	ax.test.js
- lint API OK
