### PR TITLE
fix(web): endurecer tipagem no fluxo prefill->bill

### DIFF
--- a/apps/web/src/services/bills.service.test.ts
+++ b/apps/web/src/services/bills.service.test.ts
@@ -13,11 +13,13 @@ vi.mock("./api", () => ({
 
 const getMock = vi.mocked(api.get);
 const postMock = vi.mocked(api.post);
+const patchMock = vi.mocked(api.patch);
 
 describe("bills service billType normalization", () => {
   beforeEach(() => {
     getMock.mockReset();
     postMock.mockReset();
+    patchMock.mockReset();
   });
 
   it("normaliza bill_type conhecido para minúsculo", async () => {
@@ -98,5 +100,60 @@ describe("bills service billType normalization", () => {
       billType: "internet",
     });
     expect(result.billType).toBe("internet");
+  });
+
+  it("sanitiza payload do create quando billType/sourceImportSessionId sao invalidos", async () => {
+    postMock.mockResolvedValueOnce({
+      data: {
+        id: 14,
+        user_id: 7,
+        title: "Conta",
+        amount: 80,
+        due_date: "2026-06-20",
+        status: "pending",
+        is_overdue: false,
+        bill_type: null,
+        source_import_session_id: null,
+      },
+    });
+
+    await billsService.create({
+      title: "Conta",
+      amount: 80,
+      dueDate: "2026-06-20",
+      billType: "steam" as unknown as "energy",
+      sourceImportSessionId: "   " as unknown as string,
+    });
+
+    expect(postMock).toHaveBeenCalledWith("/bills", {
+      title: "Conta",
+      amount: 80,
+      dueDate: "2026-06-20",
+      billType: null,
+      sourceImportSessionId: null,
+    });
+  });
+
+  it("preserva update parcial sem limpar billType/sourceImportSessionId ausentes", async () => {
+    patchMock.mockResolvedValueOnce({
+      data: {
+        id: 15,
+        user_id: 7,
+        title: "Conta editada",
+        amount: 100,
+        due_date: "2026-06-25",
+        status: "pending",
+        is_overdue: false,
+        bill_type: "gas",
+      },
+    });
+
+    await billsService.update(15, {
+      title: "Conta editada",
+    });
+
+    expect(patchMock).toHaveBeenCalledWith("/bills/15", {
+      title: "Conta editada",
+    });
   });
 });

--- a/apps/web/src/services/bills.service.ts
+++ b/apps/web/src/services/bills.service.ts
@@ -209,6 +209,34 @@ const normalizeBillType = (value: unknown): BillType | null => {
   return BILL_TYPE_VALUES.has(normalized as BillType) ? (normalized as BillType) : null;
 };
 
+const normalizeCreatePayload = (payload: CreateBillPayload): CreateBillPayload => {
+  const normalizedPayload: CreateBillPayload = { ...payload };
+
+  if (Object.prototype.hasOwnProperty.call(payload, "billType")) {
+    normalizedPayload.billType = normalizeBillType(payload.billType);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(payload, "sourceImportSessionId")) {
+    normalizedPayload.sourceImportSessionId = normalizeStringOrNull(payload.sourceImportSessionId);
+  }
+
+  return normalizedPayload;
+};
+
+const normalizeUpdatePayload = (payload: UpdateBillPayload): UpdateBillPayload => {
+  const normalizedPayload: UpdateBillPayload = { ...payload };
+
+  if (Object.prototype.hasOwnProperty.call(payload, "billType")) {
+    normalizedPayload.billType = normalizeBillType(payload.billType);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(payload, "sourceImportSessionId")) {
+    normalizedPayload.sourceImportSessionId = normalizeStringOrNull(payload.sourceImportSessionId);
+  }
+
+  return normalizedPayload;
+};
+
 const normalizeISOString = (value: unknown): string => {
   if (typeof value === "string" && value.trim()) return value.trim();
   return "";
@@ -355,12 +383,12 @@ export const billsService = {
   },
 
   create: async (payload: CreateBillPayload): Promise<Bill> => {
-    const { data } = await api.post("/bills", payload);
+    const { data } = await api.post("/bills", normalizeCreatePayload(payload));
     return normalizeBill(data as BillApiPayload);
   },
 
   update: async (id: number, payload: UpdateBillPayload): Promise<Bill> => {
-    const { data } = await api.patch(`/bills/${id}`, payload);
+    const { data } = await api.patch(`/bills/${id}`, normalizeUpdatePayload(payload));
     return normalizeBill(data as BillApiPayload);
   },
 
@@ -369,7 +397,9 @@ export const billsService = {
   },
 
   createBatch: async (bills: CreateBillPayload[]): Promise<Bill[]> => {
-    const { data } = await api.post<BillsBatchResult>("/bills/batch", { bills });
+    const { data } = await api.post<BillsBatchResult>("/bills/batch", {
+      bills: bills.map(normalizeCreatePayload),
+    });
     return (data.bills as BillApiPayload[]).map(normalizeBill);
   },
 


### PR DESCRIPTION
## Resumo
- endurece o fluxo `prefill -> create/update bill` com sanitizacao runtime de `billType` e `sourceImportSessionId`
- no `create`, normaliza campos opcionais somente quando presentes (preserva semantica anterior)
- no `update`, mantém patch parcial e sanitiza apenas campos opcionais explicitamente enviados
- adiciona testes unitarios para payload sanitizado e para garantir que update parcial nao limpa campos ausentes

## Validacao local
- npm -w apps/web run test:run -- src/services/bills.service.test.ts src/services/transactions.service.test.ts src/components/ImportCsvModal.test.jsx
- npm -w apps/web run typecheck
