### PR TITLE
fix(web): remove string fallback from paywall resolver

### DIFF
--- a/apps/web/src/services/api.test.ts
+++ b/apps/web/src/services/api.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { resolvePaywallPayload } from "./api";
+
+describe("resolvePaywallPayload", () => {
+  it("classifica trial_expired apenas pelo codigo estruturado", () => {
+    const payload = resolvePaywallPayload(
+      "/forecasts/current",
+      "Mensagem qualquer sem palavra-chave",
+      "TRIAL_EXPIRED",
+    );
+
+    expect(payload).toEqual({
+      reason: "Mensagem qualquer sem palavra-chave",
+      feature: "unknown",
+      context: "trial_expired",
+    });
+  });
+
+  it("nao usa fallback por texto para trial_expired", () => {
+    const payload = resolvePaywallPayload(
+      "/forecasts/current",
+      "Periodo de teste encerrado. Ative seu plano.",
+      "",
+    );
+
+    expect(payload.context).toBe("feature_gate");
+    expect(payload.feature).toBe("forecast");
+    expect(payload.reason).toMatch(/A projeção do mês é um recurso do Pro/i);
+  });
+
+  it("mantem fallback de feature unknown quando rota nao mapeada", () => {
+    const payload = resolvePaywallPayload(
+      "/qualquer/rota",
+      "Pagamento necessário.",
+      "FEATURE_DISABLED",
+    );
+
+    expect(payload).toEqual({
+      reason: "Pagamento necessário.",
+      feature: "unknown",
+      context: "feature_gate",
+    });
+  });
+});

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -278,18 +278,13 @@ const PAYWALL_COPY: Array<{ pattern: RegExp; reason: string; feature: PaywallFea
   },
 ];
 
-const resolvePaywallPayload = (
+export const resolvePaywallPayload = (
   url: string,
   serverMessage: string,
   serverCode: string,
 ): PaymentRequiredPayload => {
-  // Prefer the structured code field from the API response.
-  // TODO: remove the string-match fallback once PR #245 (fix/paywall-structured-error, v1.30+)
-  //       is stable in prod with no old API instances running — the includes("teste encerrado")
-  //       branch is dead code after that point.
-  const isTrialExpired =
-    serverCode === "TRIAL_EXPIRED" ||
-    serverMessage.toLowerCase().includes("teste encerrado");
+  // Structured backend code is the contract for paywall context classification.
+  const isTrialExpired = serverCode === "TRIAL_EXPIRED";
 
   if (isTrialExpired) {
     return { reason: serverMessage, feature: "unknown", context: "trial_expired" };


### PR DESCRIPTION
Sprint A item 2 (P0): remove fallback por string em api.ts e usa apenas serverCode=TRIAL_EXPIRED para classificar trial_expired. Inclui testes unitarios em apps/web/src/services/api.test.ts para blindar contrato. Validacao: npm -w apps/web run test:run -- src/services/api.test.ts. Governanca: sem merge automatico do agente; merge apenas apos diff completo e aprovacao explicita do usuario.