### PR TITLE
feat(pages): add contextual import shortcuts to income sources and credit cards

### DIFF
--- a/apps/web/src/pages/CreditCardsPage.tsx
+++ b/apps/web/src/pages/CreditCardsPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import ImportCsvModal from "../components/ImportCsvModal";
 import CreditCardModal from "../components/CreditCardModal";
 import CreditCardPurchaseModal from "../components/CreditCardPurchaseModal";
 import { billsService } from "../services/bills.service";
@@ -110,6 +111,7 @@ const getInvoiceBadge = (invoice: CreditCardItem["invoices"][number]) => {
 const CreditCardsPage = ({
   onBack = undefined,
 }: CreditCardsPageProps): JSX.Element => {
+  const [isImportOpen, setIsImportOpen] = useState(false);
   const [cards, setCards] = useState<CreditCardItem[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [pageError, setPageError] = useState("");
@@ -267,16 +269,25 @@ const CreditCardsPage = ({
               </p>
             </div>
           </div>
-          <button
-            type="button"
-            onClick={() => {
-              setEditingCard(null);
-              setIsCardModalOpen(true);
-            }}
-            className="rounded bg-brand-1 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-2"
-          >
-            + Novo cartão
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setIsImportOpen(true)}
+              className="rounded border border-cf-border px-4 py-2 text-sm font-semibold text-cf-text-secondary hover:bg-cf-bg-subtle hover:text-cf-text-primary"
+            >
+              Importar fatura
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setEditingCard(null);
+                setIsCardModalOpen(true);
+              }}
+              className="rounded bg-brand-1 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-2"
+            >
+              + Novo cartão
+            </button>
+          </div>
         </div>
 
         {pageError ? (
@@ -572,6 +583,10 @@ const CreditCardsPage = ({
         cardName={purchaseCard?.name || ""}
         onClose={() => setPurchaseCard(null)}
         onSave={handleSavePurchase}
+      />
+      <ImportCsvModal
+        isOpen={isImportOpen}
+        onClose={() => setIsImportOpen(false)}
       />
     </div>
   );

--- a/apps/web/src/pages/IncomeSourcesPage.tsx
+++ b/apps/web/src/pages/IncomeSourcesPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import ImportCsvModal from "../components/ImportCsvModal";
 import IncomeSourceModal from "../components/IncomeSourceModal";
 import IncomeDeductionModal from "../components/IncomeDeductionModal";
 import IncomeStatementModal from "../components/IncomeStatementModal";
@@ -70,6 +71,7 @@ const getStatementStatusBadge = (status: "draft" | "posted") => {
 const IncomeSourcesPage = ({
   onBack = undefined,
 }: IncomeSourcesPageProps): JSX.Element => {
+  const [isImportOpen, setIsImportOpen] = useState(false);
   const [sources, setSources] = useState<IncomeSourceWithDeductions[]>([]);
   const [statementsBySource, setStatementsBySource] = useState<Record<number, IncomeStatement[]>>({});
   const [isLoading, setIsLoading] = useState(false);
@@ -303,13 +305,22 @@ const IncomeSourcesPage = ({
             ) : null}
             <h1 className="text-xl font-bold text-cf-text-primary">Fontes de Renda</h1>
           </div>
-          <button
-            type="button"
-            onClick={openCreateSourceModal}
-            className="rounded bg-brand-1 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-2"
-          >
-            + Nova fonte
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setIsImportOpen(true)}
+              className="rounded border border-cf-border px-4 py-2 text-sm font-semibold text-cf-text-secondary hover:bg-cf-bg-subtle hover:text-cf-text-primary"
+            >
+              Importar extrato
+            </button>
+            <button
+              type="button"
+              onClick={openCreateSourceModal}
+              className="rounded bg-brand-1 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-2"
+            >
+              + Nova fonte
+            </button>
+          </div>
         </div>
 
         {/* Feedback */}
@@ -609,6 +620,10 @@ const IncomeSourcesPage = ({
           onPosted={handlePosted}
         />
       ) : null}
+      <ImportCsvModal
+        isOpen={isImportOpen}
+        onClose={() => setIsImportOpen(false)}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary

- **Fontes de Renda**: botão "Importar extrato" no header, antes do "+ Nova fonte"
- **Cartões**: botão "Importar fatura" no header, antes do "+ Novo cartão"
- Ambos abrem o `ImportCsvModal` existente de forma autônoma (sem prop drilling via AppRoutes)
- Modal instanciado localmente com `isOpen` iniciando `false` — não abre no mount
- `onOpenHistory` não passado — sem dependência de estado externo
- Botões com estilo secundário (borda) para não competir com o CTA primário

## Test plan

- [x] 390/390 web tests passing
- [ ] "Importar extrato" abre modal em Fontes de Renda
- [ ] "Importar fatura" abre modal em Cartões
- [ ] Modal fecha ao clicar onClose sem side effects
- [ ] CTAs primários (+ Nova fonte, + Novo cartão) mantêm comportamento inalterado