### PR TITLE
Sprint B · PR M · Slice 2 — Explicabilidade de isentos/exclusivos

### DIFF
--- a/apps/api/src/domain/tax/tax-obligation.calculator.js
+++ b/apps/api/src/domain/tax/tax-obligation.calculator.js
@@ -65,6 +65,20 @@ const buildTaxableIncomeLimitMessage = ({
   )}; limite: ${formatMoneyForMessage(taxableIncomeThreshold)}.${compositionMessage}`;
 };
 
+const buildExemptAndExclusiveIncomeLimitMessage = ({
+  annualCombinedExemptAndExclusiveIncome,
+  exemptAndExclusiveIncomeThreshold,
+  annualExemptIncome,
+  annualExclusiveIncome,
+}) =>
+  `Rendimentos isentos ou tributados exclusivamente na fonte acima do limite. Total: ${formatMoneyForMessage(
+    annualCombinedExemptAndExclusiveIncome,
+  )}; limite: ${formatMoneyForMessage(
+    exemptAndExclusiveIncomeThreshold,
+  )}. Composicao: ISENTOS ${formatMoneyForMessage(annualExemptIncome)}, EXCLUSIVOS ${formatMoneyForMessage(
+    annualExclusiveIncome,
+  )}.`;
+
 export const summarizeReviewedTaxFacts = (facts = []) => {
   const totals = {
     annualTaxableIncome: 0,
@@ -198,6 +212,9 @@ export const calculateTaxObligation = ({
   const reasons = [];
 
   const taxableIncomeThreshold = Number(obligationRules.taxableIncomeThreshold || 0);
+  const exemptAndExclusiveIncomeThreshold = Number(
+    obligationRules.exemptAndExclusiveIncomeThreshold || 0,
+  );
 
   if (annualTaxableIncome > taxableIncomeThreshold) {
     reasons.push({
@@ -212,13 +229,15 @@ export const calculateTaxObligation = ({
     });
   }
 
-  if (
-    annualCombinedExemptAndExclusiveIncome >
-    Number(obligationRules.exemptAndExclusiveIncomeThreshold || 0)
-  ) {
+  if (annualCombinedExemptAndExclusiveIncome > exemptAndExclusiveIncomeThreshold) {
     reasons.push({
       code: "EXEMPT_AND_EXCLUSIVE_INCOME_LIMIT",
-      message: "Rendimentos isentos ou tributados exclusivamente na fonte acima do limite.",
+      message: buildExemptAndExclusiveIncomeLimitMessage({
+        annualCombinedExemptAndExclusiveIncome,
+        exemptAndExclusiveIncomeThreshold,
+        annualExemptIncome,
+        annualExclusiveIncome,
+      }),
     });
   }
 

--- a/apps/api/src/tax.test.js
+++ b/apps/api/src/tax.test.js
@@ -2326,6 +2326,61 @@ describe("Tax API foundation", () => {
     });
   });
 
+  it("GET /tax/obligation/:taxYear explica total e composicao no gatilho de isentos/exclusivos", async () => {
+    const email = "tax-obligation-exempt-exclusive@test.dev";
+    const token = await registerAndLogin(email);
+    const userResult = await dbQuery(
+      `SELECT id
+       FROM users
+       WHERE email = $1`,
+      [email],
+    );
+    const userId = Number(userResult.rows[0].id);
+
+    await dbQuery(
+      `INSERT INTO tax_facts (
+         user_id,
+         tax_year,
+         fact_type,
+         category,
+         subcategory,
+         reference_period,
+         currency,
+         amount,
+         metadata_json,
+         review_status
+       )
+       VALUES
+       ($1, 2026, 'exempt_income', 'income_report_inss', 'inss_retirement_65_plus_exempt', '2025-annual', 'BRL', 150000, '{}'::jsonb, 'approved'),
+       ($1, 2026, 'exclusive_tax_income', 'income_report_employer', 'thirteenth_salary', '2025-annual', 'BRL', 70000, '{}'::jsonb, 'approved')`,
+      [userId],
+    );
+
+    const response = await request(app)
+      .get("/tax/obligation/2026")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.mustDeclare).toBe(true);
+    expect(response.body.reasons).toHaveLength(1);
+    expect(response.body.reasons[0]).toMatchObject({
+      code: "EXEMPT_AND_EXCLUSIVE_INCOME_LIMIT",
+    });
+    expect(response.body.reasons[0].message).toContain(
+      "Rendimentos isentos ou tributados exclusivamente na fonte acima do limite.",
+    );
+    expect(response.body.reasons[0].message).toContain("Total: 220000.00");
+    expect(response.body.reasons[0].message).toContain("limite: 200000.00");
+    expect(response.body.reasons[0].message).toContain("ISENTOS 150000.00");
+    expect(response.body.reasons[0].message).toContain("EXCLUSIVOS 70000.00");
+    expect(response.body.totals).toMatchObject({
+      annualTaxableIncome: 0,
+      annualExemptIncome: 150000,
+      annualExclusiveIncome: 70000,
+      annualCombinedExemptAndExclusiveIncome: 220000,
+    });
+  });
+
   it("exclui do calculo oficial fatos revisados com CPF divergente do titular cadastrado", async () => {
     const email = "tax-obligation-taxpayer-filter@test.dev";
     const token = await registerAndLogin(email);

--- a/docs/roadmaps/sprint-b-pr-m-plano-cirurgico.md
+++ b/docs/roadmaps/sprint-b-pr-m-plano-cirurgico.md
@@ -1,7 +1,7 @@
 # Sprint B - PR M - Plano cirurgico (validacoes e alertas de obrigatoriedade)
 
 Data: 2026-04-02  
-Status: em execucao (slice 1)
+Status: em execucao (slice 2)
 
 ## Objetivo
 
@@ -72,3 +72,32 @@ Roadmap:
 - Diff pequeno e escopo unico por slice.
 - Sem merge sem diff completo e aprovacao explicita.
 - Sem alterar contratos estaveis do PR L sem necessidade objetiva.
+
+## Slice 2 (este PR)
+
+Escopo:
+- detalhar o motivo `EXEMPT_AND_EXCLUSIVE_INCOME_LIMIT` com total, limite e composicao (isentos e exclusivos);
+- validar via teste de integracao de `/tax/obligation/:taxYear` para o gatilho de isentos/exclusivos.
+
+Fora de escopo:
+- alteracao de thresholds oficiais;
+- mudanca de semantica dos codigos de gatilho;
+- mudancas de UX na TaxPage.
+
+## Criterios de aceite (slice 2)
+
+1. Quando `EXEMPT_AND_EXCLUSIVE_INCOME_LIMIT` disparar, a mensagem deve incluir:
+- total combinado;
+- limite aplicavel;
+- composicao entre rendimentos isentos e exclusivos.
+
+2. Endpoint `/tax/obligation/:taxYear` continua deterministico:
+- codigo do gatilho preservado;
+- `mustDeclare` sem regressao.
+
+3. Suite focada verde.
+
+## Validacao (slice 2)
+
+- npm -w apps/api run test -- src/tax.test.js -t "explica composicao CLT e INSS no gatilho tributavel"
+- npm -w apps/api run test -- src/tax.test.js -t "explica total e composicao no gatilho de isentos/exclusivos"


### PR DESCRIPTION
## Contexto
Implementa o slice 2 do PR M para ampliar a explicabilidade da obrigatoriedade no gatilho de rendimentos isentos/exclusivos.

## O que muda
- Backend: detalha a mensagem de `EXEMPT_AND_EXCLUSIVE_INCOME_LIMIT` com total, limite e composicao (ISENTOS/EXCLUSIVOS).
- Testes API: adiciona teste de integracao cobrindo o gatilho de isentos/exclusivos com assert por trechos essenciais.
- Docs: atualiza o plano cirurgico do PR M para refletir status, escopo e validacao do slice 2.

## Validacao
- npm -w apps/api run test -- src/tax.test.js -t "considera apenas fatos approved ou corrected"
- npm -w apps/api run test -- src/tax.test.js -t "explica composicao CLT e INSS no gatilho tributavel"
- npm -w apps/api run test -- src/tax.test.js -t "explica total e composicao no gatilho de isentos/exclusivos"

## Riscos e mitigacao
- Risco: mensagem mais rica aumentar fragilidade de teste por string literal.
- Mitigacao: asserts ancorados em codigo do gatilho e fragmentos essenciais da mensagem.

## Fora de escopo
- Alteracao de thresholds oficiais.
- Mudanca de codigos de gatilho.
- Mudancas amplas de UX.
