### PR TITLE
feat(dashboard): priorizar contas proximas no resumo operacional

### DIFF
--- a/apps/api/src/dashboard.test.js
+++ b/apps/api/src/dashboard.test.js
@@ -105,6 +105,8 @@ describe("dashboard snapshot", () => {
     expect(res.body.bills.overdueTotal).toBe(0);
     expect(res.body.bills.dueSoonCount).toBe(0);
     expect(res.body.bills.dueSoonTotal).toBe(0);
+    expect(res.body.bills.upcomingCount).toBe(0);
+    expect(res.body.bills.upcomingTotal).toBe(0);
     expect(res.body.cards.openPurchasesTotal).toBe(0);
     expect(res.body.cards.pendingInvoicesTotal).toBe(0);
     expect(res.body.income.receivedThisMonth).toBe(0);
@@ -165,13 +167,16 @@ describe("dashboard snapshot", () => {
 
     await createBill(token, { dueDate: isoDate(0), amount: 100 });  // today
     await createBill(token, { dueDate: isoDate(3), amount: 200 });  // in 3 days
+    await createBill(token, { dueDate: isoDate(7), amount: 50 });   // boundary day (inclusive)
     await createBill(token, { dueDate: isoDate(10), amount: 999 }); // beyond 7 days
 
     const res = await getSnapshot(token);
 
     expect(res.status).toBe(200);
-    expect(res.body.bills.dueSoonCount).toBe(2);
-    expect(res.body.bills.dueSoonTotal).toBe(300);
+    expect(res.body.bills.dueSoonCount).toBe(3);
+    expect(res.body.bills.dueSoonTotal).toBe(350);
+    expect(res.body.bills.upcomingCount).toBe(1);
+    expect(res.body.bills.upcomingTotal).toBe(999);
   });
 
   it("bills nao conta faturas pagas", async () => {

--- a/apps/api/src/services/dashboard.service.js
+++ b/apps/api/src/services/dashboard.service.js
@@ -43,8 +43,10 @@ export const getDashboardSnapshot = async (userId) => {
       `SELECT
          COUNT(CASE WHEN due_date < $2 THEN 1 END) AS overdue_count,
          COALESCE(SUM(CASE WHEN due_date < $2 THEN amount ELSE 0 END), 0) AS overdue_total,
-         COUNT(CASE WHEN due_date >= $2 AND due_date < $3 THEN 1 END) AS due_soon_count,
-         COALESCE(SUM(CASE WHEN due_date >= $2 AND due_date < $3 THEN amount ELSE 0 END), 0) AS due_soon_total
+         COUNT(CASE WHEN due_date >= $2 AND due_date <= $3 THEN 1 END) AS due_soon_count,
+         COALESCE(SUM(CASE WHEN due_date >= $2 AND due_date <= $3 THEN amount ELSE 0 END), 0) AS due_soon_total,
+         COUNT(CASE WHEN due_date > $3 THEN 1 END) AS upcoming_count,
+         COALESCE(SUM(CASE WHEN due_date > $3 THEN amount ELSE 0 END), 0) AS upcoming_total
        FROM bills
        WHERE user_id = $1 AND status = 'pending'`,
       [uid, today, in7Days],
@@ -113,6 +115,8 @@ export const getDashboardSnapshot = async (userId) => {
       overdueTotal: toNum(bills.overdue_total),
       dueSoonCount: toInt(bills.due_soon_count),
       dueSoonTotal: toNum(bills.due_soon_total),
+      upcomingCount: toInt(bills.upcoming_count),
+      upcomingTotal: toNum(bills.upcoming_total),
     },
     cards: {
       openPurchasesTotal: toNum(cardPurchasesRes.rows[0]?.total),

--- a/apps/web/src/components/OperationalSummaryPanel.test.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.test.tsx
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import OperationalSummaryPanel from "./OperationalSummaryPanel";
+import { dashboardService, type DashboardSnapshot } from "../services/dashboard.service";
+
+vi.mock("../services/dashboard.service", () => ({
+  dashboardService: {
+    getSnapshot: vi.fn(),
+  },
+}));
+
+const buildSnapshot = (overrides: Partial<DashboardSnapshot> = {}): DashboardSnapshot => ({
+  bankBalance: 1000,
+  bills: {
+    overdueCount: 0,
+    overdueTotal: 0,
+    dueSoonCount: 0,
+    dueSoonTotal: 0,
+    upcomingCount: 0,
+    upcomingTotal: 0,
+    ...(overrides.bills ?? {}),
+  },
+  cards: {
+    openPurchasesTotal: 0,
+    pendingInvoicesTotal: 0,
+    ...(overrides.cards ?? {}),
+  },
+  income: {
+    receivedThisMonth: 0,
+    pendingThisMonth: 0,
+    referenceMonth: "2026-04",
+    ...(overrides.income ?? {}),
+  },
+  forecast: overrides.forecast ?? null,
+  consignado: {
+    monthlyTotal: 0,
+    contractsCount: 0,
+    comprometimentoPct: null,
+    ...(overrides.consignado ?? {}),
+  },
+  ...overrides,
+});
+
+describe("OperationalSummaryPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(dashboardService.getSnapshot).mockResolvedValue(buildSnapshot());
+  });
+
+  it("mostra proximas contas quando nao ha urgencia imediata", async () => {
+    vi.mocked(dashboardService.getSnapshot).mockResolvedValueOnce(
+      buildSnapshot({
+        bills: {
+          overdueCount: 0,
+          overdueTotal: 0,
+          dueSoonCount: 0,
+          dueSoonTotal: 0,
+          upcomingCount: 2,
+          upcomingTotal: 480,
+        },
+      }),
+    );
+
+    render(<OperationalSummaryPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Contas a pagar")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/480[,.]00/)).toBeInTheDocument();
+    expect(screen.getByText("2 próximas")).toBeInTheDocument();
+  });
+
+  it("mantem foco em urgencia imediata e sinaliza proximas no contexto", async () => {
+    vi.mocked(dashboardService.getSnapshot).mockResolvedValueOnce(
+      buildSnapshot({
+        bills: {
+          overdueCount: 1,
+          overdueTotal: 100,
+          dueSoonCount: 1,
+          dueSoonTotal: 200,
+          upcomingCount: 2,
+          upcomingTotal: 900,
+        },
+      }),
+    );
+
+    render(<OperationalSummaryPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText("1 vencida")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/300[,.]00/)).toBeInTheDocument();
+    expect(screen.getByText(/2 próximas/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/OperationalSummaryPanel.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.tsx
@@ -141,23 +141,38 @@ const OperationalSummaryPanel = (): JSX.Element | null => {
   };
 
   // ── Tile 2: Bills ─────────────────────────────────────────────────────────
-  const totalBillsCount = bills.overdueCount + bills.dueSoonCount;
-  const totalBillsAmount = bills.overdueTotal + bills.dueSoonTotal;
+  const totalImmediateBillsCount = bills.overdueCount + bills.dueSoonCount;
+  const totalImmediateBillsAmount = bills.overdueTotal + bills.dueSoonTotal;
+  const hasUpcomingBills = bills.upcomingCount > 0;
+  const shouldHighlightImmediateBills = totalImmediateBillsCount > 0;
+  const billsPrimaryAmount = shouldHighlightImmediateBills
+    ? totalImmediateBillsAmount
+    : hasUpcomingBills
+      ? bills.upcomingTotal
+      : 0;
   const billsAccent: TileProps["accent"] =
     bills.overdueCount > 0 ? "danger" : bills.dueSoonCount > 0 ? "warning" : "muted";
+  const billsTertiaryTokens: string[] = [];
+  if (bills.overdueCount > 0 && bills.dueSoonCount > 0) {
+    billsTertiaryTokens.push(`${bills.dueSoonCount} a vencer`);
+  }
+  if (hasUpcomingBills) {
+    billsTertiaryTokens.push(
+      `${bills.upcomingCount} próxima${bills.upcomingCount > 1 ? "s" : ""}`,
+    );
+  }
   const billsTile: TileProps = {
     label: "Contas a pagar",
-    primary: totalBillsCount > 0 ? money(totalBillsAmount) : "—",
+    primary: shouldHighlightImmediateBills || hasUpcomingBills ? money(billsPrimaryAmount) : "—",
     secondary:
       bills.overdueCount > 0
         ? `${bills.overdueCount} vencida${bills.overdueCount > 1 ? "s" : ""}`
         : bills.dueSoonCount > 0
           ? `${bills.dueSoonCount} em 7 dias`
+          : hasUpcomingBills
+            ? `${bills.upcomingCount} próxima${bills.upcomingCount > 1 ? "s" : ""}`
           : "Nenhuma pendente",
-    tertiary:
-      bills.overdueCount > 0 && bills.dueSoonCount > 0
-        ? `+ ${bills.dueSoonCount} a vencer`
-        : undefined,
+    tertiary: billsTertiaryTokens.length > 0 ? `+ ${billsTertiaryTokens.join(" • ")}` : undefined,
     accent: billsAccent,
   };
 

--- a/apps/web/src/services/dashboard.service.test.ts
+++ b/apps/web/src/services/dashboard.service.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "./api";
+import { dashboardService } from "./dashboard.service";
+
+vi.mock("./api", () => ({
+  api: {
+    get: vi.fn(),
+  },
+  withApiRequestContext: vi.fn((context) => context),
+}));
+
+const getMock = vi.mocked(api.get);
+
+describe("dashboardService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("normaliza snapshot com agregados de proximas contas", async () => {
+    getMock.mockResolvedValueOnce({
+      data: {
+        bankBalance: 1200,
+        bills: {
+          overdueCount: 1,
+          overdueTotal: 150,
+          dueSoonCount: 2,
+          dueSoonTotal: 220,
+          upcomingCount: 3,
+          upcomingTotal: 480,
+        },
+        cards: {
+          openPurchasesTotal: 350,
+          pendingInvoicesTotal: 700,
+        },
+        income: {
+          receivedThisMonth: 2500,
+          pendingThisMonth: 0,
+          referenceMonth: "2026-04",
+        },
+        forecast: {
+          projectedBalance: 900,
+          month: "2026-04",
+        },
+        consignado: {
+          monthlyTotal: 0,
+          contractsCount: 0,
+          comprometimentoPct: null,
+        },
+      },
+    });
+
+    const result = await dashboardService.getSnapshot();
+
+    expect(getMock).toHaveBeenCalledWith("/dashboard/snapshot", undefined);
+    expect(result.bills).toMatchObject({
+      overdueCount: 1,
+      overdueTotal: 150,
+      dueSoonCount: 2,
+      dueSoonTotal: 220,
+      upcomingCount: 3,
+      upcomingTotal: 480,
+    });
+  });
+});

--- a/apps/web/src/services/dashboard.service.ts
+++ b/apps/web/src/services/dashboard.service.ts
@@ -5,6 +5,8 @@ export interface DashboardBills {
   overdueTotal: number;
   dueSoonCount: number;
   dueSoonTotal: number;
+  upcomingCount: number;
+  upcomingTotal: number;
 }
 
 export interface DashboardCards {
@@ -43,6 +45,8 @@ const normalizeBills = (raw: Record<string, unknown>): DashboardBills => ({
   overdueTotal: Number(raw.overdueTotal) || 0,
   dueSoonCount: Number(raw.dueSoonCount) || 0,
   dueSoonTotal: Number(raw.dueSoonTotal) || 0,
+  upcomingCount: Number(raw.upcomingCount) || 0,
+  upcomingTotal: Number(raw.upcomingTotal) || 0,
 });
 
 const normalizeCards = (raw: Record<string, unknown>): DashboardCards => ({


### PR DESCRIPTION
## Objetivo\nAvancar o PR 12 com priorizacao operacional na home, incorporando bucket de proximas contas no resumo operacional sem misturar status de liquidacao.\n\n## Mudancas\n- API dashboard snapshot:\n  - adiciona ills.upcomingCount e ills.upcomingTotal\n  - ajusta janela de dueSoon para incluir exatamente 7 dias\n- Web dashboard service:\n  - propaga e normaliza novos campos de bills\n- OperationalSummaryPanel:\n  - passa a considerar proximas contas no tile de contas\n  - quando nao ha urgencia imediata, mostra valor das proximas\n  - quando ha urgencia, mantem foco em vencidas/a vencer e sinaliza proximas no contexto\n- Testes:\n  - API: atualizacoes em src/dashboard.test.js\n  - Web: novos testes para dashboard.service e OperationalSummaryPanel\n\n## Validacao local\n- npm -w apps/api run test -- src/dashboard.test.js\n- npm -w apps/web run test:run -- src/services/dashboard.service.test.ts src/components/OperationalSummaryPanel.test.tsx\n- npm -w apps/web run typecheck\n