### PR TITLE
feat(tax): PR L slice 1 - filtros de revisão ponta a ponta

### DIFF
--- a/apps/api/src/domain/tax/tax.constants.js
+++ b/apps/api/src/domain/tax/tax.constants.js
@@ -37,6 +37,8 @@ export const TAX_FACT_REVIEW_STATUSES = Object.freeze([
   "rejected",
 ]);
 
+export const TAX_FACT_SOURCE_FILTERS = Object.freeze(["with_document", "without_document"]);
+
 export const TAX_RULE_FAMILIES = Object.freeze([
   "obligation",
   "annual_table",

--- a/apps/api/src/domain/tax/tax.validation.js
+++ b/apps/api/src/domain/tax/tax.validation.js
@@ -1,6 +1,7 @@
 import {
   TAX_DEFAULT_PAGE_SIZE,
   TAX_DOCUMENT_PROCESSING_STATUSES,
+  TAX_FACT_SOURCE_FILTERS,
   TAX_FACT_REVIEW_STATUSES,
   TAX_FACT_TYPES,
   TAX_MAX_PAGE_SIZE,
@@ -78,6 +79,20 @@ export const normalizeOptionalTaxFactReviewStatus = (value) => {
 
   if (!TAX_FACT_REVIEW_STATUSES.includes(normalizedValue)) {
     throw createTaxError(400, "reviewStatus invalido.");
+  }
+
+  return normalizedValue;
+};
+
+export const normalizeOptionalTaxFactSourceFilter = (value) => {
+  if (typeof value === "undefined" || value === null || value === "") {
+    return undefined;
+  }
+
+  const normalizedValue = String(value).trim();
+
+  if (!TAX_FACT_SOURCE_FILTERS.includes(normalizedValue)) {
+    throw createTaxError(400, "sourceFilter invalido.");
   }
 
   return normalizedValue;

--- a/apps/api/src/services/tax-facts.service.js
+++ b/apps/api/src/services/tax-facts.service.js
@@ -2,6 +2,7 @@ import { dbQuery, withDbTransaction } from "../db/index.js";
 import { generateTaxFactDedupeKey } from "../domain/tax/tax-fact-normalizer.js";
 import {
   createTaxError,
+  normalizeOptionalTaxFactSourceFilter,
   normalizeOptionalTaxFactReviewStatus,
   normalizePagination,
   normalizeTaxFactType,
@@ -169,6 +170,11 @@ export const listTaxFactsByUser = async (userId, query = {}) => {
   const normalizedUserId = normalizeTaxUserId(userId);
   const taxYear = normalizeTaxYear(query.taxYear);
   const reviewStatus = normalizeOptionalTaxFactReviewStatus(query.reviewStatus);
+  const factType =
+    typeof query.factType === "undefined" || query.factType === null || query.factType === ""
+      ? undefined
+      : normalizeTaxFactType(query.factType, "factType");
+  const sourceFilter = normalizeOptionalTaxFactSourceFilter(query.sourceFilter);
   const pagination = normalizePagination(query);
   const whereClauses = ["tf.user_id = $1", "tf.tax_year = $2"];
   const params = [normalizedUserId, taxYear];
@@ -176,6 +182,17 @@ export const listTaxFactsByUser = async (userId, query = {}) => {
   if (reviewStatus) {
     params.push(reviewStatus);
     whereClauses.push(`tf.review_status = $${params.length}`);
+  }
+
+  if (factType) {
+    params.push(factType);
+    whereClauses.push(`tf.fact_type = $${params.length}`);
+  }
+
+  if (sourceFilter === "with_document") {
+    whereClauses.push("tf.source_document_id IS NOT NULL");
+  } else if (sourceFilter === "without_document") {
+    whereClauses.push("tf.source_document_id IS NULL");
   }
 
   const whereSql = whereClauses.join(" AND ");

--- a/apps/api/src/tax.test.js
+++ b/apps/api/src/tax.test.js
@@ -1585,6 +1585,105 @@ describe("Tax API foundation", () => {
     ]);
   });
 
+  it("GET /tax/facts aplica filtros por status, tipo e origem", async () => {
+    const token = await registerAndLogin("tax-facts-filters@test.dev");
+    const uploadResponse = await request(app)
+      .post("/tax/documents")
+      .set("Authorization", `Bearer ${token}`)
+      .field("taxYear", "2026")
+      .field("sourceLabel", "ACME")
+      .attach(
+        "file",
+        Buffer.from(
+          [
+            "Comprovante de Rendimentos Pagos e de Imposto sobre a Renda Retido na Fonte",
+            "Fonte pagadora ACME LTDA",
+            "CNPJ 12.345.678/0001-90",
+            "Rendimentos tributaveis R$ 54.321,00",
+            "Imposto sobre a renda retido na fonte R$ 4.321,09",
+          ].join("\n"),
+          "utf8",
+        ),
+        {
+          filename: "facts-filters.csv",
+          contentType: "text/csv",
+        },
+      );
+
+    expect(uploadResponse.status).toBe(201);
+
+    const reprocessResponse = await request(app)
+      .post(`/tax/documents/${uploadResponse.body.document.id}/reprocess`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(reprocessResponse.status).toBe(200);
+
+    const taxableFactResult = await dbQuery(
+      `SELECT id
+       FROM tax_facts
+       WHERE source_document_id = $1
+         AND fact_type = 'taxable_income'
+       LIMIT 1`,
+      [uploadResponse.body.document.id],
+    );
+    const taxableFactId = Number(taxableFactResult.rows[0].id);
+
+    const approveResponse = await request(app)
+      .patch(`/tax/facts/${taxableFactId}/review`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        action: "approve",
+        note: "Aprovado para validar filtros.",
+      });
+
+    expect(approveResponse.status).toBe(200);
+
+    const createManualResponse = await request(app)
+      .post("/tax/facts")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        taxYear: 2026,
+        factType: "other",
+        subcategory: "Fato manual sem documento",
+        payerName: "Manual",
+        referencePeriod: "2025-12",
+        amount: 100,
+      });
+
+    expect(createManualResponse.status).toBe(201);
+
+    const approvedWithDocumentResponse = await request(app)
+      .get("/tax/facts?taxYear=2026&reviewStatus=approved&factType=taxable_income&sourceFilter=with_document")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(approvedWithDocumentResponse.status).toBe(200);
+    expect(approvedWithDocumentResponse.body.total).toBe(1);
+    expect(approvedWithDocumentResponse.body.items).toEqual([
+      expect.objectContaining({
+        factType: "taxable_income",
+        reviewStatus: "approved",
+        sourceDocument: expect.objectContaining({
+          id: uploadResponse.body.document.id,
+        }),
+      }),
+    ]);
+
+    const pendingWithoutDocumentResponse = await request(app)
+      .get("/tax/facts?taxYear=2026&reviewStatus=pending&sourceFilter=without_document")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(pendingWithoutDocumentResponse.status).toBe(200);
+    expect(pendingWithoutDocumentResponse.body.total).toBe(1);
+    expect(pendingWithoutDocumentResponse.body.items).toEqual([
+      expect.objectContaining({
+        factType: "other",
+        reviewStatus: "pending",
+        sourceDocumentId: null,
+        sourceDocument: null,
+      }),
+    ]);
+  });
+
   it("POST /tax/facts cria fato manual pendente para a fila de revisao", async () => {
     const token = await registerAndLogin("tax-facts-manual@test.dev");
     const userResult = await dbQuery(

--- a/apps/web/src/pages/TaxPage.test.tsx
+++ b/apps/web/src/pages/TaxPage.test.tsx
@@ -435,6 +435,34 @@ describe("TaxPage", () => {
     });
   });
 
+  it("aplica filtros da fila e recarrega listagem com os parametros selecionados", async () => {
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Central do Leão" })).toBeInTheDocument();
+    });
+
+    await user.selectOptions(screen.getByLabelText("Status de revisão"), "approved");
+    await user.selectOptions(screen.getByLabelText("Tipo de fato"), "withheld_tax");
+    await user.selectOptions(screen.getByLabelText("Fonte do fato"), "with_document");
+
+    await waitFor(() => {
+      const calledWithFilters = vi
+        .mocked(taxService.listFacts)
+        .mock.calls.some(
+          ([params]) =>
+            params.taxYear === 2026 &&
+            params.reviewStatus === "approved" &&
+            params.factType === "withheld_tax" &&
+            params.sourceFilter === "with_document",
+        );
+
+      expect(calledWithFilters).toBe(true);
+    });
+  });
+
   it("consome preview do bulk-review sem recarregar summary snapshotado", async () => {
     const user = userEvent.setup();
 

--- a/apps/web/src/pages/TaxPage.tsx
+++ b/apps/web/src/pages/TaxPage.tsx
@@ -10,6 +10,8 @@ import {
   type TaxDocumentsListResult,
   type TaxFact,
   type TaxFactsListResult,
+  type TaxFactReviewStatus,
+  type TaxFactSourceFilter,
   type TaxObligation,
   type TaxSummary,
 } from "../services/tax.service";
@@ -100,6 +102,48 @@ const FACT_TYPE_LABELS: Record<string, string> = {
   education_deduction: "Dedução de instrução",
   other: "Outro fato fiscal",
 };
+
+const REVIEW_STATUS_LABELS: Record<TaxFactReviewStatus, string> = {
+  pending: "Pendente",
+  approved: "Aprovado",
+  corrected: "Corrigido",
+  rejected: "Rejeitado",
+};
+
+const REVIEW_STATUS_CLASSNAMES: Record<TaxFactReviewStatus, string> = {
+  pending: "border-amber-300 bg-amber-100 text-amber-800",
+  approved: "border-green-300 bg-green-100 text-green-800",
+  corrected: "border-blue-300 bg-blue-100 text-blue-800",
+  rejected: "border-red-300 bg-red-100 text-red-800",
+};
+
+const REVIEW_FILTER_OPTIONS: Array<{
+  value: TaxFactReviewStatus | "all";
+  label: string;
+}> = [
+  { value: "pending", label: "Pendentes" },
+  { value: "approved", label: "Aprovados" },
+  { value: "corrected", label: "Corrigidos" },
+  { value: "rejected", label: "Rejeitados" },
+  { value: "all", label: "Todos" },
+];
+
+const SOURCE_FILTER_OPTIONS: Array<{
+  value: TaxFactSourceFilter | "all";
+  label: string;
+}> = [
+  { value: "all", label: "Todas as fontes" },
+  { value: "with_document", label: "Com documento" },
+  { value: "without_document", label: "Sem documento" },
+];
+
+const FACT_TYPE_FILTER_OPTIONS: Array<{
+  value: string;
+  label: string;
+}> = [
+  { value: "all", label: "Todos os tipos" },
+  ...Object.entries(FACT_TYPE_LABELS).map(([value, label]) => ({ value, label })),
+];
 
 const METHOD_LABELS: Record<string, string> = {
   legal_deductions: "Deduções legais",
@@ -362,6 +406,11 @@ const TaxPage = ({ onBack = undefined, onOpenProfileSettings = undefined }: TaxP
     pageSize: DEFAULT_FACTS_PAGE_SIZE,
     total: 0,
   });
+  const [reviewStatusFilter, setReviewStatusFilter] = useState<TaxFactReviewStatus | "all">(
+    "pending",
+  );
+  const [factTypeFilter, setFactTypeFilter] = useState<string>("all");
+  const [sourceFilter, setSourceFilter] = useState<TaxFactSourceFilter | "all">("all");
   const [taxpayerCpf, setTaxpayerCpf] = useState<string | null>(null);
   const [isLoadingPage, setIsLoadingPage] = useState(true);
   const [isRebuildingSummary, setIsRebuildingSummary] = useState(false);
@@ -424,7 +473,9 @@ const TaxPage = ({ onBack = undefined, onOpenProfileSettings = undefined }: TaxP
       }),
       taxService.listFacts({
         taxYear,
-        reviewStatus: "pending",
+        reviewStatus: reviewStatusFilter === "all" ? undefined : reviewStatusFilter,
+        factType: factTypeFilter === "all" ? undefined : factTypeFilter,
+        sourceFilter: sourceFilter === "all" ? undefined : sourceFilter,
         pageSize: DEFAULT_FACTS_PAGE_SIZE,
       }),
       profileService.getMe(),
@@ -474,7 +525,7 @@ const TaxPage = ({ onBack = undefined, onOpenProfileSettings = undefined }: TaxP
     setPageError(nextErrors[0] || "");
     setIsLoadingPage(false);
     return freshFacts;
-  }, [taxYear]);
+  }, [factTypeFilter, reviewStatusFilter, sourceFilter, taxYear]);
 
   useEffect(() => {
     void loadPageData();
@@ -816,11 +867,13 @@ const TaxPage = ({ onBack = undefined, onOpenProfileSettings = undefined }: TaxP
   };
 
   const handleBulkApprove = async () => {
-    if (factsPage.items.length === 0) {
+    const factIds = factsPage.items
+      .filter((fact) => fact.reviewStatus === "pending")
+      .map((fact) => fact.id);
+
+    if (factIds.length === 0) {
       return;
     }
-
-    const factIds = factsPage.items.map((fact) => fact.id);
 
     setIsBulkApproving(true);
     setPageError("");
@@ -976,6 +1029,7 @@ const TaxPage = ({ onBack = undefined, onOpenProfileSettings = undefined }: TaxP
   const pendingDebtBalanceAmount = factsPage.items
     .filter((fact) => fact.factType === "debt_balance")
     .reduce((sum, fact) => sum + fact.amount, 0);
+  const pendingFactsInView = factsPage.items.filter((fact) => fact.reviewStatus === "pending").length;
   const reviewStatusLabel = showLoadingPlaceholders
     ? "Revisão fiscal em carregamento"
     : summary.sourceCounts.factsPending > 0
@@ -1625,11 +1679,66 @@ const TaxPage = ({ onBack = undefined, onOpenProfileSettings = undefined }: TaxP
             <button
               type="button"
               onClick={handleBulkApprove}
-              disabled={isBulkApproving || factsPage.items.length === 0}
+              disabled={isBulkApproving || pendingFactsInView === 0}
               className="rounded border border-brand-1 px-3 py-2 text-sm font-semibold text-brand-1 hover:bg-brand-1/10 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {isBulkApproving ? "Aprovando..." : "Aprovar todos pendentes"}
             </button>
+          </div>
+
+          <div className="mt-4 grid gap-3 md:grid-cols-3">
+            <label className="block">
+              <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-cf-text-secondary">
+                Status de revisão
+              </span>
+              <select
+                value={reviewStatusFilter}
+                onChange={(event) =>
+                  setReviewStatusFilter(event.target.value as TaxFactReviewStatus | "all")
+                }
+                className="w-full rounded border border-cf-border bg-cf-bg-subtle px-3 py-2 text-sm text-cf-text-primary outline-none focus:border-brand-1"
+              >
+                {REVIEW_FILTER_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="block">
+              <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-cf-text-secondary">
+                Tipo de fato
+              </span>
+              <select
+                value={factTypeFilter}
+                onChange={(event) => setFactTypeFilter(event.target.value)}
+                className="w-full rounded border border-cf-border bg-cf-bg-subtle px-3 py-2 text-sm text-cf-text-primary outline-none focus:border-brand-1"
+              >
+                {FACT_TYPE_FILTER_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="block">
+              <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-cf-text-secondary">
+                Fonte do fato
+              </span>
+              <select
+                value={sourceFilter}
+                onChange={(event) => setSourceFilter(event.target.value as TaxFactSourceFilter | "all")}
+                className="w-full rounded border border-cf-border bg-cf-bg-subtle px-3 py-2 text-sm text-cf-text-primary outline-none focus:border-brand-1"
+              >
+                {SOURCE_FILTER_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
           </div>
 
           <div className="mt-4 grid gap-3 sm:grid-cols-3">
@@ -1653,11 +1762,11 @@ const TaxPage = ({ onBack = undefined, onOpenProfileSettings = undefined }: TaxP
           <div className="mt-4 space-y-3">
             {isLoadingPage ? (
               <p className="py-6 text-center text-sm text-cf-text-secondary">
-                Carregando fatos pendentes...
+                Carregando fatos da revisão...
               </p>
             ) : factsPage.items.length === 0 ? (
               <p className="py-6 text-center text-sm text-cf-text-secondary">
-                Nenhum fato pendente neste exercício.
+                Nenhum fato encontrado com os filtros selecionados.
               </p>
             ) : (
               factsPage.items.map((fact) => (
@@ -1665,10 +1774,16 @@ const TaxPage = ({ onBack = undefined, onOpenProfileSettings = undefined }: TaxP
                   const ownerDocument = resolveFactOwnerDocument(fact);
                   const hasTaxpayerCpf = Boolean(taxpayerCpf);
                   const hasOwnerDocument = Boolean(ownerDocument);
+                  const isPendingFact = fact.reviewStatus === "pending";
                   const ownershipMismatch =
                     hasTaxpayerCpf &&
                     hasOwnerDocument &&
                     normalizeDocumentNumber(taxpayerCpf) !== ownerDocument;
+                  const reviewStatusLabel =
+                    REVIEW_STATUS_LABELS[fact.reviewStatus] || humanizeTaxIdentifier(fact.reviewStatus);
+                  const reviewStatusClassName =
+                    REVIEW_STATUS_CLASSNAMES[fact.reviewStatus] ||
+                    "border-cf-border bg-cf-bg-subtle text-cf-text-secondary";
 
                   return (
                     <div key={fact.id} className="rounded border border-cf-border bg-cf-bg-subtle p-4">
@@ -1679,6 +1794,9 @@ const TaxPage = ({ onBack = undefined, onOpenProfileSettings = undefined }: TaxP
                               {FACT_TYPE_LABELS[fact.factType] || fact.factType}
                             </span>
                             <span className="text-xs text-cf-text-secondary">#{fact.id}</span>
+                            <span className={`rounded-full border px-2 py-0.5 text-xs font-semibold ${reviewStatusClassName}`}>
+                              {reviewStatusLabel}
+                            </span>
                             {fact.conflictCode ? (
                               <span className="rounded-full border border-amber-300 bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-800">
                                 {formatFactConflictLabel(fact.conflictCode)}
@@ -1724,50 +1842,56 @@ const TaxPage = ({ onBack = undefined, onOpenProfileSettings = undefined }: TaxP
                           ) : null}
                         </div>
 
-                        <div className="flex flex-wrap gap-2">
-                          <button
-                            type="button"
-                            onClick={() =>
-                              void reviewFact(
-                                fact.id,
-                                {
-                                  action: "approve",
-                                  note: "Aprovado pela Central do Leão.",
-                                },
-                                "Fato fiscal aprovado.",
-                              )
-                            }
-                            disabled={processingFactId === fact.id}
-                            className="rounded border border-green-300 px-3 py-2 text-sm font-semibold text-green-700 hover:bg-green-50 disabled:cursor-not-allowed disabled:opacity-60"
-                          >
-                            Aprovar
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => handleOpenCorrection(fact)}
-                            disabled={processingFactId === fact.id}
-                            className="rounded border border-amber-300 px-3 py-2 text-sm font-semibold text-amber-800 hover:bg-amber-50 disabled:cursor-not-allowed disabled:opacity-60"
-                          >
-                            Corrigir
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() =>
-                              void reviewFact(
-                                fact.id,
-                                {
-                                  action: "reject",
-                                  note: "Rejeitado pela Central do Leão.",
-                                },
-                                "Fato fiscal rejeitado.",
-                              )
-                            }
-                            disabled={processingFactId === fact.id}
-                            className="rounded border border-red-300 px-3 py-2 text-sm font-semibold text-red-700 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
-                          >
-                            Rejeitar
-                          </button>
-                        </div>
+                        {isPendingFact ? (
+                          <div className="flex flex-wrap gap-2">
+                            <button
+                              type="button"
+                              onClick={() =>
+                                void reviewFact(
+                                  fact.id,
+                                  {
+                                    action: "approve",
+                                    note: "Aprovado pela Central do Leão.",
+                                  },
+                                  "Fato fiscal aprovado.",
+                                )
+                              }
+                              disabled={processingFactId === fact.id}
+                              className="rounded border border-green-300 px-3 py-2 text-sm font-semibold text-green-700 hover:bg-green-50 disabled:cursor-not-allowed disabled:opacity-60"
+                            >
+                              Aprovar
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => handleOpenCorrection(fact)}
+                              disabled={processingFactId === fact.id}
+                              className="rounded border border-amber-300 px-3 py-2 text-sm font-semibold text-amber-800 hover:bg-amber-50 disabled:cursor-not-allowed disabled:opacity-60"
+                            >
+                              Corrigir
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() =>
+                                void reviewFact(
+                                  fact.id,
+                                  {
+                                    action: "reject",
+                                    note: "Rejeitado pela Central do Leão.",
+                                  },
+                                  "Fato fiscal rejeitado.",
+                                )
+                              }
+                              disabled={processingFactId === fact.id}
+                              className="rounded border border-red-300 px-3 py-2 text-sm font-semibold text-red-700 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+                            >
+                              Rejeitar
+                            </button>
+                          </div>
+                        ) : (
+                          <p className="text-xs font-semibold uppercase tracking-wide text-cf-text-secondary">
+                            Fato já revisado
+                          </p>
+                        )}
                       </div>
                     </div>
                   );

--- a/apps/web/src/services/tax.service.ts
+++ b/apps/web/src/services/tax.service.ts
@@ -3,6 +3,7 @@ import { api } from "./api";
 export type TaxFactReviewStatus = "pending" | "approved" | "corrected" | "rejected";
 export type TaxFactReviewAction = "approve" | "correct" | "reject";
 export type TaxExportFormat = "json" | "csv";
+export type TaxFactSourceFilter = "with_document" | "without_document";
 export type TaxDocumentProcessingStatus =
   | "uploaded"
   | "classified"
@@ -821,6 +822,8 @@ export const taxService = {
   listFacts: async (params: {
     taxYear: number;
     reviewStatus?: TaxFactReviewStatus;
+    factType?: string;
+    sourceFilter?: TaxFactSourceFilter;
     page?: number;
     pageSize?: number;
   }): Promise<TaxFactsListResult> => {
@@ -828,6 +831,8 @@ export const taxService = {
       params: {
         taxYear: params.taxYear,
         reviewStatus: params.reviewStatus,
+        factType: params.factType,
+        sourceFilter: params.sourceFilter,
         page: params.page,
         pageSize: params.pageSize,
       },

--- a/docs/roadmaps/sprint-b-irpf-kickoff.md
+++ b/docs/roadmaps/sprint-b-irpf-kickoff.md
@@ -49,6 +49,10 @@ Escopo:
 - filtros por status/tipo/fonte
 - status visível por fato na fila
 
+Plano cirúrgico detalhado:
+
+- `docs/roadmaps/sprint-b-pr-l-plano-cirurgico.md`
+
 Critério de aceite:
 
 - revisar lotes sem operação manual linha a linha

--- a/docs/roadmaps/sprint-b-pr-l-plano-cirurgico.md
+++ b/docs/roadmaps/sprint-b-pr-l-plano-cirurgico.md
@@ -1,0 +1,124 @@
+# Sprint B - PR L - Plano cirurgico (fluxo principal de revisao de fatos)
+
+Data: 2026-04-02  
+Status: pronto para execucao
+
+## Objetivo
+
+Entregar o fluxo principal da fila de revisao de fatos da Central do Leao com foco em produtividade operacional e previsibilidade:
+
+- aprovar em lote sem acao linha a linha;
+- filtrar rapidamente o que precisa ser tratado;
+- deixar o status de cada fato explicito na tela.
+
+## Escopo (dentro do PR L)
+
+1. Filtros na fila de revisao
+- filtro por status de revisao do fato (pending, approved, corrected, rejected);
+- filtro por tipo de fato (factType);
+- filtro por origem/fonte (com ou sem documento, e/ou sourceLabel quando disponivel);
+- atualizacao da listagem via query no backend, sem carregar tudo em memoria para filtrar no frontend.
+
+2. Bulk approve operacional
+- manter acao de aprovacao em lote no fluxo principal;
+- aplicar a acao sobre o conjunto visivel/ativo da fila (compatibilizado com filtros);
+- feedback claro de sucesso/erro e contagem de itens afetados.
+
+3. Status por fato visivel
+- badge de status por fato na linha/cartao da fila;
+- sem ambiguidade entre pendente, aprovado, corrigido e rejeitado;
+- manter alertas ja existentes (conflito, duplicidade, CPF divergente) sem regressao.
+
+## Fora de escopo (nao entra no PR L)
+
+- mudanca de regra de deduplicacao SHA256 (gate ja decidido: por ano-calendario);
+- novas regras de obrigatoriedade fiscal (PR M);
+- fluxo guiado de exportacao/snapshot e UX de export (PR N);
+- refactor amplo de layout da pagina fora da fila de revisao.
+
+## Arquivos-alvo
+
+Frontend:
+- apps/web/src/pages/TaxPage.tsx
+- apps/web/src/pages/TaxPage.test.tsx
+- apps/web/src/services/tax.service.ts
+
+Backend:
+- apps/api/src/routes/tax.routes.js
+- apps/api/src/services/tax-facts.service.js
+- apps/api/src/services/tax-reviews.service.js (somente se ajuste de bulk exigir)
+- apps/api/src/tax.test.js
+
+Documentacao de acompanhamento:
+- docs/roadmaps/sprint-b-irpf-kickoff.md (referencia de sequencia L -> M -> N)
+
+## Criterios de aceite
+
+1. Filtros funcionam de forma deterministica
+- dado um conjunto de fatos com status/tipos diferentes, cada filtro retorna somente o subconjunto esperado;
+- combinacao de filtros nao mistura estados nem ignora parametros;
+- limpar filtros restaura a visao base da fila.
+
+2. Bulk approve respeita o contexto de revisao
+- ao acionar bulk approve, somente fatos elegiveis sao aprovados;
+- UI remove/atualiza itens afetados sem estado fantasma;
+- usuario recebe mensagem com resultado da operacao.
+
+3. Status por fato fica evidente
+- cada item da fila exibe status de revisao sem depender de inferencia;
+- rotulos de conflito continuam visiveis em paralelo;
+- nao ha regressao na leitura de alertas fiscais.
+
+4. Sem regressao de contratos
+- chamadas existentes de revisao individual continuam funcionando;
+- contrato de listagem de fatos permanece retrocompativel para campos existentes.
+
+## Validacao
+
+Frontend (foco):
+- npm -w apps/web run test:run -- src/pages/TaxPage.test.tsx
+
+Backend (foco):
+- npm -w apps/api run test -- src/tax.test.js
+
+Validacao de seguranca do PR:
+- npm run test
+
+## Estrategia de implementacao (pequena e segura)
+
+1. Expandir contrato de listagem de fatos
+- adicionar parametros opcionais de filtro no service web e no endpoint de listagem.
+
+2. Aplicar filtros no backend
+- traduzir query params para where clauses seguras no listTaxFactsByUser;
+- manter paginacao e resposta padrao.
+
+3. Conectar filtros na TaxPage
+- estados de filtro locais + disparo de recarga de fila;
+- preservar comportamento atual de sucesso/erro e carregamento.
+
+4. Ajustar bulk approve para contexto filtrado
+- operar sobre conjunto visivel/elegivel;
+- atualizar contadores e feedback sem reload desnecessario quando possivel.
+
+5. Cobrir com testes
+- casos de filtro + bulk + status por fato no web;
+- caso de listagem com filtros no backend.
+
+## Riscos e mitigacao
+
+- Risco: filtro por fonte gerar consultas caras.
+- Mitigacao: comecar com filtros index-friendly (status, tipo, presence de documento) e validar performance.
+
+- Risco: bulk approve em itens nao pendentes.
+- Mitigacao: garantir elegibilidade no backend e mensagens claras no retorno.
+
+- Risco: regressao em contadores da tela.
+- Mitigacao: atualizar via preview quando disponivel e validar em teste de pagina.
+
+## Definition of Done do PR L
+
+- escopo acima entregue sem extrapolacao;
+- testes-alvo verdes + suite relevante verde;
+- diff pequeno, causa raiz explicita e sem alteracoes laterais;
+- pronto para revisao com diff completo antes de qualquer merge.


### PR DESCRIPTION
## Sprint B - PR L - Slice 1 (filtros ponta a ponta)

### Objetivo
Implementar o primeiro slice do PR L no fluxo principal de revisao de fatos da Central do Leao, com filtros operacionais e comportamento consistente de revisao.

### Entregas
- Backend: filtros opcionais em `GET /tax/facts` por:
  - `reviewStatus`
  - `factType`
  - `sourceFilter` (`with_document` | `without_document`)
- Validacao explicita de `sourceFilter` com erro 400 para valor invalido.
- Service web: extensao de assinatura do `listFacts` para repassar `factType` e `sourceFilter`.
- TaxPage:
  - controles de filtro por status, tipo e origem na fila;
  - status por fato visivel (pendente, aprovado, corrigido, rejeitado);
  - bulk approve atuando somente em pendentes visiveis;
  - itens ja revisados sem acoes indevidas;
  - mensagem de vazio contextual aos filtros.
- Documentacao:
  - referencia ao plano cirurgico no kickoff da Sprint B;
  - plano cirurgico do PR L versionado.

### Arquivos principais
- `apps/api/src/domain/tax/tax.constants.js`
- `apps/api/src/domain/tax/tax.validation.js`
- `apps/api/src/services/tax-facts.service.js`
- `apps/api/src/tax.test.js`
- `apps/web/src/services/tax.service.ts`
- `apps/web/src/pages/TaxPage.tsx`
- `apps/web/src/pages/TaxPage.test.tsx`
- `docs/roadmaps/sprint-b-irpf-kickoff.md`
- `docs/roadmaps/sprint-b-pr-l-plano-cirurgico.md`

### Validacao executada
- `npm -w apps/api run test -- src/tax.test.js -t "aplica filtros por status, tipo e origem"`
- `npm -w apps/web run test:run -- src/pages/TaxPage.test.tsx -t "aplica filtros da fila"`
- `npm -w apps/web run test:run -- src/pages/TaxPage.test.tsx -t "aprovar todos pendentes chama bulkApproveFacts"`
- `npm -w apps/api run test -- src/tax.test.js -t "retorna fatos pendentes com documento de origem"`

Todos os comandos acima passaram.

### Guardrails
- Diff pequeno e escopo unico (slice 1 do PR L).
- Sem merge automatico; merge somente apos revisao explicita e checks verdes.
