### PR TITLE
Epic 1 · Issue 1.1 — Schemas canônicos financeiros

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -33,7 +33,8 @@
     "pg": "^8.16.3",
     "prom-client": "^15.1.3",
     "stripe": "^20.3.1",
-    "tesseract.js": "^7.0.0"
+    "tesseract.js": "^7.0.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "eslint": "^8.57.1",

--- a/apps/api/src/domain/contracts/balance.schema.ts
+++ b/apps/api/src/domain/contracts/balance.schema.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const BalanceSourceSchema = z.enum(["bank_account", "net_transactions"]);
+
+export const BalanceSnapshotSchema = z.object({
+  bankBalance: z.number(),
+  technicalBalance: z.number(),
+  source: BalanceSourceSchema,
+  asOf: z.string().datetime({ offset: true }),
+});
+
+export type BalanceSource = z.infer<typeof BalanceSourceSchema>;
+export type BalanceSnapshot = z.infer<typeof BalanceSnapshotSchema>;

--- a/apps/api/src/domain/contracts/contracts.schema.test.ts
+++ b/apps/api/src/domain/contracts/contracts.schema.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+
+import { BalanceSnapshotSchema } from "./balance.schema";
+import { ForecastResultSchema } from "./forecast.schema";
+import { IncomeEntrySchema } from "./income.schema";
+import { ObligationSchema } from "./obligation.schema";
+
+describe("financial contracts schemas", () => {
+  describe("BalanceSnapshotSchema", () => {
+    it("accepts valid payload", () => {
+      const result = BalanceSnapshotSchema.safeParse({
+        bankBalance: 1200.45,
+        technicalBalance: 1100.1,
+        source: "bank_account",
+        asOf: "2026-04-02T12:00:00.000Z",
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects payload missing required field", () => {
+      const result = BalanceSnapshotSchema.safeParse({
+        bankBalance: 1200.45,
+        source: "bank_account",
+        asOf: "2026-04-02T12:00:00.000Z",
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects payload with wrong type", () => {
+      const result = BalanceSnapshotSchema.safeParse({
+        bankBalance: 1200.45,
+        technicalBalance: 1100.1,
+        source: 1,
+        asOf: "2026-04-02T12:00:00.000Z",
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("IncomeEntrySchema", () => {
+    it("accepts valid payload", () => {
+      const result = IncomeEntrySchema.safeParse({
+        grossAmount: 7000,
+        netAmount: 5500,
+        status: "confirmed",
+        incomeType: "salary",
+        isInferred: false,
+        sourceId: "statement-123",
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects payload missing required field", () => {
+      const result = IncomeEntrySchema.safeParse({
+        grossAmount: 7000,
+        netAmount: 5500,
+        incomeType: "salary",
+        isInferred: false,
+        sourceId: "statement-123",
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects payload with wrong type", () => {
+      const result = IncomeEntrySchema.safeParse({
+        grossAmount: 7000,
+        netAmount: 5500,
+        status: "confirmed",
+        incomeType: "salary",
+        isInferred: "no",
+        sourceId: "statement-123",
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("ObligationSchema", () => {
+    it("accepts valid payload", () => {
+      const result = ObligationSchema.safeParse({
+        amount: 1800,
+        obligationType: "open_invoice",
+        dueDate: "2026-04-10T00:00:00.000Z",
+        status: "open",
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects payload missing required field", () => {
+      const result = ObligationSchema.safeParse({
+        amount: 1800,
+        obligationType: "open_invoice",
+        status: "open",
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects payload with wrong type", () => {
+      const result = ObligationSchema.safeParse({
+        amount: 1800,
+        obligationType: "open_invoice",
+        dueDate: "2026-04-10T00:00:00.000Z",
+        status: "pending",
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("ForecastResultSchema", () => {
+    it("accepts valid payload", () => {
+      const result = ForecastResultSchema.safeParse({
+        projectedBalance: 3210.8,
+        basis: {
+          balanceBasis: "bank_account",
+          incomeBasis: "confirmed_statement",
+          pendingItems: {
+            bills: 2,
+            invoices: 1,
+            creditCardCycles: 1,
+          },
+          fallbacksUsed: [],
+        },
+        confidence: "high",
+        periodEnd: "2026-04-30T23:59:59.000Z",
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects payload missing required field", () => {
+      const result = ForecastResultSchema.safeParse({
+        projectedBalance: 3210.8,
+        basis: {
+          balanceBasis: "bank_account",
+          incomeBasis: "confirmed_statement",
+          pendingItems: {
+            bills: 2,
+            invoices: 1,
+            creditCardCycles: 1,
+          },
+          fallbacksUsed: [],
+        },
+        periodEnd: "2026-04-30T23:59:59.000Z",
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects payload with wrong type", () => {
+      const result = ForecastResultSchema.safeParse({
+        projectedBalance: "3210.8",
+        basis: {
+          balanceBasis: "bank_account",
+          incomeBasis: "confirmed_statement",
+          pendingItems: {
+            bills: 2,
+            invoices: 1,
+            creditCardCycles: 1,
+          },
+          fallbacksUsed: [],
+        },
+        confidence: "high",
+        periodEnd: "2026-04-30T23:59:59.000Z",
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/apps/api/src/domain/contracts/forecast.schema.ts
+++ b/apps/api/src/domain/contracts/forecast.schema.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+
+export const ForecastBalanceBasisSchema = z.enum([
+  "bank_account",
+  "net_month_transactions",
+]);
+
+export const ForecastIncomeBasisSchema = z.enum([
+  "confirmed_statement",
+  "salary_profile_fallback",
+]);
+
+export const ForecastPendingItemsSchema = z.object({
+  bills: z.number().int().nonnegative(),
+  invoices: z.number().int().nonnegative(),
+  creditCardCycles: z.number().int().nonnegative(),
+});
+
+export const ForecastBasisSchema = z.object({
+  balanceBasis: ForecastBalanceBasisSchema,
+  incomeBasis: ForecastIncomeBasisSchema,
+  pendingItems: ForecastPendingItemsSchema,
+  fallbacksUsed: z.array(z.string()),
+});
+
+export const ForecastConfidenceSchema = z.enum(["high", "medium", "low"]);
+
+export const ForecastResultSchema = z.object({
+  projectedBalance: z.number(),
+  basis: ForecastBasisSchema,
+  confidence: ForecastConfidenceSchema,
+  periodEnd: z.string().datetime({ offset: true }),
+});
+
+export type ForecastBalanceBasis = z.infer<typeof ForecastBalanceBasisSchema>;
+export type ForecastIncomeBasis = z.infer<typeof ForecastIncomeBasisSchema>;
+export type ForecastPendingItems = z.infer<typeof ForecastPendingItemsSchema>;
+export type ForecastBasis = z.infer<typeof ForecastBasisSchema>;
+export type ForecastConfidence = z.infer<typeof ForecastConfidenceSchema>;
+export type ForecastResult = z.infer<typeof ForecastResultSchema>;

--- a/apps/api/src/domain/contracts/income.schema.ts
+++ b/apps/api/src/domain/contracts/income.schema.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+export const IncomeStatusSchema = z.enum(["confirmed", "pending", "detected"]);
+
+export const IncomeTypeSchema = z.enum(["salary", "benefit", "imported", "other"]);
+
+export const IncomeSourceIdSchema = z.union([
+  z.string().min(1),
+  z.number().int().nonnegative(),
+]);
+
+export const IncomeEntrySchema = z.object({
+  grossAmount: z.number(),
+  netAmount: z.number(),
+  status: IncomeStatusSchema,
+  incomeType: IncomeTypeSchema,
+  isInferred: z.boolean(),
+  sourceId: IncomeSourceIdSchema,
+});
+
+export type IncomeStatus = z.infer<typeof IncomeStatusSchema>;
+export type IncomeType = z.infer<typeof IncomeTypeSchema>;
+export type IncomeSourceId = z.infer<typeof IncomeSourceIdSchema>;
+export type IncomeEntry = z.infer<typeof IncomeEntrySchema>;

--- a/apps/api/src/domain/contracts/index.ts
+++ b/apps/api/src/domain/contracts/index.ts
@@ -1,0 +1,53 @@
+export {
+  BalanceSourceSchema,
+  BalanceSnapshotSchema,
+} from "./balance.schema";
+
+export {
+  IncomeEntrySchema,
+  IncomeSourceIdSchema,
+  IncomeStatusSchema,
+  IncomeTypeSchema,
+} from "./income.schema";
+
+export {
+  ObligationSchema,
+  ObligationStatusSchema,
+  ObligationTypeSchema,
+} from "./obligation.schema";
+
+export {
+  ForecastBalanceBasisSchema,
+  ForecastBasisSchema,
+  ForecastConfidenceSchema,
+  ForecastIncomeBasisSchema,
+  ForecastPendingItemsSchema,
+  ForecastResultSchema,
+} from "./forecast.schema";
+
+export type {
+  BalanceSnapshot,
+  BalanceSource,
+} from "./balance.schema";
+
+export type {
+  IncomeEntry,
+  IncomeSourceId,
+  IncomeStatus,
+  IncomeType,
+} from "./income.schema";
+
+export type {
+  Obligation,
+  ObligationStatus,
+  ObligationType,
+} from "./obligation.schema";
+
+export type {
+  ForecastBalanceBasis,
+  ForecastBasis,
+  ForecastConfidence,
+  ForecastIncomeBasis,
+  ForecastPendingItems,
+  ForecastResult,
+} from "./forecast.schema";

--- a/apps/api/src/domain/contracts/obligation.schema.ts
+++ b/apps/api/src/domain/contracts/obligation.schema.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+export const ObligationTypeSchema = z.enum([
+  "bill",
+  "open_invoice",
+  "credit_card_cycle",
+  "pending_charge",
+]);
+
+export const ObligationStatusSchema = z.enum(["open", "due", "paid"]);
+
+export const ObligationSchema = z.object({
+  amount: z.number(),
+  obligationType: ObligationTypeSchema,
+  dueDate: z.string().datetime({ offset: true }),
+  status: ObligationStatusSchema,
+});
+
+export type ObligationType = z.infer<typeof ObligationTypeSchema>;
+export type ObligationStatus = z.infer<typeof ObligationStatusSchema>;
+export type Obligation = z.infer<typeof ObligationSchema>;

--- a/apps/api/src/domain/contracts/types.ts
+++ b/apps/api/src/domain/contracts/types.ts
@@ -1,0 +1,26 @@
+export type {
+  BalanceSnapshot,
+  BalanceSource,
+} from "./balance.schema";
+
+export type {
+  IncomeEntry,
+  IncomeSourceId,
+  IncomeStatus,
+  IncomeType,
+} from "./income.schema";
+
+export type {
+  Obligation,
+  ObligationStatus,
+  ObligationType,
+} from "./obligation.schema";
+
+export type {
+  ForecastBalanceBasis,
+  ForecastBasis,
+  ForecastConfidence,
+  ForecastIncomeBasis,
+  ForecastPendingItems,
+  ForecastResult,
+} from "./forecast.schema";

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -19,7 +19,13 @@
     "forceConsistentCasingInFileNames": true,
     "types": [
       "vite/client"
-    ]
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@control/contracts": [
+        "../api/src/domain/contracts/types"
+      ]
+    }
   },
   "include": [
     "src",

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -1,9 +1,17 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'node:url'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@control/contracts': fileURLToPath(
+        new URL('../api/src/domain/contracts/types.ts', import.meta.url),
+      ),
+    },
+  },
   test: {
     environment: 'jsdom',
     setupFiles: './src/test/setup.js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,8 @@
         "pg": "^8.16.3",
         "prom-client": "^15.1.3",
         "stripe": "^20.3.1",
-        "tesseract.js": "^7.0.0"
+        "tesseract.js": "^7.0.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "eslint": "^8.57.1",
@@ -10275,6 +10276,15 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }


### PR DESCRIPTION
## Contexto
Implementa a Issue 1.1 (Epic 1) com os schemas canônicos de domínio financeiro no API, mantendo separação entre consumo runtime (API) e type-only (web).

## Decisões de design aplicadas
- Schemas em `apps/api/src/domain/contracts` (sem criar `packages/domain` neste momento).
- `zod` apenas no workspace API (`dependencies`) para validação runtime.
- Barrel `types.ts` separado com re-export **somente de types** para consumo do web.
- Alias do web `@control/contracts` apontando para `../api/src/domain/contracts/types`.

## O que mudou
- Criados 4 schemas + tipos inferidos:
  - `balance.schema.ts`
  - `income.schema.ts`
  - `obligation.schema.ts`
  - `forecast.schema.ts`
- Criados barrels:
  - `index.ts` (schemas + types, consumo API)
  - `types.ts` (types-only, consumo web)
- Configuração do web:
  - `tsconfig.json` com paths para `@control/contracts`
  - `vite.config.js` com alias `@control/contracts`
- Dependência:
  - `zod` adicionada em `apps/api/package.json`

## Testes
- Nova suíte: `apps/api/src/domain/contracts/contracts.schema.test.ts`
- Cobertura mínima da issue atendida: 12 testes (3 por schema)
  - válido
  - campo obrigatório faltando
  - tipo inválido

## Validação executada
- `npm -w apps/api run test -- src/domain/contracts/contracts.schema.test.ts`
- `npm -w apps/web run typecheck`

## Fora de escopo
- Validação runtime de responses dos endpoints (Issue 1.2)
- Adoção dos tipos nos services/componentes do web (Issue 1.3)
