### PR TITLE
feat(bills): fechar agregados do bucket de proximas no painel utilitario

### DIFF
--- a/apps/api/src/services/bills.service.js
+++ b/apps/api/src/services/bills.service.js
@@ -621,6 +621,8 @@ export const getUtilityBillsPanelForUser = async (userId) => {
       overdueAmount: toMoney2(overdue),
       dueSoonCount: dueSoon.length,
       dueSoonAmount: toMoney2(dueSoon),
+      upcomingCount: upcoming.length,
+      upcomingAmount: toMoney2(upcoming),
       paidCount: paid.length,
       paidAmount: toMoney2(paid),
     },

--- a/apps/api/src/utility-bills-panel.test.js
+++ b/apps/api/src/utility-bills-panel.test.js
@@ -82,6 +82,8 @@ describe("GET /bills/utility-panel", () => {
     expect(res.body.summary.totalAmount).toBe(0);
     expect(res.body.summary.overdueCount).toBe(0);
     expect(res.body.summary.dueSoonCount).toBe(0);
+    expect(res.body.summary.upcomingCount).toBe(0);
+    expect(res.body.summary.upcomingAmount).toBe(0);
     expect(res.body.summary.paidCount).toBe(0);
     expect(res.body.summary.paidAmount).toBe(0);
   });
@@ -165,6 +167,8 @@ describe("GET /bills/utility-panel", () => {
     expect(res.body.summary.overdueAmount).toBeCloseTo(200);
     expect(res.body.summary.dueSoonCount).toBe(2);
     expect(res.body.summary.dueSoonAmount).toBeCloseTo(130);
+    expect(res.body.summary.upcomingCount).toBe(2);
+    expect(res.body.summary.upcomingAmount).toBeCloseTo(100);
     expect(res.body.summary.totalPending).toBe(6);
     expect(res.body.summary.totalAmount).toBeCloseTo(430);
     expect(res.body.summary.paidCount).toBe(0);
@@ -214,6 +218,8 @@ describe("GET /bills/utility-panel", () => {
     expect(res.body.summary.totalPending).toBe(1);
     expect(res.body.summary.paidCount).toBe(1);
     expect(res.body.summary.paidAmount).toBeCloseTo(150);
+    expect(res.body.summary.upcomingCount).toBe(0);
+    expect(res.body.summary.upcomingAmount).toBe(0);
     expect(res.body.paid).toHaveLength(1);
     expect(res.body.paid[0].title).toBe("Energia paga");
     const allBills = [...res.body.overdue, ...res.body.dueSoon, ...res.body.upcoming];

--- a/apps/web/src/components/UtilityBillsWidget.tsx
+++ b/apps/web/src/components/UtilityBillsWidget.tsx
@@ -274,6 +274,8 @@ const EMPTY_PANEL: UtilityPanel = {
     overdueAmount: 0,
     dueSoonCount: 0,
     dueSoonAmount: 0,
+    upcomingCount: 0,
+    upcomingAmount: 0,
     paidCount: 0,
     paidAmount: 0,
   },
@@ -484,9 +486,12 @@ const UtilityBillsWidget = (): JSX.Element => {
           {/* Futuras */}
           {upcoming.length > 0 ? (
             <div>
-              <div className="mb-1">
+              <div className="mb-1 flex items-center justify-between">
                 <p className="text-[10px] font-semibold uppercase tracking-wide text-cf-text-secondary">
                   Próximas ({upcoming.length})
+                </p>
+                <p className="text-[10px] font-medium text-cf-text-secondary">
+                  {money(summary.upcomingAmount)}
                 </p>
               </div>
               <div className="divide-y divide-cf-border rounded border border-cf-border bg-cf-bg-subtle px-3">

--- a/apps/web/src/services/bills.service.test.ts
+++ b/apps/web/src/services/bills.service.test.ts
@@ -182,6 +182,8 @@ describe("bills service billType normalization", () => {
           overdueAmount: 0,
           dueSoonCount: 0,
           dueSoonAmount: 0,
+          upcomingCount: 0,
+          upcomingAmount: 0,
           paidCount: 1,
           paidAmount: 150,
         },
@@ -200,5 +202,7 @@ describe("bills service billType normalization", () => {
     });
     expect(result.summary.paidCount).toBe(1);
     expect(result.summary.paidAmount).toBe(150);
+    expect(result.summary.upcomingCount).toBe(0);
+    expect(result.summary.upcomingAmount).toBe(0);
   });
 });

--- a/apps/web/src/services/bills.service.ts
+++ b/apps/web/src/services/bills.service.ts
@@ -77,6 +77,8 @@ export interface UtilityPanelSummary {
   overdueAmount: number;
   dueSoonCount: number;
   dueSoonAmount: number;
+  upcomingCount: number;
+  upcomingAmount: number;
   paidCount: number;
   paidAmount: number;
 }
@@ -426,6 +428,8 @@ export const billsService = {
         overdueAmount: Number(data.summary?.overdueAmount) || 0,
         dueSoonCount: Number(data.summary?.dueSoonCount) || 0,
         dueSoonAmount: Number(data.summary?.dueSoonAmount) || 0,
+        upcomingCount: Number(data.summary?.upcomingCount) || 0,
+        upcomingAmount: Number(data.summary?.upcomingAmount) || 0,
         paidCount: Number(data.summary?.paidCount) || 0,
         paidAmount: Number(data.summary?.paidAmount) || 0,
       },


### PR DESCRIPTION
## Objetivo\nFechar o contrato operacional dos buckets de contas de consumo, adicionando agregados para o bucket de proximas no painel utilitario.\n\n## Mudancas\n- API: inclui summary.upcomingCount e summary.upcomingAmount em GET /bills/utility-panel\n- Web service: atualiza UtilityPanelSummary e mapeamento dos novos campos\n- Widget: exibe valor agregado no bloco Proximas\n- Testes: cobertura API/web atualizada para os novos agregados\n\n## Validacao local\n- npm -w apps/api run test -- src/utility-bills-panel.test.js\n- npm -w apps/web run test:run -- src/services/bills.service.test.ts\n- npm -w apps/web run typecheck\n