### PR TITLE
docs(roadmap): explicitar UX fiscal e resumo conferivel na Sprint 9

### DIFF
--- a/docs/roadmap-execution.md
+++ b/docs/roadmap-execution.md
@@ -407,6 +407,9 @@ Legenda de status:
 - Sprint 7 concluida.
 - Sprint 8 concluida.
 - Sprint 9 iniciada.
+- S9.1 concluida (contrato fiscal anual e bootstrap) no PR #375.
+- Subfrente oficial da Sprint 9: UX fiscal + espelhamento frontend do dominio fiscal.
+- Gap critico explicitado: resumo do IRPF ainda precisa fechar como superficie de conferencia guiada.
 - Documento operacional da Sprint 6: `docs/roadmaps/sprint-6-guard-rails-documentais.md`.
 - Documento operacional da Sprint 7: `docs/roadmaps/sprint-7-conta-corrente-operacional.md`.
 - Documento operacional da Sprint 8: `docs/roadmaps/sprint-8-cartao-ciclo-conciliacao.md`.
@@ -416,6 +419,7 @@ Legenda de status:
 - Evidencias da Sprint 6: PR #359, PR #360, PR #361, PR #362.
 - Evidencias da Sprint 7: PR #364, PR #365, PR #366, PR #367.
 - Evidencias da Sprint 8: PR #369, PR #370, PR #371, PR #372.
+- Evidencias iniciais da Sprint 9: PR #374, PR #375.
 - Pendências manuais continuam rastreadas fora de CI (prova visual do PR #348 e validação E2E real do OAuth).
 
 ---

--- a/docs/roadmaps/sprint-9-central-do-leao-irpf-mvp.md
+++ b/docs/roadmaps/sprint-9-central-do-leao-irpf-mvp.md
@@ -6,6 +6,23 @@ Status: iniciada em 31/03/2026.
 
 ---
 
+## 0. Entregas executadas ate agora
+
+### PRs ja executados na Sprint 9
+
+1. PR #374 - kickoff documental da sprint
+2. PR #375 - S9.1 (contrato fiscal anual e bootstrap)
+
+### Resultado consolidado da S9.1
+
+- Contrato anual fiscal unificado entre bootstrap e summary.
+- Bootstrap fiscal expondo `supportedTaxYears` a partir dos anos seedados.
+- Summary fiscal alinhando `exerciseYear` e `calendarYear` via configuracao ativa de regras.
+- Regressao de API para retorno `404` quando nao ha regras fiscais ativas para o exercicio.
+- Validacao local: `npm -w apps/api run test -- src/tax.test.js` (54 testes verdes) e `npm -w apps/api run lint`.
+
+---
+
 ## 1. Objetivo
 
 Concluir o ciclo MVP da Central do Leao na Fase 3 com foco operacional:
@@ -25,6 +42,10 @@ Concluir o ciclo MVP da Central do Leao na Fase 3 com foco operacional:
 - Refinar guard rails de review e rebuild de resumo anual.
 - Melhorar leitura operacional no frontend de `/app/tax` para pendencias e decisao.
 - Cobrir cenarios criticos com testes direcionados de API e Web.
+- Subfrente explicita: UX fiscal + espelhamento frontend do dominio fiscal.
+- Preview fiscal estruturado antes de confirmacoes finais.
+- Resumo da declaracao em tela com leitura conferivel por bloco fiscal.
+- Modo imprimivel e PDF de conferencia para revisao e arquivo pessoal.
 
 ### Fora de escopo
 
@@ -44,6 +65,7 @@ A Sprint 9 so fecha quando:
 3. Rebuild e export oficial permanecem deterministas e sem efeitos ocultos.
 4. UI fiscal deixa pendencias e proximos passos explicitos para o usuario.
 5. API e UI mantem semantica fiscal unica para tax year e exercise year.
+6. Resumo do IRPF funciona como superficie real de conferencia antes da decisao final.
 
 ---
 
@@ -77,24 +99,33 @@ A Sprint 9 so fecha quando:
 - Revisar consistencia entre regra anual, obrigatoriedade e bootstrap.
 - Endurecer cenarios de ano/exercicio e ownership fiscal.
 - Resultado esperado: contrato anual fiscal deterministico.
+- Status: concluida (PR #375).
 
-### Slice S9.2 - Guard rails de revisao e resumo
+### Slice S9.2 - Guard rails de revisao + preview fiscal estruturado
 
 - Reforcar trilha de revisao e impacto no resumo anual.
-- Cobrir bordas de pending/approved/corrected e warnings operacionais.
-- Resultado esperado: resumo fiscal confiavel e auditavel.
+- Cobrir bordas de pending/approved/corrected, conflitos e warnings operacionais.
+- Tornar preview fiscal estruturado antes da confirmacao final.
+- Resultado esperado: revisao guiada e previsivel para conferencia.
 
-### Slice S9.3 - Export e lifecycle documental
+### Slice S9.3 - Resumo da declaracao em tela
 
-- Fortalecer consistencia de export (JSON/CSV) e lifecycle de documentos.
-- Cobrir bordas de reprocess/delete sem quebrar rastreabilidade.
-- Resultado esperado: dossie oficial estavel ponta a ponta.
+- Consolidar blocos fiscais principais em leitura conferivel e acionavel.
+- Tornar comparacao de regimes explicita (deducoes legais x simplificado).
+- Resultado esperado: resumo anual confiavel e compreensivel para decisao.
 
-### Slice S9.4 - Hardening, smoke e fechamento executivo
+### Slice S9.4 - Modo imprimivel/PDF + fechamento executivo
 
+- Fortalecer consistencia de export (JSON/CSV) e modo de conferencia imprimivel.
+- Entregar PDF de conferencia com rastreabilidade clara.
 - Rodar lint, typecheck e suites direcionadas.
 - Atualizar roadmap para status de conclusao quando criterios forem cumpridos.
 - Resultado esperado: PR final da Sprint 9 pronto para merge com CI verde.
+
+### Trilha transversal da sprint
+
+- Copy semantica correta por tipo documental no modulo fiscal.
+- Ajustes de layout para modulos fiscais/operacionais densos.
 
 ---
 
@@ -107,6 +138,18 @@ A Sprint 9 so fecha quando:
 ---
 
 ## 7. Definition of Done da Sprint 9
+
+### DoD especifico do resumo do IRPF
+
+O resumo deve apresentar minimamente:
+
+- Cabecalho: exercicio, ano-calendario, CPF do titular, status da revisao e ultima atualizacao.
+- Blocos principais: rendimentos tributaveis, isentos/nao tributaveis, tributacao exclusiva, IR retido, bens relevantes, dividas relevantes, deducoes e pendencias.
+- Comparacao de regimes: deducoes legais x simplificado com indicacao explicita de melhor cenario para conferencia (sem decisao invisivel).
+- Painel de pendencias: itens sem documento, com conflito, duplicados e aguardando revisao humana.
+- Saidas: visualizacao em tela, versao imprimivel, export "dados para declarar" e PDF de conferencia.
+
+### DoD geral da Sprint 9
 
 - Criterios funcionais da secao 3 cumpridos.
 - CI dos PRs da Sprint 9 fechado em verde.


### PR DESCRIPTION
## Contexto
Alinhamento oficial da Sprint 9 apos conclusao da S9.1, sem trocar a tese da sprint.

## O que foi atualizado
- registra S9.1 como concluida (PR #375)
- explicita subfrente UX fiscal + espelhamento frontend do dominio fiscal
- explicita gap critico do resumo IRPF como superficie de conferencia
- detalha trilha de slices S9.2-S9.4 focada em preview, resumo em tela e modo imprimivel/PDF
- adiciona Definition of Done especifica do resumo do IRPF

## Arquivos
- docs/roadmaps/sprint-9-central-do-leao-irpf-mvp.md
- docs/roadmap-execution.md

## Fora de escopo
- sem alteracoes de implementacao em API/Web nesta PR
