### PR TITLE
fix(web): endurecer normalizacao de billType em bills

### DIFF
--- a/apps/web/src/components/BillModal.tsx
+++ b/apps/web/src/components/BillModal.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useState } from "react";
 import { parseCurrencyInput, getTodayISODate, isValidISODate } from "./DatabaseUtils";
-import { billsService, type Bill, type CreateBillPayload } from "../services/bills.service";
+import {
+  billsService,
+  type Bill,
+  type BillType,
+  type CreateBillPayload,
+} from "../services/bills.service";
 
 interface CategoryOption {
   id: number;
@@ -13,7 +18,7 @@ export interface BillPrefill {
   dueDate?: string;
   provider?: string;
   referenceMonth?: string;
-  billType?: string;
+  billType?: BillType;
   sourceImportSessionId?: string;
 }
 

--- a/apps/web/src/services/bills.service.test.ts
+++ b/apps/web/src/services/bills.service.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "./api";
+import { billsService } from "./bills.service";
+
+vi.mock("./api", () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+const getMock = vi.mocked(api.get);
+const postMock = vi.mocked(api.post);
+
+describe("bills service billType normalization", () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    postMock.mockReset();
+  });
+
+  it("normaliza bill_type conhecido para minúsculo", async () => {
+    getMock.mockResolvedValueOnce({
+      data: {
+        items: [
+          {
+            id: 11,
+            user_id: 7,
+            title: "Conta COMGAS",
+            amount: 95.4,
+            due_date: "2026-05-12",
+            status: "pending",
+            is_overdue: false,
+            bill_type: " GAS ",
+          },
+        ],
+        pagination: { limit: 20, offset: 0, total: 1 },
+      },
+    });
+
+    const result = await billsService.list();
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].billType).toBe("gas");
+  });
+
+  it("retorna billType null quando API envia tipo desconhecido", async () => {
+    getMock.mockResolvedValueOnce({
+      data: {
+        items: [
+          {
+            id: 12,
+            user_id: 7,
+            title: "Conta desconhecida",
+            amount: 10,
+            due_date: "2026-05-20",
+            status: "pending",
+            is_overdue: false,
+            bill_type: "steam",
+          },
+        ],
+        pagination: { limit: 20, offset: 0, total: 1 },
+      },
+    });
+
+    const result = await billsService.list();
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].billType).toBeNull();
+  });
+
+  it("preserva billType conhecido no retorno de create", async () => {
+    postMock.mockResolvedValueOnce({
+      data: {
+        id: 13,
+        user_id: 7,
+        title: "Conta de internet",
+        amount: 129.9,
+        due_date: "2026-06-10",
+        status: "pending",
+        is_overdue: false,
+        bill_type: "internet",
+      },
+    });
+
+    const result = await billsService.create({
+      title: "Conta de internet",
+      amount: 129.9,
+      dueDate: "2026-06-10",
+      billType: "internet",
+    });
+
+    expect(postMock).toHaveBeenCalledWith("/bills", {
+      title: "Conta de internet",
+      amount: 129.9,
+      dueDate: "2026-06-10",
+      billType: "internet",
+    });
+    expect(result.billType).toBe("internet");
+  });
+});

--- a/apps/web/src/services/bills.service.ts
+++ b/apps/web/src/services/bills.service.ts
@@ -6,6 +6,15 @@ export type BillStatus = "pending" | "paid";
 export type BillOperationalBucket = "paid" | "overdue" | "due_soon" | "future";
 export type BillStatusFilter = "pending" | "paid" | "overdue" | "due_soon" | "future" | undefined;
 export type MatchStatus = "unmatched" | "matched";
+export type BillType =
+  | "energy"
+  | "water"
+  | "internet"
+  | "phone"
+  | "tv"
+  | "gas"
+  | "rent"
+  | "other";
 
 export interface Bill {
   id: number;
@@ -22,7 +31,7 @@ export interface Bill {
   notes: string | null;
   provider: string | null;
   referenceMonth: string | null;
-  billType: string | null;
+  billType: BillType | null;
   sourceImportSessionId: string | null;
   matchStatus: MatchStatus;
   linkedTransactionId: number | null;
@@ -50,7 +59,7 @@ export interface CreateBillPayload {
   notes?: string | null;
   provider?: string | null;
   referenceMonth?: string | null;
-  billType?: string | null;
+  billType?: BillType | null;
   sourceImportSessionId?: string | null;
 }
 
@@ -180,6 +189,24 @@ const normalizeStringOrNull = (value: unknown): string | null => {
   return trimmed || null;
 };
 
+const BILL_TYPE_VALUES = new Set<BillType>([
+  "energy",
+  "water",
+  "internet",
+  "phone",
+  "tv",
+  "gas",
+  "rent",
+  "other",
+]);
+
+const normalizeBillType = (value: unknown): BillType | null => {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return null;
+  return BILL_TYPE_VALUES.has(normalized as BillType) ? (normalized as BillType) : null;
+};
+
 const normalizeISOString = (value: unknown): string => {
   if (typeof value === "string" && value.trim()) return value.trim();
   return "";
@@ -263,7 +290,7 @@ const normalizeBill = (raw: BillApiPayload): Bill => {
     notes: normalizeStringOrNull(raw.notes),
     provider: normalizeStringOrNull(raw.provider),
     referenceMonth: normalizeStringOrNull(raw.referenceMonth ?? raw.reference_month),
-    billType: normalizeStringOrNull(raw.billType ?? raw.bill_type),
+    billType: normalizeBillType(raw.billType ?? raw.bill_type),
     sourceImportSessionId: normalizeStringOrNull(raw.sourceImportSessionId ?? raw.source_import_session_id),
     matchStatus: raw.matchStatus === "matched" ? "matched" : "unmatched",
     linkedTransactionId: (() => {

--- a/apps/web/src/services/bills.service.ts
+++ b/apps/web/src/services/bills.service.ts
@@ -7,6 +7,7 @@ export type BillOperationalBucket = "paid" | "overdue" | "due_soon" | "future";
 export type BillStatusFilter = "pending" | "paid" | "overdue" | "due_soon" | "future" | undefined;
 export type MatchStatus = "unmatched" | "matched";
 export type BillType =
+  | "credit_card_invoice"
   | "energy"
   | "water"
   | "internet"
@@ -190,6 +191,7 @@ const normalizeStringOrNull = (value: unknown): string | null => {
 };
 
 const BILL_TYPE_VALUES = new Set<BillType>([
+  "credit_card_invoice",
   "energy",
   "water",
   "internet",


### PR DESCRIPTION
## Resumo
- endurece a normalizacao de `billType` no `bills.service` com conjunto explicito de tipos aceitos
- adiciona `BillType` no contrato do frontend para reduzir drift semantico
- converte tipos desconhecidos de `bill_type` para `null` de forma defensiva
- adiciona teste unitario dedicado para parse de tipos conhecidos e fallback de desconhecido

## Validacao local
- npm -w apps/web run test:run -- src/services/bills.service.test.ts src/services/transactions.service.test.ts
