### PR TITLE
Sprint B · PR M · Slice 3 — Explicabilidade patrimonial

### DIFF
--- a/apps/api/src/domain/tax/tax-obligation.calculator.js
+++ b/apps/api/src/domain/tax/tax-obligation.calculator.js
@@ -79,6 +79,14 @@ const buildExemptAndExclusiveIncomeLimitMessage = ({
     annualExclusiveIncome,
   )}.`;
 
+const buildAssetBalanceLimitMessage = ({
+  totalAssetBalance,
+  assetBalanceThreshold,
+}) =>
+  `Bens e direitos acima do limite patrimonial do exercicio. Total: ${formatMoneyForMessage(
+    totalAssetBalance,
+  )}; limite: ${formatMoneyForMessage(assetBalanceThreshold)}.`;
+
 export const summarizeReviewedTaxFacts = (facts = []) => {
   const totals = {
     annualTaxableIncome: 0,
@@ -215,6 +223,7 @@ export const calculateTaxObligation = ({
   const exemptAndExclusiveIncomeThreshold = Number(
     obligationRules.exemptAndExclusiveIncomeThreshold || 0,
   );
+  const assetBalanceThreshold = Number(obligationRules.assetBalanceThreshold || 0);
 
   if (annualTaxableIncome > taxableIncomeThreshold) {
     reasons.push({
@@ -241,10 +250,13 @@ export const calculateTaxObligation = ({
     });
   }
 
-  if (totalAssetBalance > Number(obligationRules.assetBalanceThreshold || 0)) {
+  if (totalAssetBalance > assetBalanceThreshold) {
     reasons.push({
       code: "ASSET_BALANCE_LIMIT",
-      message: "Bens e direitos acima do limite patrimonial do exercicio.",
+      message: buildAssetBalanceLimitMessage({
+        totalAssetBalance,
+        assetBalanceThreshold,
+      }),
     });
   }
 

--- a/apps/api/src/tax.test.js
+++ b/apps/api/src/tax.test.js
@@ -2381,6 +2381,58 @@ describe("Tax API foundation", () => {
     });
   });
 
+  it("GET /tax/obligation/:taxYear explica total e limite no gatilho patrimonial", async () => {
+    const email = "tax-obligation-asset-balance@test.dev";
+    const token = await registerAndLogin(email);
+    const userResult = await dbQuery(
+      `SELECT id
+       FROM users
+       WHERE email = $1`,
+      [email],
+    );
+    const userId = Number(userResult.rows[0].id);
+
+    await dbQuery(
+      `INSERT INTO tax_facts (
+         user_id,
+         tax_year,
+         fact_type,
+         category,
+         subcategory,
+         reference_period,
+         currency,
+         amount,
+         metadata_json,
+         review_status
+       )
+       VALUES
+       ($1, 2026, 'asset_balance', 'manual_entry', 'asset_balance_total', '2025-annual', 'BRL', 900000, '{}'::jsonb, 'approved')`,
+      [userId],
+    );
+
+    const response = await request(app)
+      .get("/tax/obligation/2026")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.mustDeclare).toBe(true);
+    expect(response.body.reasons).toHaveLength(1);
+    expect(response.body.reasons[0]).toMatchObject({
+      code: "ASSET_BALANCE_LIMIT",
+    });
+    expect(response.body.reasons[0].message).toContain(
+      "Bens e direitos acima do limite patrimonial do exercicio.",
+    );
+    expect(response.body.reasons[0].message).toContain("Total: 900000.00");
+    expect(response.body.reasons[0].message).toContain("limite: 800000.00");
+    expect(response.body.totals).toMatchObject({
+      annualTaxableIncome: 0,
+      annualExemptIncome: 0,
+      annualExclusiveIncome: 0,
+      totalAssetBalance: 900000,
+    });
+  });
+
   it("exclui do calculo oficial fatos revisados com CPF divergente do titular cadastrado", async () => {
     const email = "tax-obligation-taxpayer-filter@test.dev";
     const token = await registerAndLogin(email);

--- a/docs/roadmaps/sprint-b-pr-m-plano-cirurgico.md
+++ b/docs/roadmaps/sprint-b-pr-m-plano-cirurgico.md
@@ -1,7 +1,7 @@
 # Sprint B - PR M - Plano cirurgico (validacoes e alertas de obrigatoriedade)
 
 Data: 2026-04-02  
-Status: em execucao (slice 2)
+Status: em execucao (slice 3)
 
 ## Objetivo
 
@@ -73,7 +73,7 @@ Roadmap:
 - Sem merge sem diff completo e aprovacao explicita.
 - Sem alterar contratos estaveis do PR L sem necessidade objetiva.
 
-## Slice 2 (este PR)
+## Slice 2 (concluido)
 
 Escopo:
 - detalhar o motivo `EXEMPT_AND_EXCLUSIVE_INCOME_LIMIT` com total, limite e composicao (isentos e exclusivos);
@@ -101,3 +101,31 @@ Fora de escopo:
 
 - npm -w apps/api run test -- src/tax.test.js -t "explica composicao CLT e INSS no gatilho tributavel"
 - npm -w apps/api run test -- src/tax.test.js -t "explica total e composicao no gatilho de isentos/exclusivos"
+
+## Slice 3 (este PR)
+
+Escopo:
+- detalhar o motivo `ASSET_BALANCE_LIMIT` com total patrimonial e limite aplicavel;
+- validar via teste de integracao de `/tax/obligation/:taxYear` para o gatilho patrimonial.
+
+Fora de escopo:
+- alteracao de thresholds oficiais;
+- mudanca de semantica dos codigos de gatilho;
+- mudancas amplas de UX.
+
+## Criterios de aceite (slice 3)
+
+1. Quando `ASSET_BALANCE_LIMIT` disparar, a mensagem deve incluir:
+- total patrimonial;
+- limite aplicavel.
+
+2. Endpoint `/tax/obligation/:taxYear` continua deterministico:
+- codigo do gatilho preservado;
+- `mustDeclare` sem regressao.
+
+3. Suite focada verde.
+
+## Validacao (slice 3)
+
+- npm -w apps/api run test -- src/tax.test.js -t "explica total e composicao no gatilho de isentos/exclusivos"
+- npm -w apps/api run test -- src/tax.test.js -t "explica total e limite no gatilho patrimonial"


### PR DESCRIPTION
## Contexto
Implementa o slice 3 do PR M para ampliar a explicabilidade da obrigatoriedade no gatilho patrimonial.

## O que muda
- Backend: detalha a mensagem de `ASSET_BALANCE_LIMIT` com total patrimonial e limite aplicavel.
- Testes API: adiciona teste de integracao cobrindo o gatilho patrimonial com asserts por fragmentos essenciais.
- Docs: atualiza plano cirurgico para refletir status e criterios do slice 3.

## Validacao
- npm -w apps/api run test -- src/tax.test.js -t "considera apenas fatos approved ou corrected"
- npm -w apps/api run test -- src/tax.test.js -t "explica total e composicao no gatilho de isentos/exclusivos"
- npm -w apps/api run test -- src/tax.test.js -t "explica total e limite no gatilho patrimonial"

## Riscos e mitigacao
- Risco: mensagens mais detalhadas aumentarem fragilidade de testes por string exata.
- Mitigacao: asserts ancorados no codigo do gatilho e em trechos essenciais.

## Fora de escopo
- Alteracao de thresholds oficiais.
- Mudanca de codigos de gatilho.
- Mudancas amplas de UX.
