### PR TITLE
feat(dashboard): destacar saldo tecnico no resumo operacional

### DIFF
--- a/apps/web/src/components/OperationalSummaryPanel.test.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.test.tsx
@@ -47,6 +47,54 @@ describe("OperationalSummaryPanel", () => {
     vi.mocked(dashboardService.getSnapshot).mockResolvedValue(buildSnapshot());
   });
 
+  it("exibe saldo tecnico quando ha contas vencidas", async () => {
+    vi.mocked(dashboardService.getSnapshot).mockResolvedValueOnce(
+      buildSnapshot({
+        bankBalance: 1000,
+        bills: {
+          overdueCount: 2,
+          overdueTotal: 300,
+          dueSoonCount: 0,
+          dueSoonTotal: 0,
+          upcomingCount: 0,
+          upcomingTotal: 0,
+        },
+      }),
+    );
+
+    render(<OperationalSummaryPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Saldo técnico: R$ 700,00")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("2 vencidas somam R$ 300,00")).toBeInTheDocument();
+  });
+
+  it("mantem saldo disponivel quando nao ha vencidas", async () => {
+    vi.mocked(dashboardService.getSnapshot).mockResolvedValueOnce(
+      buildSnapshot({
+        bankBalance: 1000,
+        bills: {
+          overdueCount: 0,
+          overdueTotal: 0,
+          dueSoonCount: 1,
+          dueSoonTotal: 80,
+          upcomingCount: 0,
+          upcomingTotal: 0,
+        },
+      }),
+    );
+
+    render(<OperationalSummaryPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Saldo disponível")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText(/Saldo técnico:/)).not.toBeInTheDocument();
+  });
+
   it("mostra proximas contas quando nao ha urgencia imediata", async () => {
     vi.mocked(dashboardService.getSnapshot).mockResolvedValueOnce(
       buildSnapshot({

--- a/apps/web/src/components/OperationalSummaryPanel.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.tsx
@@ -133,11 +133,16 @@ const OperationalSummaryPanel = (): JSX.Element | null => {
   const { bankBalance, bills, cards, income, forecast, consignado } = snapshot;
 
   // ── Tile 1: Bank balance ──────────────────────────────────────────────────
+  const hasOverdueBills = bills.overdueCount > 0;
+  const technicalBalance = bankBalance - bills.overdueTotal;
   const bankTile: TileProps = {
     label: "Conta",
     primary: money(bankBalance),
-    secondary: "Saldo disponível",
-    accent: bankBalance < 0 ? "danger" : "default",
+    secondary: hasOverdueBills ? `Saldo técnico: ${money(technicalBalance)}` : "Saldo disponível",
+    tertiary: hasOverdueBills
+      ? `${bills.overdueCount} vencida${bills.overdueCount > 1 ? "s" : ""} somam ${money(bills.overdueTotal)}`
+      : undefined,
+    accent: technicalBalance < 0 ? "danger" : hasOverdueBills ? "warning" : bankBalance < 0 ? "danger" : "default",
   };
 
   // ── Tile 2: Bills ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Objetivo\nAvancar o PR 12 na home com um sinal operacional direto de pressao financeira: saldo tecnico (saldo bancario menos vencidas).\n\n## Mudancas\n- OperationalSummaryPanel\n  - tile Conta passa a exibir Saldo técnico quando houver contas vencidas\n  - inclui contexto: quantidade de vencidas e valor total vencido\n  - accent de risco considera saldo tecnico negativo\n- Testes\n  - adiciona cenarios com e sem vencidas em OperationalSummaryPanel.test.tsx\n\n## Validacao local\n- npm -w apps/web run test:run -- src/components/OperationalSummaryPanel.test.tsx src/services/dashboard.service.test.ts\n- npm -w apps/web run typecheck\n