### PR TITLE
feat: inicia S9.5 com smoke operacional IRPF MVP

### DIFF
--- a/docs/roadmap-execution.md
+++ b/docs/roadmap-execution.md
@@ -411,6 +411,7 @@ Legenda de status:
 - S9.1 concluida (contrato fiscal anual e bootstrap) no PR #375.
 - S9.2 backend concluida no PR #377 (preview pos-review, guard rail de taxYear e contrato anual consistente).
 - S9.2 frontend + S9.3 + S9.4 oficializadas no PR #378 (preview na TaxPage, resumo conferivel e modo imprimivel/PDF).
+- S9.5 iniciada com smoke operacional ponta a ponta e checklist objetivo de prontidao (`scripts/smoke-tax-irpf-mvp.ps1` + `docs/runbooks/s9-5-smoke-irpf-mvp.md`).
 - Subfrente oficial da Sprint 9: UX fiscal + espelhamento frontend do dominio fiscal.
 - Documento operacional da Sprint 6: `docs/roadmaps/sprint-6-guard-rails-documentais.md`.
 - Documento operacional da Sprint 7: `docs/roadmaps/sprint-7-conta-corrente-operacional.md`.
@@ -422,7 +423,7 @@ Legenda de status:
 - Evidencias da Sprint 7: PR #364, PR #365, PR #366, PR #367.
 - Evidencias da Sprint 8: PR #369, PR #370, PR #371, PR #372.
 - Evidencias da Sprint 9: PR #374, PR #375, PR #376, PR #377, PR #378.
-- Proxima linha: continuar os proximos slices do IRPF MVP a partir da base fiscal ja conferivel e imprimivel, ate gate formal de encerramento da Sprint 9.
+- Proxima linha: executar ciclo de evidencias da S9.5 (smoke tecnico + conferencia manual) e fechar pendencias residualizadas antes do gate formal de encerramento da Sprint 9.
 - Sprint 10 pode ser aberta em paralelo de forma nao bloqueante (discovery, contrato e DoD), sem misturar PRs com continuidade fiscal da Sprint 9.
 - Pendências manuais continuam rastreadas fora de CI (prova visual do PR #348 e validação E2E real do OAuth).
 

--- a/docs/roadmaps/sprint-9-central-do-leao-irpf-mvp.md
+++ b/docs/roadmaps/sprint-9-central-do-leao-irpf-mvp.md
@@ -140,8 +140,9 @@ A Sprint 9 so fecha quando:
 
 - Consolidar o fluxo fim a fim com checklist objetivo de prontidao (ingestao -> revisao -> resumo -> export -> conferencia).
 - Endurecer evidencias operacionais de smoke para cenarios criticos do MVP fiscal.
+- Artefatos iniciais publicados: `scripts/smoke-tax-irpf-mvp.ps1` e `docs/runbooks/s9-5-smoke-irpf-mvp.md`.
 - Resultado esperado: frente IRPF MVP com pendencias explicitamente residualizadas e sem lacunas de rastreabilidade.
-- Status: pendente (proximo slice).
+- Status: em andamento (slice iniciado em 01/04/2026).
 
 ### Slice S9.6 - Gate formal de encerramento da Sprint 9
 

--- a/docs/runbooks/s9-5-smoke-irpf-mvp.md
+++ b/docs/runbooks/s9-5-smoke-irpf-mvp.md
@@ -1,0 +1,70 @@
+# Runbook S9.5 - Smoke operacional IRPF MVP
+
+## Objetivo
+
+Validar o fluxo ponta a ponta da Central do Leao no exercicio fiscal alvo:
+
+1. ingestao documental
+2. reprocessamento
+3. revisao humana em lote
+4. resumo + obrigatoriedade
+5. rebuild versionado
+6. export oficial JSON/CSV
+
+## Script oficial
+
+- Script: `scripts/smoke-tax-irpf-mvp.ps1`
+- Saida de evidencias: `tmp/smoke-irpf-mvp-<runId>/`
+
+## Como executar
+
+### Modo padrao (auth automatica)
+
+```powershell
+.\scripts\smoke-tax-irpf-mvp.ps1 -BaseUrl "https://control-finance-react-tailwind.onrender.com" -TaxYear 2026
+```
+
+### Com token existente
+
+```powershell
+.\scripts\smoke-tax-irpf-mvp.ps1 -BaseUrl "https://control-finance-react-tailwind.onrender.com" -TaxYear 2026 -Token "<jwt>"
+```
+
+### Pre-validacao sem chamadas de rede
+
+```powershell
+.\scripts\smoke-tax-irpf-mvp.ps1 -WhatIf
+```
+
+## Checklist de aceite S9.5
+
+Marcar como concluido somente quando todos os itens abaixo estiverem verdadeiros:
+
+- [ ] Upload documental retorna `201` com `documentId` valido.
+- [ ] Reprocessamento retorna `200` e documento sai de `uploaded` para fluxo normalizado.
+- [ ] Fila de revisao retorna fatos pendentes para o exercicio.
+- [ ] Bulk review retorna `200` com preview fiscal consistente.
+- [ ] Summary e obligation retornam `200` para o exercicio.
+- [ ] Rebuild retorna `200` e atualiza snapshot fiscal.
+- [ ] Export `JSON` retorna `200` com manifesto.
+- [ ] Export `CSV` retorna `200` com cabecalho oficial.
+
+## Evidencias geradas automaticamente
+
+- `01-bootstrap.json`
+- `02-upload-document.json`
+- `03-reprocess-document.json`
+- `04-facts-pending.json`
+- `05-bulk-review.json`
+- `06-summary-before-rebuild.json`
+- `07-obligation.json`
+- `08-summary-rebuild.json`
+- `09-export-dossie.json`
+- `10-export-dossie.csv`
+- `checklist-s9-5.json`
+
+## Observacoes operacionais
+
+- O script exige PowerShell com suporte ao parametro `-Form` no `Invoke-WebRequest` (recomendado: PowerShell 7+).
+- Em ambiente sem token, o script cria um usuario temporario para nao depender de contas manuais.
+- O runbook cobre a evidencia tecnica da API; a conferencia visual da pagina imprimivel/PDF continua como validacao manual complementar da S9.5.

--- a/scripts/smoke-tax-irpf-mvp.ps1
+++ b/scripts/smoke-tax-irpf-mvp.ps1
@@ -1,0 +1,392 @@
+<#
+.SYNOPSIS
+  Smoke test ponta a ponta da Central do Leao (IRPF MVP).
+
+.DESCRIPTION
+  Executa o fluxo fiscal operacional de S9.5:
+    1) bootstrap fiscal
+    2) upload documental
+    3) reprocessamento
+    4) revisao em lote
+    5) resumo + obrigatoriedade
+    6) rebuild de snapshot
+    7) export oficial JSON e CSV
+
+  Tambem salva evidencias em pasta local dentro de tmp/.
+
+.PARAMETER BaseUrl
+  URL base da API.
+
+.PARAMETER TaxYear
+  Exercicio fiscal usado no smoke.
+
+.PARAMETER Token
+  Token JWT opcional. Se nao informado, o script cria usuario temporario e faz login.
+
+.PARAMETER Email
+  Email opcional para login/registro automatico quando Token nao for informado.
+
+.PARAMETER LoginSecret
+  Segredo opcional para login/registro automatico quando Token nao for informado.
+
+.PARAMETER OutputDir
+  Pasta base para evidencias (default: tmp).
+
+.PARAMETER WhatIf
+  Modo de pre-validacao: imprime etapas sem chamar API.
+
+.EXAMPLE
+  .\scripts\smoke-tax-irpf-mvp.ps1 -BaseUrl "https://control-finance-react-tailwind.onrender.com" -TaxYear 2026
+
+.EXAMPLE
+  .\scripts\smoke-tax-irpf-mvp.ps1 -BaseUrl "http://localhost:3000" -TaxYear 2026 -Token "<jwt>"
+#>
+
+param(
+    [string]$BaseUrl = "https://control-finance-react-tailwind.onrender.com",
+    [int]$TaxYear = 2026,
+    [string]$Token = "",
+    [string]$Email = "",
+    [string]$LoginSecret = "",
+    [string]$OutputDir = "tmp",
+    [switch]$WhatIf
+)
+
+$ErrorActionPreference = "Stop"
+
+$runId = "{0:yyyyMMdd-HHmmss}-{1}" -f (Get-Date), (Get-Random -Maximum 9999)
+$artifactDir = Join-Path $OutputDir "smoke-irpf-mvp-$runId"
+$sampleCsvPath = Join-Path $artifactDir "documento-irpf-smoke.csv"
+$checklistPath = Join-Path $artifactDir "checklist-s9-5.json"
+
+$script:passed = 0
+$script:failed = 0
+
+function Pass([string]$message) {
+    Write-Host "[PASS] $message" -ForegroundColor Green
+    $script:passed++
+}
+
+function Fail([string]$message) {
+    Write-Host "[FAIL] $message" -ForegroundColor Red
+    $script:failed++
+}
+
+function Save-JsonArtifact {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+        [Parameter(Mandatory = $true)]
+        $Payload
+    )
+
+    $path = Join-Path $artifactDir $Name
+    ($Payload | ConvertTo-Json -Depth 20) | Out-File -FilePath $path -Encoding utf8
+}
+
+function Invoke-Api {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Method,
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+        [hashtable]$Headers = @{},
+        $BodyObject = $null,
+        [hashtable]$Form = $null
+    )
+
+    $uri = "$BaseUrl$Path"
+
+    try {
+        if ($null -ne $Form) {
+            $response = Invoke-WebRequest -Method $Method -Uri $uri -Headers $Headers -Form $Form
+        }
+        elseif ($null -ne $BodyObject) {
+            $jsonBody = $BodyObject | ConvertTo-Json -Depth 20
+            $response = Invoke-WebRequest -Method $Method -Uri $uri -Headers $Headers -ContentType "application/json" -Body $jsonBody
+        }
+        else {
+            $response = Invoke-WebRequest -Method $Method -Uri $uri -Headers $Headers
+        }
+
+        $json = $null
+        if ($response.Content) {
+            try {
+                $json = $response.Content | ConvertFrom-Json
+            }
+            catch {
+                $json = $null
+            }
+        }
+
+        return [pscustomobject]@{
+            StatusCode = [int]$response.StatusCode
+            Headers    = $response.Headers
+            Raw        = $response.Content
+            Json       = $json
+        }
+    }
+    catch {
+        $errorDetails = $_.Exception.Message
+        if ($_.ErrorDetails -and $_.ErrorDetails.Message) {
+            $errorDetails = "{0}`n{1}" -f $errorDetails, $_.ErrorDetails.Message
+        }
+
+        throw "Erro em $Method $Path`n$errorDetails"
+    }
+}
+
+Write-Host ""
+Write-Host "=== Smoke S9.5 - IRPF MVP ===" -ForegroundColor Cyan
+Write-Host "RunId   : $runId"
+Write-Host "BaseUrl : $BaseUrl"
+Write-Host "TaxYear : $TaxYear"
+Write-Host ""
+
+if ($WhatIf) {
+    Write-Host "[WhatIf] Etapas que seriam executadas:" -ForegroundColor Yellow
+    Write-Host "  1) Auth (token existente ou register/login temporario)"
+    Write-Host "  2) GET /tax"
+    Write-Host "  3) POST /tax/documents"
+    Write-Host "  4) POST /tax/documents/:id/reprocess"
+    Write-Host "  5) GET /tax/facts?taxYear=<ano>&reviewStatus=pending"
+    Write-Host "  6) POST /tax/facts/bulk-review"
+    Write-Host "  7) GET /tax/summary/:taxYear e GET /tax/obligation/:taxYear"
+    Write-Host "  8) POST /tax/summary/:taxYear/rebuild"
+    Write-Host "  9) GET /tax/export/:taxYear?format=json e csv"
+    exit 0
+}
+
+if (-not (Get-Command Invoke-WebRequest).Parameters.ContainsKey("Form")) {
+    throw "Este script precisa de PowerShell com suporte a -Form em Invoke-WebRequest (recomendado: PowerShell 7+)."
+}
+
+New-Item -ItemType Directory -Path $artifactDir -Force | Out-Null
+
+$sampleCsv = @(
+    "Comprovante de Rendimentos Pagos e de Imposto sobre a Renda Retido na Fonte"
+    "Fonte pagadora ACME LTDA"
+    "CNPJ 12.345.678/0001-90"
+    "Rendimentos tributaveis R$ 54.321,00"
+    "Imposto sobre a renda retido na fonte R$ 4.321,09"
+    "Decimo terceiro R$ 5.000,00"
+) -join "`n"
+
+$sampleCsv | Out-File -FilePath $sampleCsvPath -Encoding utf8
+Pass "Arquivo de entrada criado em $sampleCsvPath"
+
+if (-not $Token) {
+    if (-not $Email) {
+        $Email = "smoke-tax-$runId@controlfinance.dev"
+    }
+
+    if (-not $LoginSecret) {
+        $LoginSecret = 'SmokeTax-' + ($runId -replace '-', '')
+    }
+
+    $registerResponse = Invoke-Api -Method "POST" -Path "/auth/register" -BodyObject @{
+        email    = $Email
+        password = $LoginSecret
+    }
+
+    if ($registerResponse.StatusCode -eq 201) {
+        Pass "POST /auth/register -> 201"
+    }
+    else {
+        Fail "POST /auth/register retornou $($registerResponse.StatusCode)"
+        exit 1
+    }
+
+    $loginResponse = Invoke-Api -Method "POST" -Path "/auth/login" -BodyObject @{
+        email    = $Email
+        password = $LoginSecret
+    }
+
+    $Token = [string]($loginResponse.Json.token)
+    if (-not $Token) {
+        $Token = [string]($loginResponse.Json.accessToken)
+    }
+
+    if ($loginResponse.StatusCode -eq 200 -and $Token) {
+        Pass "POST /auth/login -> 200 com token"
+    }
+    else {
+        Fail "POST /auth/login sem token valido"
+        exit 1
+    }
+}
+else {
+    Pass "Token informado manualmente"
+}
+
+$authHeaders = @{ Authorization = "Bearer $Token" }
+
+$bootstrapResponse = Invoke-Api -Method "GET" -Path "/tax" -Headers $authHeaders
+if ($bootstrapResponse.StatusCode -eq 200) {
+    Pass "GET /tax -> 200"
+    Save-JsonArtifact -Name "01-bootstrap.json" -Payload $bootstrapResponse.Json
+}
+else {
+    Fail "GET /tax retornou $($bootstrapResponse.StatusCode)"
+    exit 1
+}
+
+$uploadResponse = Invoke-Api -Method "POST" -Path "/tax/documents" -Headers $authHeaders -Form @{
+    taxYear     = "$TaxYear"
+    sourceLabel = "Smoke S9.5 $runId"
+    sourceHint  = "Fluxo ponta a ponta IRPF MVP"
+    file        = Get-Item $sampleCsvPath
+}
+
+$documentId = [int]($uploadResponse.Json.document.id)
+if ($uploadResponse.StatusCode -eq 201 -and $documentId -gt 0) {
+    Pass "POST /tax/documents -> 201 (documentId=$documentId)"
+    Save-JsonArtifact -Name "02-upload-document.json" -Payload $uploadResponse.Json
+}
+else {
+    Fail "POST /tax/documents nao retornou documentId valido"
+    exit 1
+}
+
+$reprocessResponse = Invoke-Api -Method "POST" -Path "/tax/documents/$documentId/reprocess" -Headers $authHeaders
+if ($reprocessResponse.StatusCode -eq 200) {
+    Pass "POST /tax/documents/$documentId/reprocess -> 200"
+    Save-JsonArtifact -Name "03-reprocess-document.json" -Payload $reprocessResponse.Json
+}
+else {
+    Fail "POST /tax/documents/$documentId/reprocess retornou $($reprocessResponse.StatusCode)"
+    exit 1
+}
+
+$factsResponse = Invoke-Api -Method "GET" -Path "/tax/facts?taxYear=$TaxYear&reviewStatus=pending&pageSize=100" -Headers $authHeaders
+$factIds = @()
+if ($factsResponse.Json -and $factsResponse.Json.items) {
+    $factIds = @($factsResponse.Json.items | ForEach-Object { [int]$_.id } | Where-Object { $_ -gt 0 })
+}
+
+if ($factsResponse.StatusCode -eq 200 -and $factIds.Count -gt 0) {
+    Pass "GET /tax/facts pendentes -> 200 ($($factIds.Count) fato(s))"
+    Save-JsonArtifact -Name "04-facts-pending.json" -Payload $factsResponse.Json
+}
+else {
+    Fail "GET /tax/facts nao retornou fatos pendentes para revisar"
+    exit 1
+}
+
+$bulkReviewResponse = Invoke-Api -Method "POST" -Path "/tax/facts/bulk-review" -Headers $authHeaders -BodyObject @{
+    factIds = $factIds
+    action  = "approve"
+    note    = "Aprovacao em lote via smoke S9.5 ($runId)."
+}
+
+if ($bulkReviewResponse.StatusCode -eq 200) {
+    Pass "POST /tax/facts/bulk-review -> 200"
+    Save-JsonArtifact -Name "05-bulk-review.json" -Payload $bulkReviewResponse.Json
+}
+else {
+    Fail "POST /tax/facts/bulk-review retornou $($bulkReviewResponse.StatusCode)"
+    exit 1
+}
+
+$summaryBeforeRebuild = Invoke-Api -Method "GET" -Path "/tax/summary/$TaxYear" -Headers $authHeaders
+$obligationResponse = Invoke-Api -Method "GET" -Path "/tax/obligation/$TaxYear" -Headers $authHeaders
+
+if ($summaryBeforeRebuild.StatusCode -eq 200) {
+    Pass "GET /tax/summary/$TaxYear -> 200"
+    Save-JsonArtifact -Name "06-summary-before-rebuild.json" -Payload $summaryBeforeRebuild.Json
+}
+else {
+    Fail "GET /tax/summary/$TaxYear retornou $($summaryBeforeRebuild.StatusCode)"
+    exit 1
+}
+
+if ($obligationResponse.StatusCode -eq 200) {
+    Pass "GET /tax/obligation/$TaxYear -> 200"
+    Save-JsonArtifact -Name "07-obligation.json" -Payload $obligationResponse.Json
+}
+else {
+    Fail "GET /tax/obligation/$TaxYear retornou $($obligationResponse.StatusCode)"
+    exit 1
+}
+
+$rebuildResponse = Invoke-Api -Method "POST" -Path "/tax/summary/$TaxYear/rebuild" -Headers $authHeaders
+if ($rebuildResponse.StatusCode -eq 200) {
+    Pass "POST /tax/summary/$TaxYear/rebuild -> 200"
+    Save-JsonArtifact -Name "08-summary-rebuild.json" -Payload $rebuildResponse.Json
+}
+else {
+    Fail "POST /tax/summary/$TaxYear/rebuild retornou $($rebuildResponse.StatusCode)"
+    exit 1
+}
+
+$exportJsonResponse = Invoke-Api -Method "GET" -Path "/tax/export/$TaxYear?format=json" -Headers $authHeaders
+$exportJsonPath = Join-Path $artifactDir "09-export-dossie.json"
+$exportJsonResponse.Raw | Out-File -FilePath $exportJsonPath -Encoding utf8
+
+$exportJsonPayload = $null
+try {
+    $exportJsonPayload = $exportJsonResponse.Raw | ConvertFrom-Json
+}
+catch {
+    $exportJsonPayload = $null
+}
+
+if ($exportJsonResponse.StatusCode -eq 200 -and $exportJsonPayload -and $exportJsonPayload.manifest) {
+    Pass "GET /tax/export/$TaxYear?format=json -> 200"
+}
+else {
+    Fail "GET /tax/export/$TaxYear?format=json sem payload valido"
+    exit 1
+}
+
+$exportCsvResponse = Invoke-Api -Method "GET" -Path "/tax/export/$TaxYear?format=csv" -Headers $authHeaders
+$exportCsvPath = Join-Path $artifactDir "10-export-dossie.csv"
+$exportCsvResponse.Raw | Out-File -FilePath $exportCsvPath -Encoding utf8
+
+if ($exportCsvResponse.StatusCode -eq 200 -and $exportCsvResponse.Raw -match "factId,factType,category") {
+    Pass "GET /tax/export/$TaxYear?format=csv -> 200"
+}
+else {
+    Fail "GET /tax/export/$TaxYear?format=csv sem cabecalho esperado"
+    exit 1
+}
+
+$checklist = [ordered]@{
+    runId     = $runId
+    baseUrl   = $BaseUrl
+    taxYear   = $TaxYear
+    timestamp = (Get-Date).ToString("o")
+    criteria  = [ordered]@{
+        ingestao   = ($documentId -gt 0)
+        revisao    = ($factIds.Count -gt 0)
+        resumo     = ($rebuildResponse.StatusCode -eq 200)
+        exportJson = ($exportJsonResponse.StatusCode -eq 200)
+        exportCsv  = ($exportCsvResponse.StatusCode -eq 200)
+    }
+    artifacts = [ordered]@{
+        bootstrap            = "01-bootstrap.json"
+        upload               = "02-upload-document.json"
+        reprocess            = "03-reprocess-document.json"
+        factsPending         = "04-facts-pending.json"
+        bulkReview           = "05-bulk-review.json"
+        summaryBeforeRebuild = "06-summary-before-rebuild.json"
+        obligation           = "07-obligation.json"
+        summaryRebuild       = "08-summary-rebuild.json"
+        exportJson           = "09-export-dossie.json"
+        exportCsv            = "10-export-dossie.csv"
+    }
+}
+
+($checklist | ConvertTo-Json -Depth 20) | Out-File -FilePath $checklistPath -Encoding utf8
+Pass "Checklist de evidencias salvo em $checklistPath"
+
+Write-Host ""
+Write-Host "=== Resultado Smoke S9.5 ===" -ForegroundColor Cyan
+Write-Host "PASS: $($script:passed)"
+Write-Host "FAIL: $($script:failed)"
+Write-Host "Evidencias: $artifactDir"
+Write-Host ""
+
+if ($script:failed -gt 0) {
+    exit 1
+}


### PR DESCRIPTION
## Objetivo\nIniciar a S9.5 com entrega operacional concreta para validacao ponta a ponta do fluxo fiscal IRPF MVP.\n\n## Entregas\n- Novo script de smoke: scripts/smoke-tax-irpf-mvp.ps1\n  - fluxo: bootstrap -> upload -> reprocess -> bulk review -> summary/obligation -> rebuild -> export JSON/CSV\n  - gera evidencias em 	mp/smoke-irpf-mvp-<runId>/\n  - modo seguro -WhatIf\n- Novo runbook: docs/runbooks/s9-5-smoke-irpf-mvp.md\n  - checklist objetivo de aceite da S9.5\n  - comandos de execucao e artefatos esperados\n- Roadmaps atualizados:\n  - docs/roadmaps/sprint-9-central-do-leao-irpf-mvp.md (S9.5 em andamento)\n  - docs/roadmap-execution.md (registro executivo do inicio da S9.5)\n\n## Validacao\n- Script executado em pre-validacao: ./scripts/smoke-tax-irpf-mvp.ps1 -WhatIf\n\n## Risco\nBaixo: alteracoes documentais + automacao operacional, sem mudanca de runtime da aplicacao.