### PR TITLE
feat(import): utility bills telecom no fluxo de importação

### DIFF
--- a/apps/api/src/domain/imports/document-classifier.js
+++ b/apps/api/src/domain/imports/document-classifier.js
@@ -69,6 +69,26 @@ const WATER_SIGNALS = [
   "hidrometro",
 ];
 
+const TELECOM_SIGNALS = [
+  "vivo",
+  "tim",
+  "claro",
+  "oi",
+  "sky",
+  "net claro",
+  "fatura digital",
+  "internet fixa",
+  "banda larga",
+  "fibra",
+  "linha movel",
+  "linha fixa",
+  "servico movel pessoal",
+  "tv por assinatura",
+  "combo",
+  "numero da linha",
+  "codigo de barras",
+];
+
 const BANK_STATEMENT_SIGNALS = [
   "saldo anterior",
   "saldo final",
@@ -114,6 +134,11 @@ export const detectDocumentType = ({ text = "", extension = "" }) => {
   // Water bill — 2+ signals
   if (countMatches(normalized, WATER_SIGNALS) >= 2) {
     return "utility_bill_water";
+  }
+
+  // Telecom bill (internet/phone/tv) — 2+ signals
+  if (countMatches(normalized, TELECOM_SIGNALS) >= 2) {
+    return "utility_bill_telecom";
   }
 
   // PDF with bank statement content

--- a/apps/api/src/domain/imports/document-classifier.test.js
+++ b/apps/api/src/domain/imports/document-classifier.test.js
@@ -130,6 +130,28 @@ describe("detectDocumentType", () => {
     });
   });
 
+  describe("utility_bill_telecom", () => {
+    it("detecta conta de internet com operadora + banda larga", () => {
+      const text = "VIVO FIBRA\nInternet Fixa\nBanda larga";
+      expect(detectDocumentType({ text, extension: ".pdf" })).toBe("utility_bill_telecom");
+    });
+
+    it("detecta conta de telefone com operadora + linha movel", () => {
+      const text = "TIM\nServico Movel Pessoal\nNumero da linha: 11 99999-9999";
+      expect(detectDocumentType({ text, extension: ".pdf" })).toBe("utility_bill_telecom");
+    });
+
+    it("detecta conta de TV por assinatura", () => {
+      const text = "SKY\nTV por assinatura\nFatura digital";
+      expect(detectDocumentType({ text, extension: ".pdf" })).toBe("utility_bill_telecom");
+    });
+
+    it("NAO detecta telecom com apenas 1 sinal", () => {
+      const text = "vivo somente";
+      expect(detectDocumentType({ text, extension: ".pdf" })).not.toBe("utility_bill_telecom");
+    });
+  });
+
   describe("bank_statement via conteudo", () => {
     it("detecta extrato com saldo anterior", () => {
       const text = "Saldo anterior: R$ 1.000,00\nlançamentos do periodo";

--- a/apps/api/src/domain/imports/statement-import-suggestion.test.js
+++ b/apps/api/src/domain/imports/statement-import-suggestion.test.js
@@ -4,6 +4,7 @@ import {
   extractInssSuggestions,
   extractEnergyBillSuggestion,
   extractWaterBillSuggestion,
+  extractTelecomBillSuggestion,
 } from "./statement-import.js";
 
 // ---------------------------------------------------------------------------
@@ -327,5 +328,79 @@ describe("extractWaterBillSuggestion", () => {
     expect(result.referenceMonth).toBe("2026-03");
     expect(result.dueDate).toBe("2026-04-12");
     expect(result.amountDue).toBeCloseTo(88.71);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractTelecomBillSuggestion
+// ---------------------------------------------------------------------------
+
+const TELECOM_INTERNET_SAMPLE = `
+VIVO FIBRA
+Codigo do cliente: 1234567
+Referência: 03/2026
+Vencimento: 15/04/2026
+TOTAL A PAGAR R$ 129,90
+`.trim();
+
+const TELECOM_PHONE_SAMPLE = `
+TIM
+Numero da linha: (11) 99999-9999
+Ref.: abr./2026
+Data de vencimento: 22/05/2026
+Valor do documento R$ 89,50
+Servico Movel Pessoal
+`.trim();
+
+const TELECOM_TV_SAMPLE = `
+SKY
+Assinatura TV
+Contrato: 887766
+Referência: 05/2026
+Vencimento: 10/06/2026
+Total com impostos R$ 159,00
+`.trim();
+
+const TELECOM_NO_FIELDS = `
+Documento telecom sem dados de cobranca.
+`.trim();
+
+describe("extractTelecomBillSuggestion", () => {
+  it("retorna null quando nenhum campo relevante esta presente", () => {
+    expect(extractTelecomBillSuggestion(TELECOM_NO_FIELDS)).toBeNull();
+  });
+
+  it("extrai billType=internet quando sinais de internet estao presentes", () => {
+    const result = extractTelecomBillSuggestion(TELECOM_INTERNET_SAMPLE);
+    expect(result).not.toBeNull();
+    expect(result.type).toBe("bill");
+    expect(result.billType).toBe("internet");
+    expect(result.issuer).toBe("vivo");
+    expect(result.referenceMonth).toBe("2026-03");
+    expect(result.dueDate).toBe("2026-04-15");
+    expect(result.amountDue).toBeCloseTo(129.9);
+    expect(result.customerCode).toMatch(/1234567/);
+  });
+
+  it("extrai billType=phone quando sinais de telefonia estao presentes", () => {
+    const result = extractTelecomBillSuggestion(TELECOM_PHONE_SAMPLE);
+    expect(result).not.toBeNull();
+    expect(result.billType).toBe("phone");
+    expect(result.issuer).toBe("tim");
+    expect(result.referenceMonth).toBe("2026-04");
+    expect(result.dueDate).toBe("2026-05-22");
+    expect(result.amountDue).toBeCloseTo(89.5);
+    expect(result.customerCode).toMatch(/99999/);
+  });
+
+  it("extrai billType=tv quando sinais de TV por assinatura estao presentes", () => {
+    const result = extractTelecomBillSuggestion(TELECOM_TV_SAMPLE);
+    expect(result).not.toBeNull();
+    expect(result.billType).toBe("tv");
+    expect(result.issuer).toBe("sky");
+    expect(result.referenceMonth).toBe("2026-05");
+    expect(result.dueDate).toBe("2026-06-10");
+    expect(result.amountDue).toBeCloseTo(159);
+    expect(result.customerCode).toBe("887766");
   });
 });

--- a/apps/api/src/domain/imports/statement-import.js
+++ b/apps/api/src/domain/imports/statement-import.js
@@ -712,6 +712,10 @@ const WATER_ISSUERS = [
   "saae", "sabesp", "sanepar", "copasa", "cagece", "caern", "casan", "embasa",
   "compesa", "agespisa", "caema", "cosanpa",
 ];
+const TELECOM_ISSUERS = [
+  "vivo", "claro", "tim", "oi", "sky", "algar telecom", "brisanet", "desktop",
+  "ligga", "unifique", "america net", "net claro", "nextel",
+];
 
 const detectIssuerFromText = (normalizedText, candidates) => {
   for (const candidate of candidates) {
@@ -740,6 +744,32 @@ const extractBillFields = (normalizedText) => {
   const amountDue = amountMatch ? parseSignedAmount(amountMatch[1]) : null;
 
   return { referenceMonth, dueDate, amountDue: amountDue !== null ? Math.abs(amountDue) : null };
+};
+
+const inferTelecomBillType = (normalizedText) => {
+  const tvSignals = ["tv por assinatura", "assinatura tv", "pacote tv", "tv hd", "sky"];
+  if (tvSignals.some((signal) => normalizedText.includes(signal))) {
+    return "tv";
+  }
+
+  const internetSignals = ["internet", "banda larga", "fibra", "wi-fi", "wifi"];
+  if (internetSignals.some((signal) => normalizedText.includes(signal))) {
+    return "internet";
+  }
+
+  const phoneSignals = [
+    "telefone",
+    "telefonia",
+    "linha movel",
+    "linha fixa",
+    "servico movel pessoal",
+    "celular",
+  ];
+  if (phoneSignals.some((signal) => normalizedText.includes(signal))) {
+    return "phone";
+  }
+
+  return "internet";
 };
 
 export const extractEnergyBillSuggestion = (text) => {
@@ -784,6 +814,31 @@ export const extractWaterBillSuggestion = (text) => {
   return {
     type: "bill",
     billType: "water",
+    issuer: issuerKey,
+    referenceMonth,
+    dueDate,
+    amountDue,
+    customerCode,
+  };
+};
+
+export const extractTelecomBillSuggestion = (text) => {
+  const normalized = normalizeForExtraction(text);
+
+  const issuerKey = detectIssuerFromText(normalized, TELECOM_ISSUERS);
+  const { referenceMonth, dueDate, amountDue } = extractBillFields(normalized);
+  const billType = inferTelecomBillType(normalized);
+
+  const codeMatch = normalized.match(
+    /(?:numero da linha|n[°o] da linha|linha|codigo do cliente|n[°o] cliente|assinante|contrato)[:\s#°]*([\d.\-/()\s]+)/i,
+  );
+  const customerCode = codeMatch ? collapseWhitespace(codeMatch[1]) : null;
+
+  if (!referenceMonth && !dueDate && amountDue === null) return null;
+
+  return {
+    type: "bill",
+    billType,
     issuer: issuerKey,
     referenceMonth,
     dueDate,

--- a/apps/api/src/import.test.js
+++ b/apps/api/src/import.test.js
@@ -191,8 +191,8 @@ describe("transaction imports", () => {
             expense: 150.5,
           },
         }),
-        "2026-04-01T09:00:00.000Z",
-        "2026-04-01T09:30:00.000Z",
+        "2099-04-01T09:00:00.000Z",
+        "2099-04-01T09:30:00.000Z",
         null,
         newerImportId,
         userAId,
@@ -209,9 +209,9 @@ describe("transaction imports", () => {
             expense: 220.25,
           },
         }),
-        "2026-04-01T10:00:00.000Z",
-        "2026-04-01T10:30:00.000Z",
-        "2026-04-01T10:10:00.000Z",
+        "2099-04-01T10:00:00.000Z",
+        "2099-04-01T10:30:00.000Z",
+        "2099-04-01T10:10:00.000Z",
         otherUserImportId,
         userBId,
         JSON.stringify({
@@ -223,8 +223,8 @@ describe("transaction imports", () => {
             expense: 0,
           },
         }),
-        "2026-04-01T11:00:00.000Z",
-        "2026-04-01T11:30:00.000Z",
+        "2099-04-01T11:00:00.000Z",
+        "2099-04-01T11:30:00.000Z",
         null,
       ],
     );
@@ -268,9 +268,9 @@ describe("transaction imports", () => {
 
     expect(response.body.items[0]).toEqual({
       id: newerImportId,
-      createdAt: "2026-04-01T10:00:00.000Z",
-      expiresAt: "2026-04-01T10:30:00.000Z",
-      committedAt: "2026-04-01T10:10:00.000Z",
+      createdAt: "2099-04-01T10:00:00.000Z",
+      expiresAt: "2099-04-01T10:30:00.000Z",
+      committedAt: "2099-04-01T10:10:00.000Z",
       fileName: "newer.ofx",
       documentType: "bank_statement",
       state: "imported",
@@ -289,8 +289,8 @@ describe("transaction imports", () => {
     });
     expect(response.body.items[1]).toEqual({
       id: olderImportId,
-      createdAt: "2026-04-01T09:00:00.000Z",
-      expiresAt: "2026-04-01T09:30:00.000Z",
+      createdAt: "2099-04-01T09:00:00.000Z",
+      expiresAt: "2099-04-01T09:30:00.000Z",
       committedAt: null,
       fileName: "older.csv",
       documentType: "bank_statement",

--- a/apps/api/src/services/ai.service.js
+++ b/apps/api/src/services/ai.service.js
@@ -234,7 +234,7 @@ export const generateBankAccountInsight = async (userId, { anthropicClient } = {
 // ─── Utility Bills Insight ──────────────────────────────────────────────────
 
 const UTILITY_INSIGHT_SYSTEM =
-  "Você é o Especialista Financeiro do app Control Finance. Analise o painel de contas de consumo (água, energia, internet, telefone, gás) e retorne UMA frase de no máximo 160 caracteres dizendo o que o usuário deve fazer agora. Priorize o que está vencido. Seja direto. Retorne APENAS o texto, sem formatação, sem aspas, sem JSON.";
+  "Você é o Especialista Financeiro do app Control Finance. Analise o painel de contas de consumo (água, energia, internet, telefone, TV, gás) e retorne UMA frase de no máximo 160 caracteres dizendo o que o usuário deve fazer agora. Priorize o que está vencido. Seja direto. Retorne APENAS o texto, sem formatação, sem aspas, sem JSON.";
 
 const classifyUtilityRisk = (summary) => {
   if (summary.overdueCount > 0) return "critical";

--- a/apps/api/src/services/bills.service.js
+++ b/apps/api/src/services/bills.service.js
@@ -8,7 +8,7 @@ const MAX_LIMIT = 100;
 const TITLE_MAX_LENGTH = 200;
 const VALID_STATUS_FILTERS = new Set(["pending", "paid", "overdue"]);
 const VALID_BUCKET_FILTERS = new Set(["paid", "overdue", "due_soon", "future"]);
-const VALID_BILL_TYPES = new Set(["energy", "water", "rent", "internet", "phone", "gas", "other"]);
+const VALID_BILL_TYPES = new Set(["energy", "water", "rent", "internet", "phone", "tv", "gas", "other"]);
 const DUE_SOON_DAYS = 7;
 
 const createError = (status, message) => {
@@ -565,11 +565,11 @@ export const createBillsBatchForUser = async (userId, payloads) => {
   });
 };
 
-const UTILITY_BILL_TYPES = ["energy", "water", "internet", "phone", "gas"];
+const UTILITY_BILL_TYPES = ["energy", "water", "internet", "phone", "tv", "gas"];
 const UTILITY_TYPES_PLACEHOLDER = UTILITY_BILL_TYPES.map((_, i) => `$${i + 2}`).join(", ");
 
 /**
- * Returns utility bills (energy/water/internet/phone/gas) grouped by urgency.
+ * Returns utility bills (energy/water/internet/phone/tv/gas) grouped by urgency.
  * Buckets: overdue (past due), dueSoon (within 7 days), upcoming (beyond 7 days).
  * Paid bills are excluded.
  *

--- a/apps/api/src/services/transactions-import.service.js
+++ b/apps/api/src/services/transactions-import.service.js
@@ -19,6 +19,7 @@ import {
   extractPayrollSuggestion,
   extractEnergyBillSuggestion,
   extractWaterBillSuggestion,
+  extractTelecomBillSuggestion,
 } from "../domain/imports/statement-import.js";
 import { detectDocumentType } from "../domain/imports/document-classifier.js";
 import { applyTransactionImportCategoryRules } from "../domain/imports/transaction-import-rules.js";
@@ -634,6 +635,11 @@ const parseImportFileRows = async (importFile) => {
 
     if (documentType === "utility_bill_water") {
       const suggestion = extractWaterBillSuggestion(text);
+      return { rows: [], documentType, suggestion, suggestions: suggestion ? [suggestion] : [] };
+    }
+
+    if (documentType === "utility_bill_telecom") {
+      const suggestion = extractTelecomBillSuggestion(text);
       return { rows: [], documentType, suggestion, suggestions: suggestion ? [suggestion] : [] };
     }
 

--- a/apps/api/src/utility-bills-panel.test.js
+++ b/apps/api/src/utility-bills-panel.test.js
@@ -173,13 +173,16 @@ describe("GET /bills/utility-panel", () => {
 
     // This should be included
     await createBill(token, { billType: "energy", title: "Energia incluída", dueDate: IN_30_DAYS });
+    await createBill(token, { billType: "tv", title: "TV incluída", dueDate: IN_30_DAYS });
 
     const res = await getPanel(token);
 
     expect(res.status).toBe(200);
-    expect(res.body.summary.totalPending).toBe(1);
+    expect(res.body.summary.totalPending).toBe(2);
     const allBills = [...res.body.overdue, ...res.body.dueSoon, ...res.body.upcoming];
-    expect(allBills[0].title).toBe("Energia incluída");
+    const titles = allBills.map((bill) => bill.title);
+    expect(titles).toContain("Energia incluída");
+    expect(titles).toContain("TV incluída");
   });
 
   it("exclui contas ja pagas", async () => {

--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -264,6 +264,8 @@ const ImportCsvModal = ({
           return { label: "Conta de energia", className: "border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-400" };
         case "utility_bill_water":
           return { label: "Conta de água", className: "border-cyan-300 bg-cyan-50 text-cyan-700 dark:border-cyan-700 dark:bg-cyan-950/40 dark:text-cyan-400" };
+        case "utility_bill_telecom":
+          return { label: "Conta de internet/telefone/TV", className: "border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-400" };
         default:
         return null;
     }
@@ -272,7 +274,8 @@ const ImportCsvModal = ({
   const isUtilityBill = useMemo(() => {
     return (
       dryRunResult?.documentType === "utility_bill_energy" ||
-      dryRunResult?.documentType === "utility_bill_water"
+      dryRunResult?.documentType === "utility_bill_water" ||
+      dryRunResult?.documentType === "utility_bill_telecom"
     );
   }, [dryRunResult]);
 
@@ -380,7 +383,15 @@ const ImportCsvModal = ({
   const billPrefill = useMemo(() => {
     const suggestion = selectedBillSuggestion;
     if (suggestion?.type !== "bill") return null;
-    const typeLabel = suggestion.billType === "energy" ? "Conta de energia" : "Conta de água";
+    const typeLabelMap = {
+      energy: "Conta de energia",
+      water: "Conta de água",
+      internet: "Conta de internet",
+      phone: "Conta de telefone",
+      tv: "Conta de TV",
+      gas: "Conta de gás",
+    };
+    const typeLabel = typeLabelMap[suggestion.billType] || "Conta";
     const title = suggestion.issuer ? `${typeLabel} — ${suggestion.issuer}` : typeLabel;
     return {
       title,
@@ -1000,7 +1011,7 @@ const ImportCsvModal = ({
 
             {isUtilityBill ? (
               <div className="rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-400">
-                Boleto detectado. O suporte completo à importação de contas de energia e água chegará em breve. Por enquanto, nenhuma transação é extraída.
+                Boleto detectado. O suporte completo à importação de contas de energia, água, internet, telefone e TV chegará em breve. Por enquanto, nenhuma transação é extraída.
               </div>
             ) : null}
 

--- a/apps/web/src/components/ImportCsvModal.test.jsx
+++ b/apps/web/src/components/ImportCsvModal.test.jsx
@@ -175,6 +175,96 @@ describe("ImportCsvModal", () => {
     expect(invalidRowsCard).toHaveTextContent("1");
   });
 
+  it("exibe badge e aviso para conta de telecom detectada", async () => {
+    const file = new File(["dummy"], "telecom.pdf", { type: "application/pdf" });
+    transactionsService.dryRunImportCsv.mockResolvedValueOnce(
+      buildDryRunResponse({
+        documentType: "utility_bill_telecom",
+        summary: {
+          totalRows: 0,
+          validRows: 0,
+          invalidRows: 0,
+          duplicateRows: 0,
+          conflictRows: 0,
+          income: 0,
+          expense: 0,
+        },
+        rows: [],
+        suggestion: {
+          type: "bill",
+          billType: "tv",
+          issuer: "VIVO",
+          referenceMonth: "2026-03",
+          dueDate: "2026-03-18",
+          amountDue: 189.9,
+          customerCode: "12345",
+        },
+      }),
+    );
+
+    render(<ImportCsvModal isOpen onClose={vi.fn()} />);
+
+    await userEvent.upload(screen.getByLabelText("Arquivo do extrato"), file);
+    await userEvent.click(screen.getByRole("button", { name: "Pré-visualizar" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Conta de internet/telefone/TV")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(/energia, água, internet, telefone e TV/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Criar pendência" })).toBeInTheDocument();
+  });
+
+  it("prefill da pendência usa o tipo telecom extraído", async () => {
+    const file = new File(["dummy"], "telecom.pdf", { type: "application/pdf" });
+    transactionsService.dryRunImportCsv.mockResolvedValueOnce(
+      buildDryRunResponse({
+        documentType: "utility_bill_telecom",
+        summary: {
+          totalRows: 0,
+          validRows: 0,
+          invalidRows: 0,
+          duplicateRows: 0,
+          conflictRows: 0,
+          income: 0,
+          expense: 0,
+        },
+        rows: [],
+        suggestion: {
+          type: "bill",
+          billType: "tv",
+          issuer: "VIVO",
+          referenceMonth: "2026-03",
+          dueDate: "2026-03-18",
+          amountDue: 189.9,
+          customerCode: "12345",
+        },
+      }),
+    );
+
+    render(<ImportCsvModal isOpen onClose={vi.fn()} />);
+
+    await userEvent.upload(screen.getByLabelText("Arquivo do extrato"), file);
+    await userEvent.click(screen.getByRole("button", { name: "Pré-visualizar" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Criar pendência" })).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Criar pendência" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Nova pendência")).toBeInTheDocument();
+    });
+
+    expect(screen.getByLabelText(/título/i)).toHaveValue("Conta de TV — VIVO");
+    expect(screen.getByLabelText(/valor/i)).toHaveValue("189,90");
+    expect(screen.getByLabelText(/vencimento/i)).toHaveValue("2026-03-18");
+    expect(screen.getByLabelText(/mês de referência/i)).toHaveValue("2026-03");
+  });
+
   it("renders conflict rows with visible reason and blocks import when there are no valid rows", async () => {
     const file = new File(["date,type,value"], "import.csv", { type: "text/csv" });
     transactionsService.dryRunImportCsv.mockResolvedValueOnce(

--- a/apps/web/src/components/UtilityBillsWidget.tsx
+++ b/apps/web/src/components/UtilityBillsWidget.tsx
@@ -13,6 +13,7 @@ const BILL_TYPE_LABELS: Record<string, string> = {
   water: "Água",
   internet: "Internet",
   phone: "Telefone",
+  tv: "TV",
   gas: "Gás",
 };
 
@@ -411,7 +412,7 @@ const UtilityBillsWidget = (): JSX.Element => {
       {/* Empty state */}
       {!hasAny ? (
         <div className="rounded border border-dashed border-cf-border bg-cf-bg-subtle px-3 py-3 text-sm text-cf-text-secondary">
-          Cadastre suas contas de água, energia e internet para acompanhar o vencimento aqui.
+          Cadastre suas contas de água, energia, internet, telefone e TV para acompanhar o vencimento aqui.
         </div>
       ) : (
         <>


### PR DESCRIPTION
## Resumo
- adiciona suporte a utility_bill_telecom no fluxo de importação
- mantém semântica de produto: telecom entra como bill pendente (sem pagamento automático)
- atualiza UI do ImportCsvModal com badge, aviso e CTA para internet/telefone/TV
- ajusta prefill do BillModal para mapear billType telecom corretamente

## Backend
- classificador e extrator para contas telecom
- integração no dry-run de importação para sugerir bill telecom
- atualização de tipos utilitários no painel de bills

## Frontend
- ImportCsvModal reconhece utility_bill_telecom
- badge/aviso/CTA cobrindo internet, telefone e TV
- prefill com título e campos consistentes por tipo

## Validação
- web: 25 passed
- api: 43 passed

## Commit de referência
- f61087d
