### PR TITLE
feat(api): telemetria de drift semântico no dry-run

### DIFF
--- a/apps/api/src/import-utility-dry-run.test.js
+++ b/apps/api/src/import-utility-dry-run.test.js
@@ -38,6 +38,10 @@ import {
 } from "./middlewares/rate-limit.middleware.js";
 import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
 import {
+  getImportMetricsSnapshot,
+  resetImportObservabilityForTests,
+} from "./observability/import-observability.js";
+import {
   makeProUser,
   registerAndLogin,
   setupTestDb,
@@ -57,6 +61,7 @@ describe("transaction imports utility bills dry-run", () => {
     resetImportRateLimiterState();
     resetWriteRateLimiterState();
     resetHttpMetricsForTests();
+    resetImportObservabilityForTests();
     vi.clearAllMocks();
 
     await dbQuery("DELETE FROM transactions");
@@ -116,6 +121,9 @@ describe("transaction imports utility bills dry-run", () => {
         billType: "internet",
       }),
     ]);
+
+    const metrics = getImportMetricsSnapshot();
+    expect(metrics.import_dry_run_semantic_drift_total).toBe(0);
   });
 
   it("POST /transactions/import/dry-run retorna documentType e suggestion para utility_bill_gas", async () => {
@@ -167,5 +175,42 @@ describe("transaction imports utility bills dry-run", () => {
         billType: "gas",
       }),
     ]);
+
+    const metrics = getImportMetricsSnapshot();
+    expect(metrics.import_dry_run_semantic_drift_total).toBe(0);
+  });
+
+  it("POST /transactions/import/dry-run incrementa metrica quando suggestion diverge do documentType utilitario", async () => {
+    const token = await registerAndLogin("import-doctype-drift@controlfinance.dev");
+    await makeProUser("import-doctype-drift@controlfinance.dev");
+
+    vi.mocked(detectDocumentType).mockReturnValue("utility_bill_gas");
+    vi.mocked(extractGasBillSuggestion).mockReturnValue({
+      type: "bill",
+      billType: "water",
+      issuer: "COMGAS",
+      referenceMonth: "2026-04",
+      dueDate: "2026-05-15",
+      amountDue: 95.4,
+      customerCode: "778899",
+    });
+
+    const response = await request(app)
+      .post("/transactions/import/dry-run")
+      .set("Authorization", `Bearer ${token}`)
+      .attach("file", Buffer.from("%PDF-1.4 gas drift"), {
+        filename: "gas-drift.pdf",
+        contentType: "application/pdf",
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.documentType).toBe("utility_bill_gas");
+    expect(response.body.suggestion).toMatchObject({
+      billType: "water",
+    });
+
+    const metrics = getImportMetricsSnapshot();
+    expect(metrics.import_dry_run_total).toBe(1);
+    expect(metrics.import_dry_run_semantic_drift_total).toBe(1);
   });
 });

--- a/apps/api/src/observability/import-observability.js
+++ b/apps/api/src/observability/import-observability.js
@@ -2,6 +2,7 @@ import { logError, logInfo } from "./logger.js";
 
 const METRIC_NAMES = {
   dryRunTotal: "import_dry_run_total",
+  dryRunSemanticDriftTotal: "import_dry_run_semantic_drift_total",
   commitTotal: "import_commit_total",
   commitSuccessTotal: "import_commit_success_total",
   commitFailTotal: "import_commit_fail_total",
@@ -11,6 +12,7 @@ const METRIC_NAMES = {
 
 const importMetricsState = {
   [METRIC_NAMES.dryRunTotal]: 0,
+  [METRIC_NAMES.dryRunSemanticDriftTotal]: 0,
   [METRIC_NAMES.commitTotal]: 0,
   [METRIC_NAMES.commitSuccessTotal]: 0,
   [METRIC_NAMES.commitFailTotal]: 0,
@@ -56,6 +58,8 @@ export const getImportMetricsSnapshot = () => {
 
   return {
     import_dry_run_total: importMetricsState[METRIC_NAMES.dryRunTotal],
+    import_dry_run_semantic_drift_total:
+      importMetricsState[METRIC_NAMES.dryRunSemanticDriftTotal],
     import_commit_total: importMetricsState[METRIC_NAMES.commitTotal],
     import_commit_success_total: importMetricsState[METRIC_NAMES.commitSuccessTotal],
     import_commit_fail_total: importMetricsState[METRIC_NAMES.commitFailTotal],
@@ -74,6 +78,14 @@ export const createElapsedTimer = () => {
 export const trackDryRunMetrics = ({ rowsTotal = 0 } = {}) => {
   incrementMetric(METRIC_NAMES.dryRunTotal);
   observeRows(rowsTotal);
+};
+
+export const trackDryRunSemanticDriftMetrics = ({ driftDetected = false } = {}) => {
+  if (!driftDetected) {
+    return;
+  }
+
+  incrementMetric(METRIC_NAMES.dryRunSemanticDriftTotal);
 };
 
 export const trackCommitAttemptMetrics = () => {

--- a/apps/api/src/routes/transactions.routes.js
+++ b/apps/api/src/routes/transactions.routes.js
@@ -14,6 +14,7 @@ import {
   trackCommitFailMetrics,
   trackCommitSuccessMetrics,
   trackDryRunMetrics,
+  trackDryRunSemanticDriftMetrics,
 } from "../observability/import-observability.js";
 import {
   createTransactionForUser,
@@ -103,6 +104,104 @@ const ensureValidImportFile = (file) => {
   ) {
     throw createError(400, "Arquivo invalido. Envie um CSV, OFX ou PDF de extrato.");
   }
+};
+
+const UTILITY_DOCUMENT_EXPECTED_BILL_TYPES = {
+  utility_bill_energy: new Set(["energy"]),
+  utility_bill_water: new Set(["water"]),
+  utility_bill_gas: new Set(["gas"]),
+  utility_bill_telecom: new Set(["internet", "phone", "tv"]),
+};
+
+const normalizeBillTypeCandidate = (value) => {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalizedValue = value.trim().toLowerCase();
+  return normalizedValue || null;
+};
+
+const collectObservedBillTypes = (dryRunResult = {}) => {
+  const observedTypes = [];
+  const suggestionCandidates = [];
+
+  if (dryRunResult?.suggestion && typeof dryRunResult.suggestion === "object") {
+    suggestionCandidates.push(dryRunResult.suggestion);
+  }
+
+  if (Array.isArray(dryRunResult?.suggestions)) {
+    suggestionCandidates.push(...dryRunResult.suggestions);
+  }
+
+  suggestionCandidates.forEach((suggestion) => {
+    if (!suggestion || typeof suggestion !== "object") {
+      return;
+    }
+
+    if (String(suggestion.type || "").trim().toLowerCase() !== "bill") {
+      return;
+    }
+
+    const normalizedBillType = normalizeBillTypeCandidate(suggestion.billType);
+    if (normalizedBillType) {
+      observedTypes.push(normalizedBillType);
+    }
+  });
+
+  return [...new Set(observedTypes)];
+};
+
+const detectUtilityDryRunSemanticDrift = (dryRunResult = {}) => {
+  const normalizedDocumentType =
+    typeof dryRunResult?.documentType === "string"
+      ? dryRunResult.documentType.trim().toLowerCase()
+      : "";
+
+  const expectedBillTypesSet = UTILITY_DOCUMENT_EXPECTED_BILL_TYPES[normalizedDocumentType];
+
+  if (!expectedBillTypesSet) {
+    return {
+      driftDetected: false,
+      documentType: normalizedDocumentType || null,
+      expectedBillTypes: [],
+      observedBillTypes: [],
+      reason: null,
+    };
+  }
+
+  const observedBillTypes = collectObservedBillTypes(dryRunResult);
+  const expectedBillTypes = [...expectedBillTypesSet];
+
+  if (observedBillTypes.length === 0) {
+    return {
+      driftDetected: true,
+      documentType: normalizedDocumentType,
+      expectedBillTypes,
+      observedBillTypes,
+      reason: "missing_bill_suggestion",
+    };
+  }
+
+  const hasExpectedBillType = observedBillTypes.some((billType) => expectedBillTypesSet.has(billType));
+
+  if (!hasExpectedBillType) {
+    return {
+      driftDetected: true,
+      documentType: normalizedDocumentType,
+      expectedBillTypes,
+      observedBillTypes,
+      reason: "bill_type_mismatch",
+    };
+  }
+
+  return {
+    driftDetected: false,
+    documentType: normalizedDocumentType,
+    expectedBillTypes,
+    observedBillTypes,
+    reason: null,
+  };
 };
 
 const getListFiltersFromQuery = (query = {}, options = {}) => {
@@ -357,8 +456,25 @@ router.post("/import/dry-run", importRateLimiter, requireFeature("csv_import"), 
       const rowsTotal = Number(dryRunResult.summary?.totalRows) || 0;
       const validRows = Number(dryRunResult.summary?.validRows) || 0;
       const invalidRows = Number(dryRunResult.summary?.invalidRows) || 0;
+      const semanticDrift = detectUtilityDryRunSemanticDrift(dryRunResult);
 
       trackDryRunMetrics({ rowsTotal });
+      trackDryRunSemanticDriftMetrics({ driftDetected: semanticDrift.driftDetected });
+
+      if (semanticDrift.driftDetected) {
+        logImportEvent("import.dry_run.semantic_drift", {
+          requestId,
+          userId,
+          importId: dryRunResult.importId || null,
+          documentType: semanticDrift.documentType,
+          expectedBillTypes: semanticDrift.expectedBillTypes,
+          observedBillTypes: semanticDrift.observedBillTypes,
+          driftReason: semanticDrift.reason,
+          elapsedMs: elapsedTimer(),
+          statusCode: 200,
+        });
+      }
+
       logImportEvent("import.dry_run.success", {
         requestId,
         userId,


### PR DESCRIPTION
## Resumo
- adiciona telemetria de consistência no endpoint `POST /transactions/import/dry-run`
- detecta drift semântico para utility bills comparando `documentType` com `suggestion.billType` observado
- incrementa métrica dedicada `import_dry_run_semantic_drift_total`
- emite evento estruturado `import.dry_run.semantic_drift` com tipos esperados/observados e motivo
- amplia teste de integração para validar incremento da métrica em cenário de mismatch

## Validacao local
- npm -w apps/api run test -- src/import-utility-dry-run.test.js src/import.test.js
