### PR TITLE
feat(web): PR D - ações operacionais por severidade

### DIFF
--- a/apps/web/src/components/BillsSummaryWidget.test.tsx
+++ b/apps/web/src/components/BillsSummaryWidget.test.tsx
@@ -81,10 +81,10 @@ describe("BillsSummaryWidget", () => {
     renderWidget(onOpenBills);
 
     await waitFor(() => {
-      expect(screen.getByText("Ver pendências →")).toBeInTheDocument();
+      expect(screen.getByText("Regularizar pendências →")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByText("Ver pendências →"));
+    await user.click(screen.getByText("Regularizar pendências →"));
     expect(onOpenBills).toHaveBeenCalledOnce();
   });
 
@@ -95,7 +95,7 @@ describe("BillsSummaryWidget", () => {
       expect(screen.getByText(/450[,.]00/)).toBeInTheDocument();
     });
 
-    expect(screen.queryByText("Ver pendências →")).not.toBeInTheDocument();
+    expect(screen.queryByText("Regularizar pendências →")).not.toBeInTheDocument();
   });
 
   it("exibe estado de risco orientativo em caso de erro do getSummary", async () => {

--- a/apps/web/src/components/BillsSummaryWidget.tsx
+++ b/apps/web/src/components/BillsSummaryWidget.tsx
@@ -53,7 +53,7 @@ const BillsSummaryWidget = ({ onOpenBills }: BillsSummaryWidgetProps): JSX.Eleme
               ? "Abra o módulo de contas para revisar os lançamentos manualmente agora."
               : "Atualize a página em instantes para tentar carregar o resumo novamente."
           }
-          ctaLabel={onOpenBills ? "Ver pendências" : undefined}
+          ctaLabel={onOpenBills ? "Regularizar pendências" : undefined}
           onCta={onOpenBills}
         />
       </div>
@@ -83,6 +83,12 @@ const BillsSummaryWidget = ({ onOpenBills }: BillsSummaryWidgetProps): JSX.Eleme
   const hasPendingBills = summary.pendingCount > 0;
   const severityLevel: OperationalSeverity = hasOverdueBills ? "risco" : hasPendingBills ? "atencao" : "normal";
   const cardToneClass = hasOverdueBills ? "border-red-300" : hasPendingBills ? "border-amber-300" : "border-cf-border";
+  const summaryActionLabel =
+    severityLevel === "risco"
+      ? "Regularizar pendências →"
+      : severityLevel === "atencao"
+        ? "Acompanhar pendências →"
+        : null;
   const statusContext = hasOverdueBills
     ? "Há contas vencidas exigindo ação imediata."
     : hasPendingBills
@@ -96,13 +102,13 @@ const BillsSummaryWidget = ({ onOpenBills }: BillsSummaryWidgetProps): JSX.Eleme
           <h3 className="text-sm font-medium text-cf-text-primary">Pendências</h3>
           <OperationalSeverityBadge severity={severityLevel} />
         </div>
-        {onOpenBills ? (
+        {onOpenBills && summaryActionLabel ? (
           <button
             type="button"
             onClick={onOpenBills}
             className="text-xs text-brand-1 hover:underline"
           >
-            Ver pendências →
+            {summaryActionLabel}
           </button>
         ) : null}
       </div>

--- a/apps/web/src/components/CreditCardsSummaryWidget.test.tsx
+++ b/apps/web/src/components/CreditCardsSummaryWidget.test.tsx
@@ -123,10 +123,10 @@ describe("CreditCardsSummaryWidget", () => {
     renderWidget(onOpenCreditCards);
 
     await waitFor(() => {
-      expect(screen.getByText("Ver cartões →")).toBeInTheDocument();
+      expect(screen.getByText("Acompanhar cartões →")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByText("Ver cartões →"));
+    await user.click(screen.getByText("Acompanhar cartões →"));
     expect(onOpenCreditCards).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/src/components/CreditCardsSummaryWidget.tsx
+++ b/apps/web/src/components/CreditCardsSummaryWidget.tsx
@@ -270,6 +270,12 @@ const CreditCardsSummaryWidget = ({
     : hasCriticalInvoices
       ? "border-amber-300"
       : "border-cf-border";
+  const summaryActionLabel =
+    severityLevel === "risco"
+      ? "Revisar cartões →"
+      : severityLevel === "atencao"
+        ? "Acompanhar cartões →"
+        : null;
 
   if (isLoading) {
     return (
@@ -297,7 +303,7 @@ const CreditCardsSummaryWidget = ({
               ? "Abra o módulo de cartões para verificar os itens manualmente nesta sessão."
               : "Atualize a página em instantes para tentar novamente a leitura deste widget."
           }
-          ctaLabel={onOpenCreditCards ? "Ver cartões" : undefined}
+          ctaLabel={onOpenCreditCards ? "Revisar cartões" : undefined}
           onCta={onOpenCreditCards}
         />
       </div>
@@ -320,13 +326,13 @@ const CreditCardsSummaryWidget = ({
                 : `${aggregate.cardsCount} cartões ativos`}
           </p>
         </div>
-        {onOpenCreditCards ? (
+        {onOpenCreditCards && summaryActionLabel ? (
           <button
             type="button"
             onClick={onOpenCreditCards}
             className="text-xs text-brand-1 hover:underline"
           >
-            Ver cartões →
+            {summaryActionLabel}
           </button>
         ) : null}
       </div>
@@ -339,7 +345,7 @@ const CreditCardsSummaryWidget = ({
             happened="Nenhum cartão cadastrado ainda."
             impact="Sem cartões ativos, não há leitura de uso de limite nem de faturas pendentes."
             nextStep="Cadastre ao menos um cartão para liberar a visão operacional desta área."
-            ctaLabel={onOpenCreditCards ? "Ver cartões" : undefined}
+            ctaLabel={onOpenCreditCards ? "Cadastrar cartões" : undefined}
             onCta={onOpenCreditCards}
           />
         </div>

--- a/apps/web/src/components/ForecastCard.tsx
+++ b/apps/web/src/components/ForecastCard.tsx
@@ -317,15 +317,15 @@ const ForecastCard = ({
         <div className="mt-3">
           <OperationalStateBlock
             severity="risco"
-            title="Leitura parcial da projeção"
-            happened="Não foi possível carregar a projeção deste widget."
-            impact="A projeção pode ficar defasada e reduzir a confiança da triagem operacional."
+            title="Fallback da projeção em uso"
+            happened="Parte dos dados da projeção não carregou nesta tentativa."
+            impact="A leitura principal continua, mas pode estar incompleta para decisões de fechamento."
             nextStep={
               hasRetriedLoad
                 ? "Recarregue a página em instantes para tentar uma nova sincronização."
-                : "Use a ação de nova tentativa para buscar os dados atualizados agora."
+                : "Recarregue a projeção para tentar recuperar os dados faltantes agora."
             }
-            ctaLabel={hasRetriedLoad ? "Nova tentativa indisponível" : "Tentar novamente"}
+            ctaLabel={hasRetriedLoad ? "Nova tentativa indisponível" : "Recarregar projeção"}
             onCta={handleRetryLoad}
             ctaDisabled={hasRetriedLoad}
             ctaDisabledLabel={hasRetriedLoad ? "Limite de 1 nova tentativa atingido." : undefined}
@@ -339,6 +339,10 @@ const ForecastCard = ({
             happened={error}
             impact="A projeção continua visível, mas sem o recálculo solicitado agora."
             nextStep="Tente novamente em alguns segundos para atualizar o cenário do mês."
+            ctaLabel="Atualizar projeção"
+            onCta={() => {
+              void handleRecompute();
+            }}
           />
         </div>
       ) : forecast !== null ? (

--- a/apps/web/src/components/OperationalStateBlock.tsx
+++ b/apps/web/src/components/OperationalStateBlock.tsx
@@ -13,13 +13,13 @@ const BADGE_CLASSNAMES: Record<OperationalSeverity, string> = {
 };
 
 const PANEL_CLASSNAMES: Record<OperationalSeverity, string> = {
-  normal: "border-emerald-200 bg-emerald-50/70 text-emerald-800",
+  normal: "border-cf-border bg-cf-surface text-cf-text-secondary",
   atencao: "border-amber-200 bg-amber-50/70 text-amber-800",
   risco: "border-red-200 bg-red-50/70 text-red-800",
 };
 
 const BUTTON_CLASSNAMES: Record<OperationalSeverity, string> = {
-  normal: "border-emerald-300 text-emerald-700 hover:bg-emerald-100",
+  normal: "border-cf-border text-cf-text-primary hover:bg-cf-bg-subtle",
   atencao: "border-amber-300 text-amber-700 hover:bg-amber-100",
   risco: "border-red-300 text-red-700 hover:bg-red-100",
 };
@@ -44,6 +44,7 @@ interface OperationalStateBlockProps {
   onCta?: () => void;
   ctaDisabled?: boolean;
   ctaDisabledLabel?: string;
+  allowNormalCta?: boolean;
 }
 
 export const OperationalStateBlock = ({
@@ -56,37 +57,43 @@ export const OperationalStateBlock = ({
   onCta,
   ctaDisabled = false,
   ctaDisabledLabel,
-}: OperationalStateBlockProps): JSX.Element => (
-  <div
-    className={`rounded border px-3 py-2.5 text-xs ${PANEL_CLASSNAMES[severity]}`}
-    role={severity === "risco" ? "alert" : "status"}
-  >
-    <div className="mb-1.5 flex items-center gap-2">
-      <OperationalSeverityBadge severity={severity} />
-      <p className="font-semibold">{title}</p>
-    </div>
-    <p>
-      <span className="font-semibold">O que aconteceu:</span> {happened}
-    </p>
-    <p>
-      <span className="font-semibold">Impacto:</span> {impact}
-    </p>
-    <p>
-      <span className="font-semibold">Próximo passo:</span> {nextStep}
-    </p>
+  allowNormalCta = false,
+}: OperationalStateBlockProps): JSX.Element => {
+  const canRenderCta =
+    Boolean(ctaLabel && onCta) && (severity !== "normal" || allowNormalCta);
 
-    {ctaLabel && onCta ? (
-      <div className="mt-2 flex items-center gap-2">
-        <button
-          type="button"
-          onClick={onCta}
-          disabled={ctaDisabled}
-          className={`rounded border bg-white px-2 py-1 text-xs font-semibold disabled:cursor-not-allowed disabled:opacity-60 ${BUTTON_CLASSNAMES[severity]}`}
-        >
-          {ctaLabel}
-        </button>
-        {ctaDisabled && ctaDisabledLabel ? <span className="text-[11px]">{ctaDisabledLabel}</span> : null}
+  return (
+    <div
+      className={`rounded border px-3 py-2.5 text-xs ${PANEL_CLASSNAMES[severity]}`}
+      role={severity === "risco" ? "alert" : "status"}
+    >
+      <div className="mb-1.5 flex items-center gap-2">
+        <OperationalSeverityBadge severity={severity} />
+        <p className="font-semibold">{title}</p>
       </div>
-    ) : null}
-  </div>
-);
+      <p>
+        <span className="font-semibold">O que aconteceu:</span> {happened}
+      </p>
+      <p>
+        <span className="font-semibold">Impacto:</span> {impact}
+      </p>
+      <p>
+        <span className="font-semibold">Próximo passo:</span> {nextStep}
+      </p>
+
+      {canRenderCta ? (
+        <div className="mt-2 flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onCta}
+            disabled={ctaDisabled}
+            className={`rounded border bg-white px-2 py-1 text-left text-xs font-semibold leading-tight whitespace-normal break-words disabled:cursor-not-allowed disabled:opacity-60 ${BUTTON_CLASSNAMES[severity]}`}
+          >
+            {ctaLabel}
+          </button>
+          {ctaDisabled && ctaDisabledLabel ? <span className="text-[11px]">{ctaDisabledLabel}</span> : null}
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/web/src/components/OperationalSummaryPanel.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.tsx
@@ -130,7 +130,7 @@ const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanel
               ? "Recarregue a página para realizar nova sincronização do resumo operacional."
               : "Use a nova tentativa para carregar os indicadores operacionais agora."
           }
-          ctaLabel={hasRetriedLoad ? "Nova tentativa indisponível" : "Tentar novamente"}
+          ctaLabel={hasRetriedLoad ? "Nova tentativa indisponível" : "Recarregar resumo operacional"}
           onCta={handleRetry}
           ctaDisabled={hasRetriedLoad}
           ctaDisabledLabel={hasRetriedLoad ? "Limite de 1 nova tentativa atingido." : undefined}

--- a/apps/web/src/components/SalaryWidget.tsx
+++ b/apps/web/src/components/SalaryWidget.tsx
@@ -587,6 +587,7 @@ function BenefitProfileView({
             nextStep="Se houver desconto em folha, adicione a rubrica para manter a leitura auditável."
             ctaLabel="Adicionar desconto"
             onCta={() => setAddingConsig(true)}
+            allowNormalCta
           />
         ) : null}
 


### PR DESCRIPTION
## Objetivo\nTransformar severidade em ação operacional real na Home, reduzindo CTA ornamental e reforçando consistência entre normal, atenção e risco.\n\n## O que mudou\n- OperationalStateBlock agora bloqueia CTA em estado 
ormal por padrão (exceção explícita com llowNormalCta).\n- Estado 
ormal ficou menos chamativo visualmente para não competir com tenção e isco.\n- Forecast: fallback com mensagem de confiança (leitura parcial) e CTA de risco com verbo forte (Recarregar projeção).\n- Pendências: CTA dinâmico por severidade (Regularizar pendências / Acompanhar pendências) e sem CTA no normal.\n- Cartões: CTA dinâmico por severidade (Revisar cartões / Acompanhar cartões) e sem CTA no normal.\n- Resumo operacional: CTA de risco mais direto (Recarregar resumo operacional).\n- Ajustes de testes para novos rótulos de CTA.\n\n## Arquivos\n- apps/web/src/components/OperationalStateBlock.tsx\n- apps/web/src/components/ForecastCard.tsx\n- apps/web/src/components/BillsSummaryWidget.tsx\n- apps/web/src/components/CreditCardsSummaryWidget.tsx\n- apps/web/src/components/OperationalSummaryPanel.tsx\n- apps/web/src/components/BillsSummaryWidget.test.tsx\n- apps/web/src/components/CreditCardsSummaryWidget.test.tsx\n\n## Validação\n- npm -w apps/web run typecheck\n- npm -w apps/web run test:run -- src/components/ForecastCard.test.tsx src/components/BillsSummaryWidget.test.tsx src/components/CreditCardsSummaryWidget.test.tsx src/components/OperationalSummaryPanel.test.tsx src/components/SalaryWidget.test.tsx src/pages/App.test.jsx\n\n## Resultado\n- Typecheck: ok\n- Testes focados: 136/136 passando (6 suítes)\n