### PR TITLE
fix(web): add visual feedback for OCR-disabled PDF import

### DIFF
--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -6,13 +6,25 @@ import { salaryService } from "../services/salary.service";
 import { forecastService } from "../services/forecast.service";
 import { categoriesService } from "../services/categories.service";
 import { formatCurrency } from "../utils/formatCurrency";
-import { getApiErrorMessage } from "../utils/apiError";
+import { getApiErrorCode, getApiErrorMessage } from "../utils/apiError";
 import BillModal from "./BillModal";
 import IncomeStatementQuickModal from "./IncomeStatementQuickModal";
 import ConfirmDialog from "./ConfirmDialog";
 
 const PREVIEW_PAGE_SIZE = 100;
 const SALARY_PROFILE_UPDATED_EVENT = "salary-profile-updated";
+const PDF_OCR_DISABLED_CODE = "IMPORT_PDF_OCR_DISABLED";
+const PDF_OCR_GUIDANCE_MESSAGE = "PDF sem texto reconhecivel. Tente OFX ou CSV.";
+
+const isOcrDisabledFeedbackError = (error, apiMessage) => {
+  const apiCode = getApiErrorCode(error);
+  if (apiCode === PDF_OCR_DISABLED_CODE) {
+    return true;
+  }
+
+  return String(apiMessage || "").trim().toLowerCase() === PDF_OCR_GUIDANCE_MESSAGE.toLowerCase();
+};
+
 const buildProfileSuggestionKey = (suggestion) =>
   [
     suggestion?.line ?? "",
@@ -133,6 +145,7 @@ const ImportCsvModal = ({
   const [isCommitting, setIsCommitting] = useState(false);
   const [dryRunResult, setDryRunResult] = useState(null);
   const [errorMessage, setErrorMessage] = useState("");
+  const [showOcrDisabledFeedback, setShowOcrDisabledFeedback] = useState(false);
   const [successMessage, setSuccessMessage] = useState("");
   const [showProfileConfirm, setShowProfileConfirm] = useState(false);
   const [isApplyingProfile, setIsApplyingProfile] = useState(false);
@@ -181,6 +194,7 @@ const ImportCsvModal = ({
     setIsCommitting(false);
     setDryRunResult(null);
     setErrorMessage("");
+    setShowOcrDisabledFeedback(false);
     setSuccessMessage("");
     setShowProfileConfirm(false);
     setIsApplyingProfile(false);
@@ -790,14 +804,17 @@ const ImportCsvModal = ({
 
     setIsDryRunning(true);
     setErrorMessage("");
+    setShowOcrDisabledFeedback(false);
     setSuccessMessage("");
 
     try {
       const result = await transactionsService.dryRunImportCsv(selectedFile);
       setDryRunResult(result);
     } catch (error) {
+      const apiMessage = getApiErrorMessage(error, "Não foi possível processar o arquivo do extrato.");
       setDryRunResult(null);
-      setErrorMessage(getApiErrorMessage(error, "Não foi possível processar o arquivo do extrato."));
+      setErrorMessage(apiMessage);
+      setShowOcrDisabledFeedback(isOcrDisabledFeedbackError(error, apiMessage));
     } finally {
       setIsDryRunning(false);
     }
@@ -943,6 +960,7 @@ const ImportCsvModal = ({
                 setSelectedFile(nextFile);
                 setDryRunResult(null);
                 setErrorMessage("");
+                setShowOcrDisabledFeedback(false);
                 setSuccessMessage("");
                 setProfileApplied(false);
                 setShowProfileConfirm(false);
@@ -993,6 +1011,16 @@ const ImportCsvModal = ({
           {errorMessage ? (
             <div className="mt-3 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
               {errorMessage}
+            </div>
+          ) : null}
+
+          {showOcrDisabledFeedback ? (
+            <div className="mt-3 rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+              <p className="font-semibold">OCR para PDF está desativado neste ambiente.</p>
+              <p className="mt-1">
+                Este arquivo parece escaneado e não possui texto nativo suficiente para leitura automática.
+              </p>
+              <p className="mt-1">Para continuar agora, use o extrato em OFX ou CSV.</p>
             </div>
           ) : null}
 

--- a/apps/web/src/components/ImportCsvModal.test.jsx
+++ b/apps/web/src/components/ImportCsvModal.test.jsx
@@ -175,6 +175,32 @@ describe("ImportCsvModal", () => {
     expect(invalidRowsCard).toHaveTextContent("1");
   });
 
+  it("exibe feedback visual quando OCR de PDF está desativado", async () => {
+    const file = new File(["dummy"], "extrato-escaneado.pdf", { type: "application/pdf" });
+    transactionsService.dryRunImportCsv.mockRejectedValueOnce({
+      response: {
+        data: {
+          message: "PDF sem texto reconhecivel. Tente OFX ou CSV.",
+          code: "IMPORT_PDF_OCR_DISABLED",
+        },
+      },
+    });
+
+    render(<ImportCsvModal isOpen onClose={vi.fn()} />);
+
+    await userEvent.upload(screen.getByLabelText("Arquivo do extrato"), file);
+    await userEvent.click(screen.getByRole("button", { name: "Pré-visualizar" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("OCR para PDF está desativado neste ambiente.")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(/este arquivo parece escaneado e não possui texto nativo suficiente/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/para continuar agora, use o extrato em OFX ou CSV/i)).toBeInTheDocument();
+  });
+
   it("exibe badge e aviso para conta de telecom detectada", async () => {
     const file = new File(["dummy"], "telecom.pdf", { type: "application/pdf" });
     transactionsService.dryRunImportCsv.mockResolvedValueOnce(

--- a/apps/web/src/services/api.test.js
+++ b/apps/web/src/services/api.test.js
@@ -219,13 +219,16 @@ describe("api service", () => {
 
   // ─── 402 handler ─────────────────────────────────────────────────────────────
 
-  it("chama paymentRequiredHandler com a mensagem quando status e 402", async () => {
+  it("chama paymentRequiredHandler com contexto trial_expired quando code=TRIAL_EXPIRED", async () => {
     const onPaymentRequired = vi.fn();
     setPaymentRequiredHandler(onPaymentRequired);
 
     await expect(
       responseErrorInterceptor({
-        response: { status: 402, data: { message: "Periodo de teste encerrado." } },
+        response: {
+          status: 402,
+          data: { message: "Periodo de teste encerrado.", code: "TRIAL_EXPIRED" },
+        },
       }),
     ).rejects.toBeTruthy();
 

--- a/apps/web/src/utils/apiError.ts
+++ b/apps/web/src/utils/apiError.ts
@@ -2,6 +2,7 @@ interface ApiLikeError {
   response?: {
     data?: {
       message?: string;
+      code?: string;
     };
     status?: number;
   };
@@ -20,4 +21,14 @@ export const getApiErrorMessage = (error: unknown, fallbackMessage: string): str
 export const getApiErrorStatus = (error: unknown): number | undefined => {
   if (!error || typeof error !== "object") return undefined;
   return (error as ApiLikeError).response?.status;
+};
+
+export const getApiErrorCode = (error: unknown): string | undefined => {
+  if (!error || typeof error !== "object") return undefined;
+
+  const code = (error as ApiLikeError).response?.data?.code;
+  if (typeof code !== "string") return undefined;
+
+  const normalized = code.trim();
+  return normalized ? normalized : undefined;
 };


### PR DESCRIPTION
Sprint A P0 item 3: exibe feedback visual explicito quando o OCR de PDF estiver indisponivel no dry-run de importacao. Inclui cobertura de teste no ImportCsvModal.