### PR TITLE
fix(visual): correct grid breakpoints, overflow and value wrapping regressions

### DIFF
--- a/apps/web/src/components/BankAccountsWidget.tsx
+++ b/apps/web/src/components/BankAccountsWidget.tsx
@@ -242,7 +242,7 @@ const BankAccountsWidget = (): JSX.Element => {
               <div className="rounded-lg border border-cf-border bg-cf-bg-subtle px-3 py-3">
                 <p className="text-xs font-medium uppercase text-cf-text-secondary">Saldo em conta</p>
                 <p
-                  className={`mt-1 text-lg font-semibold leading-none ${
+                  className={`mt-1 whitespace-nowrap text-base font-semibold leading-none ${
                     summary.totalBalance < 0 ? "text-red-600" : "text-cf-text-primary"
                   }`}
                 >
@@ -256,7 +256,7 @@ const BankAccountsWidget = (): JSX.Element => {
                 <p className="text-xs font-medium uppercase text-cf-text-secondary">
                   Limite disponível
                 </p>
-                <p className={`mt-1 text-lg font-semibold leading-none ${limitTone}`}>
+                <p className={`mt-1 whitespace-nowrap text-base font-semibold leading-none ${limitTone}`}>
                   {money(summary.totalLimitAvailable)}
                 </p>
                 <p className={`mt-1 text-[11px] ${limitSupportTone}`}>
@@ -274,7 +274,7 @@ const BankAccountsWidget = (): JSX.Element => {
               <div className="rounded-lg border border-cf-border bg-cf-bg-subtle px-3 py-3">
                 <p className="text-xs font-medium uppercase text-cf-text-secondary">Posição real</p>
                 <p
-                  className={`mt-1 text-lg font-semibold leading-none ${
+                  className={`mt-1 whitespace-nowrap text-base font-semibold leading-none ${
                     summary.totalBalance + summary.totalLimitAvailable <= 0
                       ? "text-red-600"
                       : "text-cf-text-primary"

--- a/apps/web/src/components/CreditCardsSummaryWidget.tsx
+++ b/apps/web/src/components/CreditCardsSummaryWidget.tsx
@@ -355,7 +355,7 @@ const CreditCardsSummaryWidget = ({
             Priorize faturas pendentes e acompanhe o uso de limite para evitar estouro no fechamento.
           </p>
 
-          <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-2 xl:grid-cols-4">
+          <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-2 lg:grid-cols-4">
             <div className={`rounded-lg border bg-cf-bg-subtle px-3 py-3 ${hasCriticalInvoices ? "border-amber-200" : "border-cf-border"}`}>
               <p className="text-xs font-medium uppercase text-cf-text-secondary">Faturas pendentes</p>
               <p

--- a/apps/web/src/components/ForecastCard.tsx
+++ b/apps/web/src/components/ForecastCard.tsx
@@ -349,7 +349,7 @@ const ForecastCard = ({
         </div>
       ) : forecast !== null ? (
         <>
-          <div className="mt-4 grid grid-cols-1 gap-3.5 sm:grid-cols-2 xl:grid-cols-4">
+          <div className="mt-4 grid grid-cols-1 gap-3.5 sm:grid-cols-2 lg:grid-cols-4">
             <div className="rounded-lg border border-cf-border bg-cf-bg-subtle px-3 py-3">
               <p className="text-xs font-medium uppercase text-cf-text-secondary">Projeção ajustada</p>
               <p

--- a/apps/web/src/components/SalaryWidget.tsx
+++ b/apps/web/src/components/SalaryWidget.tsx
@@ -593,7 +593,7 @@ function BenefitProfileView({
 
         {consignacoes.length > 0 ? (
           <>
-            <ul className="max-h-72 space-y-1.5 overflow-auto pr-1">
+            <ul className="space-y-1.5 pr-1">
               {consignacoes.map((c) => (
               <li
                 key={c.id}

--- a/apps/web/src/components/TransactionList.jsx
+++ b/apps/web/src/components/TransactionList.jsx
@@ -136,7 +136,7 @@ const TransactionList = ({ transactions, onDelete, onEdit, onBulkDelete }) => {
                 <button
                   type="button"
                   onClick={() => onEdit(transaction)}
-                  className="whitespace-nowrap text-[11px] font-semibold text-cf-text-secondary transition-colors hover:text-cf-text-primary"
+                  className="rounded border border-cf-border px-2 py-0.5 text-xs font-medium text-cf-text-secondary transition-colors hover:bg-cf-bg-subtle hover:text-cf-text-primary"
                   aria-label={`Editar transação ${transaction.id}`}
                 >
                   Editar
@@ -144,7 +144,7 @@ const TransactionList = ({ transactions, onDelete, onEdit, onBulkDelete }) => {
                 <button
                   type="button"
                   onClick={() => onDelete(transaction.id)}
-                  className="whitespace-nowrap text-[11px] font-semibold text-cf-text-secondary transition-colors hover:text-cf-text-primary"
+                  className="rounded border border-red-200 px-2 py-0.5 text-xs font-medium text-red-500 transition-colors hover:border-red-300 hover:bg-red-50 hover:text-red-700 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-900/30"
                   aria-label={`Excluir transação ${transaction.id}`}
                 >
                   Excluir

--- a/apps/web/src/pages/TaxPage.tsx
+++ b/apps/web/src/pages/TaxPage.tsx
@@ -1395,7 +1395,7 @@ const TaxPage = ({ onBack = undefined, onOpenProfileSettings = undefined }: TaxP
             Blocos fiscais conferíveis para apoiar a decisão antes do snapshot e da exportação oficial.
           </p>
 
-          <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
             <FactSummaryCard
               title="Rendimentos Tributáveis"
               value={showLoadingPlaceholders ? "Carregando..." : formatCurrency(displayAnnualTaxableIncome)}


### PR DESCRIPTION
## Summary

Regressões visuais identificadas pós-sprint PR14 / sprint-confiabilidade-produto:

- **BankAccountsWidget**: valores no grid de 3 colunas usavam `text-lg` — valor negativo (`-R$ 149,46`) quebrava em duas linhas. Fix: `text-base + whitespace-nowrap` nos 3 cards de resumo.
- **ForecastCard / CreditCardsSummaryWidget / TaxPage**: grids de 4 colunas com breakpoint `xl:grid-cols-4` (≥1280px) ficavam em 2×2 entre 640–1279px. Fix: `lg:grid-cols-4` (≥1024px), alinhado com o padrão anterior.
- **SalaryWidget**: `max-h-72 overflow-auto` no `<ul>` de consignações criava scroll interno desnecessário. Removido.
- **TransactionList**: botões Editar/Excluir sem borda/background ficavam invisíveis. Fix: borda sutil + `text-xs`; Excluir com semântica vermelha.

## Test plan

- [x] 390/390 web tests passing
- [ ] Verificar BankAccountsWidget com valor negativo não quebra em tela ≤ 900px
- [ ] Verificar ForecastCard em 4 colunas entre 1024–1279px
- [ ] Verificar SalaryWidget sem scrollbar interno na lista de consignações
- [ ] Verificar botões Editar/Excluir visíveis em TransactionList