### PR TITLE
fix(api): S9.2 preview pos-review e guard rail de taxYear

### DIFF
--- a/apps/api/src/routes/tax.routes.js
+++ b/apps/api/src/routes/tax.routes.js
@@ -16,7 +16,11 @@ import { createManualTaxFactByUser, listTaxFactsByUser } from "../services/tax-f
 import { getTaxObligationByYear } from "../services/tax-obligation.service.js";
 import { bulkApproveTaxFactsByUser, reviewTaxFactByUser } from "../services/tax-reviews.service.js";
 import { getTaxRuleSetsByYear } from "../services/tax-rules.service.js";
-import { getTaxSummaryByYear, rebuildTaxSummaryByYear } from "../services/tax-summary.service.js";
+import {
+  getTaxSummaryByYear,
+  previewTaxSummaryByYear,
+  rebuildTaxSummaryByYear,
+} from "../services/tax-summary.service.js";
 
 const router = Router();
 const TAX_DOCUMENT_MAX_FILE_SIZE_BYTES = Number(
@@ -38,6 +42,19 @@ const createError = (status, message) => {
   const error = new Error(message);
   error.status = status;
   return error;
+};
+
+const buildTaxReviewPreviewByYear = async (userId, taxYear) => {
+  const summary = await previewTaxSummaryByYear(userId, taxYear);
+  const obligation = await getTaxObligationByYear(userId, taxYear);
+
+  return {
+    taxYear: summary.taxYear,
+    exerciseYear: summary.exerciseYear,
+    calendarYear: summary.calendarYear,
+    summary,
+    obligation,
+  };
 };
 
 const ensureValidTaxDocumentFile = (file) => {
@@ -174,7 +191,11 @@ router.post("/app-sync/:taxYear", async (req, res, next) => {
 router.post("/facts/bulk-review", async (req, res, next) => {
   try {
     const result = await bulkApproveTaxFactsByUser(req.user.id, req.body ?? {});
-    res.status(200).json(result);
+    const preview = await buildTaxReviewPreviewByYear(req.user.id, result.taxYear);
+    res.status(200).json({
+      ...result,
+      preview,
+    });
   } catch (error) {
     next(error);
   }
@@ -183,7 +204,11 @@ router.post("/facts/bulk-review", async (req, res, next) => {
 router.patch("/facts/:id/review", async (req, res, next) => {
   try {
     const result = await reviewTaxFactByUser(req.user.id, req.params.id, req.body ?? {});
-    res.status(200).json(result);
+    const preview = await buildTaxReviewPreviewByYear(req.user.id, result.fact.taxYear);
+    res.status(200).json({
+      ...result,
+      preview,
+    });
   } catch (error) {
     next(error);
   }

--- a/apps/api/src/services/tax-reviews.service.js
+++ b/apps/api/src/services/tax-reviews.service.js
@@ -494,6 +494,15 @@ export const bulkApproveTaxFactsByUser = async (userId, payload = {}) => {
       throw createTaxError(404, "Um ou mais fatos fiscais nao foram encontrados.");
     }
 
+    const taxYears = [...new Set(facts.map((fact) => Number(fact.tax_year)))];
+
+    if (taxYears.length !== 1) {
+      throw createTaxError(
+        400,
+        "Aprovacao em lote exige fatos do mesmo exercicio fiscal (taxYear).",
+      );
+    }
+
     const factIdsSql = buildFactIdsQuery(factIds);
     const updateResult = await client.query(
       `UPDATE tax_facts
@@ -518,6 +527,7 @@ export const bulkApproveTaxFactsByUser = async (userId, payload = {}) => {
 
     return {
       updatedCount: Number(updateResult.rowCount || 0),
+      taxYear: taxYears[0],
     };
   });
 };

--- a/apps/api/src/services/tax-summary.service.js
+++ b/apps/api/src/services/tax-summary.service.js
@@ -163,6 +163,25 @@ const buildCalculatedSummaryPayload = ({
   };
 };
 
+const buildCalculatedSummaryStateByYear = async (normalizedUserId, taxYear) => {
+  const activeRuleConfig = await requireActiveTaxRuleConfigByYear(taxYear);
+  const sourceCounts = await getSourceCountsByUserAndYear(normalizedUserId, taxYear);
+  const factSelection = await getReviewedTaxFactsSelectionByUserAndYear(normalizedUserId, taxYear);
+  const summaryPayload = buildCalculatedSummaryPayload({
+    reviewedFacts: factSelection.includedFacts,
+    excludedFactsCount: factSelection.excludedFacts.length,
+    sourceCounts,
+    activeRuleConfig,
+  });
+
+  return {
+    activeRuleConfig,
+    sourceCounts,
+    factSelection,
+    summaryPayload,
+  };
+};
+
 const getLatestStoredSummaryRow = async (userId, taxYear) => {
   const result = await dbQuery(
     `SELECT snapshot_version, summary_json, source_counts_json, facts_json, generated_at
@@ -200,21 +219,35 @@ export const getTaxSummaryByYear = async (userId, taxYearValue) => {
   };
 };
 
+export const previewTaxSummaryByYear = async (userId, taxYearValue) => {
+  const normalizedUserId = normalizeTaxUserId(userId);
+  const taxYear = normalizeTaxYear(taxYearValue);
+  const { activeRuleConfig, sourceCounts, summaryPayload } = await buildCalculatedSummaryStateByYear(
+    normalizedUserId,
+    taxYear,
+  );
+
+  return {
+    taxYear,
+    exerciseYear: activeRuleConfig.exerciseYear,
+    calendarYear: activeRuleConfig.calendarYear,
+    status: "preview",
+    snapshotVersion: null,
+    ...buildDefaultSummaryPayload(),
+    ...summaryPayload,
+    sourceCounts,
+    generatedAt: null,
+  };
+};
+
 export const rebuildTaxSummaryByYear = async (userId, taxYearValue) => {
   const normalizedUserId = normalizeTaxUserId(userId);
   const taxYear = normalizeTaxYear(taxYearValue);
-  const activeRuleConfig = await requireActiveTaxRuleConfigByYear(taxYear);
-  const sourceCounts = await getSourceCountsByUserAndYear(normalizedUserId, taxYear);
-  const factSelection = await getReviewedTaxFactsSelectionByUserAndYear(normalizedUserId, taxYear);
+  const { activeRuleConfig, sourceCounts, factSelection, summaryPayload } =
+    await buildCalculatedSummaryStateByYear(normalizedUserId, taxYear);
   const persistedFactsSnapshot = [...factSelection.includedFacts]
     .sort((leftFact, rightFact) => Number(leftFact.id) - Number(rightFact.id))
     .map(mapStoredTaxFactToSnapshotPayload);
-  const summaryPayload = buildCalculatedSummaryPayload({
-    reviewedFacts: factSelection.includedFacts,
-    excludedFactsCount: factSelection.excludedFacts.length,
-    sourceCounts,
-    activeRuleConfig,
-  });
 
   const persistedSummary = await withDbTransaction(async (client) => {
     const currentVersionResult = await client.query(

--- a/apps/api/src/tax.test.js
+++ b/apps/api/src/tax.test.js
@@ -1401,6 +1401,18 @@ describe("Tax API foundation", () => {
       id: factId,
       reviewStatus: "approved",
     });
+    expect(reviewResponse.body.preview).toMatchObject({
+      taxYear: 2026,
+      exerciseYear: 2026,
+      calendarYear: 2025,
+      summary: expect.objectContaining({
+        status: "preview",
+        taxYear: 2026,
+      }),
+      obligation: expect.objectContaining({
+        taxYear: 2026,
+      }),
+    });
 
     const persistedFactResult = await dbQuery(
       `SELECT review_status, updated_at
@@ -1493,6 +1505,18 @@ describe("Tax API foundation", () => {
       amount: 54000,
       dedupeStrength: "strong",
     });
+    expect(reviewResponse.body.preview).toMatchObject({
+      taxYear: 2026,
+      exerciseYear: 2026,
+      calendarYear: 2025,
+      summary: expect.objectContaining({
+        status: "preview",
+        taxYear: 2026,
+      }),
+      obligation: expect.objectContaining({
+        taxYear: 2026,
+      }),
+    });
 
     const persistedFactResult = await dbQuery(
       `SELECT amount, subcategory, dedupe_key, review_status
@@ -1581,8 +1605,27 @@ describe("Tax API foundation", () => {
       });
 
     expect(bulkResponse.status).toBe(200);
-    expect(bulkResponse.body).toEqual({
+    expect(bulkResponse.body).toMatchObject({
       updatedCount: 3,
+      taxYear: 2026,
+      preview: {
+        taxYear: 2026,
+        exerciseYear: 2026,
+        calendarYear: 2025,
+        summary: expect.objectContaining({
+          status: "preview",
+          taxYear: 2026,
+          sourceCounts: {
+            documents: 1,
+            factsPending: 0,
+            factsApproved: 3,
+          },
+        }),
+        obligation: expect.objectContaining({
+          taxYear: 2026,
+          approvedFactsCount: 3,
+        }),
+      },
     });
 
     const persistedFactsResult = await dbQuery(
@@ -1621,6 +1664,48 @@ describe("Tax API foundation", () => {
       factsPending: 0,
       factsApproved: 3,
     });
+  });
+
+  it("POST /tax/facts/bulk-review retorna 400 quando recebe factIds de taxYears diferentes", async () => {
+    const token = await registerAndLogin("tax-facts-bulk-mixed-taxyear@test.dev");
+
+    const firstFactResponse = await request(app)
+      .post("/tax/facts")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        taxYear: 2026,
+        factType: "taxable_income",
+        subcategory: "manual_income_2026",
+        referencePeriod: "2025-12",
+        amount: 1000,
+      });
+    const secondFactResponse = await request(app)
+      .post("/tax/facts")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        taxYear: 2025,
+        factType: "taxable_income",
+        subcategory: "manual_income_2025",
+        referencePeriod: "2024-12",
+        amount: 900,
+      });
+
+    expect(firstFactResponse.status).toBe(201);
+    expect(secondFactResponse.status).toBe(201);
+
+    const response = await request(app)
+      .post("/tax/facts/bulk-review")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        factIds: [firstFactResponse.body.fact.id, secondFactResponse.body.fact.id],
+        action: "approve",
+      });
+
+    expectErrorResponseWithRequestId(
+      response,
+      400,
+      "Aprovacao em lote exige fatos do mesmo exercicio fiscal (taxYear).",
+    );
   });
 
   it("GET /tax/rules/:taxYear retorna regras oficiais seedadas para o exercicio 2026", async () => {


### PR DESCRIPTION
## Contexto
Slice S9.2 backend para estabilizar contrato fiscal apos revisao individual e em lote.

## Escopo
- Retorna preview (summary + obligation) em review e bulk-review
- Inclui 	axYear no retorno de bulk-review
- Bloqueia bulk-review com actIds de exercicios diferentes
- Reuso de calculo para preview/rebuild no summary service
- Testes de API atualizados para novo contrato

## Arquivos
- apps/api/src/routes/tax.routes.js
- apps/api/src/services/tax-reviews.service.js
- apps/api/src/services/tax-summary.service.js
- apps/api/src/tax.test.js

## Fora de escopo
- Sem alteracoes de frontend
- Sem superficie visual de resumo/painel/impressao

## Validacao
- npm -w apps/api test -- src/tax.test.js (55 testes verdes)