### PR TITLE
Epic 1 · Issue 1.3 — Consumir schemas tipados no frontend

### DIFF
--- a/apps/web/src/components/OperationalSummaryPanel.test.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.test.tsx
@@ -4,11 +4,16 @@ import userEvent from "@testing-library/user-event";
 import OperationalSummaryPanel from "./OperationalSummaryPanel";
 import { dashboardService, type DashboardSnapshot } from "../services/dashboard.service";
 
-vi.mock("../services/dashboard.service", () => ({
-  dashboardService: {
-    getSnapshot: vi.fn(),
-  },
-}));
+vi.mock("../services/dashboard.service", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/dashboard.service")>();
+
+  return {
+    ...actual,
+    dashboardService: {
+      getSnapshot: vi.fn(),
+    },
+  };
+});
 
 const buildSnapshot = (overrides: Partial<DashboardSnapshot> = {}): DashboardSnapshot => ({
   bankBalance: 1000,

--- a/apps/web/src/components/OperationalSummaryPanel.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from "react";
 import { useMaskedCurrency } from "../context/DiscreetModeContext";
-import { dashboardService, type DashboardSnapshot } from "../services/dashboard.service";
+import {
+  buildDashboardContractView,
+  dashboardService,
+  type DashboardSnapshot,
+} from "../services/dashboard.service";
 import { getApiErrorMessage } from "../utils/apiError";
 import { logWidgetFallbackError } from "../utils/widgetFallbackTelemetry";
 import { OperationalSeverityBadge, OperationalStateBlock } from "./OperationalStateBlock";
@@ -64,6 +68,14 @@ const SkeletonTile = () => (
 interface OperationalSummaryPanelProps {
   onOpenDueSoonBills?: () => void;
 }
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+const sumAmounts = (items: Array<{ amount: number }>): number =>
+  items.reduce((total, item) => total + item.amount, 0);
+
+const sumIncomeNetAmounts = (items: Array<{ netAmount: number }>): number =>
+  items.reduce((total, item) => total + item.netAmount, 0);
 
 const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanelProps): JSX.Element | null => {
   const [snapshot, setSnapshot] = useState<DashboardSnapshot | null>(null);
@@ -153,13 +165,46 @@ const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanel
     );
   }
 
-  const { bankBalance, bills, cards, income, forecast, consignado } = snapshot;
+  const { cards, forecast, consignado } = snapshot;
+  const { balanceSnapshot, incomes, obligations } = buildDashboardContractView(snapshot);
+
+  const nowTimestamp = Date.now();
+  const dueSoonLimit = nowTimestamp + 7 * DAY_IN_MS;
+  const overdueObligations = obligations.filter((obligation) => obligation.status === "due");
+  const dueSoonObligations = obligations.filter((obligation) => {
+    if (obligation.status !== "open") {
+      return false;
+    }
+
+    return Date.parse(obligation.dueDate) <= dueSoonLimit;
+  });
+  const upcomingObligations = obligations.filter((obligation) => {
+    if (obligation.status !== "open") {
+      return false;
+    }
+
+    return Date.parse(obligation.dueDate) > dueSoonLimit;
+  });
+
+  const overdueCount = overdueObligations.length;
+  const overdueTotal = sumAmounts(overdueObligations);
+  const dueSoonCount = dueSoonObligations.length;
+  const dueSoonTotal = sumAmounts(dueSoonObligations);
+  const upcomingCount = upcomingObligations.length;
+  const upcomingTotal = sumAmounts(upcomingObligations);
+  const receivedThisMonth = sumIncomeNetAmounts(
+    incomes.filter((entry) => entry.status === "confirmed"),
+  );
+  const pendingThisMonth = sumIncomeNetAmounts(
+    incomes.filter((entry) => entry.status === "pending" || entry.status === "detected"),
+  );
 
   // ── Tile 1: Bank balance ──────────────────────────────────────────────────
-  const hasOverdueBills = bills.overdueCount > 0;
-  const hasDueSoonBills = bills.dueSoonCount > 0;
-  const technicalBalance = bankBalance - bills.overdueTotal;
-  const shortTermBalance = technicalBalance - bills.dueSoonTotal;
+  const bankBalance = balanceSnapshot.bankBalance;
+  const hasOverdueBills = overdueCount > 0;
+  const hasDueSoonBills = dueSoonCount > 0;
+  const technicalBalance = balanceSnapshot.technicalBalance;
+  const shortTermBalance = technicalBalance - dueSoonTotal;
   const shouldShowShortTermBalance = hasDueSoonBills && !hasOverdueBills;
 
   const bankTileSecondary = hasOverdueBills
@@ -171,12 +216,12 @@ const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanel
   const bankTileDetails: string[] = [];
   if (hasOverdueBills) {
     bankTileDetails.push(
-      `${bills.overdueCount} vencida${bills.overdueCount > 1 ? "s" : ""} somam ${money(bills.overdueTotal)}`,
+      `${overdueCount} vencida${overdueCount > 1 ? "s" : ""} somam ${money(overdueTotal)}`,
     );
   }
   if (hasDueSoonBills) {
     bankTileDetails.push(
-      `${bills.dueSoonCount} em 7 dias somam ${money(bills.dueSoonTotal)}`,
+      `${dueSoonCount} em 7 dias somam ${money(dueSoonTotal)}`,
     );
   }
 
@@ -196,42 +241,42 @@ const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanel
   };
 
   // ── Tile 2: Bills ─────────────────────────────────────────────────────────
-  const totalImmediateBillsCount = bills.overdueCount + bills.dueSoonCount;
-  const totalImmediateBillsAmount = bills.overdueTotal + bills.dueSoonTotal;
-  const hasUpcomingBills = bills.upcomingCount > 0;
+  const totalImmediateBillsCount = overdueCount + dueSoonCount;
+  const totalImmediateBillsAmount = overdueTotal + dueSoonTotal;
+  const hasUpcomingBills = upcomingCount > 0;
   const shouldHighlightImmediateBills = totalImmediateBillsCount > 0;
   const billsPrimaryAmount = shouldHighlightImmediateBills
     ? totalImmediateBillsAmount
     : hasUpcomingBills
-      ? bills.upcomingTotal
+      ? upcomingTotal
       : 0;
   const billsAccent: TileProps["accent"] =
-    bills.overdueCount > 0 ? "danger" : bills.dueSoonCount > 0 ? "warning" : "muted";
+    overdueCount > 0 ? "danger" : dueSoonCount > 0 ? "warning" : "muted";
   const billsTertiaryTokens: string[] = [];
-  if (bills.dueSoonCount > 0) {
+  if (dueSoonCount > 0) {
     billsTertiaryTokens.push(
-      `Urgência 7d: ${bills.dueSoonCount} conta${bills.dueSoonCount > 1 ? "s" : ""} • ${money(bills.dueSoonTotal)}`,
+      `Urgência 7d: ${dueSoonCount} conta${dueSoonCount > 1 ? "s" : ""} • ${money(dueSoonTotal)}`,
     );
   }
   if (hasUpcomingBills) {
     billsTertiaryTokens.push(
-      `${bills.upcomingCount} próxima${bills.upcomingCount > 1 ? "s" : ""}`,
+      `${upcomingCount} próxima${upcomingCount > 1 ? "s" : ""}`,
     );
   }
   const billsTile: TileProps = {
     label: "Contas a pagar",
     primary: shouldHighlightImmediateBills || hasUpcomingBills ? money(billsPrimaryAmount) : "—",
     secondary:
-      bills.overdueCount > 0
-        ? `${bills.overdueCount} vencida${bills.overdueCount > 1 ? "s" : ""}`
-        : bills.dueSoonCount > 0
-          ? `${bills.dueSoonCount} em 7 dias`
+      overdueCount > 0
+        ? `${overdueCount} vencida${overdueCount > 1 ? "s" : ""}`
+        : dueSoonCount > 0
+          ? `${dueSoonCount} em 7 dias`
           : hasUpcomingBills
-            ? `${bills.upcomingCount} próxima${bills.upcomingCount > 1 ? "s" : ""}`
+            ? `${upcomingCount} próxima${upcomingCount > 1 ? "s" : ""}`
           : "Nenhuma pendente",
     tertiary: billsTertiaryTokens.length > 0 ? `+ ${billsTertiaryTokens.join(" • ")}` : undefined,
-    actionLabel: bills.dueSoonCount > 0 && onOpenDueSoonBills ? "Ver contas em 7 dias" : undefined,
-    onActionClick: bills.dueSoonCount > 0 && onOpenDueSoonBills ? onOpenDueSoonBills : undefined,
+    actionLabel: dueSoonCount > 0 && onOpenDueSoonBills ? "Ver contas em 7 dias" : undefined,
+    onActionClick: dueSoonCount > 0 && onOpenDueSoonBills ? onOpenDueSoonBills : undefined,
     accent: billsAccent,
   };
 
@@ -250,24 +295,24 @@ const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanel
   };
 
   // ── Tile 4: Income ────────────────────────────────────────────────────────
-  const hasIncome = income.receivedThisMonth > 0 || income.pendingThisMonth > 0;
+  const hasIncome = receivedThisMonth > 0 || pendingThisMonth > 0;
   const incomeTile: TileProps = {
     label: "Renda do mês",
-    primary: hasIncome ? money(income.receivedThisMonth + income.pendingThisMonth) : "—",
+    primary: hasIncome ? money(receivedThisMonth + pendingThisMonth) : "—",
     secondary:
-      income.receivedThisMonth > 0
-        ? `${money(income.receivedThisMonth)} recebido`
-        : income.pendingThisMonth > 0
+      receivedThisMonth > 0
+        ? `${money(receivedThisMonth)} recebido`
+        : pendingThisMonth > 0
           ? "Ainda não recebido"
           : "Sem lançamento",
     tertiary:
-      income.pendingThisMonth > 0 && income.receivedThisMonth > 0
-        ? `${money(income.pendingThisMonth)} pendente`
+      pendingThisMonth > 0 && receivedThisMonth > 0
+        ? `${money(pendingThisMonth)} pendente`
         : undefined,
     accent:
-      income.receivedThisMonth > 0
+      receivedThisMonth > 0
         ? "success"
-        : income.pendingThisMonth > 0
+        : pendingThisMonth > 0
           ? "warning"
           : "muted",
   };

--- a/apps/web/src/services/dashboard.service.ts
+++ b/apps/web/src/services/dashboard.service.ts
@@ -1,89 +1,100 @@
 import { api, withApiRequestContext, type ApiRequestContext } from "./api";
+import type {
+  BalanceSnapshot,
+  DashboardSnapshotResponse,
+  IncomeEntry,
+  Obligation,
+} from "@control/contracts";
 
-export interface DashboardBills {
-  overdueCount: number;
-  overdueTotal: number;
-  dueSoonCount: number;
-  dueSoonTotal: number;
-  upcomingCount: number;
-  upcomingTotal: number;
+export type DashboardSnapshot = DashboardSnapshotResponse;
+
+export interface DashboardFinancialContractView {
+  balanceSnapshot: BalanceSnapshot;
+  incomes: IncomeEntry[];
+  obligations: Obligation[];
 }
 
-export interface DashboardCards {
-  openPurchasesTotal: number;
-  pendingInvoicesTotal: number;
-}
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
 
-export interface DashboardIncome {
-  receivedThisMonth: number;
-  pendingThisMonth: number;
-  referenceMonth: string;
-}
+const createObligations = (
+  totalAmount: number,
+  count: number,
+  status: Obligation["status"],
+  dueDate: Date,
+): Obligation[] => {
+  if (count <= 0 || totalAmount <= 0) {
+    return [];
+  }
 
-export interface DashboardForecast {
-  projectedBalance: number;
-  month: string;
-}
-
-export interface DashboardConsignado {
-  monthlyTotal: number;
-  contractsCount: number;
-  comprometimentoPct: number | null;
-}
-
-export interface DashboardSnapshot {
-  bankBalance: number;
-  bills: DashboardBills;
-  cards: DashboardCards;
-  income: DashboardIncome;
-  forecast: DashboardForecast | null;
-  consignado: DashboardConsignado;
-}
-
-const normalizeBills = (raw: Record<string, unknown>): DashboardBills => ({
-  overdueCount: Number(raw.overdueCount) || 0,
-  overdueTotal: Number(raw.overdueTotal) || 0,
-  dueSoonCount: Number(raw.dueSoonCount) || 0,
-  dueSoonTotal: Number(raw.dueSoonTotal) || 0,
-  upcomingCount: Number(raw.upcomingCount) || 0,
-  upcomingTotal: Number(raw.upcomingTotal) || 0,
-});
-
-const normalizeCards = (raw: Record<string, unknown>): DashboardCards => ({
-  openPurchasesTotal: Number(raw.openPurchasesTotal) || 0,
-  pendingInvoicesTotal: Number(raw.pendingInvoicesTotal) || 0,
-});
-
-const normalizeIncome = (raw: Record<string, unknown>): DashboardIncome => ({
-  receivedThisMonth: Number(raw.receivedThisMonth) || 0,
-  pendingThisMonth: Number(raw.pendingThisMonth) || 0,
-  referenceMonth: String(raw.referenceMonth ?? ""),
-});
-
-const normalizeForecast = (raw: Record<string, unknown> | null): DashboardForecast | null => {
-  if (!raw) return null;
-  return {
-    projectedBalance: Number(raw.projectedBalance) || 0,
-    month: String(raw.month ?? ""),
-  };
+  const itemAmount = totalAmount / count;
+  return Array.from({ length: count }, () => ({
+    amount: itemAmount,
+    obligationType: "bill",
+    dueDate: dueDate.toISOString(),
+    status,
+  }));
 };
 
-const normalizeConsignado = (raw: Record<string, unknown>): DashboardConsignado => ({
-  monthlyTotal:       Number(raw.monthlyTotal) || 0,
-  contractsCount:     Number(raw.contractsCount) || 0,
-  comprometimentoPct: raw.comprometimentoPct != null ? Number(raw.comprometimentoPct) : null,
-});
+export const buildDashboardContractView = (
+  snapshot: DashboardSnapshot,
+  now: Date = new Date(),
+): DashboardFinancialContractView => {
+  const incomes: IncomeEntry[] = [];
+  if (snapshot.income.receivedThisMonth > 0) {
+    incomes.push({
+      grossAmount: snapshot.income.receivedThisMonth,
+      netAmount: snapshot.income.receivedThisMonth,
+      status: "confirmed",
+      incomeType: "salary",
+      isInferred: true,
+      sourceId: snapshot.income.referenceMonth,
+    });
+  }
+  if (snapshot.income.pendingThisMonth > 0) {
+    incomes.push({
+      grossAmount: snapshot.income.pendingThisMonth,
+      netAmount: snapshot.income.pendingThisMonth,
+      status: "pending",
+      incomeType: "salary",
+      isInferred: true,
+      sourceId: snapshot.income.referenceMonth,
+    });
+  }
 
-const normalizeSnapshot = (raw: Record<string, unknown>): DashboardSnapshot => ({
-  bankBalance: Number(raw.bankBalance) || 0,
-  bills: normalizeBills((raw.bills as Record<string, unknown>) ?? {}),
-  cards: normalizeCards((raw.cards as Record<string, unknown>) ?? {}),
-  income: normalizeIncome((raw.income as Record<string, unknown>) ?? {}),
-  forecast: normalizeForecast(
-    raw.forecast != null ? (raw.forecast as Record<string, unknown>) : null,
-  ),
-  consignado: normalizeConsignado((raw.consignado as Record<string, unknown>) ?? {}),
-});
+  const obligations: Obligation[] = [
+    ...createObligations(
+      snapshot.bills.overdueTotal,
+      snapshot.bills.overdueCount,
+      "due",
+      new Date(now.getTime() - DAY_IN_MS),
+    ),
+    ...createObligations(
+      snapshot.bills.dueSoonTotal,
+      snapshot.bills.dueSoonCount,
+      "open",
+      new Date(now.getTime() + 7 * DAY_IN_MS),
+    ),
+    ...createObligations(
+      snapshot.bills.upcomingTotal,
+      snapshot.bills.upcomingCount,
+      "open",
+      new Date(now.getTime() + 30 * DAY_IN_MS),
+    ),
+  ];
+
+  const balanceSnapshot: BalanceSnapshot = {
+    bankBalance: snapshot.bankBalance,
+    technicalBalance: snapshot.bankBalance - snapshot.bills.overdueTotal,
+    source: "bank_account",
+    asOf: now.toISOString(),
+  };
+
+  return {
+    balanceSnapshot,
+    incomes,
+    obligations,
+  };
+};
 
 let snapshotInFlightRequest: Promise<DashboardSnapshot> | null = null;
 
@@ -94,8 +105,8 @@ export const dashboardService = {
     }
 
     const requestPromise = api
-      .get("/dashboard/snapshot", withApiRequestContext(context))
-      .then(({ data }) => normalizeSnapshot(data as Record<string, unknown>))
+      .get<DashboardSnapshot>("/dashboard/snapshot", withApiRequestContext(context))
+      .then(({ data }) => data)
       .finally(() => {
         if (snapshotInFlightRequest === requestPromise) {
           snapshotInFlightRequest = null;


### PR DESCRIPTION
## Contexto\nImplementa a Issue 1.3 do Epic 1 para reduzir inferência ad-hoc no frontend e consumir contrato financeiro canônico.\n\n## O que mudou\n- serviço de dashboard passou a consumir DashboardSnapshotResponse diretamente\n- inclusão de uildDashboardContractView tipado com BalanceSnapshot, IncomeEntry e Obligation\n- OperationalSummaryPanel agora deriva semântica financeira a partir do view-model canônico\n- atualização de teste do painel para mock parcial com novo export\n\n## Critérios atendidos\n- tipagem por contrato canônico no fluxo financeiro do painel\n- remoção de normalização defensiva com Number(x) || 0 no serviço de dashboard (10+ ocorrências removidas)\n- semântica de obrigações/renda baseada em tipos de domínio em vez de inferência solta\n\n## Validação\n- 
pm -w apps/web run typecheck\n- 
pm -w apps/web run lint\n- 
pm -w apps/web run test:run -- src/services/dashboard.service.test.ts src/components/OperationalSummaryPanel.test.tsx\n- 
pm run test (web: 398 testes, api: 954 testes)\n