### PR TITLE
Epic 1 · Issue 1.2 — Validação de fronteira na API

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,8 +7,8 @@
     "node": "24.x"
   },
   "scripts": {
-    "dev": "node --watch src/server.js",
-    "start": "node src/server.js",
+    "dev": "node --import tsx/esm --watch src/server.js",
+    "start": "node --import tsx/esm src/server.js",
     "build": "node -e \"console.log('api build: no-op')\"",
     "db:migrate": "node src/db/migrate.js",
     "db:backfill:categories-normalized": "node src/db/backfill-categories-normalized.js",
@@ -34,6 +34,7 @@
     "prom-client": "^15.1.3",
     "stripe": "^20.3.1",
     "tesseract.js": "^7.0.0",
+    "tsx": "^4.21.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/apps/api/src/domain/contracts/dashboard-response.schema.ts
+++ b/apps/api/src/domain/contracts/dashboard-response.schema.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+
+const DashboardBillsSchema = z.object({
+  overdueCount: z.number().int().nonnegative(),
+  overdueTotal: z.number(),
+  dueSoonCount: z.number().int().nonnegative(),
+  dueSoonTotal: z.number(),
+  upcomingCount: z.number().int().nonnegative(),
+  upcomingTotal: z.number(),
+});
+
+const DashboardCardsSchema = z.object({
+  openPurchasesTotal: z.number(),
+  pendingInvoicesTotal: z.number(),
+});
+
+const DashboardIncomeSchema = z.object({
+  receivedThisMonth: z.number(),
+  pendingThisMonth: z.number(),
+  referenceMonth: z.string().regex(/^\d{4}-\d{2}$/),
+});
+
+const DashboardForecastSchema = z.object({
+  projectedBalance: z.number(),
+  month: z.string().min(1),
+});
+
+const DashboardConsignadoSchema = z.object({
+  monthlyTotal: z.number(),
+  contractsCount: z.number().int().nonnegative(),
+  comprometimentoPct: z.number().nullable(),
+});
+
+export const DashboardSnapshotResponseSchema = z.object({
+  bankBalance: z.number(),
+  bills: DashboardBillsSchema,
+  cards: DashboardCardsSchema,
+  income: DashboardIncomeSchema,
+  forecast: DashboardForecastSchema.nullable(),
+  consignado: DashboardConsignadoSchema,
+});
+
+export type DashboardSnapshotResponse = z.infer<typeof DashboardSnapshotResponseSchema>;

--- a/apps/api/src/domain/contracts/forecast-response.schema.ts
+++ b/apps/api/src/domain/contracts/forecast-response.schema.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+const YearMonthSchema = z.string().regex(/^\d{4}-\d{2}$/);
+
+const GeneratedAtSchema = z.union([
+  z.string().datetime({ offset: true }),
+  z.date(),
+]);
+
+const ForecastBankLimitProjectionSchema = z.object({
+  total: z.number(),
+  used: z.number(),
+  remaining: z.number(),
+  exceededBy: z.number(),
+  usagePct: z.number(),
+  status: z.enum(["unused", "using", "exceeded"]),
+  alertTriggered: z.boolean(),
+});
+
+const ForecastHttpPayloadSchema = z.object({
+  month: YearMonthSchema,
+  engineVersion: z.string(),
+  projectedBalance: z.number(),
+  incomeExpected: z.number().nullable(),
+  spendingToDate: z.number(),
+  dailyAvgSpending: z.number(),
+  daysRemaining: z.number().int().positive(),
+  flipDetected: z.boolean(),
+  flipDirection: z.string().nullable(),
+  generatedAt: GeneratedAtSchema,
+  billsPendingTotal: z.number(),
+  billsPendingCount: z.number().int().nonnegative(),
+  adjustedProjectedBalance: z.number(),
+  bankLimit: ForecastBankLimitProjectionSchema.nullable(),
+});
+
+export const ForecastCurrentResponseSchema = ForecastHttpPayloadSchema.nullable();
+
+export const ForecastRecomputeResponseSchema = ForecastHttpPayloadSchema;
+
+export type ForecastBankLimitProjection = z.infer<typeof ForecastBankLimitProjectionSchema>;
+export type ForecastHttpPayload = z.infer<typeof ForecastHttpPayloadSchema>;
+export type ForecastCurrentResponse = z.infer<typeof ForecastCurrentResponseSchema>;
+export type ForecastRecomputeResponse = z.infer<typeof ForecastRecomputeResponseSchema>;

--- a/apps/api/src/domain/contracts/index.ts
+++ b/apps/api/src/domain/contracts/index.ts
@@ -25,6 +25,15 @@ export {
   ForecastResultSchema,
 } from "./forecast.schema";
 
+export {
+  DashboardSnapshotResponseSchema,
+} from "./dashboard-response.schema";
+
+export {
+  ForecastCurrentResponseSchema,
+  ForecastRecomputeResponseSchema,
+} from "./forecast-response.schema";
+
 export type {
   BalanceSnapshot,
   BalanceSource,
@@ -51,3 +60,14 @@ export type {
   ForecastPendingItems,
   ForecastResult,
 } from "./forecast.schema";
+
+export type {
+  DashboardSnapshotResponse,
+} from "./dashboard-response.schema";
+
+export type {
+  ForecastBankLimitProjection,
+  ForecastCurrentResponse,
+  ForecastHttpPayload,
+  ForecastRecomputeResponse,
+} from "./forecast-response.schema";

--- a/apps/api/src/domain/contracts/types.ts
+++ b/apps/api/src/domain/contracts/types.ts
@@ -24,3 +24,14 @@ export type {
   ForecastPendingItems,
   ForecastResult,
 } from "./forecast.schema";
+
+export type {
+  DashboardSnapshotResponse,
+} from "./dashboard-response.schema";
+
+export type {
+  ForecastBankLimitProjection,
+  ForecastCurrentResponse,
+  ForecastHttpPayload,
+  ForecastRecomputeResponse,
+} from "./forecast-response.schema";

--- a/apps/api/src/routes/dashboard.routes.js
+++ b/apps/api/src/routes/dashboard.routes.js
@@ -1,5 +1,7 @@
 import { Router } from "express";
 import { authMiddleware } from "../middlewares/auth.middleware.js";
+import { DashboardSnapshotResponseSchema } from "../domain/contracts/dashboard-response.schema.ts";
+import { respondValidated } from "./respond-validated.js";
 import { getDashboardSnapshot } from "../services/dashboard.service.js";
 
 const router = Router();
@@ -9,7 +11,9 @@ router.use(authMiddleware);
 router.get("/snapshot", async (req, res, next) => {
   try {
     const snapshot = await getDashboardSnapshot(req.user.id);
-    res.status(200).json(snapshot);
+    respondValidated(DashboardSnapshotResponseSchema, snapshot, req, res, {
+      routeLabel: "GET /dashboard/snapshot",
+    });
   } catch (error) {
     next(error);
   }

--- a/apps/api/src/routes/forecast.routes.js
+++ b/apps/api/src/routes/forecast.routes.js
@@ -1,7 +1,12 @@
 import { Router } from "express";
 import { authMiddleware } from "../middlewares/auth.middleware.js";
+import {
+  ForecastCurrentResponseSchema,
+  ForecastRecomputeResponseSchema,
+} from "../domain/contracts/forecast-response.schema.ts";
 import { requireActiveTrialOrPaidPlan } from "../middlewares/entitlement.middleware.js";
 import { logWarn } from "../observability/logger.js";
+import { respondValidated } from "./respond-validated.js";
 import {
   maybeSendFlipNotification,
   maybeSendPaydayReminder,
@@ -26,7 +31,9 @@ const logNotificationError = (requestId, userId, notificationType, error) => {
 router.get("/current", async (req, res, next) => {
   try {
     const forecast = await getLatestForecast(req.user.id);
-    res.status(200).json(forecast);
+    respondValidated(ForecastCurrentResponseSchema, forecast, req, res, {
+      routeLabel: "GET /forecasts/current",
+    });
   } catch (error) {
     next(error);
   }
@@ -47,7 +54,9 @@ router.post("/recompute", async (req, res, next) => {
       logNotificationError(requestId, userId, "payday_reminder", error);
     });
 
-    res.status(200).json(forecast);
+    respondValidated(ForecastRecomputeResponseSchema, forecast, req, res, {
+      routeLabel: "POST /forecasts/recompute",
+    });
   } catch (error) {
     next(error);
   }

--- a/apps/api/src/routes/respond-validated.js
+++ b/apps/api/src/routes/respond-validated.js
@@ -1,0 +1,75 @@
+import { logWarn } from "../observability/logger.js";
+
+const resolveRoutePath = (req, routeLabel) => {
+  if (typeof routeLabel === "string" && routeLabel.trim()) {
+    return routeLabel.trim();
+  }
+
+  const rawRoute = (req?.originalUrl || req?.url || "/").split("?")[0];
+  return rawRoute || "/";
+};
+
+const resolveUserId = (req) => {
+  const parsedUserId = Number(req?.user?.id);
+  if (!Number.isInteger(parsedUserId) || parsedUserId <= 0) {
+    return null;
+  }
+
+  return parsedUserId;
+};
+
+const summarizeIssues = (error) =>
+  Array.isArray(error?.issues)
+    ? error.issues.map((issue) => ({
+        code: issue.code,
+        path: Array.isArray(issue.path) ? issue.path.join(".") : "",
+        message: issue.message,
+      }))
+    : [];
+
+const buildDegradedPayload = (payload) => {
+  if (payload !== null && typeof payload === "object" && !Array.isArray(payload)) {
+    return {
+      ...payload,
+      _degraded: true,
+    };
+  }
+
+  return {
+    data: payload,
+    _degraded: true,
+  };
+};
+
+const isTestEnvironment = () => process.env.NODE_ENV === "test";
+
+export const respondValidated = (schema, payload, req, res, options = {}) => {
+  const status = Number.isInteger(options?.status) ? options.status : 200;
+  const route = resolveRoutePath(req, options?.routeLabel);
+
+  const parsed = schema.safeParse(payload);
+  if (parsed.success) {
+    return res.status(status).json(parsed.data);
+  }
+
+  const issues = summarizeIssues(parsed.error);
+  logWarn({
+    event: "http.response.validation.failed",
+    requestId: req?.requestId || null,
+    route,
+    method: req?.method || null,
+    userId: resolveUserId(req),
+    status,
+    degraded: !isTestEnvironment(),
+    issues,
+  });
+
+  if (isTestEnvironment()) {
+    const error = new Error("Response contract validation failed.");
+    error.status = 500;
+    error.internalMessage = `route=${route}; issues=${JSON.stringify(issues)}`;
+    throw error;
+  }
+
+  return res.status(status).json(buildDegradedPayload(payload));
+};

--- a/apps/api/src/routes/respond-validated.test.js
+++ b/apps/api/src/routes/respond-validated.test.js
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import * as logger from "../observability/logger.js";
+import { respondValidated } from "./respond-validated.js";
+
+const createMockRes = () => ({
+  statusCode: null,
+  payload: undefined,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(body) {
+    this.payload = body;
+    return this;
+  },
+});
+
+describe("respondValidated", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+    vi.restoreAllMocks();
+  });
+
+  it("returns payload when schema validation succeeds", () => {
+    process.env.NODE_ENV = "test";
+    const schema = z.object({ amount: z.number() });
+    const payload = { amount: 100 };
+    const req = { requestId: "req-1", method: "GET", originalUrl: "/sample", user: { id: 10 } };
+    const res = createMockRes();
+
+    const response = respondValidated(schema, payload, req, res, { routeLabel: "GET /sample" });
+
+    expect(response).toBe(res);
+    expect(res.statusCode).toBe(200);
+    expect(res.payload).toEqual({ amount: 100 });
+  });
+
+  it("returns degraded payload in production when schema validation fails", () => {
+    process.env.NODE_ENV = "production";
+    const schema = z.object({ amount: z.number() });
+    const payload = { amount: "100" };
+    const req = { requestId: "req-2", method: "GET", originalUrl: "/sample", user: { id: 10 } };
+    const res = createMockRes();
+    const warnSpy = vi.spyOn(logger, "logWarn");
+
+    const response = respondValidated(schema, payload, req, res, { routeLabel: "GET /sample" });
+
+    expect(response).toBe(res);
+    expect(res.statusCode).toBe(200);
+    expect(res.payload).toMatchObject({
+      amount: "100",
+      _degraded: true,
+    });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws error in test environment when schema validation fails", () => {
+    process.env.NODE_ENV = "test";
+    const schema = z.object({ amount: z.number() });
+    const payload = { amount: "100" };
+    const req = { requestId: "req-3", method: "GET", originalUrl: "/sample", user: { id: 10 } };
+    const res = createMockRes();
+
+    expect(() =>
+      respondValidated(schema, payload, req, res, { routeLabel: "GET /sample" }),
+    ).toThrow("Response contract validation failed.");
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "prom-client": "^15.1.3",
         "stripe": "^20.3.1",
         "tesseract.js": "^7.0.0",
+        "tsx": "^4.21.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -578,7 +579,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -595,7 +595,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -612,7 +611,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -629,7 +627,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -646,7 +643,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -663,7 +659,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -680,7 +675,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -697,7 +691,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -714,7 +707,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -731,7 +723,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -748,7 +739,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -765,7 +755,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -782,7 +771,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -799,7 +787,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -816,7 +803,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -833,7 +819,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -850,7 +835,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -867,7 +851,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -884,7 +867,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -901,7 +883,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -918,7 +899,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -935,7 +915,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -952,7 +931,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -969,7 +947,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -986,7 +963,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1003,7 +979,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4273,7 +4248,6 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5246,6 +5220,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -8057,6 +8043,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -9356,6 +9351,25 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",


### PR DESCRIPTION
## Contexto
Implementa a Issue 1.2 (validação de fronteira na API) no recorte inicial de rotas financeiras: `GET /dashboard/snapshot`, `GET /forecasts/current` e `POST /forecasts/recompute`.

## Decisões aplicadas
- Runtime da API atualizado para suportar imports `.ts` com `tsx` loader:
  - `dev`: `node --import tsx/esm --watch src/server.js`
  - `start`: `node --import tsx/esm src/server.js`
- Validação aplicada na **rota** (entre service e `res.json(...)`), não no service e não em middleware genérico.
- Helper único `respondValidated(...)` para centralizar política de validação/degradação.

## O que mudou
- Novos schemas de response:
  - `apps/api/src/domain/contracts/dashboard-response.schema.ts`
  - `apps/api/src/domain/contracts/forecast-response.schema.ts`
- Barrels atualizados para exportar os novos tipos/schemas:
  - `apps/api/src/domain/contracts/index.ts`
  - `apps/api/src/domain/contracts/types.ts`
- Helper de validação de fronteira:
  - `apps/api/src/routes/respond-validated.js`
- Rotas com validação antes da resposta:
  - `apps/api/src/routes/dashboard.routes.js`
  - `apps/api/src/routes/forecast.routes.js`

## Política de falha
- `NODE_ENV=test`: hard fail (lança erro 500 via error middleware)
- produção (ambientes != test): responde payload degradado com `_degraded: true` e gera log estruturado (`http.response.validation.failed`)

## Testes adicionados
- `apps/api/src/routes/respond-validated.test.js`
  - sucesso
  - mismatch degradado em produção
  - mismatch com falha em test

## Validação executada
- `node --import tsx/esm -e "import('./apps/api/src/domain/contracts/index.ts').then(m => console.log(Object.keys(m).slice(0,10)))"`
- `npm -w apps/api run test -- src/routes/respond-validated.test.js`
- `npm -w apps/api run test -- src/dashboard.test.js src/forecast.test.js src/routes/respond-validated.test.js`
- `npm -w apps/api run lint`

## Observações
- Ajuste intencional no schema de `dashboard.forecast.month` para aceitar string não vazia (compatível com retorno real atual do service).
