### PR TITLE
docs(roadmap): oficializa Sprint 9 e hygiene local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,11 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment files (keep only examples versioned)
+.env
+.env.*
+!.env.example
+
+# Local operational artifacts and smoke/debug evidence
+tmp/

--- a/docs/roadmap-execution.md
+++ b/docs/roadmap-execution.md
@@ -406,10 +406,11 @@ Legenda de status:
 - Sprint 6 concluida.
 - Sprint 7 concluida.
 - Sprint 8 concluida.
-- Sprint 9 iniciada.
+- Sprint 9 em andamento com base fiscal oficializada na main.
 - S9.1 concluida (contrato fiscal anual e bootstrap) no PR #375.
+- S9.2 backend concluida no PR #377 (preview pos-review, guard rail de taxYear e contrato anual consistente).
+- S9.2 frontend + S9.3 + S9.4 oficializadas no PR #378 (preview na TaxPage, resumo conferivel e modo imprimivel/PDF).
 - Subfrente oficial da Sprint 9: UX fiscal + espelhamento frontend do dominio fiscal.
-- Gap critico explicitado: resumo do IRPF ainda precisa fechar como superficie de conferencia guiada.
 - Documento operacional da Sprint 6: `docs/roadmaps/sprint-6-guard-rails-documentais.md`.
 - Documento operacional da Sprint 7: `docs/roadmaps/sprint-7-conta-corrente-operacional.md`.
 - Documento operacional da Sprint 8: `docs/roadmaps/sprint-8-cartao-ciclo-conciliacao.md`.
@@ -419,7 +420,8 @@ Legenda de status:
 - Evidencias da Sprint 6: PR #359, PR #360, PR #361, PR #362.
 - Evidencias da Sprint 7: PR #364, PR #365, PR #366, PR #367.
 - Evidencias da Sprint 8: PR #369, PR #370, PR #371, PR #372.
-- Evidencias iniciais da Sprint 9: PR #374, PR #375.
+- Evidencias da Sprint 9: PR #374, PR #375, PR #376, PR #377, PR #378.
+- Proxima linha: continuar os proximos slices do IRPF MVP a partir da base fiscal ja conferivel e imprimivel.
 - Pendências manuais continuam rastreadas fora de CI (prova visual do PR #348 e validação E2E real do OAuth).
 
 ---

--- a/docs/roadmaps/sprint-9-central-do-leao-irpf-mvp.md
+++ b/docs/roadmaps/sprint-9-central-do-leao-irpf-mvp.md
@@ -2,7 +2,7 @@
 
 > Documento operacional para executar a Sprint 9 com foco em consolidar a Central do Leao como modulo fiscal confiavel, auditavel e acionavel no fluxo real do usuario.
 
-Status: iniciada em 31/03/2026.
+Status: em andamento; S9.1, S9.2, S9.3 e S9.4 oficializadas na main em 31/03/2026.
 
 ---
 
@@ -12,6 +12,9 @@ Status: iniciada em 31/03/2026.
 
 1. PR #374 - kickoff documental da sprint
 2. PR #375 - S9.1 (contrato fiscal anual e bootstrap)
+3. PR #376 - docs de escopo UX fiscal
+4. PR #377 - S9.2 backend (preview pos-review + guard rail taxYear)
+5. PR #378 - frontend pendente oficializado (S9.2 frontend + S9.3 + S9.4)
 
 ### Resultado consolidado da S9.1
 
@@ -20,6 +23,14 @@ Status: iniciada em 31/03/2026.
 - Summary fiscal alinhando `exerciseYear` e `calendarYear` via configuracao ativa de regras.
 - Regressao de API para retorno `404` quando nao ha regras fiscais ativas para o exercicio.
 - Validacao local: `npm -w apps/api run test -- src/tax.test.js` (54 testes verdes) e `npm -w apps/api run lint`.
+
+### Resultado consolidado da S9.2, S9.3 e S9.4
+
+- S9.2 backend oficializada no PR #377 com `preview` em review/bulk-review, `taxYear` no retorno de lote e guard rail para impedir aprovacao em lote com exercicios diferentes.
+- S9.2 frontend oficializada no PR #378 com consumo de `preview` na TaxPage sem recarga obrigatoria do snapshot.
+- S9.3 oficializada no PR #378 com resumo da declaracao em tela, comparacao de regimes e painel operacional de pendencias.
+- S9.4 oficializada no PR #378 com modo imprimivel/PDF, botao dedicado de impressao e ajuste de layout para saida limpa.
+- Validacoes registradas no ciclo de oficializacao: backend (`src/tax.test.js` com 55 testes verdes) e frontend (`TaxPage.test.tsx` com 22 testes verdes + typecheck).
 
 ---
 
@@ -107,12 +118,14 @@ A Sprint 9 so fecha quando:
 - Cobrir bordas de pending/approved/corrected, conflitos e warnings operacionais.
 - Tornar preview fiscal estruturado antes da confirmacao final.
 - Resultado esperado: revisao guiada e previsivel para conferencia.
+- Status: concluida (PR #377 backend + PR #378 frontend).
 
 ### Slice S9.3 - Resumo da declaracao em tela
 
 - Consolidar blocos fiscais principais em leitura conferivel e acionavel.
 - Tornar comparacao de regimes explicita (deducoes legais x simplificado).
 - Resultado esperado: resumo anual confiavel e compreensivel para decisao.
+- Status: concluida (PR #378).
 
 ### Slice S9.4 - Modo imprimivel/PDF + fechamento executivo
 
@@ -121,6 +134,7 @@ A Sprint 9 so fecha quando:
 - Rodar lint, typecheck e suites direcionadas.
 - Atualizar roadmap para status de conclusao quando criterios forem cumpridos.
 - Resultado esperado: PR final da Sprint 9 pronto para merge com CI verde.
+- Status: concluida (PR #378).
 
 ### Trilha transversal da sprint
 


### PR DESCRIPTION
## Contexto\nCommit local ja existente na main (ahead 1) com ajustes documentais e hygiene de artefatos locais.\n\n## Escopo\n- atualiza roadmap executivo com estado oficial da Sprint 9\n- atualiza roadmap operacional da Sprint 9\n- reforca .gitignore para .env e tmp\n\n## Arquivos\n- .gitignore\n- docs/roadmap-execution.md\n- docs/roadmaps/sprint-9-central-do-leao-irpf-mvp.md\n\n## Fora de escopo\n- sem alteracoes de codigo de produto\n