### PR TITLE
Epic 2 · Issue 2.2 — UI display do _meta do forecast

### DIFF
--- a/apps/web/src/components/ForecastCard.test.tsx
+++ b/apps/web/src/components/ForecastCard.test.tsx
@@ -33,6 +33,16 @@ const buildForecast = (overrides: Partial<Forecast> = {}): Forecast => ({
   incomeExpected: 1200,
   billsPendingTotal: 0,
   billsPendingCount: 0,
+  _meta: {
+    balanceBasis: "bank_account",
+    incomeBasis: "confirmed_statement",
+    pendingItems: {
+      bills: 2,
+      invoices: 1,
+      creditCardCycles: 1,
+    },
+    fallbacksUsed: [],
+  },
   bankLimit: {
     total: 1000,
     used: 220,
@@ -110,6 +120,48 @@ describe("ForecastCard", () => {
       expect(screen.getByText(/A projeção ultrapassa o limite/)).toBeInTheDocument(),
     );
     expect(screen.getByText(/100% do limite/)).toBeInTheDocument();
+  });
+
+  it("exibe a base de cálculo do forecast com os metadados da API", async () => {
+    vi.mocked(forecastService.getCurrent).mockResolvedValue(
+      buildForecast({
+        _meta: {
+          balanceBasis: "net_month_transactions",
+          incomeBasis: "salary_profile_fallback",
+          pendingItems: {
+            bills: 3,
+            invoices: 1,
+            creditCardCycles: 2,
+          },
+          fallbacksUsed: [
+            "balanceBasis:net_month_transactions",
+            "incomeBasis:salary_profile_fallback",
+          ],
+        },
+      }),
+    );
+
+    renderCard();
+
+    await waitFor(() => expect(screen.getByText("Base do cálculo")).toBeInTheDocument());
+    expect(screen.getByText("Saldo líquido do mês (entradas - saídas)")).toBeInTheDocument();
+    expect(screen.getByText("Fallback pelo perfil salarial")).toBeInTheDocument();
+    expect(screen.getByText(/3 contas, 1 faturas e 2 ciclos de cartão/i)).toBeInTheDocument();
+    expect(screen.getByText(/Sem conta bancária ativa, usando saldo líquido do mês/i)).toBeInTheDocument();
+    expect(screen.getByText(/Sem extrato confirmado no mês, usando perfil salarial/i)).toBeInTheDocument();
+  });
+
+  it("mantém fallback silencioso quando _meta não está disponível", async () => {
+    vi.mocked(forecastService.getCurrent).mockResolvedValue(
+      buildForecast({ _meta: undefined }),
+    );
+
+    renderCard();
+
+    await waitFor(() => expect(screen.getByText("Base do cálculo")).toBeInTheDocument());
+    expect(
+      screen.getByText("Detalhes de origem do cálculo indisponíveis no momento."),
+    ).toBeInTheDocument();
   });
 
   it("exibe aviso claro quando a projeção está congelada", async () => {

--- a/apps/web/src/components/ForecastCard.tsx
+++ b/apps/web/src/components/ForecastCard.tsx
@@ -90,6 +90,77 @@ const BankLimitPanel = ({ forecast, money }: { forecast: Forecast; money: (value
   );
 };
 
+const BALANCE_BASIS_LABEL: Record<"bank_account" | "net_month_transactions", string> = {
+  bank_account: "Saldo atual das contas bancárias ativas",
+  net_month_transactions: "Saldo líquido do mês (entradas - saídas)",
+};
+
+const INCOME_BASIS_LABEL: Record<"confirmed_statement" | "salary_profile_fallback", string> = {
+  confirmed_statement: "Extratos confirmados no mês",
+  salary_profile_fallback: "Fallback pelo perfil salarial",
+};
+
+const FALLBACK_REASON_LABEL: Record<string, string> = {
+  "balanceBasis:net_month_transactions": "Sem conta bancária ativa, usando saldo líquido do mês.",
+  "incomeBasis:salary_profile_fallback": "Sem extrato confirmado no mês, usando perfil salarial.",
+};
+
+const ForecastTransparencyPanel = ({
+  forecast,
+}: {
+  forecast: Forecast;
+}): JSX.Element => {
+  const meta = forecast._meta;
+
+  if (!meta) {
+    return (
+      <div className="mt-4 rounded-lg border border-cf-border bg-cf-bg-subtle px-3.5 py-3">
+        <p className="text-xs font-medium uppercase text-cf-text-secondary">Base do cálculo</p>
+        <p className="mt-1 text-sm text-cf-text-secondary">
+          Detalhes de origem do cálculo indisponíveis no momento.
+        </p>
+      </div>
+    );
+  }
+
+  const fallbackReasons = meta.fallbacksUsed
+    .map((item) => FALLBACK_REASON_LABEL[item] ?? item)
+    .filter(Boolean);
+
+  return (
+    <div className="mt-4 rounded-lg border border-cf-border bg-cf-bg-subtle px-3.5 py-3">
+      <p className="text-xs font-medium uppercase text-cf-text-secondary">Base do cálculo</p>
+
+      <div className="mt-2 grid gap-3 sm:grid-cols-2">
+        <div>
+          <p className="text-[11px] font-semibold uppercase text-cf-text-secondary">Saldo</p>
+          <p className="mt-0.5 text-sm text-cf-text-primary">{BALANCE_BASIS_LABEL[meta.balanceBasis]}</p>
+        </div>
+        <div>
+          <p className="text-[11px] font-semibold uppercase text-cf-text-secondary">Renda</p>
+          <p className="mt-0.5 text-sm text-cf-text-primary">{INCOME_BASIS_LABEL[meta.incomeBasis]}</p>
+        </div>
+      </div>
+
+      <div className="mt-3">
+        <p className="text-[11px] font-semibold uppercase text-cf-text-secondary">Itens pendentes considerados</p>
+        <p className="mt-0.5 text-sm text-cf-text-primary">
+          {meta.pendingItems.bills} contas, {meta.pendingItems.invoices} faturas e {meta.pendingItems.creditCardCycles} ciclos de cartão.
+        </p>
+      </div>
+
+      <div className="mt-3">
+        <p className="text-[11px] font-semibold uppercase text-cf-text-secondary">Fallbacks usados</p>
+        {fallbackReasons.length > 0 ? (
+          <p className="mt-0.5 text-sm text-cf-text-primary">{fallbackReasons.join(" ")}</p>
+        ) : (
+          <p className="mt-0.5 text-sm text-cf-text-secondary">Nenhum fallback foi necessário neste cálculo.</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
 const ForecastCard = ({
   onOpenProfileSettings,
   trialExpired = false,
@@ -423,6 +494,8 @@ const ForecastCard = ({
           {forecast.flipDetected && forecast.flipDirection ? (
             <FlipBanner direction={forecast.flipDirection} />
           ) : null}
+
+          <ForecastTransparencyPanel forecast={forecast} />
 
           <BankLimitPanel forecast={forecast} money={money} />
         </>

--- a/apps/web/src/services/forecast.service.ts
+++ b/apps/web/src/services/forecast.service.ts
@@ -10,6 +10,19 @@ export interface ForecastBankLimit {
   alertTriggered: boolean;
 }
 
+export interface ForecastMetaPendingItems {
+  bills: number;
+  invoices: number;
+  creditCardCycles: number;
+}
+
+export interface ForecastMeta {
+  balanceBasis: "bank_account" | "net_month_transactions";
+  incomeBasis: "confirmed_statement" | "salary_profile_fallback";
+  pendingItems: ForecastMetaPendingItems;
+  fallbacksUsed: string[];
+}
+
 export interface Forecast {
   month: string;
   projectedBalance: number;
@@ -24,6 +37,8 @@ export interface Forecast {
   billsPendingCount: number;
   adjustedProjectedBalance: number;
   bankLimit?: ForecastBankLimit | null;
+  _meta?: ForecastMeta;
+  _degraded?: boolean;
 }
 
 let getCurrentInFlightRequest: Promise<Forecast | null> | null = null;


### PR DESCRIPTION
## Contexto\nImplementa a Issue 2.2 do Epic 2: exibir no frontend o _meta já exposto pela API no 2.1.\n\n## O que mudou\n- tipagem de _meta no serviço de forecast do web\n- painel de transparência no ForecastCard com:\n  - base de saldo (alanceBasis)\n  - base de renda (incomeBasis)\n  - itens pendentes (pendingItems)\n  - fallbacks usados (allbacksUsed)\n- fallback silencioso de UI quando _meta não estiver disponível\n\n## Garantias de escopo\n- sem recálculo no frontend\n- sem mudança de regra de negócio\n- sem refactor oportunista fora do fluxo/tela de forecast\n\n## Validação\n- 
pm -w apps/web run typecheck\n- 
pm -w apps/web run lint\n- 
pm -w apps/web run test:run -- src/components/ForecastCard.test.tsx\n- 
pm -w apps/web run test:run -- src/pages/TaxPage.test.tsx (reanálise de flake fora de escopo)\n\n## Nota sobre suíte completa\n- em uma execução de 
pm -w apps/web run test:run, ocorreu uma falha pontual em TaxPage (fora do escopo desta issue), que passou ao ser reexecutada isoladamente.\n