### PR TITLE
fix(web): normalizar billType utility bills no dry-run

### DIFF
--- a/apps/web/src/services/transactions.service.test.ts
+++ b/apps/web/src/services/transactions.service.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "./api";
+import { transactionsService } from "./transactions.service";
+
+vi.mock("./api", () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+const postMock = vi.mocked(api.post);
+
+const BASE_DRY_RUN_RESPONSE = {
+  importId: "import-session-1",
+  expiresAt: "2026-04-10T12:00:00.000Z",
+  summary: {
+    totalRows: 0,
+    validRows: 0,
+    invalidRows: 0,
+    duplicateRows: 0,
+    conflictRows: 0,
+    income: 0,
+    expense: 0,
+  },
+  rows: [],
+};
+
+describe("transactions service import dry-run", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+  });
+
+  it("preserva billType=gas na suggestion principal", async () => {
+    postMock.mockResolvedValueOnce({
+      data: {
+        ...BASE_DRY_RUN_RESPONSE,
+        suggestion: {
+          type: "bill",
+          billType: "gas",
+          issuer: "COMGAS",
+        },
+      },
+    });
+
+    const file = new File(["dummy"], "gas.pdf", { type: "application/pdf" });
+    const result = await transactionsService.dryRunImportCsv(file);
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/transactions/import/dry-run",
+      expect.any(FormData),
+    );
+    expect(result.suggestion).toMatchObject({
+      type: "bill",
+      billType: "gas",
+      issuer: "COMGAS",
+    });
+  });
+
+  it("preserva billType telecom no array de suggestions", async () => {
+    postMock.mockResolvedValueOnce({
+      data: {
+        ...BASE_DRY_RUN_RESPONSE,
+        suggestions: [
+          { type: "bill", billType: "internet" },
+          { type: "bill", billType: "phone" },
+          { type: "bill", billType: "tv" },
+        ],
+      },
+    });
+
+    const file = new File(["dummy"], "telecom.pdf", { type: "application/pdf" });
+    const result = await transactionsService.dryRunImportCsv(file);
+
+    expect(result.suggestions?.map((suggestion) =>
+      suggestion.type === "bill" ? suggestion.billType : null,
+    )).toEqual(["internet", "phone", "tv"]);
+  });
+
+  it("normaliza billType desconhecido para null", async () => {
+    postMock.mockResolvedValueOnce({
+      data: {
+        ...BASE_DRY_RUN_RESPONSE,
+        suggestion: {
+          type: "bill",
+          billType: "unknown",
+        },
+      },
+    });
+
+    const file = new File(["dummy"], "unknown.pdf", { type: "application/pdf" });
+    const result = await transactionsService.dryRunImportCsv(file);
+
+    expect(result.suggestion).toMatchObject({
+      type: "bill",
+      billType: null,
+    });
+  });
+});

--- a/apps/web/src/services/transactions.service.ts
+++ b/apps/web/src/services/transactions.service.ts
@@ -205,13 +205,22 @@ export interface ImportDryRunProfileSuggestion {
 
 export interface ImportDryRunBillSuggestion {
   type: "bill";
-  billType?: "energy" | "water" | null;
+  billType?: "energy" | "water" | "internet" | "phone" | "tv" | "gas" | null;
   issuer?: string | null;
   referenceMonth?: string | null;
   dueDate?: string | null;
   amountDue?: number | null;
   customerCode?: string | null;
 }
+
+const IMPORT_DRY_RUN_BILL_TYPES = new Set([
+  "energy",
+  "water",
+  "internet",
+  "phone",
+  "tv",
+  "gas",
+] as const);
 
 export type ImportDryRunSuggestion = ImportDryRunProfileSuggestion | ImportDryRunBillSuggestion;
 
@@ -613,10 +622,9 @@ const normalizeImportDryRunSuggestion = (
     const normalizedBillType = String(parsed.billType || "").trim();
     return {
       type: "bill",
-      billType:
-        normalizedBillType === "energy" || normalizedBillType === "water"
-          ? normalizedBillType
-          : null,
+      billType: IMPORT_DRY_RUN_BILL_TYPES.has(normalizedBillType as never)
+        ? (normalizedBillType as "energy" | "water" | "internet" | "phone" | "tv" | "gas")
+        : null,
       issuer:
         typeof parsed.issuer === "string" && parsed.issuer.trim() ? parsed.issuer.trim() : null,
       referenceMonth:


### PR DESCRIPTION
## Resumo
- corrige o parse do dry-run no frontend para preservar `billType` de utility bills (`energy`, `water`, `internet`, `phone`, `tv`, `gas`)
- evita perda silenciosa para `null` quando a API retorna tipos telecom/gas
- adiciona teste dedicado de `transactions.service` cobrindo parse de `gas`, telecom e fallback para tipo desconhecido

## Validacao local
- npm -w apps/web run test:run -- src/services/transactions.service.test.ts src/components/ImportCsvModal.test.jsx
