### PR TITLE
Sprint B · PR M · Slice 1 — Explicabilidade da obrigatoriedade (CLT/INSS)

### DIFF
--- a/apps/api/src/domain/tax/tax-obligation.calculator.js
+++ b/apps/api/src/domain/tax/tax-obligation.calculator.js
@@ -9,13 +9,68 @@ const normalizeMoney = (value) => {
 };
 
 const normalizeFactSubcategory = (value) => String(value || "").trim().toLowerCase();
+const normalizeFactCategory = (value) => String(value || "").trim().toLowerCase();
+
+const formatMoneyForMessage = (value) => normalizeMoney(value).toFixed(2);
 
 const isTriggeredOtherFact = (fact, expectedSubcategory) =>
   fact.fact_type === "other" && normalizeFactSubcategory(fact.subcategory) === expectedSubcategory;
 
+const isInssTaxableIncomeFact = (fact) => {
+  const normalizedCategory = normalizeFactCategory(fact.category);
+  const normalizedSubcategory = normalizeFactSubcategory(fact.subcategory);
+
+  return normalizedCategory === "income_report_inss" || normalizedSubcategory.startsWith("inss_");
+};
+
+const isCltTaxableIncomeFact = (fact) => {
+  const normalizedCategory = normalizeFactCategory(fact.category);
+  const normalizedSubcategory = normalizeFactSubcategory(fact.subcategory);
+
+  return (
+    normalizedCategory === "clt_payslip" ||
+    normalizedCategory === "income_report_employer" ||
+    normalizedSubcategory.startsWith("clt_") ||
+    normalizedSubcategory === "annual_taxable_income" ||
+    normalizedSubcategory.startsWith("app_income_statement_")
+  );
+};
+
+const buildTaxableIncomeLimitMessage = ({
+  annualTaxableIncome,
+  taxableIncomeThreshold,
+  annualTaxableIncomeClt,
+  annualTaxableIncomeInss,
+  annualTaxableIncomeOther,
+}) => {
+  const composition = [];
+
+  if (annualTaxableIncomeClt > 0) {
+    composition.push(`CLT ${formatMoneyForMessage(annualTaxableIncomeClt)}`);
+  }
+
+  if (annualTaxableIncomeInss > 0) {
+    composition.push(`INSS ${formatMoneyForMessage(annualTaxableIncomeInss)}`);
+  }
+
+  if (annualTaxableIncomeOther > 0) {
+    composition.push(`OUTROS ${formatMoneyForMessage(annualTaxableIncomeOther)}`);
+  }
+
+  const compositionMessage =
+    composition.length > 0 ? ` Composicao: ${composition.join(", ")}.` : "";
+
+  return `Rendimentos tributaveis acima do limite do exercicio. Total: ${formatMoneyForMessage(
+    annualTaxableIncome,
+  )}; limite: ${formatMoneyForMessage(taxableIncomeThreshold)}.${compositionMessage}`;
+};
+
 export const summarizeReviewedTaxFacts = (facts = []) => {
   const totals = {
     annualTaxableIncome: 0,
+    annualTaxableIncomeClt: 0,
+    annualTaxableIncomeInss: 0,
+    annualTaxableIncomeOther: 0,
     annualExemptIncome: 0,
     annualExclusiveIncome: 0,
     annualWithheldTax: 0,
@@ -44,6 +99,14 @@ export const summarizeReviewedTaxFacts = (facts = []) => {
     switch (fact.fact_type) {
       case "taxable_income":
         totals.annualTaxableIncome += amount;
+
+        if (isInssTaxableIncomeFact(fact)) {
+          totals.annualTaxableIncomeInss += amount;
+        } else if (isCltTaxableIncomeFact(fact)) {
+          totals.annualTaxableIncomeClt += amount;
+        } else {
+          totals.annualTaxableIncomeOther += amount;
+        }
         break;
       case "exempt_income":
         totals.annualExemptIncome += amount;
@@ -96,6 +159,9 @@ export const summarizeReviewedTaxFacts = (facts = []) => {
   }
 
   totals.annualTaxableIncome = normalizeMoney(totals.annualTaxableIncome);
+  totals.annualTaxableIncomeClt = normalizeMoney(totals.annualTaxableIncomeClt);
+  totals.annualTaxableIncomeInss = normalizeMoney(totals.annualTaxableIncomeInss);
+  totals.annualTaxableIncomeOther = normalizeMoney(totals.annualTaxableIncomeOther);
   totals.annualExemptIncome = normalizeMoney(totals.annualExemptIncome);
   totals.annualExclusiveIncome = normalizeMoney(totals.annualExclusiveIncome);
   totals.annualWithheldTax = normalizeMoney(totals.annualWithheldTax);
@@ -116,6 +182,9 @@ export const calculateTaxObligation = ({
   obligationRules = {},
 }) => {
   const annualTaxableIncome = normalizeMoney(totals.annualTaxableIncome);
+  const annualTaxableIncomeClt = normalizeMoney(totals.annualTaxableIncomeClt);
+  const annualTaxableIncomeInss = normalizeMoney(totals.annualTaxableIncomeInss);
+  const annualTaxableIncomeOther = normalizeMoney(totals.annualTaxableIncomeOther);
   const annualExemptIncome = normalizeMoney(totals.annualExemptIncome);
   const annualExclusiveIncome = normalizeMoney(totals.annualExclusiveIncome);
   const annualWithheldTax = normalizeMoney(totals.annualWithheldTax);
@@ -128,10 +197,18 @@ export const calculateTaxObligation = ({
   const totalStockOperations = normalizeMoney(totals.totalStockOperations);
   const reasons = [];
 
-  if (annualTaxableIncome > Number(obligationRules.taxableIncomeThreshold || 0)) {
+  const taxableIncomeThreshold = Number(obligationRules.taxableIncomeThreshold || 0);
+
+  if (annualTaxableIncome > taxableIncomeThreshold) {
     reasons.push({
       code: "TAXABLE_INCOME_LIMIT",
-      message: "Rendimentos tributaveis acima do limite do exercicio.",
+      message: buildTaxableIncomeLimitMessage({
+        annualTaxableIncome,
+        taxableIncomeThreshold,
+        annualTaxableIncomeClt,
+        annualTaxableIncomeInss,
+        annualTaxableIncomeOther,
+      }),
     });
   }
 
@@ -239,6 +316,9 @@ export const calculateTaxObligation = ({
     },
     totals: {
       annualTaxableIncome,
+      annualTaxableIncomeClt,
+      annualTaxableIncomeInss,
+      annualTaxableIncomeOther,
       annualExemptIncome,
       annualExclusiveIncome,
       annualWithheldTax,

--- a/apps/api/src/tax.test.js
+++ b/apps/api/src/tax.test.js
@@ -2249,20 +2249,81 @@ describe("Tax API foundation", () => {
 
     expect(afterApprovalResponse.status).toBe(200);
     expect(afterApprovalResponse.body.mustDeclare).toBe(true);
-    expect(afterApprovalResponse.body.reasons).toEqual([
-      {
-        code: "TAXABLE_INCOME_LIMIT",
-        message: "Rendimentos tributaveis acima do limite do exercicio.",
-      },
-    ]);
+    expect(afterApprovalResponse.body.reasons).toHaveLength(1);
+    expect(afterApprovalResponse.body.reasons[0]).toMatchObject({
+      code: "TAXABLE_INCOME_LIMIT",
+    });
+    expect(afterApprovalResponse.body.reasons[0].message).toContain(
+      "Rendimentos tributaveis acima do limite do exercicio.",
+    );
+    expect(afterApprovalResponse.body.reasons[0].message).toContain("Total: 54321.00");
+    expect(afterApprovalResponse.body.reasons[0].message).toContain("limite: 35584.00");
+    expect(afterApprovalResponse.body.reasons[0].message).toContain("CLT 54321.00");
     expect(afterApprovalResponse.body.totals).toMatchObject({
       annualTaxableIncome: 54321,
+      annualTaxableIncomeClt: 54321,
+      annualTaxableIncomeInss: 0,
+      annualTaxableIncomeOther: 0,
       annualExemptIncome: 0,
       annualExclusiveIncome: 5000,
       annualCombinedExemptAndExclusiveIncome: 5000,
       totalAssetBalance: 0,
     });
     expect(afterApprovalResponse.body.approvedFactsCount).toBe(3);
+  });
+
+  it("GET /tax/obligation/:taxYear explica composicao CLT e INSS no gatilho tributavel", async () => {
+    const email = "tax-obligation-composition@test.dev";
+    const token = await registerAndLogin(email);
+    const userResult = await dbQuery(
+      `SELECT id
+       FROM users
+       WHERE email = $1`,
+      [email],
+    );
+    const userId = Number(userResult.rows[0].id);
+
+    await dbQuery(
+      `INSERT INTO tax_facts (
+         user_id,
+         tax_year,
+         fact_type,
+         category,
+         subcategory,
+         reference_period,
+         currency,
+         amount,
+         metadata_json,
+         review_status
+       )
+       VALUES
+       ($1, 2026, 'taxable_income', 'income_report_employer', 'annual_taxable_income', '2025-annual', 'BRL', 22000, '{}'::jsonb, 'approved'),
+       ($1, 2026, 'taxable_income', 'income_report_inss', 'inss_annual_taxable_income', '2025-annual', 'BRL', 15000, '{}'::jsonb, 'approved'),
+       ($1, 2026, 'taxable_income', 'manual_entry', 'custom_taxable_income', '2025-annual', 'BRL', 3000, '{}'::jsonb, 'approved')`,
+      [userId],
+    );
+
+    const response = await request(app)
+      .get("/tax/obligation/2026")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.mustDeclare).toBe(true);
+    expect(response.body.reasons).toHaveLength(1);
+    expect(response.body.reasons[0]).toMatchObject({
+      code: "TAXABLE_INCOME_LIMIT",
+    });
+    expect(response.body.reasons[0].message).toContain("Total: 40000.00");
+    expect(response.body.reasons[0].message).toContain("limite: 35584.00");
+    expect(response.body.reasons[0].message).toContain("CLT 22000.00");
+    expect(response.body.reasons[0].message).toContain("INSS 15000.00");
+    expect(response.body.reasons[0].message).toContain("OUTROS 3000.00");
+    expect(response.body.totals).toMatchObject({
+      annualTaxableIncome: 40000,
+      annualTaxableIncomeClt: 22000,
+      annualTaxableIncomeInss: 15000,
+      annualTaxableIncomeOther: 3000,
+    });
   });
 
   it("exclui do calculo oficial fatos revisados com CPF divergente do titular cadastrado", async () => {

--- a/apps/web/src/services/tax.service.ts
+++ b/apps/web/src/services/tax.service.ts
@@ -137,6 +137,9 @@ export interface TaxObligation {
   };
   totals: {
     annualTaxableIncome: number;
+    annualTaxableIncomeClt?: number;
+    annualTaxableIncomeInss?: number;
+    annualTaxableIncomeOther?: number;
     annualExemptIncome: number;
     annualExclusiveIncome: number;
     annualWithheldTax: number;

--- a/docs/roadmaps/sprint-b-irpf-kickoff.md
+++ b/docs/roadmaps/sprint-b-irpf-kickoff.md
@@ -66,6 +66,10 @@ Escopo:
 - limites de isenção e sinalização de risco
 - alertas explicáveis com origem da regra
 
+Plano cirúrgico detalhado:
+
+- `docs/roadmaps/sprint-b-pr-m-plano-cirurgico.md`
+
 Critério de aceite:
 
 - alertas acionam de forma determinística

--- a/docs/roadmaps/sprint-b-pr-m-plano-cirurgico.md
+++ b/docs/roadmaps/sprint-b-pr-m-plano-cirurgico.md
@@ -1,0 +1,74 @@
+# Sprint B - PR M - Plano cirurgico (validacoes e alertas de obrigatoriedade)
+
+Data: 2026-04-02  
+Status: em execucao (slice 1)
+
+## Objetivo
+
+Aumentar a explicabilidade e previsibilidade da obrigatoriedade IRPF sem alterar contratos de negocio ja estabilizados no PR L:
+
+- regras de obrigatoriedade deterministicas;
+- mensagens de alerta rastreaveis ao gatilho fiscal;
+- evolucao incremental em slices pequenos e auditaveis.
+
+## Escopo geral do PR M
+
+1. Explicabilidade dos gatilhos
+- mensagens de obrigatoriedade com origem e contexto numerico;
+- foco inicial no gatilho de rendimentos tributaveis.
+
+2. Cobertura de validacao
+- testes de integracao para garantir disparo e mensagem esperada;
+- sem regressao de filtros/revisao da fila ja entregues no PR L.
+
+3. UX de alertas (fatias seguintes)
+- manter linguagem clara na TaxPage sem abrir escopo de layout amplo;
+- preservar operacao do bulk approve e filtros persistidos.
+
+## Slice 1 (este PR)
+
+Escopo:
+- detalhar o motivo `TAXABLE_INCOME_LIMIT` com total, limite e composicao de rendimentos tributaveis (CLT/INSS/OUTROS);
+- expor totais de composicao no payload de obrigatoriedade;
+- validar via teste de integracao de `/tax/obligation/:taxYear`.
+
+Fora de escopo:
+- novos gatilhos fiscais;
+- alteracao de thresholds oficiais;
+- mudanca de contrato de `sourceFilter`.
+
+## Arquivos-alvo
+
+Backend:
+- apps/api/src/domain/tax/tax-obligation.calculator.js
+- apps/api/src/tax.test.js
+
+Tipagem web (compatibilidade):
+- apps/web/src/services/tax.service.ts
+
+Roadmap:
+- docs/roadmaps/sprint-b-irpf-kickoff.md
+
+## Criterios de aceite (slice 1)
+
+1. Quando `TAXABLE_INCOME_LIMIT` disparar, a mensagem deve incluir:
+- total tributavel;
+- limite aplicavel;
+- composicao por origem (CLT, INSS, OUTROS quando houver).
+
+2. O endpoint `/tax/obligation/:taxYear` deve manter comportamento deterministico:
+- mesmos codigos de gatilho;
+- sem regressao em `mustDeclare`.
+
+3. Suite focada verde.
+
+## Validacao (slice 1)
+
+- npm -w apps/api run test -- src/tax.test.js -t "considera apenas fatos approved ou corrected"
+- npm -w apps/api run test -- src/tax.test.js -t "explica composicao CLT e INSS no gatilho tributavel"
+
+## Guardrails
+
+- Diff pequeno e escopo unico por slice.
+- Sem merge sem diff completo e aprovacao explicita.
+- Sem alterar contratos estaveis do PR L sem necessidade objetiva.


### PR DESCRIPTION
## Contexto
Implementa o slice 1 do PR M para tornar explicavel o gatilho de obrigatoriedade por rendimentos tributaveis.

## O que muda
- Backend: detalha a mensagem de `TAXABLE_INCOME_LIMIT` com total, limite e composicao (CLT/INSS/OUTROS).
- Backend: expoe no payload os totais `annualTaxableIncomeClt`, `annualTaxableIncomeInss` e `annualTaxableIncomeOther`.
- Testes API: ajusta caso existente e adiciona teste de integracao cobrindo composicao CLT+INSS+OUTROS.
- Web typing: adiciona campos opcionais na interface de obrigacao para compatibilidade de contrato.
- Docs: adiciona plano cirurgico do PR M e vincula no kickoff da Sprint B.

## Validacao
- npm -w apps/api run test -- src/tax.test.js -t "considera apenas fatos approved ou corrected"
- npm -w apps/api run test -- src/tax.test.js -t "explica composicao CLT e INSS no gatilho tributavel"

## Riscos e mitigacao
- Risco: mudanca textual no `reason.message` quebrar expectativa rigida de teste.
- Mitigacao: testes usam assert por conteudo essencial + codigo do gatilho.

## Fora de escopo
- Inclusao de novos gatilhos fiscais.
- Alteracao de thresholds oficiais.
- Mudancas de UX amplas na TaxPage.
