### PR TITLE
style(web): rebalance density on critical operational cards

### DIFF
--- a/apps/web/src/components/BillsSummaryWidget.tsx
+++ b/apps/web/src/components/BillsSummaryWidget.tsx
@@ -29,7 +29,7 @@ const BillsSummaryWidget = ({ onOpenBills }: BillsSummaryWidgetProps): JSX.Eleme
   const money = useMaskedCurrency();
   if (isLoading) {
     return (
-      <div className="rounded border border-cf-border bg-cf-surface p-4">
+      <div className="rounded-lg border border-cf-border bg-cf-surface p-4 md:p-5">
         <p className="text-xs text-cf-text-secondary">Carregando pendências...</p>
       </div>
     );
@@ -37,7 +37,7 @@ const BillsSummaryWidget = ({ onOpenBills }: BillsSummaryWidgetProps): JSX.Eleme
 
   if (hasLoadError) {
     return (
-      <div className="rounded border border-red-300 bg-cf-surface p-4">
+      <div className="rounded-lg border border-red-300 bg-cf-surface p-4 md:p-5">
         <div className="mb-2 flex items-center justify-between gap-2">
           <h3 className="text-sm font-medium text-cf-text-primary">Pendências</h3>
           <OperationalSeverityBadge severity="risco" />
@@ -62,7 +62,7 @@ const BillsSummaryWidget = ({ onOpenBills }: BillsSummaryWidgetProps): JSX.Eleme
 
   if (!summary) {
     return (
-      <div className="rounded border border-amber-300 bg-cf-surface p-4">
+      <div className="rounded-lg border border-amber-300 bg-cf-surface p-4 md:p-5">
         <div className="mb-2 flex items-center justify-between gap-2">
           <h3 className="text-sm font-medium text-cf-text-primary">Pendências</h3>
           <OperationalSeverityBadge severity="atencao" />
@@ -96,8 +96,8 @@ const BillsSummaryWidget = ({ onOpenBills }: BillsSummaryWidgetProps): JSX.Eleme
       : "Sem pendências ou vencimentos no recorte atual.";
 
   return (
-    <div className={`rounded border bg-cf-surface p-4 ${cardToneClass}`}>
-      <div className="mb-2 flex items-center justify-between">
+    <div className={`rounded-lg border bg-cf-surface p-4 md:p-5 ${cardToneClass}`}>
+      <div className="mb-2 flex items-start justify-between gap-2">
         <div className="flex items-center gap-2">
           <h3 className="text-sm font-medium text-cf-text-primary">Pendências</h3>
           <OperationalSeverityBadge severity={severityLevel} />
@@ -113,29 +113,29 @@ const BillsSummaryWidget = ({ onOpenBills }: BillsSummaryWidgetProps): JSX.Eleme
         ) : null}
       </div>
 
-      <p className="mb-3 text-xs text-cf-text-secondary">
+      <p className="mb-4 text-[11px] text-cf-text-secondary">
         {statusContext}
       </p>
 
-      <div className="grid grid-cols-2 gap-3">
-        <div className={`rounded border bg-cf-bg-subtle px-3 py-2.5 ${hasOverdueBills ? "border-red-200" : "border-cf-border"}`}>
+      <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-2">
+        <div className={`rounded-lg border bg-cf-bg-subtle px-3 py-3 ${hasOverdueBills ? "border-red-200" : "border-cf-border"}`}>
           <p className="text-xs font-medium uppercase text-cf-text-secondary">Vencidas</p>
           <p
-            className={`text-sm font-semibold ${summary.overdueCount > 0 ? "text-red-600" : "text-cf-text-primary"}`}
+            className={`mt-1 text-lg font-semibold leading-none ${summary.overdueCount > 0 ? "text-red-600" : "text-cf-text-primary"}`}
           >
             {money(summary.overdueTotal)}
           </p>
-          <p className={`text-xs ${summary.overdueCount > 0 ? "text-red-500" : "text-cf-text-secondary"}`}>
+          <p className={`mt-1 text-[11px] ${summary.overdueCount > 0 ? "text-red-500" : "text-cf-text-secondary"}`}>
             {summary.overdueCount} {summary.overdueCount === 1 ? "conta" : "contas"}
           </p>
         </div>
 
-        <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
+        <div className="rounded-lg border border-cf-border bg-cf-bg-subtle px-3 py-3">
           <p className="text-xs font-medium uppercase text-cf-text-secondary">Pendentes</p>
-          <p className="text-sm font-semibold text-cf-text-primary">
+          <p className="mt-1 text-lg font-semibold leading-none text-cf-text-primary">
             {money(summary.pendingTotal)}
           </p>
-          <p className="text-xs text-cf-text-secondary">
+          <p className="mt-1 text-[11px] text-cf-text-secondary">
             {summary.pendingCount} {summary.pendingCount === 1 ? "conta" : "contas"}
           </p>
         </div>

--- a/apps/web/src/components/CreditCardsSummaryWidget.tsx
+++ b/apps/web/src/components/CreditCardsSummaryWidget.tsx
@@ -279,7 +279,7 @@ const CreditCardsSummaryWidget = ({
 
   if (isLoading) {
     return (
-      <div className="rounded border border-cf-border bg-cf-surface p-4">
+      <div className="rounded-lg border border-cf-border bg-cf-surface p-4 md:p-5">
         <p className="text-xs text-cf-text-secondary">Carregando cartões...</p>
       </div>
     );
@@ -287,7 +287,7 @@ const CreditCardsSummaryWidget = ({
 
   if (hasError) {
     return (
-      <div className="rounded border border-red-300 bg-cf-surface p-4">
+      <div className="rounded-lg border border-red-300 bg-cf-surface p-4 md:p-5">
         <div className="mb-2 flex items-center justify-between gap-2">
           <h3 className="text-sm font-medium text-cf-text-primary">Cartões</h3>
           <OperationalSeverityBadge severity="risco" />
@@ -311,8 +311,8 @@ const CreditCardsSummaryWidget = ({
   }
 
   return (
-    <div className={`rounded border bg-cf-surface p-4 ${cardToneClass}`}>
-      <div className="mb-2 flex items-center justify-between gap-2">
+    <div className={`rounded-lg border bg-cf-surface p-4 md:p-5 ${cardToneClass}`}>
+      <div className="mb-2 flex items-start justify-between gap-2">
         <div>
           <div className="flex items-center gap-2">
             <h3 className="text-sm font-medium text-cf-text-primary">Cartões</h3>
@@ -351,22 +351,22 @@ const CreditCardsSummaryWidget = ({
         </div>
       ) : (
         <>
-          <p className="mb-3 text-xs text-cf-text-secondary">
+          <p className="mb-4 text-[11px] text-cf-text-secondary">
             Priorize faturas pendentes e acompanhe o uso de limite para evitar estouro no fechamento.
           </p>
 
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
-            <div className={`rounded border bg-cf-bg-subtle px-3 py-2.5 ${hasCriticalInvoices ? "border-amber-200" : "border-cf-border"}`}>
+          <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-2 xl:grid-cols-4">
+            <div className={`rounded-lg border bg-cf-bg-subtle px-3 py-3 ${hasCriticalInvoices ? "border-amber-200" : "border-cf-border"}`}>
               <p className="text-xs font-medium uppercase text-cf-text-secondary">Faturas pendentes</p>
               <p
-                className={`text-sm font-semibold ${
+                className={`mt-1 text-lg font-semibold leading-none ${
                   aggregate.pendingInvoicesCount > 0 ? "text-amber-700" : "text-cf-text-primary"
                 }`}
               >
                 {money(aggregate.pendingInvoicesTotal)}
               </p>
               <p
-                className={`text-xs ${
+                className={`mt-1 text-[11px] ${
                   aggregate.pendingInvoicesCount > 0 ? "text-amber-700" : "text-cf-text-secondary"
                 }`}
               >
@@ -375,7 +375,7 @@ const CreditCardsSummaryWidget = ({
               </p>
             </div>
 
-            <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
+            <div className="rounded-lg border border-cf-border bg-cf-bg-subtle px-3 py-3">
               <div className="flex items-center justify-between gap-2">
                 <p className="text-xs font-medium uppercase text-cf-text-secondary">Limite em uso</p>
                 <span
@@ -384,7 +384,7 @@ const CreditCardsSummaryWidget = ({
                   {usageStatusLabel}
                 </span>
               </div>
-              <p className="mt-1 text-sm font-semibold text-cf-text-primary">
+              <p className="mt-1 text-lg font-semibold leading-none text-cf-text-primary">
                 {money(aggregate.limitUsed)}
               </p>
               <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-cf-border/60">
@@ -393,23 +393,23 @@ const CreditCardsSummaryWidget = ({
                   style={{ width: `${usageProgressWidthPct}%` }}
                 />
               </div>
-              <p className="mt-1 text-xs text-cf-text-secondary">{aggregate.usagePct.toFixed(2)}% do limite total</p>
+              <p className="mt-1 text-[11px] text-cf-text-secondary">{aggregate.usagePct.toFixed(2)}% do limite total</p>
             </div>
 
-            <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
+            <div className="rounded-lg border border-cf-border bg-cf-bg-subtle px-3 py-3">
               <p className="text-xs font-medium uppercase text-cf-text-secondary">Disponível</p>
-              <p className="text-sm font-semibold text-cf-text-primary">
+              <p className="mt-1 text-lg font-semibold leading-none text-cf-text-primary">
                 {money(aggregate.availableTotal)}
               </p>
-              <p className="text-xs text-cf-text-secondary">Soma dos limites livres</p>
+              <p className="mt-1 text-[11px] text-cf-text-secondary">Soma dos limites livres</p>
             </div>
 
-            <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
+            <div className="rounded-lg border border-cf-border bg-cf-bg-subtle px-3 py-3">
               <p className="text-xs font-medium uppercase text-cf-text-secondary">Compras abertas</p>
-              <p className="text-sm font-semibold text-cf-text-primary">
+              <p className="mt-1 text-lg font-semibold leading-none text-cf-text-primary">
                 {money(aggregate.openPurchasesTotal)}
               </p>
-              <p className="text-xs text-cf-text-secondary">Ainda não fechadas em fatura</p>
+              <p className="mt-1 text-[11px] text-cf-text-secondary">Ainda não fechadas em fatura</p>
             </div>
           </div>
 

--- a/apps/web/src/components/ForecastCard.tsx
+++ b/apps/web/src/components/ForecastCard.tsx
@@ -67,8 +67,8 @@ const BankLimitPanel = ({ forecast, money }: { forecast: Forecast; money: (value
         : "A projeção do mês não entra no limite da conta.";
 
   return (
-    <div className={`mt-3 rounded border px-3 py-2.5 ${statusTone}`}>
-      <div className="flex flex-wrap items-start justify-between gap-3">
+    <div className={`mt-4 rounded-lg border px-3.5 py-3 ${statusTone}`}>
+      <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-start">
         <div>
           <p className="text-xs font-medium uppercase">Limite bancário</p>
           <p className="mt-1 text-sm font-semibold">{headline}</p>
@@ -76,7 +76,7 @@ const BankLimitPanel = ({ forecast, money }: { forecast: Forecast; money: (value
             Total {money(bankLimit.total)} · disponível {money(bankLimit.remaining)}
           </p>
         </div>
-        <div className="text-right">
+        <div className="text-left md:border-l md:border-current/20 md:pl-3 md:text-right">
           <p className="text-xs font-medium uppercase">Uso projetado</p>
           <p className="mt-1 text-base font-semibold">
             {money(bankLimit.used)}
@@ -294,23 +294,25 @@ const ForecastCard = ({
 
   // Active state
   return (
-    <div className={`rounded border bg-cf-surface p-4 ${cardToneClass}`}>
+    <div className={`rounded-lg border bg-cf-surface p-4 md:p-5 ${cardToneClass}`}>
       <div className="flex items-start justify-between gap-3">
-        <div>
+        <div className="min-w-0">
           <h3 className="text-sm font-semibold text-cf-text-primary">Projeção de saldo</h3>
           <p className="mt-1 text-xs text-cf-text-secondary">
             Saldo estimado até o fim do mês com lançamentos e pendências atuais.
           </p>
         </div>
-        <OperationalSeverityBadge severity={severityLevel} />
-        <button
-          type="button"
-          onClick={handleRecompute}
-          disabled={isRecomputing}
-          className="shrink-0 rounded border border-cf-border bg-cf-surface px-2.5 py-1 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {isRecomputing ? "Atualizando..." : "Atualizar"}
-        </button>
+        <div className="flex shrink-0 items-center gap-2">
+          <OperationalSeverityBadge severity={severityLevel} />
+          <button
+            type="button"
+            onClick={handleRecompute}
+            disabled={isRecomputing}
+            className="h-8 rounded border border-cf-border bg-cf-surface px-2.5 text-xs font-semibold text-cf-text-primary hover:bg-cf-bg-subtle disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isRecomputing ? "Atualizando..." : "Atualizar"}
+          </button>
+        </div>
       </div>
 
       {hasLoadError ? (
@@ -347,59 +349,59 @@ const ForecastCard = ({
         </div>
       ) : forecast !== null ? (
         <>
-          <div className="mt-3 grid grid-cols-2 gap-3 lg:grid-cols-4">
-            <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
+          <div className="mt-4 grid grid-cols-1 gap-3.5 sm:grid-cols-2 xl:grid-cols-4">
+            <div className="rounded-lg border border-cf-border bg-cf-bg-subtle px-3 py-3">
               <p className="text-xs font-medium uppercase text-cf-text-secondary">Projeção ajustada</p>
               <p
-                className={`mt-1 text-lg font-bold ${
+                className={`mt-1 text-2xl font-bold leading-none ${
                   forecast.adjustedProjectedBalance < 0 ? "text-red-600" : "text-cf-text-primary"
                 }`}
               >
                 {money(forecast.adjustedProjectedBalance)}
               </p>
               {forecast.incomeExpected !== null ? (
-                <p className="mt-0.5 text-xs text-cf-text-secondary">
+                <p className="mt-1 text-[11px] text-cf-text-secondary">
                   Salário esperado: {money(forecast.incomeExpected)}
                 </p>
               ) : null}
               {forecast.billsPendingCount > 0 ? (
-                <p className="mt-0.5 text-xs text-amber-600">
+                <p className="mt-0.5 text-[11px] text-amber-600">
                   {forecast.billsPendingCount}{" "}
                   {forecast.billsPendingCount === 1 ? "pendência incluída" : "pendências incluídas"}
                 </p>
               ) : (
-                <p className="mt-0.5 text-xs text-cf-text-secondary">Sem pendências este mês</p>
+                <p className="mt-0.5 text-[11px] text-cf-text-secondary">Sem pendências este mês</p>
               )}
             </div>
 
-            <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
+            <div className="rounded-lg border border-cf-border bg-cf-bg-subtle px-3 py-3">
               <p className="text-xs font-medium uppercase text-cf-text-secondary">Gasto até agora</p>
-              <p className="mt-1 text-base font-semibold text-cf-text-primary">
+              <p className="mt-1 text-lg font-semibold leading-none text-cf-text-primary">
                 {money(forecast.spendingToDate)}
               </p>
-              <p className="mt-0.5 text-xs text-cf-text-secondary">
+              <p className="mt-1 text-[11px] text-cf-text-secondary">
                 Media diaria: {money(forecast.dailyAvgSpending)}/dia
               </p>
             </div>
 
-            <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
+            <div className="rounded-lg border border-cf-border bg-cf-bg-subtle px-3 py-3">
               <p className="text-xs font-medium uppercase text-cf-text-secondary">Dias restantes</p>
-              <p className="mt-1 text-base font-semibold text-cf-text-primary">
+              <p className="mt-1 text-lg font-semibold leading-none text-cf-text-primary">
                 {forecast.daysRemaining}
               </p>
-              <p className="mt-0.5 text-xs text-cf-text-secondary">mês {forecast.month}</p>
+              <p className="mt-1 text-[11px] text-cf-text-secondary">mês {forecast.month}</p>
             </div>
 
-            <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
+            <div className="rounded-lg border border-cf-border bg-cf-bg-subtle px-3 py-3">
               <p className="text-xs font-medium uppercase text-cf-text-secondary">Pendências do mês</p>
               <p
-                className={`mt-1 text-base font-semibold ${
+                className={`mt-1 text-lg font-semibold leading-none ${
                   forecast.billsPendingCount > 0 ? "text-amber-600" : "text-cf-text-primary"
                 }`}
               >
                 {money(forecast.billsPendingTotal)}
               </p>
-              <p className="mt-0.5 text-xs text-cf-text-secondary">
+              <p className="mt-1 text-[11px] text-cf-text-secondary">
                 {forecast.billsPendingCount > 0
                   ? `${forecast.billsPendingCount} ${forecast.billsPendingCount === 1 ? "conta" : "contas"} este mês`
                   : "Nenhuma pendência"}

--- a/apps/web/src/components/OperationalSummaryPanel.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.tsx
@@ -26,22 +26,22 @@ const ACCENT_CLASSES: Record<NonNullable<TileProps["accent"]>, string> = {
 };
 
 const Tile = ({ label, primary, secondary, tertiary, actionLabel, onActionClick, accent = "default" }: TileProps) => (
-  <div className="flex min-h-[132px] flex-col rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
+  <div className="flex min-h-[124px] flex-col rounded-lg border border-cf-border bg-cf-bg-subtle px-3.5 py-3">
     <p className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-cf-text-secondary">
       {label}
     </p>
-    <p className={`text-sm font-semibold leading-tight ${ACCENT_CLASSES[accent]}`}>{primary}</p>
+    <p className={`text-base font-semibold leading-tight ${ACCENT_CLASSES[accent]}`}>{primary}</p>
     {secondary ? (
-      <p className="mt-0.5 text-xs text-cf-text-secondary">{secondary}</p>
+      <p className="mt-1 text-[11px] text-cf-text-secondary">{secondary}</p>
     ) : null}
     {tertiary ? (
-      <p className="text-xs text-cf-text-secondary">{tertiary}</p>
+      <p className="mt-0.5 text-[11px] text-cf-text-secondary">{tertiary}</p>
     ) : null}
     {actionLabel && onActionClick ? (
       <button
         type="button"
         onClick={onActionClick}
-        className="mt-auto pt-1 text-left text-xs font-semibold text-brand-1 hover:text-brand-2"
+        className="mt-auto pt-1.5 text-left text-xs font-semibold text-brand-1 hover:text-brand-2"
       >
         {actionLabel} →
       </button>
@@ -52,7 +52,7 @@ const Tile = ({ label, primary, secondary, tertiary, actionLabel, onActionClick,
 // ─── Loading skeleton ─────────────────────────────────────────────────────────
 
 const SkeletonTile = () => (
-  <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5 animate-pulse">
+  <div className="animate-pulse rounded-lg border border-cf-border bg-cf-bg-subtle px-3.5 py-3">
     <div className="mb-1.5 h-2 w-16 rounded bg-cf-border" />
     <div className="h-4 w-24 rounded bg-cf-border" />
     <div className="mt-1 h-3 w-20 rounded bg-cf-border" />
@@ -319,15 +319,15 @@ const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanel
         };
 
   return (
-    <div className="space-y-2">
-      <div className="flex flex-wrap items-center gap-2">
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-1.5">
         <span className="text-[11px] font-semibold uppercase tracking-wide text-cf-text-secondary">Severidade</span>
         <OperationalSeverityBadge severity="normal" />
         <OperationalSeverityBadge severity="atencao" />
         <OperationalSeverityBadge severity="risco" />
       </div>
 
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+      <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-2 xl:grid-cols-3">
         <Tile {...bankTile} />
         <Tile {...billsTile} />
         <Tile {...cardTile} />

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -2469,12 +2469,12 @@ const App = ({
                 <span className="text-xs text-cf-text-secondary">Prioridade de triagem</span>
               </div>
 
-              <div className="grid gap-4 xl:grid-cols-12">
+              <div className="grid gap-5 xl:grid-cols-12">
                 <div className="xl:col-span-7">
                   <ForecastCard onOpenProfileSettings={onOpenProfileSettings} />
                 </div>
 
-                <div className="space-y-4 xl:col-span-5">
+                <div className="space-y-5 xl:col-span-5">
                   <BillsSummaryWidget onOpenBills={handleOpenBills} />
                   <CreditCardsSummaryWidget onOpenCreditCards={handleOpenCreditCards} />
                 </div>


### PR DESCRIPTION
## Contexto\nA home já tinha os widgets críticos corretos funcionalmente, mas com densidade visual alta em alguns pontos.\n\n## O que foi feito\n- Reequilíbrio de espaçamento, tipografia e hierarquia visual no ForecastCard.\n- Reequilíbrio de densidade no CreditCardsSummaryWidget (cards mais legíveis, números mais proeminentes).\n- Reequilíbrio no BillsSummaryWidget (respiro e leitura dos valores críticos).\n- Harmonização dos tiles no OperationalSummaryPanel.\n- Ajuste de gap no container dos cards críticos em App.tsx para manter ritmo vertical consistente.\n\n## Escopo\n- Apenas visual/polish de layout e hierarquia.\n- Sem alteração de contratos de dados, regras de negócio ou fluxos.\n\n## Validação\n- 
pm -w apps/web run typecheck\n- 
pm -w apps/web run test:run -- src/components/ForecastCard.test.tsx src/components/CreditCardsSummaryWidget.test.tsx src/components/BillsSummaryWidget.test.tsx src/components/OperationalSummaryPanel.test.tsx src/pages/App.test.jsx\n- Resultado: 5 arquivos de teste, 101 testes passando.