### PR TITLE
feat(import): suporte a conta de gas no PR11

### DIFF
--- a/apps/api/src/domain/imports/document-classifier.js
+++ b/apps/api/src/domain/imports/document-classifier.js
@@ -69,6 +69,19 @@ const WATER_SIGNALS = [
   "hidrometro",
 ];
 
+const GAS_SIGNALS = [
+  "comgas",
+  "naturgy",
+  "gas natural",
+  "gas canalizado",
+  "fornecimento de gas",
+  "tarifa de gas",
+  "conta de gas",
+  "leitura anterior",
+  "leitura atual",
+  "consumo m3",
+];
+
 const TELECOM_SIGNALS = [
   "vivo",
   "tim",
@@ -134,6 +147,11 @@ export const detectDocumentType = ({ text = "", extension = "" }) => {
   // Water bill — 2+ signals
   if (countMatches(normalized, WATER_SIGNALS) >= 2) {
     return "utility_bill_water";
+  }
+
+  // Gas bill — 2+ signals
+  if (countMatches(normalized, GAS_SIGNALS) >= 2) {
+    return "utility_bill_gas";
   }
 
   // Telecom bill (internet/phone/tv) — 2+ signals

--- a/apps/api/src/domain/imports/document-classifier.test.js
+++ b/apps/api/src/domain/imports/document-classifier.test.js
@@ -130,6 +130,23 @@ describe("detectDocumentType", () => {
     });
   });
 
+  describe("utility_bill_gas", () => {
+    it("detecta conta de gas com comgas + gas canalizado", () => {
+      const text = "COMGAS\nFornecimento de gas canalizado\nTarifa de gas";
+      expect(detectDocumentType({ text, extension: ".pdf" })).toBe("utility_bill_gas");
+    });
+
+    it("detecta conta de gas com naturgy + consumo m3", () => {
+      const text = "NATURGY\nConsumo m3: 12\nConta de gas";
+      expect(detectDocumentType({ text, extension: ".pdf" })).toBe("utility_bill_gas");
+    });
+
+    it("NAO detecta gas com apenas 1 sinal", () => {
+      const text = "comgas somente";
+      expect(detectDocumentType({ text, extension: ".pdf" })).not.toBe("utility_bill_gas");
+    });
+  });
+
   describe("utility_bill_telecom", () => {
     it("detecta conta de internet com operadora + banda larga", () => {
       const text = "VIVO FIBRA\nInternet Fixa\nBanda larga";

--- a/apps/api/src/domain/imports/statement-import-suggestion.test.js
+++ b/apps/api/src/domain/imports/statement-import-suggestion.test.js
@@ -4,6 +4,7 @@ import {
   extractInssSuggestions,
   extractEnergyBillSuggestion,
   extractWaterBillSuggestion,
+  extractGasBillSuggestion,
   extractTelecomBillSuggestion,
 } from "./statement-import.js";
 
@@ -328,6 +329,52 @@ describe("extractWaterBillSuggestion", () => {
     expect(result.referenceMonth).toBe("2026-03");
     expect(result.dueDate).toBe("2026-04-12");
     expect(result.amountDue).toBeCloseTo(88.71);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractGasBillSuggestion
+// ---------------------------------------------------------------------------
+
+const GAS_SAMPLE = `
+COMGÁS
+Código do cliente: 778899
+Referência: 04/2026
+Vencimento: 12/05/2026
+TOTAL A PAGAR R$ 95,40
+`.trim();
+
+const GAS_NO_FIELDS = `
+Documento qualquer sem campos de boleto de gas.
+`.trim();
+
+describe("extractGasBillSuggestion", () => {
+  it("retorna null quando nenhum campo relevante esta presente", () => {
+    expect(extractGasBillSuggestion(GAS_NO_FIELDS)).toBeNull();
+  });
+
+  it("retorna type=bill e billType=gas", () => {
+    const result = extractGasBillSuggestion(GAS_SAMPLE);
+    expect(result).not.toBeNull();
+    expect(result.type).toBe("bill");
+    expect(result.billType).toBe("gas");
+  });
+
+  it("extrai issuer da lista de prestadoras conhecidas", () => {
+    const result = extractGasBillSuggestion(GAS_SAMPLE);
+    expect(result.issuer).toBe("comgas");
+  });
+
+  it("resolve referenceMonth e dueDate", () => {
+    const result = extractGasBillSuggestion(GAS_SAMPLE);
+    expect(result.referenceMonth).toBe("2026-04");
+    expect(result.dueDate).toBe("2026-05-12");
+  });
+
+  it("extrai amountDue e customerCode", () => {
+    const result = extractGasBillSuggestion(GAS_SAMPLE);
+    expect(result.amountDue).toBeCloseTo(95.4);
+    expect(result.customerCode).toBe("778899");
   });
 });
 

--- a/apps/api/src/domain/imports/statement-import.js
+++ b/apps/api/src/domain/imports/statement-import.js
@@ -712,6 +712,9 @@ const WATER_ISSUERS = [
   "saae", "sabesp", "sanepar", "copasa", "cagece", "caern", "casan", "embasa",
   "compesa", "agespisa", "caema", "cosanpa",
 ];
+const GAS_ISSUERS = [
+  "comgas", "naturgy", "gas natural", "ceg", "ceg rio",
+];
 const TELECOM_ISSUERS = [
   "vivo", "claro", "tim", "oi", "sky", "algar telecom", "brisanet", "desktop",
   "ligga", "unifique", "america net", "net claro", "nextel",
@@ -814,6 +817,31 @@ export const extractWaterBillSuggestion = (text) => {
   return {
     type: "bill",
     billType: "water",
+    issuer: issuerKey,
+    referenceMonth,
+    dueDate,
+    amountDue,
+    customerCode,
+  };
+};
+
+export const extractGasBillSuggestion = (text) => {
+  const normalized = normalizeForExtraction(text);
+
+  const issuerKey = detectIssuerFromText(normalized, GAS_ISSUERS);
+  const { referenceMonth, dueDate, amountDue } = extractBillFields(normalized);
+
+  // Customer code: "Código do cliente", "N° instalação", "Matrícula"
+  const codeMatch = normalized.match(
+    /(?:codigo do cliente|numero do cliente|n[°o] instalacao|instalacao|matricula)[:\s#°]*([\d.\-/]+)/i,
+  );
+  const customerCode = codeMatch ? codeMatch[1].trim() : null;
+
+  if (!referenceMonth && !dueDate && amountDue === null) return null;
+
+  return {
+    type: "bill",
+    billType: "gas",
     issuer: issuerKey,
     referenceMonth,
     dueDate,

--- a/apps/api/src/services/transactions-import.service.js
+++ b/apps/api/src/services/transactions-import.service.js
@@ -19,6 +19,7 @@ import {
   extractPayrollSuggestion,
   extractEnergyBillSuggestion,
   extractWaterBillSuggestion,
+  extractGasBillSuggestion,
   extractTelecomBillSuggestion,
 } from "../domain/imports/statement-import.js";
 import { detectDocumentType } from "../domain/imports/document-classifier.js";
@@ -635,6 +636,11 @@ const parseImportFileRows = async (importFile) => {
 
     if (documentType === "utility_bill_water") {
       const suggestion = extractWaterBillSuggestion(text);
+      return { rows: [], documentType, suggestion, suggestions: suggestion ? [suggestion] : [] };
+    }
+
+    if (documentType === "utility_bill_gas") {
+      const suggestion = extractGasBillSuggestion(text);
       return { rows: [], documentType, suggestion, suggestions: suggestion ? [suggestion] : [] };
     }
 

--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -264,6 +264,8 @@ const ImportCsvModal = ({
           return { label: "Conta de energia", className: "border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-400" };
         case "utility_bill_water":
           return { label: "Conta de água", className: "border-cyan-300 bg-cyan-50 text-cyan-700 dark:border-cyan-700 dark:bg-cyan-950/40 dark:text-cyan-400" };
+        case "utility_bill_gas":
+          return { label: "Conta de gás", className: "border-orange-300 bg-orange-50 text-orange-700 dark:border-orange-700 dark:bg-orange-950/40 dark:text-orange-300" };
         case "utility_bill_telecom":
           return { label: "Conta de internet/telefone/TV", className: "border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-400" };
         default:
@@ -275,6 +277,7 @@ const ImportCsvModal = ({
     return (
       dryRunResult?.documentType === "utility_bill_energy" ||
       dryRunResult?.documentType === "utility_bill_water" ||
+      dryRunResult?.documentType === "utility_bill_gas" ||
       dryRunResult?.documentType === "utility_bill_telecom"
     );
   }, [dryRunResult]);
@@ -1011,7 +1014,7 @@ const ImportCsvModal = ({
 
             {isUtilityBill ? (
               <div className="rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-400">
-                Boleto detectado. O suporte completo à importação de contas de energia, água, internet, telefone e TV chegará em breve. Por enquanto, nenhuma transação é extraída.
+                Boleto detectado. O suporte completo à importação de contas de energia, água, gás, internet, telefone e TV chegará em breve. Por enquanto, nenhuma transação é extraída.
               </div>
             ) : null}
 

--- a/apps/web/src/components/ImportCsvModal.test.jsx
+++ b/apps/web/src/components/ImportCsvModal.test.jsx
@@ -212,9 +212,57 @@ describe("ImportCsvModal", () => {
     });
 
     expect(
-      screen.getByText(/energia, água, internet, telefone e TV/i),
+      screen.getByText(/energia, água, gás, internet, telefone e TV/i),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Criar pendência" })).toBeInTheDocument();
+  });
+
+  it("exibe badge e prefill para conta de gás detectada", async () => {
+    const file = new File(["dummy"], "gas.pdf", { type: "application/pdf" });
+    transactionsService.dryRunImportCsv.mockResolvedValueOnce(
+      buildDryRunResponse({
+        documentType: "utility_bill_gas",
+        summary: {
+          totalRows: 0,
+          validRows: 0,
+          invalidRows: 0,
+          duplicateRows: 0,
+          conflictRows: 0,
+          income: 0,
+          expense: 0,
+        },
+        rows: [],
+        suggestion: {
+          type: "bill",
+          billType: "gas",
+          issuer: "COMGAS",
+          referenceMonth: "2026-04",
+          dueDate: "2026-05-12",
+          amountDue: 95.4,
+          customerCode: "778899",
+        },
+      }),
+    );
+
+    render(<ImportCsvModal isOpen onClose={vi.fn()} />);
+
+    await userEvent.upload(screen.getByLabelText("Arquivo do extrato"), file);
+    await userEvent.click(screen.getByRole("button", { name: "Pré-visualizar" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Conta de gás")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Criar pendência" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Nova pendência")).toBeInTheDocument();
+    });
+
+    expect(screen.getByLabelText(/título/i)).toHaveValue("Conta de gás — COMGAS");
+    expect(screen.getByLabelText(/valor/i)).toHaveValue("95,40");
+    expect(screen.getByLabelText(/vencimento/i)).toHaveValue("2026-05-12");
+    expect(screen.getByLabelText(/mês de referência/i)).toHaveValue("2026-04");
   });
 
   it("prefill da pendência usa o tipo telecom extraído", async () => {


### PR DESCRIPTION
## Resumo
- adiciona classificador de documento utility_bill_gas com sinais de conta de gas
- adiciona extrator extractGasBillSuggestion e integra no dry-run de importacao
- atualiza modal de importacao para badge/aviso e prefill de pendencia de gas
- amplia testes da API e do web para cobrir o novo fluxo

## Validacao local
- npm -w apps/api run test -- src/domain/imports/document-classifier.test.js src/domain/imports/statement-import-suggestion.test.js
- npm -w apps/web run test:run -- src/components/ImportCsvModal.test.jsx
