### PR TITLE
feat(dashboard): destacar saldo em 7 dias na home operacional

### DIFF
--- a/apps/web/src/components/OperationalSummaryPanel.test.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.test.tsx
@@ -71,7 +71,7 @@ describe("OperationalSummaryPanel", () => {
     expect(screen.getByText("2 vencidas somam R$ 300,00")).toBeInTheDocument();
   });
 
-  it("mantem saldo disponivel quando nao ha vencidas", async () => {
+  it("exibe saldo em 7 dias quando ha contas a vencer e nenhuma vencida", async () => {
     vi.mocked(dashboardService.getSnapshot).mockResolvedValueOnce(
       buildSnapshot({
         bankBalance: 1000,
@@ -89,9 +89,35 @@ describe("OperationalSummaryPanel", () => {
     render(<OperationalSummaryPanel />);
 
     await waitFor(() => {
+      expect(screen.getByText("Saldo em 7 dias: R$ 920,00")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("1 em 7 dias somam R$ 80,00")).toBeInTheDocument();
+    expect(screen.queryByText("Saldo disponível")).not.toBeInTheDocument();
+  });
+
+  it("mantem saldo disponivel quando nao ha vencidas nem contas em 7 dias", async () => {
+    vi.mocked(dashboardService.getSnapshot).mockResolvedValueOnce(
+      buildSnapshot({
+        bankBalance: 1000,
+        bills: {
+          overdueCount: 0,
+          overdueTotal: 0,
+          dueSoonCount: 0,
+          dueSoonTotal: 0,
+          upcomingCount: 1,
+          upcomingTotal: 120,
+        },
+      }),
+    );
+
+    render(<OperationalSummaryPanel />);
+
+    await waitFor(() => {
       expect(screen.getByText("Saldo disponível")).toBeInTheDocument();
     });
 
+    expect(screen.queryByText(/Saldo em 7 dias:/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Saldo técnico:/)).not.toBeInTheDocument();
   });
 

--- a/apps/web/src/components/OperationalSummaryPanel.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.tsx
@@ -134,15 +134,42 @@ const OperationalSummaryPanel = (): JSX.Element | null => {
 
   // ── Tile 1: Bank balance ──────────────────────────────────────────────────
   const hasOverdueBills = bills.overdueCount > 0;
+  const hasDueSoonBills = bills.dueSoonCount > 0;
   const technicalBalance = bankBalance - bills.overdueTotal;
+  const shortTermBalance = technicalBalance - bills.dueSoonTotal;
+  const shouldShowShortTermBalance = hasDueSoonBills && !hasOverdueBills;
+
+  const bankTileSecondary = hasOverdueBills
+    ? `Saldo técnico: ${money(technicalBalance)}`
+    : shouldShowShortTermBalance
+      ? `Saldo em 7 dias: ${money(shortTermBalance)}`
+      : "Saldo disponível";
+
+  const bankTileDetails: string[] = [];
+  if (hasOverdueBills) {
+    bankTileDetails.push(
+      `${bills.overdueCount} vencida${bills.overdueCount > 1 ? "s" : ""} somam ${money(bills.overdueTotal)}`,
+    );
+  }
+  if (hasDueSoonBills) {
+    bankTileDetails.push(
+      `${bills.dueSoonCount} em 7 dias somam ${money(bills.dueSoonTotal)}`,
+    );
+  }
+
   const bankTile: TileProps = {
     label: "Conta",
     primary: money(bankBalance),
-    secondary: hasOverdueBills ? `Saldo técnico: ${money(technicalBalance)}` : "Saldo disponível",
-    tertiary: hasOverdueBills
-      ? `${bills.overdueCount} vencida${bills.overdueCount > 1 ? "s" : ""} somam ${money(bills.overdueTotal)}`
-      : undefined,
-    accent: technicalBalance < 0 ? "danger" : hasOverdueBills ? "warning" : bankBalance < 0 ? "danger" : "default",
+    secondary: bankTileSecondary,
+    tertiary: bankTileDetails.length > 0 ? bankTileDetails.join(" • ") : undefined,
+    accent:
+      shortTermBalance < 0
+        ? "danger"
+        : hasOverdueBills || hasDueSoonBills
+          ? "warning"
+          : bankBalance < 0
+            ? "danger"
+            : "default",
   };
 
   // ── Tile 2: Bills ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Objetivo\nDar mais honestidade operacional ao tile Conta da home, evidenciando pressão de curto prazo mesmo sem contas vencidas.\n\n## Mudanças\n- OperationalSummaryPanel\n  - adiciona leitura de Saldo em 7 dias quando existem contas dueSoon e não há vencidas\n  - mantém Saldo técnico para cenário com vencidas\n  - complementa contexto com valor/quantidade em 7 dias no detalhe do tile\n  - mantém Saldo disponível quando não há pressão imediata\n- Testes\n  - atualiza cenário de dueSoon para validar Saldo em 7 dias\n  - adiciona cenário sem overdue/dueSoon para validar manutenção de Saldo disponível\n\n## Validação local\n- npm -w apps/web run test:run -- src/components/OperationalSummaryPanel.test.tsx src/services/dashboard.service.test.ts\n- npm -w apps/web run typecheck\n