### PR TITLE
fix(goals): stabilize goal card layout and responsive grid

### DIFF
--- a/apps/web/src/components/GoalsSection.tsx
+++ b/apps/web/src/components/GoalsSection.tsx
@@ -80,19 +80,19 @@ function GoalCard({ goal, projectedBalance, onEdit, onDelete, onContribute }: Go
   };
 
   return (
-    <div className="flex flex-col gap-3 rounded border border-cf-border bg-cf-surface p-4">
+    <article className="flex h-full min-h-[260px] min-w-[240px] flex-col gap-4 rounded border border-cf-border bg-cf-surface p-4">
       {/* Header */}
-      <div className="flex items-start justify-between gap-2">
-        <div className="flex items-center gap-2">
-          <span className="text-2xl" aria-hidden="true">{emoji}</span>
-          <span className="text-sm font-semibold text-cf-text-primary leading-snug">{goal.title}</span>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex items-center gap-2.5">
+          <span className="text-2xl leading-none" aria-hidden="true">{emoji}</span>
+          <span className="line-clamp-2 text-sm font-semibold leading-snug text-cf-text-primary">{goal.title}</span>
         </div>
-        <div className="flex shrink-0 gap-1">
+        <div className="flex shrink-0 gap-1.5">
           <button
             type="button"
             onClick={() => onEdit(goal)}
             aria-label={`Editar meta ${goal.title}`}
-            className="rounded p-1 text-cf-text-secondary hover:bg-cf-bg-subtle hover:text-cf-text-primary"
+            className="inline-flex h-7 w-7 items-center justify-center rounded text-cf-text-secondary hover:bg-cf-bg-subtle hover:text-cf-text-primary"
           >
             <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
               <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
@@ -102,7 +102,7 @@ function GoalCard({ goal, projectedBalance, onEdit, onDelete, onContribute }: Go
             type="button"
             onClick={() => onDelete(goal)}
             aria-label={`Excluir meta ${goal.title}`}
-            className="rounded p-1 text-cf-text-secondary hover:bg-cf-bg-subtle hover:text-red-500"
+            className="inline-flex h-7 w-7 items-center justify-center rounded text-cf-text-secondary hover:bg-cf-bg-subtle hover:text-red-500"
           >
             <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
               <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
@@ -132,74 +132,88 @@ function GoalCard({ goal, projectedBalance, onEdit, onDelete, onContribute }: Go
       </div>
 
       {/* Footer stats */}
-      <div className="flex items-center justify-between text-xs text-cf-text-secondary">
+      <div className="rounded border border-cf-border bg-cf-bg-subtle/60 px-3 py-2.5">
         {goal.monthlyNeeded > 0 ? (
-          <span className="flex items-center gap-1">
-            <span className="font-semibold text-cf-text-primary">{money(goal.monthlyNeeded)}</span>
-            /mês necessário
-            {isAtRisk && (
-              <span
-                title="Esta meta consome mais do que seu saldo projetado este mês."
-                aria-label="Meta em risco: necessidade mensal supera saldo projetado"
-                className="inline-flex items-center justify-center rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-bold text-amber-500"
-              >
-                ⚠ risco
-              </span>
-            )}
-          </span>
+          <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-3 gap-y-1 text-xs">
+            <div className="min-w-0">
+              <p className="text-base font-semibold leading-none text-cf-text-primary">{money(goal.monthlyNeeded)}</p>
+              <p className="mt-1 text-[11px] uppercase tracking-wide text-cf-text-secondary">/mês necessário</p>
+            </div>
+            <div className="text-right">
+              <p className="text-[11px] uppercase tracking-wide text-cf-text-secondary">Prazo</p>
+              <p className="mt-1 font-medium text-cf-text-primary whitespace-nowrap">até {deadline}</p>
+              {isAtRisk ? (
+                <span
+                  title="Esta meta consome mais do que seu saldo projetado este mês."
+                  aria-label="Meta em risco: necessidade mensal supera saldo projetado"
+                  className="mt-1 inline-flex items-center justify-center rounded-full border border-amber-500/30 bg-amber-500/15 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-amber-600"
+                >
+                  Risco
+                </span>
+              ) : null}
+            </div>
+          </div>
         ) : (
-          <span className="font-semibold text-green-500">Meta atingida 🎉</span>
+          <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-3 text-xs">
+            <p className="text-sm font-semibold text-green-600">Meta atingida 🎉</p>
+            <div className="text-right">
+              <p className="text-[11px] uppercase tracking-wide text-cf-text-secondary">Prazo</p>
+              <p className="mt-1 font-medium text-cf-text-primary whitespace-nowrap">até {deadline}</p>
+            </div>
+          </div>
         )}
-        <span>até {deadline}</span>
       </div>
 
       {/* Quick contribution */}
       {goal.monthlyNeeded > 0 && (
-        <div className="border-t border-cf-border pt-2">
+        <div className="mt-auto border-t border-cf-border pt-3">
           {!showContrib ? (
             <button
               type="button"
               onClick={handleContribOpen}
-              className="text-xs font-medium text-brand-1 hover:underline"
+              className="inline-flex min-h-8 items-center rounded border border-brand-1/25 px-2.5 text-xs font-medium text-brand-1 hover:bg-brand-3/20"
             >
               + Registrar poupança
             </button>
           ) : (
-            <form onSubmit={handleContribSubmit} className="flex items-center gap-2">
-              <span className="shrink-0 text-xs text-cf-text-secondary">R$</span>
-              <input
-                ref={contribInputRef}
-                type="number"
-                min="0.01"
-                step="0.01"
-                value={contribAmt}
-                onChange={(e) => { setContribAmt(e.target.value); setContribError(null); }}
-                placeholder="0,00"
-                aria-label="Valor da contribuição"
-                className="w-24 rounded border border-cf-border-input bg-cf-bg-subtle px-2 py-1 text-xs text-cf-text-primary focus:outline-none focus:ring-1 focus:ring-brand-1"
-              />
-              <button
-                type="submit"
-                disabled={contributing}
-                className="rounded bg-brand-1 px-2 py-1 text-xs font-semibold text-white hover:bg-brand-2 disabled:opacity-50"
-              >
-                {contributing ? "…" : "Guardar"}
-              </button>
-              <button
-                type="button"
-                onClick={() => setShowContrib(false)}
-                className="text-xs text-cf-text-secondary hover:text-cf-text-primary"
-              >
-                ✕
-              </button>
-              {contribError && (
+            <form onSubmit={handleContribSubmit} className="space-y-2">
+              <div className="flex items-center gap-2">
+                <span className="shrink-0 text-xs text-cf-text-secondary">R$</span>
+                <input
+                  ref={contribInputRef}
+                  type="number"
+                  min="0.01"
+                  step="0.01"
+                  value={contribAmt}
+                  onChange={(e) => { setContribAmt(e.target.value); setContribError(null); }}
+                  placeholder="0,00"
+                  aria-label="Valor da contribuição"
+                  className="h-8 min-w-0 flex-1 rounded border border-cf-border-input bg-cf-bg-subtle px-2.5 text-xs text-cf-text-primary focus:outline-none focus:ring-1 focus:ring-brand-1"
+                />
+                <button
+                  type="submit"
+                  disabled={contributing}
+                  className="inline-flex h-8 items-center rounded bg-brand-1 px-3 text-xs font-semibold text-white hover:bg-brand-2 disabled:opacity-50"
+                >
+                  {contributing ? "…" : "Guardar"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setShowContrib(false)}
+                  className="inline-flex h-8 w-8 items-center justify-center rounded text-xs text-cf-text-secondary hover:bg-cf-bg-subtle hover:text-cf-text-primary"
+                  aria-label="Cancelar registro de poupança"
+                >
+                  ✕
+                </button>
+              </div>
+              {contribError ? (
                 <span className="text-xs text-red-500" role="alert">{contribError}</span>
-              )}
+              ) : null}
             </form>
           )}
         </div>
       )}
-    </div>
+    </article>
   );
 }
 
@@ -313,10 +327,10 @@ export default function GoalsSection() {
   };
 
   return (
-    <section>
-      <div className="rounded border border-cf-border bg-cf-surface p-4">
+    <section className="h-full">
+      <div className="flex h-full flex-col rounded border border-cf-border bg-cf-surface p-4">
         {/* Header */}
-        <div className="mb-4 flex items-center justify-between gap-2">
+        <div className="mb-4 flex items-center justify-between gap-3">
           <div>
             <h3 className="text-sm font-semibold text-cf-text-primary">Metas de Poupança</h3>
             <p className="text-xs text-cf-text-secondary">
@@ -334,7 +348,7 @@ export default function GoalsSection() {
 
         {/* Content */}
         {loading ? (
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="grid gap-3 [grid-template-columns:repeat(auto-fit,minmax(260px,1fr))]">
             {[1, 2, 3].map((i) => (
               <div key={i} className="h-40 animate-pulse rounded border border-cf-border bg-cf-bg-subtle" />
             ))}
@@ -378,7 +392,7 @@ export default function GoalsSection() {
             </button>
           </div>
         ) : (
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="grid gap-3 [grid-template-columns:repeat(auto-fit,minmax(260px,1fr))]">
             {goals.map((goal) => (
               <GoalCard
                 key={goal.id}

--- a/apps/web/src/components/HealthOverview.tsx
+++ b/apps/web/src/components/HealthOverview.tsx
@@ -151,7 +151,7 @@ const HealthOverview = (): JSX.Element | null => {
 
   if (isLoadingForecast) {
     return (
-      <div className="rounded border border-cf-border bg-cf-surface p-4">
+      <div className="h-full rounded border border-cf-border bg-cf-surface p-4">
         <p className="text-xs text-cf-text-secondary">Carregando saúde financeira...</p>
       </div>
     );
@@ -159,7 +159,7 @@ const HealthOverview = (): JSX.Element | null => {
 
   if (forecastError) {
     return (
-      <div className="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
+      <div className="h-full rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
         <p>{forecastError}</p>
         <div className="mt-2 flex items-center gap-2">
           <button
@@ -180,7 +180,7 @@ const HealthOverview = (): JSX.Element | null => {
 
   if (forecast === null || forecast.daysRemaining <= 0) {
     return (
-      <div className="rounded border border-cf-border bg-cf-surface p-4">
+      <div className="h-full rounded border border-cf-border bg-cf-surface p-4">
         <h3 className="text-sm font-semibold text-cf-text-primary">Saúde Financeira do Mês</h3>
         <p className="mt-2 text-xs text-cf-text-secondary">Sem dados suficientes para exibir este widget.</p>
       </div>
@@ -199,7 +199,7 @@ const HealthOverview = (): JSX.Element | null => {
   const showInsightPanel = isLoadingInsight || insight !== null;
 
   return (
-    <div className="rounded border border-cf-border bg-cf-surface p-4">
+    <div className="h-full rounded border border-cf-border bg-cf-surface p-4">
       <h3 className="mb-4 text-sm font-semibold text-cf-text-primary">Saúde Financeira do Mês</h3>
       <div className={`grid gap-4 ${showInsightPanel ? "sm:grid-cols-3" : "sm:grid-cols-2"}`}>
         {/* D5 — Gauge */}


### PR DESCRIPTION
## Resumo
- estabiliza o layout do card de metas para evitar colapso de prazo/status
- ancora o badge de risco na coluna de prazo (fora do fluxo do texto principal)
- fixa o CTA de contribuição no rodapé do card
- aplica grid responsiva auto-fit com minmax(260px, 1fr)
- ajusta HealthOverview com h-full nos retornos para consistência de altura

## Validação
- npm -w apps/web run typecheck
- npm -w apps/web run test:run