### PR TITLE
fix(web): aviso explícito para forecast congelado

### DIFF
--- a/apps/web/src/components/ForecastCard.test.tsx
+++ b/apps/web/src/components/ForecastCard.test.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
-import ForecastCard from "./ForecastCard";
+import ForecastCard, { FORECAST_CACHE_KEY } from "./ForecastCard";
 import { DiscreetModeProvider } from "../context/DiscreetModeContext";
 import type { Forecast } from "../services/forecast.service";
 
@@ -114,7 +114,7 @@ describe("ForecastCard", () => {
 
   it("exibe aviso claro quando a projeção está congelada", async () => {
     const frozenForecast = buildForecast({ month: "2026-03", projectedBalance: 1750 });
-    window.localStorage.setItem("cf.forecast.last", JSON.stringify(frozenForecast));
+    window.localStorage.setItem(FORECAST_CACHE_KEY, JSON.stringify(frozenForecast));
 
     vi.mocked(profileService.getMe).mockResolvedValue({
       ...buildMe(),
@@ -134,5 +134,6 @@ describe("ForecastCard", () => {
     expect(screen.getByText(/o período de teste encerrou/i)).toBeInTheDocument();
     expect(screen.getByText(/3 transações registradas desde o congelamento/i)).toBeInTheDocument();
     expect(screen.getByText(/os valores exibidos podem estar desatualizados/i)).toBeInTheDocument();
+    expect(screen.getByText(/ative um plano para voltar a atualizar a projeção/i)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/ForecastCard.test.tsx
+++ b/apps/web/src/components/ForecastCard.test.tsx
@@ -73,6 +73,7 @@ const renderCard = () =>
 describe("ForecastCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.localStorage.clear();
     vi.mocked(profileService.getMe).mockResolvedValue(buildMe());
     vi.mocked(forecastService.getCurrent).mockResolvedValue(buildForecast());
     vi.mocked(forecastService.recompute).mockResolvedValue(buildForecast());
@@ -109,5 +110,29 @@ describe("ForecastCard", () => {
       expect(screen.getByText(/A projeção ultrapassa o limite/)).toBeInTheDocument(),
     );
     expect(screen.getByText(/100% do limite/)).toBeInTheDocument();
+  });
+
+  it("exibe aviso claro quando a projeção está congelada", async () => {
+    const frozenForecast = buildForecast({ month: "2026-03", projectedBalance: 1750 });
+    window.localStorage.setItem("cf.forecast.last", JSON.stringify(frozenForecast));
+
+    vi.mocked(profileService.getMe).mockResolvedValue({
+      ...buildMe(),
+      trialExpired: true,
+    });
+
+    render(
+      <DiscreetModeProvider>
+        <ForecastCard txCountSinceFreeze={3} />
+      </DiscreetModeProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("Projeção congelada no plano gratuito")).toBeInTheDocument(),
+    );
+
+    expect(screen.getByText(/o período de teste encerrou/i)).toBeInTheDocument();
+    expect(screen.getByText(/3 transações registradas desde o congelamento/i)).toBeInTheDocument();
+    expect(screen.getByText(/os valores exibidos podem estar desatualizados/i)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/ForecastCard.tsx
+++ b/apps/web/src/components/ForecastCard.tsx
@@ -232,8 +232,15 @@ const ForecastCard = ({
   }
 
   if (cardState === "frozen") {
+    const staleDataSignal =
+      txCountSinceFreeze > 0
+        ? `${txCountSinceFreeze} ${
+            txCountSinceFreeze === 1 ? "transação registrada" : "transações registradas"
+          } desde o congelamento.`
+        : "Novas transações podem não estar refletidas nesta leitura.";
+
     return (
-      <div className="rounded border border-cf-border bg-cf-surface p-4 opacity-80">
+      <div className="rounded border border-amber-300 bg-cf-surface p-4">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
             <div className="flex items-center gap-2">
@@ -248,21 +255,15 @@ const ForecastCard = ({
                   {money(forecast.projectedBalance)}
                 </p>
                 <p className="mt-1 text-xs text-cf-text-secondary">
-                  Projeção do mês {forecast.month} - congelada no fim do período de teste.
+                  Última projeção disponível do mês {forecast.month}. Este valor não está mais sendo
+                  recalculado automaticamente.
                 </p>
               </>
             ) : (
               <p className="mt-2 text-sm text-cf-text-secondary">
-                Sua última projeção está congelada no plano free. Assine para continuar atualizando.
+                Não há projeção atualizada disponível após o fim do período de teste.
               </p>
             )}
-            {txCountSinceFreeze > 0 ? (
-              <p className="mt-1 text-xs text-cf-text-secondary">
-                {txCountSinceFreeze}{" "}
-                {txCountSinceFreeze === 1 ? "transação registrada" : "transações registradas"} desde
-                então.
-              </p>
-            ) : null}
           </div>
           {onOpenProfileSettings ? (
             <button
@@ -273,6 +274,16 @@ const ForecastCard = ({
               Ativar plano
             </button>
           ) : null}
+        </div>
+
+        <div className="mt-3">
+          <OperationalStateBlock
+            severity="atencao"
+            title="Projeção congelada no plano gratuito"
+            happened="O período de teste encerrou e o Forecast foi pausado para novos recálculos."
+            impact={`Os valores exibidos podem estar desatualizados. ${staleDataSignal}`}
+            nextStep="Ative um plano para voltar a atualizar a projeção com os lançamentos mais recentes."
+          />
         </div>
       </div>
     );

--- a/apps/web/src/components/ForecastCard.tsx
+++ b/apps/web/src/components/ForecastCard.tsx
@@ -13,7 +13,7 @@ interface ForecastCardProps {
 
 type CardState = "loading" | "awaiting-profile" | "active" | "frozen";
 
-const FORECAST_CACHE_KEY = "cf.forecast.last";
+export const FORECAST_CACHE_KEY = "cf.forecast.last";
 
 const loadCachedForecast = (): Forecast | null => {
   try {
@@ -240,7 +240,7 @@ const ForecastCard = ({
         : "Novas transações podem não estar refletidas nesta leitura.";
 
     return (
-      <div className="rounded border border-amber-300 bg-cf-surface p-4">
+      <div className="rounded border border-cf-warning bg-cf-surface p-4">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
             <div className="flex items-center gap-2">

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -14,6 +14,7 @@
   --cf-text-secondary: #495057;
   --cf-border:         #ADB5BD;
   --cf-border-input:   #E9ECEF;
+  --cf-warning:        #FCD34D;
 }
 
 .dark {
@@ -25,6 +26,7 @@
   --cf-text-secondary: #888888;
   --cf-border:         #2e2e2e;
   --cf-border-input:   #3a3a3a;
+  --cf-warning:        #D97706;
 }
 
 

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -28,6 +28,7 @@ export default {
         'cf-text-secondary': 'var(--cf-text-secondary)',
         'cf-border':         'var(--cf-border)',
         'cf-border-input':   'var(--cf-border-input)',
+        'cf-warning':        'var(--cf-warning)',
         brand: {
           1: '#6741D9',
           2: '#4C3299',


### PR DESCRIPTION
## Contexto\nSprint A - Item 1 (P0): Forecast congelado sem aviso claro ao usuário.\n\n## O que foi feito\n- Tornei o estado congelado explícito com mensagem operacional clara (causa, impacto e próximo passo).\n- Removi a opacidade que prejudicava leitura no card congelado.\n- Mantive CTA para ativação de plano.\n- Adicionei teste de regressão cobrindo trial expirado + cache congelado + mensagem de desatualização.\n\n## Arquivos\n- apps/web/src/components/ForecastCard.tsx\n- apps/web/src/components/ForecastCard.test.tsx\n\n## Validação\n- npm -w apps/web run test:run -- src/components/ForecastCard.test.tsx\n\n## Regras operacionais\n- git log main..HEAD --oneline executado\n- git diff main...HEAD -- <files> executado\n