### PR TITLE
Epic 3 · Issue 3.1 — income split no painel operacional

### DIFF
--- a/apps/web/src/components/OperationalSummaryPanel.test.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.test.tsx
@@ -209,4 +209,49 @@ describe("OperationalSummaryPanel", () => {
     ).toBeInTheDocument();
     expect(screen.getByText(/2 próximas/)).toBeInTheDocument();
   });
+
+  it("separa renda recebida e prevista sem somar no valor principal", async () => {
+    vi.mocked(dashboardService.getSnapshot).mockResolvedValueOnce(
+      buildSnapshot({
+        income: {
+          receivedThisMonth: 1200,
+          pendingThisMonth: 350,
+          referenceMonth: "2026-04",
+        },
+      }),
+    );
+
+    render(<OperationalSummaryPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Renda do mês")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("R$ 1.200,00")).toBeInTheDocument();
+    expect(screen.getByText("Recebido")).toBeInTheDocument();
+    expect(screen.getByText("Previsto: R$ 350,00")).toBeInTheDocument();
+    expect(screen.queryByText("R$ 1.550,00")).not.toBeInTheDocument();
+  });
+
+  it("mantem recebido e previsto explícitos mesmo sem credito confirmado", async () => {
+    vi.mocked(dashboardService.getSnapshot).mockResolvedValueOnce(
+      buildSnapshot({
+        income: {
+          receivedThisMonth: 0,
+          pendingThisMonth: 900,
+          referenceMonth: "2026-04",
+        },
+      }),
+    );
+
+    render(<OperationalSummaryPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Renda do mês")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("R$ 0,00")).toBeInTheDocument();
+    expect(screen.getByText("Recebido")).toBeInTheDocument();
+    expect(screen.getByText("Previsto: R$ 900,00")).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/OperationalSummaryPanel.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.tsx
@@ -74,9 +74,6 @@ const DAY_IN_MS = 24 * 60 * 60 * 1000;
 const sumAmounts = (items: Array<{ amount: number }>): number =>
   items.reduce((total, item) => total + item.amount, 0);
 
-const sumIncomeNetAmounts = (items: Array<{ netAmount: number }>): number =>
-  items.reduce((total, item) => total + item.netAmount, 0);
-
 const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanelProps): JSX.Element | null => {
   const [snapshot, setSnapshot] = useState<DashboardSnapshot | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -166,7 +163,7 @@ const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanel
   }
 
   const { cards, forecast, consignado } = snapshot;
-  const { balanceSnapshot, incomes, obligations } = buildDashboardContractView(snapshot);
+  const { balanceSnapshot, obligations } = buildDashboardContractView(snapshot);
 
   const nowTimestamp = Date.now();
   const dueSoonLimit = nowTimestamp + 7 * DAY_IN_MS;
@@ -192,12 +189,8 @@ const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanel
   const dueSoonTotal = sumAmounts(dueSoonObligations);
   const upcomingCount = upcomingObligations.length;
   const upcomingTotal = sumAmounts(upcomingObligations);
-  const receivedThisMonth = sumIncomeNetAmounts(
-    incomes.filter((entry) => entry.status === "confirmed"),
-  );
-  const pendingThisMonth = sumIncomeNetAmounts(
-    incomes.filter((entry) => entry.status === "pending" || entry.status === "detected"),
-  );
+  const receivedThisMonth = snapshot.income.receivedThisMonth;
+  const projectedThisMonth = snapshot.income.pendingThisMonth;
 
   // ── Tile 1: Bank balance ──────────────────────────────────────────────────
   const bankBalance = balanceSnapshot.bankBalance;
@@ -295,24 +288,17 @@ const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanel
   };
 
   // ── Tile 4: Income ────────────────────────────────────────────────────────
-  const hasIncome = receivedThisMonth > 0 || pendingThisMonth > 0;
+  const hasConfirmedIncome = receivedThisMonth > 0;
+  const hasProjectedIncome = projectedThisMonth > 0;
   const incomeTile: TileProps = {
     label: "Renda do mês",
-    primary: hasIncome ? money(receivedThisMonth + pendingThisMonth) : "—",
-    secondary:
-      receivedThisMonth > 0
-        ? `${money(receivedThisMonth)} recebido`
-        : pendingThisMonth > 0
-          ? "Ainda não recebido"
-          : "Sem lançamento",
-    tertiary:
-      pendingThisMonth > 0 && receivedThisMonth > 0
-        ? `${money(pendingThisMonth)} pendente`
-        : undefined,
+    primary: money(receivedThisMonth),
+    secondary: "Recebido",
+    tertiary: `Previsto: ${money(projectedThisMonth)}`,
     accent:
-      receivedThisMonth > 0
+      hasConfirmedIncome
         ? "success"
-        : pendingThisMonth > 0
+        : hasProjectedIncome
           ? "warning"
           : "muted",
   };


### PR DESCRIPTION
## Contexto
Implementa a Issue 3.1 do Epic 3: separar no painel operacional o que já foi recebido do que ainda é previsto.

## O que mudou
- ajusta OperationalSummaryPanel para não somar renda recebida com renda prevista no valor principal
- mantém o valor principal como **recebido**
- exibe renda **prevista** de forma explícita em linha separada
- mantém semântica baseada nos contratos atuais (snapshot.income.receivedThisMonth e snapshot.income.pendingThisMonth)
- adiciona testes de componente cobrindo split recebido vs previsto e proteção contra soma indevida

## Garantias de escopo
- sem mudança de API
- sem refactor de service
- sem mistura com split de cartão (Issue 3.2)
- sem frente paralela

## Validação
- 
pm -w apps/web run test:run -- src/components/OperationalSummaryPanel.test.tsx
- 
pm -w apps/web run typecheck
- 
pm -w apps/web run lint

## Resultado
Painel operacional passa a separar claramente renda realizada de renda projetada, reduzindo ambiguidade semântica.