### PR TITLE
feat(web): PR B - reforça cards críticos da home

### DIFF
--- a/apps/web/src/components/BillsSummaryWidget.tsx
+++ b/apps/web/src/components/BillsSummaryWidget.tsx
@@ -31,10 +31,21 @@ const BillsSummaryWidget = ({ onOpenBills }: BillsSummaryWidgetProps): JSX.Eleme
 
   if (!summary) return null;
 
+  const hasOverdueBills = summary.overdueCount > 0;
+  const cardToneClass = hasOverdueBills ? "border-red-300" : "border-cf-border";
+  const statusBadgeClass = hasOverdueBills
+    ? "border-red-200 bg-red-50 text-red-700"
+    : "border-emerald-200 bg-emerald-50 text-emerald-700";
+
   return (
-    <div className="rounded border border-cf-border bg-cf-surface p-4">
+    <div className={`rounded border bg-cf-surface p-4 ${cardToneClass}`}>
       <div className="mb-2 flex items-center justify-between">
-        <h3 className="text-sm font-medium text-cf-text-primary">Pendências</h3>
+        <div className="flex items-center gap-2">
+          <h3 className="text-sm font-medium text-cf-text-primary">Pendências</h3>
+          <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${statusBadgeClass}`}>
+            {hasOverdueBills ? "Ação imediata" : "Em dia"}
+          </span>
+        </div>
         {onOpenBills ? (
           <button
             type="button"
@@ -46,18 +57,12 @@ const BillsSummaryWidget = ({ onOpenBills }: BillsSummaryWidgetProps): JSX.Eleme
         ) : null}
       </div>
 
-      <div className="grid grid-cols-2 gap-3">
-        <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
-          <p className="text-xs font-medium uppercase text-cf-text-secondary">Pendentes</p>
-          <p className="text-sm font-semibold text-cf-text-primary">
-            {money(summary.pendingTotal)}
-          </p>
-          <p className="text-xs text-cf-text-secondary">
-            {summary.pendingCount} {summary.pendingCount === 1 ? "conta" : "contas"}
-          </p>
-        </div>
+      <p className="mb-3 text-xs text-cf-text-secondary">
+        Priorize contas vencidas para evitar juros e, depois, trate as próximas pendências.
+      </p>
 
-        <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
+      <div className="grid grid-cols-2 gap-3">
+        <div className={`rounded border bg-cf-bg-subtle px-3 py-2.5 ${hasOverdueBills ? "border-red-200" : "border-cf-border"}`}>
           <p className="text-xs font-medium uppercase text-cf-text-secondary">Vencidas</p>
           <p
             className={`text-sm font-semibold ${summary.overdueCount > 0 ? "text-red-600" : "text-cf-text-primary"}`}
@@ -66,6 +71,16 @@ const BillsSummaryWidget = ({ onOpenBills }: BillsSummaryWidgetProps): JSX.Eleme
           </p>
           <p className={`text-xs ${summary.overdueCount > 0 ? "text-red-500" : "text-cf-text-secondary"}`}>
             {summary.overdueCount} {summary.overdueCount === 1 ? "conta" : "contas"}
+          </p>
+        </div>
+
+        <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
+          <p className="text-xs font-medium uppercase text-cf-text-secondary">Pendentes</p>
+          <p className="text-sm font-semibold text-cf-text-primary">
+            {money(summary.pendingTotal)}
+          </p>
+          <p className="text-xs text-cf-text-secondary">
+            {summary.pendingCount} {summary.pendingCount === 1 ? "conta" : "contas"}
           </p>
         </div>
       </div>

--- a/apps/web/src/components/CreditCardsSummaryWidget.tsx
+++ b/apps/web/src/components/CreditCardsSummaryWidget.tsx
@@ -261,6 +261,23 @@ const CreditCardsSummaryWidget = ({
   const usageStatusClassName = USAGE_STATUS_CLASSNAMES[aggregate.usageStatus];
   const usageProgressClassName = USAGE_PROGRESS_CLASSNAMES[aggregate.usageStatus];
   const usageProgressWidthPct = Math.min(100, aggregate.usagePct);
+  const hasCriticalInvoices = aggregate.pendingInvoicesCount > 0;
+  const hasExceededLimit = aggregate.usageStatus === "exceeded";
+  const cardToneClass = hasExceededLimit
+    ? "border-red-300"
+    : hasCriticalInvoices
+      ? "border-amber-300"
+      : "border-cf-border";
+  const statusBadgeClass = hasExceededLimit
+    ? "border-red-200 bg-red-50 text-red-700"
+    : hasCriticalInvoices
+      ? "border-amber-200 bg-amber-50 text-amber-700"
+      : "border-emerald-200 bg-emerald-50 text-emerald-700";
+  const statusBadgeLabel = hasExceededLimit
+    ? "Limite excedido"
+    : hasCriticalInvoices
+      ? "Atenção"
+      : "Estável";
 
   if (isLoading) {
     return (
@@ -293,10 +310,15 @@ const CreditCardsSummaryWidget = ({
   }
 
   return (
-    <div className="rounded border border-cf-border bg-cf-surface p-4">
+    <div className={`rounded border bg-cf-surface p-4 ${cardToneClass}`}>
       <div className="mb-2 flex items-center justify-between gap-2">
         <div>
-          <h3 className="text-sm font-medium text-cf-text-primary">Cartões</h3>
+          <div className="flex items-center gap-2">
+            <h3 className="text-sm font-medium text-cf-text-primary">Cartões</h3>
+            <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${statusBadgeClass}`}>
+              {statusBadgeLabel}
+            </span>
+          </div>
           <p className="text-xs text-cf-text-secondary">
             {aggregate.cardsCount === 0
               ? "Nenhum cartão cadastrado ainda."
@@ -322,7 +344,30 @@ const CreditCardsSummaryWidget = ({
         </div>
       ) : (
         <>
+          <p className="mb-3 text-xs text-cf-text-secondary">
+            Priorize faturas pendentes e acompanhe o uso de limite para evitar estouro no fechamento.
+          </p>
+
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <div className={`rounded border bg-cf-bg-subtle px-3 py-2.5 ${hasCriticalInvoices ? "border-amber-200" : "border-cf-border"}`}>
+              <p className="text-xs font-medium uppercase text-cf-text-secondary">Faturas pendentes</p>
+              <p
+                className={`text-sm font-semibold ${
+                  aggregate.pendingInvoicesCount > 0 ? "text-amber-700" : "text-cf-text-primary"
+                }`}
+              >
+                {money(aggregate.pendingInvoicesTotal)}
+              </p>
+              <p
+                className={`text-xs ${
+                  aggregate.pendingInvoicesCount > 0 ? "text-amber-700" : "text-cf-text-secondary"
+                }`}
+              >
+                {aggregate.pendingInvoicesCount}{" "}
+                {aggregate.pendingInvoicesCount === 1 ? "fatura" : "faturas"}
+              </p>
+            </div>
+
             <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
               <div className="flex items-center justify-between gap-2">
                 <p className="text-xs font-medium uppercase text-cf-text-secondary">Limite em uso</p>
@@ -358,25 +403,6 @@ const CreditCardsSummaryWidget = ({
                 {money(aggregate.openPurchasesTotal)}
               </p>
               <p className="text-xs text-cf-text-secondary">Ainda não fechadas em fatura</p>
-            </div>
-
-            <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
-              <p className="text-xs font-medium uppercase text-cf-text-secondary">Faturas pendentes</p>
-              <p
-                className={`text-sm font-semibold ${
-                  aggregate.pendingInvoicesCount > 0 ? "text-amber-700" : "text-cf-text-primary"
-                }`}
-              >
-                {money(aggregate.pendingInvoicesTotal)}
-              </p>
-              <p
-                className={`text-xs ${
-                  aggregate.pendingInvoicesCount > 0 ? "text-amber-700" : "text-cf-text-secondary"
-                }`}
-              >
-                {aggregate.pendingInvoicesCount}{" "}
-                {aggregate.pendingInvoicesCount === 1 ? "fatura" : "faturas"}
-              </p>
             </div>
           </div>
 

--- a/apps/web/src/components/ForecastCard.tsx
+++ b/apps/web/src/components/ForecastCard.tsx
@@ -277,11 +277,37 @@ const ForecastCard = ({
     );
   }
 
+  const hasNegativeProjection = forecast !== null && forecast.adjustedProjectedBalance < 0;
+  const hasPendingBills = forecast !== null && forecast.billsPendingCount > 0;
+  const cardToneClass = hasNegativeProjection
+    ? "border-red-300"
+    : hasPendingBills
+      ? "border-amber-300"
+      : "border-brand-1";
+  const statusBadgeClass = hasNegativeProjection
+    ? "border-red-200 bg-red-50 text-red-700"
+    : hasPendingBills
+      ? "border-amber-200 bg-amber-50 text-amber-700"
+      : "border-emerald-200 bg-emerald-50 text-emerald-700";
+  const statusLabel = hasNegativeProjection
+    ? "Risco de fechamento negativo"
+    : hasPendingBills
+      ? "Atenção às pendências"
+      : "Trajetória estável";
+
   // Active state
   return (
-    <div className="rounded border border-brand-1 bg-cf-surface p-4">
+    <div className={`rounded border bg-cf-surface p-4 ${cardToneClass}`}>
       <div className="flex items-start justify-between gap-3">
-        <h3 className="text-sm font-semibold text-cf-text-primary">Projeção de saldo</h3>
+        <div>
+          <h3 className="text-sm font-semibold text-cf-text-primary">Projeção de saldo</h3>
+          <p className="mt-1 text-xs text-cf-text-secondary">
+            Saldo estimado até o fim do mês com lançamentos e pendências atuais.
+          </p>
+        </div>
+        <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${statusBadgeClass}`}>
+          {statusLabel}
+        </span>
         <button
           type="button"
           onClick={handleRecompute}

--- a/apps/web/src/components/SalaryWidget.tsx
+++ b/apps/web/src/components/SalaryWidget.tsx
@@ -89,11 +89,13 @@ function SummaryMetric({
   value,
   tone = "default",
   helper,
+  emphasis = false,
 }: {
   label: string;
   value: number;
   tone?: "default" | "negative" | "highlight";
   helper?: string;
+  emphasis?: boolean;
 }) {
   const valueClass =
     tone === "highlight"
@@ -101,9 +103,12 @@ function SummaryMetric({
       : tone === "negative"
         ? "text-red-600"
         : "text-cf-text-primary";
+  const emphasisClass = emphasis
+    ? "border-brand-1/30 bg-brand-3/20 shadow-[inset_0_0_0_1px_rgba(76,113,255,0.16)]"
+    : "border-cf-border bg-cf-surface";
 
   return (
-    <div className="rounded border border-cf-border bg-cf-surface px-3 py-2.5">
+    <div className={`rounded border px-3 py-2.5 ${emphasisClass}`}>
       <p className="text-[11px] font-medium uppercase tracking-wide text-cf-text-secondary">{label}</p>
       <p className={`mt-1 text-base font-bold ${valueClass}`}>{formatCurrency(value)}</p>
       {helper ? <p className="mt-1 text-xs text-cf-text-secondary">{helper}</p> : null}
@@ -458,6 +463,7 @@ function BenefitProfileView({
           label="Benefício líquido"
           value={calculation.netMonthly}
           tone="highlight"
+          emphasis
           helper={
             calculation.netAnnual == null
               ? "Líquido anual: disponível no Pro"

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -2458,13 +2458,25 @@ const App = ({
 
             <OperationalSummaryPanel onOpenDueSoonBills={handleOpenDueSoonBills} />
 
-            <div className="grid gap-4 xl:grid-cols-4">
-              <div className="xl:col-span-2">
-                <ForecastCard onOpenProfileSettings={onOpenProfileSettings} />
+            <section className="space-y-3" aria-labelledby="critical-cards-title">
+              <div className="flex items-center justify-between gap-2">
+                <h4 id="critical-cards-title" className="text-xs font-semibold uppercase tracking-wide text-cf-text-secondary">
+                  Cards críticos
+                </h4>
+                <span className="text-xs text-cf-text-secondary">Prioridade de triagem</span>
               </div>
-              <BillsSummaryWidget onOpenBills={handleOpenBills} />
-              <CreditCardsSummaryWidget onOpenCreditCards={handleOpenCreditCards} />
-            </div>
+
+              <div className="grid gap-4 xl:grid-cols-12">
+                <div className="xl:col-span-7">
+                  <ForecastCard onOpenProfileSettings={onOpenProfileSettings} />
+                </div>
+
+                <div className="space-y-4 xl:col-span-5">
+                  <BillsSummaryWidget onOpenBills={handleOpenBills} />
+                  <CreditCardsSummaryWidget onOpenCreditCards={handleOpenCreditCards} />
+                </div>
+              </div>
+            </section>
 
             <UtilityBillsWidget />
           </section>


### PR DESCRIPTION
## Objetivo
Reforçar os cards críticos da Home após a recomposição do PR A, priorizando leitura de risco e ação operacional.

## O que mudou
- Reorganiza a área de cards críticos na Home com Forecast em destaque e coluna de Pendências + Cartões.
- Projeção de saldo: borda/badge de risco dinâmicos e contexto de leitura no topo do card.
- Pendências: estado de ação imediata quando há vencidas, com ordem de leitura priorizando vencidas.
- Cartões: estado de atenção/limite excedido no topo e destaque para faturas pendentes.
- Benefício líquido: reforço visual do resumo principal no SalaryWidget.

## Arquivos
- apps/web/src/pages/App.tsx
- apps/web/src/components/ForecastCard.tsx
- apps/web/src/components/BillsSummaryWidget.tsx
- apps/web/src/components/CreditCardsSummaryWidget.tsx
- apps/web/src/components/SalaryWidget.tsx

## Validação
- npm -w apps/web run typecheck
- npm -w apps/web run test:run -- src/components/ForecastCard.test.tsx src/components/BillsSummaryWidget.test.tsx src/components/CreditCardsSummaryWidget.test.tsx src/components/SalaryWidget.test.tsx src/pages/App.test.jsx

## Resultado
- Typecheck: ok
- Testes focados: 130/130 passando (5 suítes)
