### PR TITLE
style(home): stack critical cards in single column

### DIFF
--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -2469,15 +2469,10 @@ const App = ({
                 <span className="text-xs text-cf-text-secondary">Prioridade de triagem</span>
               </div>
 
-              <div className="grid gap-5 xl:grid-cols-12">
-                <div className="xl:col-span-7">
-                  <ForecastCard onOpenProfileSettings={onOpenProfileSettings} />
-                </div>
-
-                <div className="space-y-5 xl:col-span-5">
-                  <BillsSummaryWidget onOpenBills={handleOpenBills} />
-                  <CreditCardsSummaryWidget onOpenCreditCards={handleOpenCreditCards} />
-                </div>
+              <div className="flex flex-col gap-5">
+                <ForecastCard onOpenProfileSettings={onOpenProfileSettings} />
+                <BillsSummaryWidget onOpenBills={handleOpenBills} />
+                <CreditCardsSummaryWidget onOpenCreditCards={handleOpenCreditCards} />
               </div>
             </section>
 


### PR DESCRIPTION
## Summary

- Cards críticos (Projeção de saldo, Pendências, Cartões) passam de layout side-by-side `xl:grid-cols-12` para coluna única `flex flex-col`
- Elimina o espremimento dos cards de Pendências e Cartões que ocorria em viewports abaixo de 1280px
- Cada card agora ocupa largura total, mantendo os grids internos de 4 colunas intactos

## Test plan

- [x] 390/390 web tests passing
- [ ] Verificar cards empilhados verticalmente em todos os breakpoints
- [ ] Confirmar que grids internos do ForecastCard (lg:grid-cols-4) e CreditCardsSummaryWidget não regridem