### PR TITLE
feat(bills): buckets operacionais com paid no painel

### DIFF
--- a/apps/api/src/services/bills.service.js
+++ b/apps/api/src/services/bills.service.js
@@ -570,8 +570,8 @@ const UTILITY_TYPES_PLACEHOLDER = UTILITY_BILL_TYPES.map((_, i) => `$${i + 2}`).
 
 /**
  * Returns utility bills (energy/water/internet/phone/tv/gas) grouped by urgency.
- * Buckets: overdue (past due), dueSoon (within 7 days), upcoming (beyond 7 days).
- * Paid bills are excluded.
+ * Buckets: overdue (past due), dueSoon (within 7 days), upcoming (beyond 7 days), paid.
+ * `status` remains the source of truth for liquidation; operational buckets only triage UI.
  *
  * @param {number} userId
  */
@@ -584,16 +584,28 @@ export const getUtilityBillsPanelForUser = async (userId) => {
     `SELECT * FROM bills
      WHERE user_id = $1
        AND bill_type IN (${UTILITY_TYPES_PLACEHOLDER})
-       AND status = 'pending'
-     ORDER BY due_date ASC`,
+     ORDER BY due_date ASC, id ASC`,
     [uid, ...UTILITY_BILL_TYPES],
   );
 
   const bills = rows.map(mapBillRow);
+  const pendingBills = bills.filter((b) => b.status === "pending");
+  const paid = bills
+    .filter((b) => b.status === "paid")
+    .sort((left, right) => {
+      const leftTs = Date.parse(String(left.paidAt || left.updatedAt || ""));
+      const rightTs = Date.parse(String(right.paidAt || right.updatedAt || ""));
 
-  const overdue = bills.filter((b) => b.dueDate < today);
-  const dueSoon = bills.filter((b) => b.dueDate >= today && b.dueDate <= in7Days);
-  const upcoming = bills.filter((b) => b.dueDate > in7Days);
+      if (Number.isFinite(leftTs) && Number.isFinite(rightTs)) {
+        return rightTs - leftTs;
+      }
+
+      return String(right.dueDate || "").localeCompare(String(left.dueDate || ""));
+    });
+
+  const overdue = pendingBills.filter((b) => b.dueDate < today);
+  const dueSoon = pendingBills.filter((b) => b.dueDate >= today && b.dueDate <= in7Days);
+  const upcoming = pendingBills.filter((b) => b.dueDate > in7Days);
 
   const toMoney2 = (arr) => Number(arr.reduce((s, b) => s + b.amount, 0).toFixed(2));
 
@@ -601,13 +613,16 @@ export const getUtilityBillsPanelForUser = async (userId) => {
     overdue,
     dueSoon,
     upcoming,
+    paid,
     summary: {
-      totalPending: bills.length,
-      totalAmount: toMoney2(bills),
+      totalPending: pendingBills.length,
+      totalAmount: toMoney2(pendingBills),
       overdueCount: overdue.length,
       overdueAmount: toMoney2(overdue),
       dueSoonCount: dueSoon.length,
       dueSoonAmount: toMoney2(dueSoon),
+      paidCount: paid.length,
+      paidAmount: toMoney2(paid),
     },
   };
 };

--- a/apps/api/src/utility-bills-panel.test.js
+++ b/apps/api/src/utility-bills-panel.test.js
@@ -77,10 +77,13 @@ describe("GET /bills/utility-panel", () => {
     expect(res.body.overdue).toHaveLength(0);
     expect(res.body.dueSoon).toHaveLength(0);
     expect(res.body.upcoming).toHaveLength(0);
+    expect(res.body.paid).toHaveLength(0);
     expect(res.body.summary.totalPending).toBe(0);
     expect(res.body.summary.totalAmount).toBe(0);
     expect(res.body.summary.overdueCount).toBe(0);
     expect(res.body.summary.dueSoonCount).toBe(0);
+    expect(res.body.summary.paidCount).toBe(0);
+    expect(res.body.summary.paidAmount).toBe(0);
   });
 
   // ─── Bucket boundaries ────────────────────────────────────────────────────
@@ -96,6 +99,7 @@ describe("GET /bills/utility-panel", () => {
     expect(res.body.overdue[0].title).toBe("Energia vencida");
     expect(res.body.dueSoon).toHaveLength(0);
     expect(res.body.upcoming).toHaveLength(0);
+    expect(res.body.paid).toHaveLength(0);
   });
 
   it("conta com vencimento hoje vai para dueSoon", async () => {
@@ -108,6 +112,7 @@ describe("GET /bills/utility-panel", () => {
     expect(res.body.overdue).toHaveLength(0);
     expect(res.body.dueSoon).toHaveLength(1);
     expect(res.body.dueSoon[0].title).toBe("Água vence hoje");
+    expect(res.body.paid).toHaveLength(0);
   });
 
   it("conta com vencimento em 7 dias vai para dueSoon (limite inclusive)", async () => {
@@ -121,6 +126,7 @@ describe("GET /bills/utility-panel", () => {
     expect(res.body.dueSoon[0].title).toBe("Internet 7 dias");
     expect(res.body.overdue).toHaveLength(0);
     expect(res.body.upcoming).toHaveLength(0);
+    expect(res.body.paid).toHaveLength(0);
   });
 
   it("conta com vencimento em 8 dias vai para upcoming (fora da janela dueSoon)", async () => {
@@ -134,6 +140,7 @@ describe("GET /bills/utility-panel", () => {
     expect(res.body.upcoming[0].title).toBe("Gás próxima semana");
     expect(res.body.overdue).toHaveLength(0);
     expect(res.body.dueSoon).toHaveLength(0);
+    expect(res.body.paid).toHaveLength(0);
   });
 
   it("mistura de buckets: distribui corretamente e totaliza summary", async () => {
@@ -152,6 +159,7 @@ describe("GET /bills/utility-panel", () => {
     expect(res.body.overdue).toHaveLength(2);
     expect(res.body.dueSoon).toHaveLength(2);
     expect(res.body.upcoming).toHaveLength(2);
+    expect(res.body.paid).toHaveLength(0);
 
     expect(res.body.summary.overdueCount).toBe(2);
     expect(res.body.summary.overdueAmount).toBeCloseTo(200);
@@ -159,6 +167,8 @@ describe("GET /bills/utility-panel", () => {
     expect(res.body.summary.dueSoonAmount).toBeCloseTo(130);
     expect(res.body.summary.totalPending).toBe(6);
     expect(res.body.summary.totalAmount).toBeCloseTo(430);
+    expect(res.body.summary.paidCount).toBe(0);
+    expect(res.body.summary.paidAmount).toBe(0);
   });
 
   // ─── bill_type filter ─────────────────────────────────────────────────────
@@ -185,7 +195,7 @@ describe("GET /bills/utility-panel", () => {
     expect(titles).toContain("TV incluída");
   });
 
-  it("exclui contas ja pagas", async () => {
+  it("separa contas ja pagas no bucket paid sem afetar total pendente", async () => {
     const token = await registerAndLogin("util-paid@test.dev");
 
     // Create and pay one bill
@@ -202,6 +212,10 @@ describe("GET /bills/utility-panel", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.summary.totalPending).toBe(1);
+    expect(res.body.summary.paidCount).toBe(1);
+    expect(res.body.summary.paidAmount).toBeCloseTo(150);
+    expect(res.body.paid).toHaveLength(1);
+    expect(res.body.paid[0].title).toBe("Energia paga");
     const allBills = [...res.body.overdue, ...res.body.dueSoon, ...res.body.upcoming];
     expect(allBills[0].title).toBe("Água pendente");
   });

--- a/apps/web/src/components/UtilityBillsWidget.tsx
+++ b/apps/web/src/components/UtilityBillsWidget.tsx
@@ -22,6 +22,12 @@ const formatDueDate = (iso: string): string => {
   return `${day}/${month}/${year}`;
 };
 
+const formatDisplayDate = (value: string | null): string => {
+  if (!value) return "";
+  const isoDate = value.includes("T") ? value.slice(0, 10) : value;
+  return formatDueDate(isoDate);
+};
+
 // ─── Reconciliation state per bill ───────────────────────────────────────────
 
 type ReconcilePhase =
@@ -260,6 +266,7 @@ const EMPTY_PANEL: UtilityPanel = {
   overdue: [],
   dueSoon: [],
   upcoming: [],
+  paid: [],
   summary: {
     totalPending: 0,
     totalAmount: 0,
@@ -267,6 +274,8 @@ const EMPTY_PANEL: UtilityPanel = {
     overdueAmount: 0,
     dueSoonCount: 0,
     dueSoonAmount: 0,
+    paidCount: 0,
+    paidAmount: 0,
   },
 };
 
@@ -371,8 +380,9 @@ const UtilityBillsWidget = (): JSX.Element => {
     );
   }
 
-  const { overdue, dueSoon, upcoming, summary } = panel;
-  const hasAny = summary.totalPending > 0;
+  const { overdue, dueSoon, upcoming, paid, summary } = panel;
+  const hasAnyPending = summary.totalPending > 0;
+  const hasAnyOperational = hasAnyPending || summary.paidCount > 0;
 
   const renderBillRow = (bill: Bill, urgency: "overdue" | "due_soon" | "upcoming") => (
     <BillRow
@@ -396,12 +406,14 @@ const UtilityBillsWidget = (): JSX.Element => {
         <div>
           <h3 className="text-sm font-medium text-cf-text-primary">Contas de consumo</h3>
           <p className="text-xs text-cf-text-secondary">
-            {hasAny
+            {hasAnyPending
               ? `${summary.totalPending} ${summary.totalPending === 1 ? "conta pendente" : "contas pendentes"}`
-              : "Nenhuma conta de consumo pendente."}
+              : summary.paidCount > 0
+                ? `${summary.paidCount} ${summary.paidCount === 1 ? "conta já paga" : "contas já pagas"}`
+                : "Nenhuma conta de consumo pendente."}
           </p>
         </div>
-        {hasAny ? (
+        {hasAnyPending ? (
           <div className="text-right">
             <p className="text-xs font-semibold text-cf-text-primary">{money(summary.totalAmount)}</p>
             <p className="text-[10px] text-cf-text-secondary">total pendente</p>
@@ -410,7 +422,7 @@ const UtilityBillsWidget = (): JSX.Element => {
       </div>
 
       {/* Empty state */}
-      {!hasAny ? (
+      {!hasAnyOperational ? (
         <div className="rounded border border-dashed border-cf-border bg-cf-bg-subtle px-3 py-3 text-sm text-cf-text-secondary">
           Cadastre suas contas de água, energia, internet, telefone e TV para acompanhar o vencimento aqui.
         </div>
@@ -479,6 +491,44 @@ const UtilityBillsWidget = (): JSX.Element => {
               </div>
               <div className="divide-y divide-cf-border rounded border border-cf-border bg-cf-bg-subtle px-3">
                 {upcoming.map((b) => renderBillRow(b, "upcoming"))}
+              </div>
+            </div>
+          ) : null}
+
+          {/* Já pagas */}
+          {paid.length > 0 ? (
+            <div className={upcoming.length > 0 ? "mt-3" : ""}>
+              <div className="mb-1 flex items-center justify-between">
+                <p className="text-[10px] font-semibold uppercase tracking-wide text-emerald-700">
+                  Já pagas ({paid.length})
+                </p>
+                <p className="text-[10px] font-medium text-emerald-700">{money(summary.paidAmount)}</p>
+              </div>
+              <div className="divide-y divide-cf-border rounded border border-emerald-200 bg-emerald-50 px-3">
+                {paid.slice(0, 5).map((bill) => {
+                  const typeLabel = bill.billType
+                    ? (BILL_TYPE_LABELS[bill.billType] ?? bill.billType)
+                    : null;
+
+                  return (
+                    <div key={bill.id} className="flex items-center justify-between gap-2 py-1.5">
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-1.5">
+                          <span className="truncate text-xs text-cf-text-primary">{bill.title}</span>
+                          {typeLabel ? (
+                            <span className="flex-shrink-0 rounded bg-white/70 px-1 py-0.5 text-[10px] text-cf-text-secondary">
+                              {typeLabel}
+                            </span>
+                          ) : null}
+                        </div>
+                        <p className="text-[10px] text-emerald-700">
+                          pago em {formatDisplayDate(bill.paidAt) || formatDueDate(bill.dueDate)}
+                        </p>
+                      </div>
+                      <p className="text-xs font-medium text-emerald-700">{money(bill.amount)}</p>
+                    </div>
+                  );
+                })}
               </div>
             </div>
           ) : null}

--- a/apps/web/src/services/bills.service.test.ts
+++ b/apps/web/src/services/bills.service.test.ts
@@ -156,4 +156,49 @@ describe("bills service billType normalization", () => {
       title: "Conta editada",
     });
   });
+
+  it("mapeia painel utilitario com bucket paid e resumo dedicado", async () => {
+    getMock.mockResolvedValueOnce({
+      data: {
+        overdue: [],
+        dueSoon: [],
+        upcoming: [],
+        paid: [
+          {
+            id: 16,
+            user_id: 7,
+            title: "Energia paga",
+            amount: 150,
+            due_date: "2026-06-10",
+            status: "paid",
+            paid_at: "2026-06-09T10:00:00.000Z",
+            bill_type: "energy",
+          },
+        ],
+        summary: {
+          totalPending: 0,
+          totalAmount: 0,
+          overdueCount: 0,
+          overdueAmount: 0,
+          dueSoonCount: 0,
+          dueSoonAmount: 0,
+          paidCount: 1,
+          paidAmount: 150,
+        },
+      },
+    });
+
+    const result = await billsService.getUtilityPanel();
+
+    expect(getMock).toHaveBeenCalledWith("/bills/utility-panel");
+    expect(result.paid).toHaveLength(1);
+    expect(result.paid[0]).toMatchObject({
+      title: "Energia paga",
+      status: "paid",
+      billType: "energy",
+      paidAt: "2026-06-09T10:00:00.000Z",
+    });
+    expect(result.summary.paidCount).toBe(1);
+    expect(result.summary.paidAmount).toBe(150);
+  });
 });

--- a/apps/web/src/services/bills.service.ts
+++ b/apps/web/src/services/bills.service.ts
@@ -77,12 +77,15 @@ export interface UtilityPanelSummary {
   overdueAmount: number;
   dueSoonCount: number;
   dueSoonAmount: number;
+  paidCount: number;
+  paidAmount: number;
 }
 
 export interface UtilityPanel {
   overdue: Bill[];
   dueSoon: Bill[];
   upcoming: Bill[];
+  paid: Bill[];
   summary: UtilityPanelSummary;
 }
 
@@ -408,12 +411,14 @@ export const billsService = {
       overdue: BillApiPayload[];
       dueSoon: BillApiPayload[];
       upcoming: BillApiPayload[];
+      paid: BillApiPayload[];
       summary: UtilityPanelSummary;
     }>("/bills/utility-panel");
     return {
       overdue: (data.overdue ?? []).map(normalizeBill).filter(isValidBill),
       dueSoon: (data.dueSoon ?? []).map(normalizeBill).filter(isValidBill),
       upcoming: (data.upcoming ?? []).map(normalizeBill).filter(isValidBill),
+      paid: (data.paid ?? []).map(normalizeBill).filter(isValidBill),
       summary: {
         totalPending: Number(data.summary?.totalPending) || 0,
         totalAmount: Number(data.summary?.totalAmount) || 0,
@@ -421,6 +426,8 @@ export const billsService = {
         overdueAmount: Number(data.summary?.overdueAmount) || 0,
         dueSoonCount: Number(data.summary?.dueSoonCount) || 0,
         dueSoonAmount: Number(data.summary?.dueSoonAmount) || 0,
+        paidCount: Number(data.summary?.paidCount) || 0,
+        paidAmount: Number(data.summary?.paidAmount) || 0,
       },
     };
   },


### PR DESCRIPTION
## PR 12 — Buckets operacionais (slice 1)

## Resumo
- adiciona bucket operacional `paid` no endpoint `/bills/utility-panel`
- mantém separação entre obrigação pendente e obrigação liquidada:
  - `totalPending` e `totalAmount` continuam contando apenas `status=pending`
  - adiciona `paidCount` e `paidAmount` para contas liquidadas
- reflete o novo contrato no frontend (`bills.service` + `UtilityBillsWidget`)
- widget passa a exibir seção **Já pagas** sem confundir com total pendente

## Validação local
- `npm -w apps/api run test -- src/utility-bills-panel.test.js`
- `npm -w apps/web run test:run -- src/services/bills.service.test.ts src/pages/BillsPage.test.tsx`
- `npm -w apps/web run typecheck`
