### PR TITLE
docs: continuidade da Sprint 9 com gate formal de encerramento

### DIFF
--- a/docs/roadmap-execution.md
+++ b/docs/roadmap-execution.md
@@ -396,8 +396,9 @@ Legenda de status:
 | Sprint | Foco | Status |
 |---|---|---|
 | Sprint 9 | Central do Leão (IRPF MVP) | 🟡 |
-| Sprint 10 | IA operacional por camadas | 🔵 |
-| Sprint 11 | Copiloto contextual ampliado | 🔵 |
+| Sprint 10 | CLT / Fundação de Holerite | ⚪ |
+| Sprint 11 | IA operacional por camadas | 🔵 |
+| Sprint 12 | Experiência avançada | 🔵 |
 
 ### Decisão executiva atual
 
@@ -421,7 +422,8 @@ Legenda de status:
 - Evidencias da Sprint 7: PR #364, PR #365, PR #366, PR #367.
 - Evidencias da Sprint 8: PR #369, PR #370, PR #371, PR #372.
 - Evidencias da Sprint 9: PR #374, PR #375, PR #376, PR #377, PR #378.
-- Proxima linha: continuar os proximos slices do IRPF MVP a partir da base fiscal ja conferivel e imprimivel.
+- Proxima linha: continuar os proximos slices do IRPF MVP a partir da base fiscal ja conferivel e imprimivel, ate gate formal de encerramento da Sprint 9.
+- Sprint 10 pode ser aberta em paralelo de forma nao bloqueante (discovery, contrato e DoD), sem misturar PRs com continuidade fiscal da Sprint 9.
 - Pendências manuais continuam rastreadas fora de CI (prova visual do PR #348 e validação E2E real do OAuth).
 
 ---

--- a/docs/roadmaps/sprint-9-central-do-leao-irpf-mvp.md
+++ b/docs/roadmaps/sprint-9-central-do-leao-irpf-mvp.md
@@ -136,6 +136,20 @@ A Sprint 9 so fecha quando:
 - Resultado esperado: PR final da Sprint 9 pronto para merge com CI verde.
 - Status: concluida (PR #378).
 
+### Slice S9.5 - Fechamento operacional do IRPF MVP
+
+- Consolidar o fluxo fim a fim com checklist objetivo de prontidao (ingestao -> revisao -> resumo -> export -> conferencia).
+- Endurecer evidencias operacionais de smoke para cenarios criticos do MVP fiscal.
+- Resultado esperado: frente IRPF MVP com pendencias explicitamente residualizadas e sem lacunas de rastreabilidade.
+- Status: pendente (proximo slice).
+
+### Slice S9.6 - Gate formal de encerramento da Sprint 9
+
+- Executar o gate de saida da sprint e registrar decisao executiva de encerramento.
+- Atualizar roadmap executivo movendo Sprint 9 para concluida quando todos os criterios forem satisfeitos.
+- Resultado esperado: Sprint 9 encerrada formalmente com evidencias remotas e documentais.
+- Status: pendente (slice de fechamento).
+
 ### Trilha transversal da sprint
 
 - Copy semantica correta por tipo documental no modulo fiscal.
@@ -169,3 +183,11 @@ O resumo deve apresentar minimamente:
 - CI dos PRs da Sprint 9 fechado em verde.
 - Evidencias de testes e smoke anexadas nos PRs.
 - Roadmap executivo atualizado movendo Sprint 9 para concluida e Sprint 10 para proximo alvo.
+
+### Gate formal de encerramento (criterios objetivos)
+
+1. Fluxo fiscal MVP validado ponta a ponta em smoke controlado: ingestao, revisao, resumo, export e conferencia.
+2. Semantica fiscal anual consistente em API e UI para `taxYear`, `exerciseYear` e `calendarYear` sem regressao aberta.
+3. Export oficial `JSON/CSV` e modo imprimivel/PDF conferidos com rastreabilidade explicita para revisao humana.
+4. Todos os PRs de fechamento da Sprint 9 com CI verde e mergeados na `main`.
+5. Roadmap executivo e operacional atualizados com decisao de encerramento e abertura da proxima frente ativa.


### PR DESCRIPTION
## Objetivo\nAlinhar os roadmaps para continuar a Sprint 9 com criterios formais de encerramento e abertura paralela segura da Sprint 10.\n\n## Alteracoes\n- Atualiza [docs/roadmap-execution.md](docs/roadmap-execution.md) com ordem estrategica Sprint 10/11/12 e proxima linha com gate formal da S9.\n- Atualiza [docs/roadmaps/sprint-9-central-do-leao-irpf-mvp.md](docs/roadmaps/sprint-9-central-do-leao-irpf-mvp.md) com slices S9.5 e S9.6.\n- Adiciona secao de gate formal com criterios objetivos de encerramento da sprint.\n\n## Risco\nBaixo (documentacao e governanca; sem mudanca de runtime).