### PR TITLE
feat(web): PR C - severidade e estados operacionais

### DIFF
--- a/apps/web/src/components/BillsSummaryWidget.test.tsx
+++ b/apps/web/src/components/BillsSummaryWidget.test.tsx
@@ -98,14 +98,15 @@ describe("BillsSummaryWidget", () => {
     expect(screen.queryByText("Ver pendências →")).not.toBeInTheDocument();
   });
 
-  it("retorna null silenciosamente em caso de erro do getSummary", async () => {
+  it("exibe estado de risco orientativo em caso de erro do getSummary", async () => {
     vi.mocked(billsService.getSummary).mockRejectedValue(new Error("Falha de rede"));
-    const { container } = renderWidget();
+    renderWidget();
 
     await waitFor(() => {
       expect(screen.queryByText("Carregando pendências...")).not.toBeInTheDocument();
     });
 
-    expect(container.firstChild).toBeNull();
+    expect(screen.getByText("Resumo de pendências indisponível")).toBeInTheDocument();
+    expect(screen.getByText(/A consulta de contas pendentes e vencidas falhou/i)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/BillsSummaryWidget.tsx
+++ b/apps/web/src/components/BillsSummaryWidget.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { billsService, type BillsSummary } from "../services/bills.service";
 import { useMaskedCurrency } from "../context/DiscreetModeContext";
+import { OperationalSeverityBadge, OperationalStateBlock, type OperationalSeverity } from "./OperationalStateBlock";
 
 interface BillsSummaryWidgetProps {
   onOpenBills?: () => void;
@@ -9,13 +10,18 @@ interface BillsSummaryWidgetProps {
 const BillsSummaryWidget = ({ onOpenBills }: BillsSummaryWidgetProps): JSX.Element | null => {
   const [summary, setSummary] = useState<BillsSummary | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [hasLoadError, setHasLoadError] = useState(false);
 
   useEffect(() => {
     billsService
       .getSummary()
-      .then(setSummary)
+      .then((data) => {
+        setSummary(data);
+        setHasLoadError(false);
+      })
       .catch(() => {
         setSummary(null);
+        setHasLoadError(true);
       })
       .finally(() => setIsLoading(false));
   }, []);
@@ -29,22 +35,66 @@ const BillsSummaryWidget = ({ onOpenBills }: BillsSummaryWidgetProps): JSX.Eleme
     );
   }
 
-  if (!summary) return null;
+  if (hasLoadError) {
+    return (
+      <div className="rounded border border-red-300 bg-cf-surface p-4">
+        <div className="mb-2 flex items-center justify-between gap-2">
+          <h3 className="text-sm font-medium text-cf-text-primary">Pendências</h3>
+          <OperationalSeverityBadge severity="risco" />
+        </div>
+
+        <OperationalStateBlock
+          severity="risco"
+          title="Resumo de pendências indisponível"
+          happened="A consulta de contas pendentes e vencidas falhou nesta tentativa."
+          impact="Você pode perder visibilidade de cobrança imediata e risco de juros."
+          nextStep={
+            onOpenBills
+              ? "Abra o módulo de contas para revisar os lançamentos manualmente agora."
+              : "Atualize a página em instantes para tentar carregar o resumo novamente."
+          }
+          ctaLabel={onOpenBills ? "Ver pendências" : undefined}
+          onCta={onOpenBills}
+        />
+      </div>
+    );
+  }
+
+  if (!summary) {
+    return (
+      <div className="rounded border border-amber-300 bg-cf-surface p-4">
+        <div className="mb-2 flex items-center justify-between gap-2">
+          <h3 className="text-sm font-medium text-cf-text-primary">Pendências</h3>
+          <OperationalSeverityBadge severity="atencao" />
+        </div>
+
+        <OperationalStateBlock
+          severity="atencao"
+          title="Sem base suficiente para o resumo"
+          happened="Ainda não há dados de pendências consolidados para este período."
+          impact="A triagem de contas pode ficar incompleta até que novas contas sejam registradas."
+          nextStep="Cadastre ou atualize contas para liberar esta leitura operacional."
+        />
+      </div>
+    );
+  }
 
   const hasOverdueBills = summary.overdueCount > 0;
-  const cardToneClass = hasOverdueBills ? "border-red-300" : "border-cf-border";
-  const statusBadgeClass = hasOverdueBills
-    ? "border-red-200 bg-red-50 text-red-700"
-    : "border-emerald-200 bg-emerald-50 text-emerald-700";
+  const hasPendingBills = summary.pendingCount > 0;
+  const severityLevel: OperationalSeverity = hasOverdueBills ? "risco" : hasPendingBills ? "atencao" : "normal";
+  const cardToneClass = hasOverdueBills ? "border-red-300" : hasPendingBills ? "border-amber-300" : "border-cf-border";
+  const statusContext = hasOverdueBills
+    ? "Há contas vencidas exigindo ação imediata."
+    : hasPendingBills
+      ? "Há contas pendentes sem atraso no momento."
+      : "Sem pendências ou vencimentos no recorte atual.";
 
   return (
     <div className={`rounded border bg-cf-surface p-4 ${cardToneClass}`}>
       <div className="mb-2 flex items-center justify-between">
         <div className="flex items-center gap-2">
           <h3 className="text-sm font-medium text-cf-text-primary">Pendências</h3>
-          <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${statusBadgeClass}`}>
-            {hasOverdueBills ? "Ação imediata" : "Em dia"}
-          </span>
+          <OperationalSeverityBadge severity={severityLevel} />
         </div>
         {onOpenBills ? (
           <button
@@ -58,7 +108,7 @@ const BillsSummaryWidget = ({ onOpenBills }: BillsSummaryWidgetProps): JSX.Eleme
       </div>
 
       <p className="mb-3 text-xs text-cf-text-secondary">
-        Priorize contas vencidas para evitar juros e, depois, trate as próximas pendências.
+        {statusContext}
       </p>
 
       <div className="grid grid-cols-2 gap-3">

--- a/apps/web/src/components/CreditCardsSummaryWidget.test.tsx
+++ b/apps/web/src/components/CreditCardsSummaryWidget.test.tsx
@@ -97,11 +97,11 @@ describe("CreditCardsSummaryWidget", () => {
     renderWidget();
 
     await waitFor(() => {
-      expect(screen.getByText("Nenhum cartão cadastrado ainda.")).toBeInTheDocument();
+      expect(screen.getAllByText("Nenhum cartão cadastrado ainda.").length).toBeGreaterThan(0);
     });
 
     expect(
-      screen.getByText(/Cadastre um cartão para acompanhar limite disponível/i),
+      screen.getByText(/Cadastre ao menos um cartão para liberar a visão operacional/i),
     ).toBeInTheDocument();
   });
 

--- a/apps/web/src/components/CreditCardsSummaryWidget.tsx
+++ b/apps/web/src/components/CreditCardsSummaryWidget.tsx
@@ -5,6 +5,7 @@ import {
   type CreditCardItem,
   type CreditCardInvoicePdf,
 } from "../services/credit-cards.service";
+import { OperationalSeverityBadge, OperationalStateBlock, type OperationalSeverity } from "./OperationalStateBlock";
 
 interface CreditCardsSummaryWidgetProps {
   onOpenCreditCards?: () => void;
@@ -263,21 +264,12 @@ const CreditCardsSummaryWidget = ({
   const usageProgressWidthPct = Math.min(100, aggregate.usagePct);
   const hasCriticalInvoices = aggregate.pendingInvoicesCount > 0;
   const hasExceededLimit = aggregate.usageStatus === "exceeded";
+  const severityLevel: OperationalSeverity = hasExceededLimit ? "risco" : hasCriticalInvoices ? "atencao" : "normal";
   const cardToneClass = hasExceededLimit
     ? "border-red-300"
     : hasCriticalInvoices
       ? "border-amber-300"
       : "border-cf-border";
-  const statusBadgeClass = hasExceededLimit
-    ? "border-red-200 bg-red-50 text-red-700"
-    : hasCriticalInvoices
-      ? "border-amber-200 bg-amber-50 text-amber-700"
-      : "border-emerald-200 bg-emerald-50 text-emerald-700";
-  const statusBadgeLabel = hasExceededLimit
-    ? "Limite excedido"
-    : hasCriticalInvoices
-      ? "Atenção"
-      : "Estável";
 
   if (isLoading) {
     return (
@@ -289,22 +281,25 @@ const CreditCardsSummaryWidget = ({
 
   if (hasError) {
     return (
-      <div className="rounded border border-cf-border bg-cf-surface p-4">
+      <div className="rounded border border-red-300 bg-cf-surface p-4">
         <div className="mb-2 flex items-center justify-between gap-2">
           <h3 className="text-sm font-medium text-cf-text-primary">Cartões</h3>
-          {onOpenCreditCards ? (
-            <button
-              type="button"
-              onClick={onOpenCreditCards}
-              className="text-xs text-brand-1 hover:underline"
-            >
-              Ver cartões →
-            </button>
-          ) : null}
+          <OperationalSeverityBadge severity="risco" />
         </div>
-        <p className="text-sm text-cf-text-secondary">
-          Não foi possível carregar o resumo de cartões agora.
-        </p>
+
+        <OperationalStateBlock
+          severity="risco"
+          title="Resumo de cartões indisponível"
+          happened="Não foi possível carregar o resumo de cartões agora."
+          impact="Você pode perder visibilidade de faturas pendentes e risco de limite no fechamento."
+          nextStep={
+            onOpenCreditCards
+              ? "Abra o módulo de cartões para verificar os itens manualmente nesta sessão."
+              : "Atualize a página em instantes para tentar novamente a leitura deste widget."
+          }
+          ctaLabel={onOpenCreditCards ? "Ver cartões" : undefined}
+          onCta={onOpenCreditCards}
+        />
       </div>
     );
   }
@@ -315,9 +310,7 @@ const CreditCardsSummaryWidget = ({
         <div>
           <div className="flex items-center gap-2">
             <h3 className="text-sm font-medium text-cf-text-primary">Cartões</h3>
-            <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${statusBadgeClass}`}>
-              {statusBadgeLabel}
-            </span>
+            <OperationalSeverityBadge severity={severityLevel} />
           </div>
           <p className="text-xs text-cf-text-secondary">
             {aggregate.cardsCount === 0
@@ -339,8 +332,16 @@ const CreditCardsSummaryWidget = ({
       </div>
 
       {aggregate.cardsCount === 0 ? (
-        <div className="rounded border border-dashed border-cf-border bg-cf-bg-subtle px-3 py-3 text-sm text-cf-text-secondary">
-          Cadastre um cartão para acompanhar limite disponível, compras abertas e faturas pendentes.
+        <div className="rounded border border-amber-200 bg-cf-bg-subtle px-3 py-3 text-sm text-cf-text-secondary">
+          <OperationalStateBlock
+            severity="atencao"
+            title="Sem cartões ativos no momento"
+            happened="Nenhum cartão cadastrado ainda."
+            impact="Sem cartões ativos, não há leitura de uso de limite nem de faturas pendentes."
+            nextStep="Cadastre ao menos um cartão para liberar a visão operacional desta área."
+            ctaLabel={onOpenCreditCards ? "Ver cartões" : undefined}
+            onCta={onOpenCreditCards}
+          />
         </div>
       ) : (
         <>

--- a/apps/web/src/components/ForecastCard.tsx
+++ b/apps/web/src/components/ForecastCard.tsx
@@ -3,6 +3,7 @@ import { forecastService, type Forecast } from "../services/forecast.service";
 import { profileService } from "../services/profile.service";
 import { useMaskedCurrency } from "../context/DiscreetModeContext";
 import { logWidgetFallbackError } from "../utils/widgetFallbackTelemetry";
+import { OperationalSeverityBadge, OperationalStateBlock, type OperationalSeverity } from "./OperationalStateBlock";
 
 interface ForecastCardProps {
   onOpenProfileSettings?: () => void;
@@ -279,21 +280,17 @@ const ForecastCard = ({
 
   const hasNegativeProjection = forecast !== null && forecast.adjustedProjectedBalance < 0;
   const hasPendingBills = forecast !== null && forecast.billsPendingCount > 0;
-  const cardToneClass = hasNegativeProjection
-    ? "border-red-300"
+  const severityLevel: OperationalSeverity = hasNegativeProjection
+    ? "risco"
     : hasPendingBills
-      ? "border-amber-300"
-      : "border-brand-1";
-  const statusBadgeClass = hasNegativeProjection
-    ? "border-red-200 bg-red-50 text-red-700"
-    : hasPendingBills
-      ? "border-amber-200 bg-amber-50 text-amber-700"
-      : "border-emerald-200 bg-emerald-50 text-emerald-700";
-  const statusLabel = hasNegativeProjection
-    ? "Risco de fechamento negativo"
-    : hasPendingBills
-      ? "Atenção às pendências"
-      : "Trajetória estável";
+      ? "atencao"
+      : "normal";
+  const cardToneClass =
+    severityLevel === "risco"
+      ? "border-red-300"
+      : severityLevel === "atencao"
+        ? "border-amber-300"
+        : "border-brand-1";
 
   // Active state
   return (
@@ -305,9 +302,7 @@ const ForecastCard = ({
             Saldo estimado até o fim do mês com lançamentos e pendências atuais.
           </p>
         </div>
-        <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${statusBadgeClass}`}>
-          {statusLabel}
-        </span>
+        <OperationalSeverityBadge severity={severityLevel} />
         <button
           type="button"
           onClick={handleRecompute}
@@ -319,24 +314,33 @@ const ForecastCard = ({
       </div>
 
       {hasLoadError ? (
-        <div className="mt-3 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700" role="alert">
-          <p>Não foi possível carregar a projeção deste widget.</p>
-          <div className="mt-2 flex items-center gap-2">
-            <button
-              type="button"
-              onClick={handleRetryLoad}
-              disabled={hasRetriedLoad}
-              className="rounded border border-red-300 bg-white px-2 py-1 text-xs font-semibold text-red-700 hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {hasRetriedLoad ? "Nova tentativa indisponível" : "Tentar novamente"}
-            </button>
-            {hasRetriedLoad ? (
-              <span className="text-xs text-red-600">Limite de 1 nova tentativa atingido.</span>
-            ) : null}
-          </div>
+        <div className="mt-3">
+          <OperationalStateBlock
+            severity="risco"
+            title="Leitura parcial da projeção"
+            happened="Não foi possível carregar a projeção deste widget."
+            impact="A projeção pode ficar defasada e reduzir a confiança da triagem operacional."
+            nextStep={
+              hasRetriedLoad
+                ? "Recarregue a página em instantes para tentar uma nova sincronização."
+                : "Use a ação de nova tentativa para buscar os dados atualizados agora."
+            }
+            ctaLabel={hasRetriedLoad ? "Nova tentativa indisponível" : "Tentar novamente"}
+            onCta={handleRetryLoad}
+            ctaDisabled={hasRetriedLoad}
+            ctaDisabledLabel={hasRetriedLoad ? "Limite de 1 nova tentativa atingido." : undefined}
+          />
         </div>
       ) : error ? (
-        <p className="mt-2 text-xs text-red-600">{error}</p>
+        <div className="mt-3">
+          <OperationalStateBlock
+            severity="atencao"
+            title="Atualização manual não concluída"
+            happened={error}
+            impact="A projeção continua visível, mas sem o recálculo solicitado agora."
+            nextStep="Tente novamente em alguns segundos para atualizar o cenário do mês."
+          />
+        </div>
       ) : forecast !== null ? (
         <>
           <div className="mt-3 grid grid-cols-2 gap-3 lg:grid-cols-4">
@@ -406,7 +410,15 @@ const ForecastCard = ({
           <BankLimitPanel forecast={forecast} money={money} />
         </>
       ) : (
-        <p className="mt-3 text-xs text-cf-text-secondary">Sem dados de projeção para exibir neste momento.</p>
+        <div className="mt-3">
+          <OperationalStateBlock
+            severity="atencao"
+            title="Projeção ainda indisponível"
+            happened="Ainda não há dados suficientes para montar a projeção do mês."
+            impact="Sem essa leitura, fica mais difícil antecipar risco de fechamento negativo."
+            nextStep="Registre lançamentos e contas do mês para liberar o cálculo desta projeção."
+          />
+        </div>
       )}
     </div>
   );

--- a/apps/web/src/components/OperationalStateBlock.tsx
+++ b/apps/web/src/components/OperationalStateBlock.tsx
@@ -1,0 +1,92 @@
+export type OperationalSeverity = "normal" | "atencao" | "risco";
+
+const SEVERITY_LABELS: Record<OperationalSeverity, string> = {
+  normal: "Normal",
+  atencao: "Atenção",
+  risco: "Risco",
+};
+
+const BADGE_CLASSNAMES: Record<OperationalSeverity, string> = {
+  normal: "border-emerald-200 bg-emerald-50 text-emerald-700",
+  atencao: "border-amber-200 bg-amber-50 text-amber-700",
+  risco: "border-red-200 bg-red-50 text-red-700",
+};
+
+const PANEL_CLASSNAMES: Record<OperationalSeverity, string> = {
+  normal: "border-emerald-200 bg-emerald-50/70 text-emerald-800",
+  atencao: "border-amber-200 bg-amber-50/70 text-amber-800",
+  risco: "border-red-200 bg-red-50/70 text-red-800",
+};
+
+const BUTTON_CLASSNAMES: Record<OperationalSeverity, string> = {
+  normal: "border-emerald-300 text-emerald-700 hover:bg-emerald-100",
+  atencao: "border-amber-300 text-amber-700 hover:bg-amber-100",
+  risco: "border-red-300 text-red-700 hover:bg-red-100",
+};
+
+interface OperationalSeverityBadgeProps {
+  severity: OperationalSeverity;
+}
+
+export const OperationalSeverityBadge = ({ severity }: OperationalSeverityBadgeProps): JSX.Element => (
+  <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${BADGE_CLASSNAMES[severity]}`}>
+    {SEVERITY_LABELS[severity]}
+  </span>
+);
+
+interface OperationalStateBlockProps {
+  severity: OperationalSeverity;
+  title: string;
+  happened: string;
+  impact: string;
+  nextStep: string;
+  ctaLabel?: string;
+  onCta?: () => void;
+  ctaDisabled?: boolean;
+  ctaDisabledLabel?: string;
+}
+
+export const OperationalStateBlock = ({
+  severity,
+  title,
+  happened,
+  impact,
+  nextStep,
+  ctaLabel,
+  onCta,
+  ctaDisabled = false,
+  ctaDisabledLabel,
+}: OperationalStateBlockProps): JSX.Element => (
+  <div
+    className={`rounded border px-3 py-2.5 text-xs ${PANEL_CLASSNAMES[severity]}`}
+    role={severity === "risco" ? "alert" : "status"}
+  >
+    <div className="mb-1.5 flex items-center gap-2">
+      <OperationalSeverityBadge severity={severity} />
+      <p className="font-semibold">{title}</p>
+    </div>
+    <p>
+      <span className="font-semibold">O que aconteceu:</span> {happened}
+    </p>
+    <p>
+      <span className="font-semibold">Impacto:</span> {impact}
+    </p>
+    <p>
+      <span className="font-semibold">Próximo passo:</span> {nextStep}
+    </p>
+
+    {ctaLabel && onCta ? (
+      <div className="mt-2 flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onCta}
+          disabled={ctaDisabled}
+          className={`rounded border bg-white px-2 py-1 text-xs font-semibold disabled:cursor-not-allowed disabled:opacity-60 ${BUTTON_CLASSNAMES[severity]}`}
+        >
+          {ctaLabel}
+        </button>
+        {ctaDisabled && ctaDisabledLabel ? <span className="text-[11px]">{ctaDisabledLabel}</span> : null}
+      </div>
+    ) : null}
+  </div>
+);

--- a/apps/web/src/components/OperationalSummaryPanel.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.tsx
@@ -3,6 +3,7 @@ import { useMaskedCurrency } from "../context/DiscreetModeContext";
 import { dashboardService, type DashboardSnapshot } from "../services/dashboard.service";
 import { getApiErrorMessage } from "../utils/apiError";
 import { logWidgetFallbackError } from "../utils/widgetFallbackTelemetry";
+import { OperationalSeverityBadge, OperationalStateBlock } from "./OperationalStateBlock";
 
 // ─── Tile ─────────────────────────────────────────────────────────────────────
 
@@ -118,29 +119,36 @@ const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanel
 
   if (loadError) {
     return (
-      <div className="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
-        <p>{loadError}</p>
-        <div className="mt-2 flex items-center gap-2">
-          <button
-            type="button"
-            onClick={handleRetry}
-            disabled={hasRetriedLoad}
-            className="rounded border border-red-300 bg-white px-2 py-1 text-xs font-semibold text-red-700 hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {hasRetriedLoad ? "Nova tentativa indisponível" : "Tentar novamente"}
-          </button>
-          {hasRetriedLoad ? (
-            <span className="text-xs text-red-600">Limite de 1 nova tentativa atingido.</span>
-          ) : null}
-        </div>
+      <div className="rounded border border-red-200 bg-cf-surface p-3">
+        <OperationalStateBlock
+          severity="risco"
+          title="Resumo operacional com falha de carregamento"
+          happened={loadError}
+          impact="A triagem inicial perde parte dos sinais de risco e prioridade do mês."
+          nextStep={
+            hasRetriedLoad
+              ? "Recarregue a página para realizar nova sincronização do resumo operacional."
+              : "Use a nova tentativa para carregar os indicadores operacionais agora."
+          }
+          ctaLabel={hasRetriedLoad ? "Nova tentativa indisponível" : "Tentar novamente"}
+          onCta={handleRetry}
+          ctaDisabled={hasRetriedLoad}
+          ctaDisabledLabel={hasRetriedLoad ? "Limite de 1 nova tentativa atingido." : undefined}
+        />
       </div>
     );
   }
 
   if (!snapshot) {
     return (
-      <div className="rounded border border-cf-border bg-cf-surface px-4 py-3 text-sm text-cf-text-secondary">
-        Resumo operacional indisponível no momento.
+      <div className="rounded border border-amber-200 bg-cf-surface p-3">
+        <OperationalStateBlock
+          severity="atencao"
+          title="Resumo operacional sem base suficiente"
+          happened="Resumo operacional indisponível no momento."
+          impact="Os blocos críticos podem não refletir o cenário completo desta competência."
+          nextStep="Registre movimentações e contas do mês para liberar a leitura consolidada."
+        />
       </div>
     );
   }
@@ -311,13 +319,22 @@ const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanel
         };
 
   return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
-      <Tile {...bankTile} />
-      <Tile {...billsTile} />
-      <Tile {...cardTile} />
-      <Tile {...incomeTile} />
-      <Tile {...forecastTile} />
-      <Tile {...consignadoTile} />
+    <div className="space-y-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-[11px] font-semibold uppercase tracking-wide text-cf-text-secondary">Severidade</span>
+        <OperationalSeverityBadge severity="normal" />
+        <OperationalSeverityBadge severity="atencao" />
+        <OperationalSeverityBadge severity="risco" />
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+        <Tile {...bankTile} />
+        <Tile {...billsTile} />
+        <Tile {...cardTile} />
+        <Tile {...incomeTile} />
+        <Tile {...forecastTile} />
+        <Tile {...consignadoTile} />
+      </div>
     </div>
   );
 };

--- a/apps/web/src/components/SalaryWidget.tsx
+++ b/apps/web/src/components/SalaryWidget.tsx
@@ -7,6 +7,7 @@ import {
   type SalaryProfile,
 } from "../services/salary.service";
 import { formatCurrency } from "../utils/formatCurrency";
+import { OperationalSeverityBadge, OperationalStateBlock, type OperationalSeverity } from "./OperationalStateBlock";
 
 // ─── Form state types ──────────────────────────────────────────────────────────
 
@@ -382,6 +383,8 @@ function BenefitProfileView({
   const cardLimit = calculation.cardLimitAmount ?? 0;
   const loanTotal = calculation.loanTotal ?? 0;
   const cardTotal = calculation.cardTotal ?? 0;
+  const loanSeverity: OperationalSeverity = calculation.isOverLoanLimit ? "risco" : "normal";
+  const cardSeverity: OperationalSeverity = calculation.isOverCardLimit ? "risco" : "normal";
   const activeReferenceMonth = formatReferenceMonthLabel(profile.activeStatement?.referenceMonth);
   const activePaymentDate = formatDateLabel(profile.activeStatement?.paymentDate);
 
@@ -522,11 +525,14 @@ function BenefitProfileView({
             ? "border-red-200 bg-red-50 text-red-700"
             : "border-cf-border bg-cf-bg-subtle text-cf-text-secondary"
         }`}>
-          <span>Empréstimos</span>
+          <div className="flex items-center gap-2">
+            <span>Empréstimos</span>
+            <OperationalSeverityBadge severity={loanSeverity} />
+          </div>
           <span>
             {formatCurrency(loanTotal)} / {formatCurrency(loanLimit)}
             {calculation.isOverLoanLimit ? (
-              <span className="ml-1 font-semibold">⚠ acima do limite 35%</span>
+              <span className="ml-1 font-semibold">acima do limite 35%</span>
             ) : (
               <span className="ml-1 text-cf-text-secondary">máx 35%</span>
             )}
@@ -538,11 +544,14 @@ function BenefitProfileView({
             ? "border-red-200 bg-red-50 text-red-700"
             : "border-cf-border bg-cf-bg-subtle text-cf-text-secondary"
         }`}>
-          <span>Cartão consignado</span>
+          <div className="flex items-center gap-2">
+            <span>Cartão consignado</span>
+            <OperationalSeverityBadge severity={cardSeverity} />
+          </div>
           <span>
             {formatCurrency(cardTotal)} / {formatCurrency(cardLimit)}
             {calculation.isOverCardLimit ? (
-              <span className="ml-1 font-semibold">⚠ acima do limite 5%</span>
+              <span className="ml-1 font-semibold">acima do limite 5%</span>
             ) : (
               <span className="ml-1 text-cf-text-secondary">máx 5%</span>
             )}
@@ -570,7 +579,15 @@ function BenefitProfileView({
         </div>
 
         {consignacoes.length === 0 && !addingConsig ? (
-          <p className="text-xs text-cf-text-secondary">Nenhum desconto cadastrado.</p>
+          <OperationalStateBlock
+            severity="normal"
+            title="Sem descontos consignados cadastrados"
+            happened="Nenhum desconto cadastrado."
+            impact="A composição atual mostra o benefício sem abatimentos consignados recorrentes."
+            nextStep="Se houver desconto em folha, adicione a rubrica para manter a leitura auditável."
+            ctaLabel="Adicionar desconto"
+            onCta={() => setAddingConsig(true)}
+          />
         ) : null}
 
         {consignacoes.length > 0 ? (

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -2454,6 +2454,9 @@ const App = ({
               <p className="mt-1 text-xs text-cf-text-secondary">
                 O que pede ação agora: projeção, pendências, cartões, renda principal e sinais de risco.
               </p>
+              <p className="mt-1 text-xs text-cf-text-secondary">
+                Níveis operacionais padronizados: normal, atenção e risco.
+              </p>
             </div>
 
             <OperationalSummaryPanel onOpenDueSoonBills={handleOpenDueSoonBills} />


### PR DESCRIPTION
## Objetivo\nPadronizar a gramática operacional da Home com severidade consistente (normal, atenção, risco) e estados claros (erro, fallback, vazio).\n\n## O que mudou\n- Nova base semântica compartilhada para severidade e mensagens de estado operacional.\n- Forecast: severidade unificada e blocos orientativos para fallback/erro de atualização/sem dados.\n- Pendências: diferencia erro x vazio com orientação e severidade coerente.\n- Cartões: severidade padronizada, estado de erro orientativo e empty state operacional.\n- Resumo operacional: estados de erro/vazio com trilha de ação e legenda de severidade.\n- Benefício líquido: badges de severidade nos alertas de margem e empty state de descontos mais acionável.\n- Home: explicita a taxonomia única normal/atenção/risco.\n\n## Arquivos\n- apps/web/src/components/OperationalStateBlock.tsx\n- apps/web/src/components/ForecastCard.tsx\n- apps/web/src/components/BillsSummaryWidget.tsx\n- apps/web/src/components/CreditCardsSummaryWidget.tsx\n- apps/web/src/components/OperationalSummaryPanel.tsx\n- apps/web/src/components/SalaryWidget.tsx\n- apps/web/src/pages/App.tsx\n- apps/web/src/components/BillsSummaryWidget.test.tsx\n- apps/web/src/components/CreditCardsSummaryWidget.test.tsx\n\n## Validação\n- npm -w apps/web run typecheck\n- npm -w apps/web run test:run -- src/components/ForecastCard.test.tsx src/components/BillsSummaryWidget.test.tsx src/components/CreditCardsSummaryWidget.test.tsx src/components/OperationalSummaryPanel.test.tsx src/components/SalaryWidget.test.tsx src/pages/App.test.jsx\n\n## Resultado\n- Typecheck: ok\n- Testes focados: 136/136 passando (6 suítes)\n\n## Guardrails aplicados\n- Severidade restrita a: normal, atenção, risco\n- Mensagens com: o que aconteceu, impacto, próximo passo\n- Distinção explícita entre erro, fallback e vazio\n- CTA apenas quando há ação real\n