### PR TITLE
feat(web): adicionar CTA de contas em 7 dias no painel operacional

### DIFF
--- a/apps/web/src/AppRoutes.tsx
+++ b/apps/web/src/AppRoutes.tsx
@@ -39,7 +39,12 @@ const Dashboard = () => {
     navigate("/app/settings/security");
   };
 
-  const handleOpenBills = () => {
+  const handleOpenBills = (filter?: "due_soon") => {
+    if (filter === "due_soon") {
+      navigate("/app/bills?status=due_soon");
+      return;
+    }
+
     navigate("/app/bills");
   };
 

--- a/apps/web/src/components/OperationalSummaryPanel.test.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.test.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import OperationalSummaryPanel from "./OperationalSummaryPanel";
 import { dashboardService, type DashboardSnapshot } from "../services/dashboard.service";
 
@@ -99,6 +100,31 @@ describe("OperationalSummaryPanel", () => {
       ),
     ).toBeInTheDocument();
     expect(screen.queryByText("Saldo disponível")).not.toBeInTheDocument();
+  });
+
+  it("dispara CTA de contas em 7 dias quando callback é fornecido", async () => {
+    const user = userEvent.setup();
+    const onOpenDueSoonBills = vi.fn();
+
+    vi.mocked(dashboardService.getSnapshot).mockResolvedValueOnce(
+      buildSnapshot({
+        bills: {
+          overdueCount: 0,
+          overdueTotal: 0,
+          dueSoonCount: 2,
+          dueSoonTotal: 150,
+          upcomingCount: 0,
+          upcomingTotal: 0,
+        },
+      }),
+    );
+
+    render(<OperationalSummaryPanel onOpenDueSoonBills={onOpenDueSoonBills} />);
+
+    const cta = await screen.findByRole("button", { name: /Ver contas em 7 dias/i });
+    await user.click(cta);
+
+    expect(onOpenDueSoonBills).toHaveBeenCalledOnce();
   });
 
   it("mantem saldo disponivel quando nao ha vencidas nem contas em 7 dias", async () => {

--- a/apps/web/src/components/OperationalSummaryPanel.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.tsx
@@ -11,6 +11,8 @@ interface TileProps {
   primary: string;
   secondary?: string;
   tertiary?: string;
+  actionLabel?: string;
+  onActionClick?: () => void;
   accent?: "default" | "warning" | "danger" | "success" | "muted";
 }
 
@@ -22,7 +24,7 @@ const ACCENT_CLASSES: Record<NonNullable<TileProps["accent"]>, string> = {
   muted: "text-cf-text-secondary",
 };
 
-const Tile = ({ label, primary, secondary, tertiary, accent = "default" }: TileProps) => (
+const Tile = ({ label, primary, secondary, tertiary, actionLabel, onActionClick, accent = "default" }: TileProps) => (
   <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
     <p className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-cf-text-secondary">
       {label}
@@ -33,6 +35,15 @@ const Tile = ({ label, primary, secondary, tertiary, accent = "default" }: TileP
     ) : null}
     {tertiary ? (
       <p className="text-xs text-cf-text-secondary">{tertiary}</p>
+    ) : null}
+    {actionLabel && onActionClick ? (
+      <button
+        type="button"
+        onClick={onActionClick}
+        className="mt-1 text-xs font-semibold text-brand-1 hover:text-brand-2"
+      >
+        {actionLabel} →
+      </button>
     ) : null}
   </div>
 );
@@ -49,7 +60,11 @@ const SkeletonTile = () => (
 
 // ─── Panel ────────────────────────────────────────────────────────────────────
 
-const OperationalSummaryPanel = (): JSX.Element | null => {
+interface OperationalSummaryPanelProps {
+  onOpenDueSoonBills?: () => void;
+}
+
+const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanelProps): JSX.Element | null => {
   const [snapshot, setSnapshot] = useState<DashboardSnapshot | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -207,6 +222,8 @@ const OperationalSummaryPanel = (): JSX.Element | null => {
             ? `${bills.upcomingCount} próxima${bills.upcomingCount > 1 ? "s" : ""}`
           : "Nenhuma pendente",
     tertiary: billsTertiaryTokens.length > 0 ? `+ ${billsTertiaryTokens.join(" • ")}` : undefined,
+    actionLabel: bills.dueSoonCount > 0 && onOpenDueSoonBills ? "Ver contas em 7 dias" : undefined,
+    onActionClick: bills.dueSoonCount > 0 && onOpenDueSoonBills ? onOpenDueSoonBills : undefined,
     accent: billsAccent,
   };
 

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -111,7 +111,7 @@ interface MonthOverMonthMetric {
 
 interface AppProps {
   onLogout?: () => void;
-  onOpenBills?: () => void;
+  onOpenBills?: (filter?: "due_soon") => void;
   onOpenCreditCards?: () => void;
   onOpenIncomeSources?: () => void;
   onOpenTax?: () => void;
@@ -1514,6 +1514,11 @@ const App = ({
     onOpenBills?.();
   };
 
+  const handleOpenDueSoonBills = () => {
+    closeMobileActionsMenu();
+    onOpenBills?.("due_soon");
+  };
+
   const handleOpenCreditCards = () => {
     closeMobileActionsMenu();
     onOpenCreditCards?.();
@@ -2451,7 +2456,7 @@ const App = ({
               </p>
             </div>
 
-            <OperationalSummaryPanel />
+            <OperationalSummaryPanel onOpenDueSoonBills={handleOpenDueSoonBills} />
 
             <div className="grid gap-4 xl:grid-cols-3">
               <ForecastCard onOpenProfileSettings={onOpenProfileSettings} />

--- a/apps/web/src/pages/BillsPage.test.tsx
+++ b/apps/web/src/pages/BillsPage.test.tsx
@@ -67,9 +67,9 @@ const buildListResult = (items: Bill[] = [buildBill()]) => ({
 
 // ─── Render helper ────────────────────────────────────────────────────────────
 
-const renderPage = () =>
+const renderPage = (initialEntries: string[] = ["/app/bills"]) =>
   render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={initialEntries}>
       <BillsPage onBack={vi.fn()} onLogout={vi.fn()} />
     </MemoryRouter>,
   );
@@ -220,6 +220,16 @@ describe("BillsPage", () => {
     await waitFor(() => {
       expect(billsService.list).toHaveBeenCalledWith(
         expect.objectContaining({ status: "due_soon" }),
+      );
+    });
+  });
+
+  it("aplica filtro inicial quando URL traz status=due_soon", async () => {
+    renderPage(["/app/bills?status=due_soon"]);
+
+    await waitFor(() => {
+      expect(billsService.list).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "due_soon", offset: 0 }),
       );
     });
   });

--- a/apps/web/src/pages/BillsPage.tsx
+++ b/apps/web/src/pages/BillsPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useLocation } from "react-router-dom";
 import BillModal from "../components/BillModal";
 import { categoriesService } from "../services/categories.service";
 import {
@@ -13,6 +14,13 @@ import { getApiErrorMessage } from "../utils/apiError";
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const DEFAULT_LIMIT = 20;
+const STATUS_FILTER_VALUES: Array<Exclude<BillStatusFilter, undefined>> = [
+  "pending",
+  "paid",
+  "overdue",
+  "due_soon",
+  "future",
+];
 
 interface CategoryOption {
   id: number;
@@ -35,6 +43,13 @@ const formatReferenceMonth = (value: string | null): string => {
 };
 
 const isCreditCardInvoice = (bill: Bill) => bill.billType === "credit_card_invoice";
+
+const parseStatusFilter = (value: string | null): BillStatusFilter => {
+  if (!value) return undefined;
+  return STATUS_FILTER_VALUES.includes(value as Exclude<BillStatusFilter, undefined>)
+    ? (value as Exclude<BillStatusFilter, undefined>)
+    : undefined;
+};
 
 // ─── Status badge ─────────────────────────────────────────────────────────────
 
@@ -79,7 +94,9 @@ interface BillsPageProps {
 const BillsPage = ({
   onBack = undefined,
 }: BillsPageProps): JSX.Element => {
-  const [statusFilter, setStatusFilter] = useState<BillStatusFilter>(undefined);
+  const location = useLocation();
+  const initialStatusFilter = parseStatusFilter(new URLSearchParams(location.search).get("status"));
+  const [statusFilter, setStatusFilter] = useState<BillStatusFilter>(() => initialStatusFilter);
   const [offset, setOffset] = useState(0);
   const [items, setItems] = useState<Bill[]>([]);
   const [paginationTotal, setPaginationTotal] = useState(0);
@@ -143,9 +160,9 @@ const BillsPage = ({
 
   useEffect(() => {
     void loadSummary();
-    void loadList(0, undefined);
+    void loadList(0, initialStatusFilter);
     void loadCategories();
-  }, [loadSummary, loadList, loadCategories]);
+  }, [loadSummary, loadList, loadCategories, initialStatusFilter]);
 
   // ─── Success message helper ─────────────────────────────────────────────────
 


### PR DESCRIPTION
## Objetivo\nFechar a ultima milha entre informacao e acao no painel operacional: quando houver urgencia de 7 dias, permitir abrir o fluxo de bills ja filtrado.\n\n## Mudancas\n- OperationalSummaryPanel\n  - adiciona CTA contextual Ver contas em 7 dias no bloco de contas quando houver dueSoonCount > 0\n  - CTA dispara callback opcional para abrir o fluxo de bills\n- App + AppRoutes\n  - encadeia callback do CTA ate a navegacao\n  - rota para /app/bills?status=due_soon\n- BillsPage\n  - aplica filtro inicial a partir de location.search (status=due_soon)\n- Testes\n  - interacao do CTA em OperationalSummaryPanel.test.tsx\n  - filtro inicial via query em BillsPage.test.tsx\n\n## Validacao local\n- npm -w apps/web run test:run -- src/components/OperationalSummaryPanel.test.tsx src/pages/BillsPage.test.tsx\n- npm -w apps/web run typecheck\n