### PR TITLE
Epic 2 · Issue 2.1 — Expor _meta no response do forecast

### DIFF
--- a/apps/api/src/domain/contracts/forecast-response.schema.ts
+++ b/apps/api/src/domain/contracts/forecast-response.schema.ts
@@ -1,4 +1,9 @@
 import { z } from "zod";
+import {
+  ForecastBalanceBasisSchema,
+  ForecastIncomeBasisSchema,
+  ForecastPendingItemsSchema,
+} from "./forecast.schema";
 
 const YearMonthSchema = z.string().regex(/^\d{4}-\d{2}$/);
 
@@ -17,6 +22,13 @@ const ForecastBankLimitProjectionSchema = z.object({
   alertTriggered: z.boolean(),
 });
 
+const ForecastResponseMetaSchema = z.object({
+  balanceBasis: ForecastBalanceBasisSchema,
+  incomeBasis: ForecastIncomeBasisSchema,
+  pendingItems: ForecastPendingItemsSchema,
+  fallbacksUsed: z.array(z.string()),
+});
+
 const ForecastHttpPayloadSchema = z.object({
   month: YearMonthSchema,
   engineVersion: z.string(),
@@ -32,6 +44,7 @@ const ForecastHttpPayloadSchema = z.object({
   billsPendingCount: z.number().int().nonnegative(),
   adjustedProjectedBalance: z.number(),
   bankLimit: ForecastBankLimitProjectionSchema.nullable(),
+  _meta: ForecastResponseMetaSchema,
 });
 
 export const ForecastCurrentResponseSchema = ForecastHttpPayloadSchema.nullable();
@@ -39,6 +52,7 @@ export const ForecastCurrentResponseSchema = ForecastHttpPayloadSchema.nullable(
 export const ForecastRecomputeResponseSchema = ForecastHttpPayloadSchema;
 
 export type ForecastBankLimitProjection = z.infer<typeof ForecastBankLimitProjectionSchema>;
+export type ForecastResponseMeta = z.infer<typeof ForecastResponseMetaSchema>;
 export type ForecastHttpPayload = z.infer<typeof ForecastHttpPayloadSchema>;
 export type ForecastCurrentResponse = z.infer<typeof ForecastCurrentResponseSchema>;
 export type ForecastRecomputeResponse = z.infer<typeof ForecastRecomputeResponseSchema>;

--- a/apps/api/src/domain/contracts/index.ts
+++ b/apps/api/src/domain/contracts/index.ts
@@ -69,5 +69,6 @@ export type {
   ForecastBankLimitProjection,
   ForecastCurrentResponse,
   ForecastHttpPayload,
+  ForecastResponseMeta,
   ForecastRecomputeResponse,
 } from "./forecast-response.schema";

--- a/apps/api/src/domain/contracts/types.ts
+++ b/apps/api/src/domain/contracts/types.ts
@@ -33,5 +33,6 @@ export type {
   ForecastBankLimitProjection,
   ForecastCurrentResponse,
   ForecastHttpPayload,
+  ForecastResponseMeta,
   ForecastRecomputeResponse,
 } from "./forecast-response.schema";

--- a/apps/api/src/forecast.test.js
+++ b/apps/api/src/forecast.test.js
@@ -104,6 +104,16 @@ describe("POST /forecasts/recompute", () => {
     expect(typeof res.body.flipDetected).toBe("boolean");
     expect(res.body.engineVersion).toBe("v2");
     expect(res.body.incomeExpected).toBeNull();
+    expect(res.body._meta).toMatchObject({
+      balanceBasis: "net_month_transactions",
+      incomeBasis: "salary_profile_fallback",
+      pendingItems: {
+        bills: 0,
+        invoices: 0,
+        creditCardCycles: 0,
+      },
+    });
+    expect(Array.isArray(res.body._meta.fallbacksUsed)).toBe(true);
   });
 
   it("reflete gastos do mes nas metricas", async () => {
@@ -445,6 +455,12 @@ describe("computeForecast — projection semantics (deterministic)", () => {
     expect(result.billsPendingTotal).toBe(300);
     expect(result.billsPendingCount).toBe(1);
     expect(result.adjustedProjectedBalance).toBe(700);
+    expect(result._meta).toMatchObject({
+      balanceBasis: "bank_account",
+      pendingItems: {
+        bills: 1,
+      },
+    });
   });
 
   it("inclui fatura aberta como obrigacao futura sem tratar como saida liquidada", async () => {
@@ -698,6 +714,42 @@ describe("forecast — bills integration", () => {
       1,
     );
   });
+
+  it("recompute expõe pendingItems com invoices e ciclos de cartão", async () => {
+    const token = await registerAndLogin("fc-meta-pending-items@test.dev");
+    const userId = await getUserIdByEmail("fc-meta-pending-items@test.dev");
+
+    const cardResult = await dbQuery(
+      `INSERT INTO credit_cards (user_id, name, limit_total, closing_day, due_day)
+       VALUES ($1, 'Cartão principal', 5000, 20, 10)
+       RETURNING id`,
+      [userId],
+    );
+    const cardId = Number(cardResult.rows[0].id);
+
+    await dbQuery(
+      `INSERT INTO bills (user_id, title, amount, due_date, status, bill_type, credit_card_id)
+       VALUES ($1, 'Fatura de cartão', 700, $2, 'pending', 'credit_card_invoice', $3)`,
+      [userId, CURRENT_MONTH_END, cardId],
+    );
+
+    await dbQuery(
+      `INSERT INTO credit_card_purchases (user_id, credit_card_id, title, amount, purchase_date, status, statement_month)
+       VALUES ($1, $2, 'Compra aberta', 120, $3, 'open', $4)`,
+      [userId, cardId, CURRENT_MONTH_START, _now.toISOString().slice(0, 7)],
+    );
+
+    const res = await request(app)
+      .post("/forecasts/recompute")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body._meta.pendingItems).toMatchObject({
+      bills: 1,
+      invoices: 1,
+      creditCardCycles: 1,
+    });
+  });
 });
 
 // ─── Forecast — statement-aware income (deterministic) ───────────────────────
@@ -741,6 +793,12 @@ describe("computeForecast — statement-aware income (deterministic)", () => {
 
     expect(result.incomeExpected).toBe(4000);
     expect(result.projectedBalance).toBe(4000); // netToDate=0, adj=4000, daily=0
+    expect(result._meta).toMatchObject({
+      balanceBasis: "net_month_transactions",
+      incomeBasis: "salary_profile_fallback",
+    });
+    expect(result._meta.fallbacksUsed).toContain("balanceBasis:net_month_transactions");
+    expect(result._meta.fallbacksUsed).toContain("incomeBasis:salary_profile_fallback");
   });
 
   it("statement posted no mes: incomeAdjustment=0, incomeExpected=net_amount", async () => {
@@ -767,6 +825,10 @@ describe("computeForecast — statement-aware income (deterministic)", () => {
     expect(result.incomeExpected).toBe(5000);
     // posted statement already in transactions — no cash adjustment
     expect(result.projectedBalance).toBe(0); // netToDate=0, adj=0, daily=0
+    expect(result._meta).toMatchObject({
+      incomeBasis: "confirmed_statement",
+    });
+    expect(result._meta.fallbacksUsed).not.toContain("incomeBasis:salary_profile_fallback");
   });
 
   it("statement draft com payment_date futuro: nao entra na projecao sem confirmacao", async () => {

--- a/apps/api/src/services/forecast.service.js
+++ b/apps/api/src/services/forecast.service.js
@@ -91,6 +91,66 @@ const buildBankLimitProjection = (bankLimitTotal, adjustedProjectedBalance) => {
   };
 };
 
+const resolveBalanceBasis = (activeAccountsCount) =>
+  activeAccountsCount > 0 ? "bank_account" : "net_month_transactions";
+
+const resolveIncomeBasis = (hasStatementsThisMonth) =>
+  hasStatementsThisMonth ? "confirmed_statement" : "salary_profile_fallback";
+
+const getForecastPendingItems = async (userId, monthEnd, currentMonth) => {
+  const billsResult = await dbQuery(
+    `SELECT
+       COUNT(*)::int AS bills_count,
+       COUNT(*) FILTER (WHERE bill_type = 'credit_card_invoice')::int AS invoices_count
+     FROM bills
+     WHERE user_id  = $1
+       AND status   = 'pending'
+       AND due_date <= $2`,
+    [userId, monthEnd],
+  );
+
+  const cyclesResult = await dbQuery(
+    `SELECT COUNT(DISTINCT statement_month)::int AS cycles_count
+     FROM credit_card_purchases
+     WHERE user_id = $1
+       AND status = 'open'
+       AND statement_month IS NOT NULL
+       AND statement_month <= $2`,
+    [userId, currentMonth],
+  );
+
+  return {
+    bills: Number(billsResult.rows[0]?.bills_count || 0),
+    invoices: Number(billsResult.rows[0]?.invoices_count || 0),
+    creditCardCycles: Number(cyclesResult.rows[0]?.cycles_count || 0),
+  };
+};
+
+const buildForecastMeta = async ({
+  userId,
+  monthEnd,
+  currentMonth,
+  balanceBasis,
+  incomeBasis,
+}) => {
+  const pendingItems = await getForecastPendingItems(userId, monthEnd, currentMonth);
+  const fallbacksUsed = [];
+
+  if (balanceBasis === "net_month_transactions") {
+    fallbacksUsed.push("balanceBasis:net_month_transactions");
+  }
+  if (incomeBasis === "salary_profile_fallback") {
+    fallbacksUsed.push("incomeBasis:salary_profile_fallback");
+  }
+
+  return {
+    balanceBasis,
+    incomeBasis,
+    pendingItems,
+    fallbacksUsed,
+  };
+};
+
 /**
  * Computes (or recomputes) the forecast for the given user and month,
  * persists it, and returns the result.
@@ -204,6 +264,8 @@ export const computeForecast = async (userId, { now = new Date() } = {}) => {
     : salaryMonthly != null && payday != null && payday > todayDay
       ? salaryMonthly
       : 0;
+  const balanceBasis = resolveBalanceBasis(activeAccountsCount);
+  const incomeBasis = resolveIncomeBasis(hasStatementsThisMonth);
 
   // 5. Projected balance
   const netToDate = incomeToDate - spendingToDate;
@@ -256,6 +318,13 @@ export const computeForecast = async (userId, { now = new Date() } = {}) => {
   const monthEnd = monthEndStr(now);
   const { billsTotal, billsCount } = await getPendingBillsDueByDate(uid, monthEnd);
   const adjustedProjectedBalance = Number((pb - billsTotal).toFixed(2));
+  const meta = await buildForecastMeta({
+    userId: uid,
+    monthEnd,
+    currentMonth,
+    balanceBasis,
+    incomeBasis,
+  });
 
   return {
     month: mStart.slice(0, 7),
@@ -272,6 +341,7 @@ export const computeForecast = async (userId, { now = new Date() } = {}) => {
     billsPendingCount: billsCount,
     adjustedProjectedBalance,
     bankLimit: buildBankLimitProjection(effectiveBankLimitTotal, adjustedProjectedBalance),
+    _meta: meta,
   };
 };
 
@@ -291,6 +361,7 @@ export const getLatestForecast = async (userId, { now = new Date() } = {}) => {
 
   const forecast = rowToForecast(result.rows[0]);
   const monthEnd = monthEndStr(now);
+  const currentMonth = mStart.slice(0, 7);
   const { billsTotal, billsCount } = await getPendingBillsDueByDate(uid, monthEnd);
   forecast.billsPendingTotal = Number(billsTotal.toFixed(2));
   forecast.billsPendingCount = billsCount;
@@ -318,9 +389,29 @@ export const getLatestForecast = async (userId, { now = new Date() } = {}) => {
   const effectiveBankLimitTotal =
     activeAccountsCount > 0 ? totalBankLimitTotal : profileBankLimitTotal;
 
+  const stmtExpectedResult = await dbQuery(
+    `SELECT COALESCE(SUM(st.net_amount), 0) AS total
+     FROM income_statements st
+     JOIN income_sources s ON s.id = st.income_source_id
+     WHERE s.user_id = $1
+       AND st.reference_month = $2
+       AND st.status = 'posted'`,
+    [uid, currentMonth],
+  );
+  const hasStatementsThisMonth = Number(stmtExpectedResult.rows[0]?.total || 0) > 0;
+  const balanceBasis = resolveBalanceBasis(activeAccountsCount);
+  const incomeBasis = resolveIncomeBasis(hasStatementsThisMonth);
+
   forecast.bankLimit = buildBankLimitProjection(
     effectiveBankLimitTotal,
     forecast.adjustedProjectedBalance,
   );
+  forecast._meta = await buildForecastMeta({
+    userId: uid,
+    monthEnd,
+    currentMonth,
+    balanceBasis,
+    incomeBasis,
+  });
   return forecast;
 };


### PR DESCRIPTION
## Contexto\nImplementa a Issue 2.1 do Epic 2 para transparência de base do forecast, sem alterar a matemática existente.\n\n## O que mudou\n- adiciona _meta no payload de /forecasts/recompute e /forecasts/current\n- _meta.balanceBasis: ank_account | 
et_month_transactions\n- _meta.incomeBasis: confirmed_statement | salary_profile_fallback\n- _meta.pendingItems: { bills, invoices, creditCardCycles }\n- _meta.fallbacksUsed: lista explícita de fallbacks acionados\n- schema de resposta atualizado para validar _meta\n\n## Garantias\n- nenhuma alteração na matemática do forecast\n- mudança restrita à exposição de metadata e contrato de resposta\n\n## Testes\n- 
pm -w apps/api run lint\n- 
pm -w apps/api run test -- src/forecast.test.js src/domain/contracts/contracts.schema.test.ts\n- cobertura adicionada para:\n  - base com conta bancária ativa\n  - fallback sem conta bancária\n  - statement confirmado vs fallback salarial\n