### PR TITLE
Epic 3 · Issue 3.2 — card split no painel operacional

### DIFF
--- a/apps/web/src/components/OperationalSummaryPanel.test.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.test.tsx
@@ -210,6 +210,85 @@ describe("OperationalSummaryPanel", () => {
     expect(screen.getByText(/2 próximas/)).toBeInTheDocument();
   });
 
+  it("cartao separa ciclo atual e faturas pendentes quando ambos existem", async () => {
+    vi.mocked(dashboardService.getSnapshot).mockResolvedValueOnce(
+      buildSnapshot({
+        cards: {
+          openPurchasesTotal: 420,
+          pendingInvoicesTotal: 900,
+        },
+      }),
+    );
+
+    render(<OperationalSummaryPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Cartão")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Faturas a pagar: R$ 900,00")).toBeInTheDocument();
+    expect(screen.getByText("Gastos no ciclo: R$ 420,00")).toBeInTheDocument();
+  });
+
+  it("cartao mostra apenas ciclo atual quando nao ha faturas pendentes", async () => {
+    vi.mocked(dashboardService.getSnapshot).mockResolvedValueOnce(
+      buildSnapshot({
+        cards: {
+          openPurchasesTotal: 280,
+          pendingInvoicesTotal: 0,
+        },
+      }),
+    );
+
+    render(<OperationalSummaryPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Cartão")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Gastos no ciclo: R$ 280,00")).toBeInTheDocument();
+    expect(screen.queryByText(/Faturas a pagar:/)).not.toBeInTheDocument();
+  });
+
+  it("cartao mostra apenas faturas pendentes quando nao ha ciclo aberto", async () => {
+    vi.mocked(dashboardService.getSnapshot).mockResolvedValueOnce(
+      buildSnapshot({
+        cards: {
+          openPurchasesTotal: 0,
+          pendingInvoicesTotal: 610,
+        },
+      }),
+    );
+
+    render(<OperationalSummaryPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Cartão")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Faturas a pagar: R$ 610,00")).toBeInTheDocument();
+    expect(screen.queryByText(/Gastos no ciclo:/)).not.toBeInTheDocument();
+  });
+
+  it("cartao mostra estado vazio quando nao ha ciclo nem faturas", async () => {
+    vi.mocked(dashboardService.getSnapshot).mockResolvedValueOnce(
+      buildSnapshot({
+        cards: {
+          openPurchasesTotal: 0,
+          pendingInvoicesTotal: 0,
+        },
+      }),
+    );
+
+    render(<OperationalSummaryPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Cartão")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Sem movimentação")).toBeInTheDocument();
+  });
+
   it("separa renda recebida e prevista sem somar no valor principal", async () => {
     vi.mocked(dashboardService.getSnapshot).mockResolvedValueOnce(
       buildSnapshot({

--- a/apps/web/src/components/OperationalSummaryPanel.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.tsx
@@ -162,20 +162,21 @@ const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanel
     );
   }
 
-  const { cards, forecast, consignado } = snapshot;
+  const { forecast, consignado } = snapshot;
   const { balanceSnapshot, obligations } = buildDashboardContractView(snapshot);
 
   const nowTimestamp = Date.now();
   const dueSoonLimit = nowTimestamp + 7 * DAY_IN_MS;
-  const overdueObligations = obligations.filter((obligation) => obligation.status === "due");
-  const dueSoonObligations = obligations.filter((obligation) => {
+  const billObligations = obligations.filter((obligation) => obligation.obligationType === "bill");
+  const overdueObligations = billObligations.filter((obligation) => obligation.status === "due");
+  const dueSoonObligations = billObligations.filter((obligation) => {
     if (obligation.status !== "open") {
       return false;
     }
 
     return Date.parse(obligation.dueDate) <= dueSoonLimit;
   });
-  const upcomingObligations = obligations.filter((obligation) => {
+  const upcomingObligations = billObligations.filter((obligation) => {
     if (obligation.status !== "open") {
       return false;
     }
@@ -191,6 +192,12 @@ const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanel
   const upcomingTotal = sumAmounts(upcomingObligations);
   const receivedThisMonth = snapshot.income.receivedThisMonth;
   const projectedThisMonth = snapshot.income.pendingThisMonth;
+  const cardCycleTotal = sumAmounts(
+    obligations.filter((obligation) => obligation.obligationType === "credit_card_cycle"),
+  );
+  const openInvoicesTotal = sumAmounts(
+    obligations.filter((obligation) => obligation.obligationType === "open_invoice"),
+  );
 
   // ── Tile 1: Bank balance ──────────────────────────────────────────────────
   const bankBalance = balanceSnapshot.bankBalance;
@@ -274,17 +281,22 @@ const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanel
   };
 
   // ── Tile 3: Credit card ───────────────────────────────────────────────────
-  const cardTotal = cards.openPurchasesTotal + cards.pendingInvoicesTotal;
+  const hasCardCycle = cardCycleTotal > 0;
+  const hasOpenInvoices = openInvoicesTotal > 0;
   const cardTile: TileProps = {
     label: "Cartão",
-    primary: cardTotal > 0 ? money(cardTotal) : "—",
+    primary: hasOpenInvoices ? money(openInvoicesTotal) : hasCardCycle ? money(cardCycleTotal) : "—",
     secondary:
-      cards.openPurchasesTotal > 0 ? `${money(cards.openPurchasesTotal)} em aberto` : undefined,
+      hasOpenInvoices
+        ? `Faturas a pagar: ${money(openInvoicesTotal)}`
+        : hasCardCycle
+          ? `Gastos no ciclo: ${money(cardCycleTotal)}`
+          : "Sem movimentação",
     tertiary:
-      cards.pendingInvoicesTotal > 0
-        ? `${money(cards.pendingInvoicesTotal)} fatura`
+      hasOpenInvoices && hasCardCycle
+        ? `Gastos no ciclo: ${money(cardCycleTotal)}`
         : undefined,
-    accent: cards.pendingInvoicesTotal > 0 ? "warning" : "default",
+    accent: hasOpenInvoices ? "warning" : hasCardCycle ? "default" : "muted",
   };
 
   // ── Tile 4: Income ────────────────────────────────────────────────────────

--- a/apps/web/src/services/dashboard.service.test.ts
+++ b/apps/web/src/services/dashboard.service.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "./api";
-import { dashboardService } from "./dashboard.service";
+import { buildDashboardContractView, dashboardService, type DashboardSnapshot } from "./dashboard.service";
 
 vi.mock("./api", () => ({
   api: {
@@ -10,6 +10,38 @@ vi.mock("./api", () => ({
 }));
 
 const getMock = vi.mocked(api.get);
+
+const buildSnapshot = (overrides: Partial<DashboardSnapshot> = {}): DashboardSnapshot => ({
+  bankBalance: 1200,
+  bills: {
+    overdueCount: 0,
+    overdueTotal: 0,
+    dueSoonCount: 0,
+    dueSoonTotal: 0,
+    upcomingCount: 0,
+    upcomingTotal: 0,
+    ...(overrides.bills ?? {}),
+  },
+  cards: {
+    openPurchasesTotal: 0,
+    pendingInvoicesTotal: 0,
+    ...(overrides.cards ?? {}),
+  },
+  income: {
+    receivedThisMonth: 0,
+    pendingThisMonth: 0,
+    referenceMonth: "2026-04",
+    ...(overrides.income ?? {}),
+  },
+  forecast: overrides.forecast ?? null,
+  consignado: {
+    monthlyTotal: 0,
+    contractsCount: 0,
+    comprometimentoPct: null,
+    ...(overrides.consignado ?? {}),
+  },
+  ...overrides,
+});
 
 describe("dashboardService", () => {
   beforeEach(() => {
@@ -60,5 +92,28 @@ describe("dashboardService", () => {
       upcomingCount: 3,
       upcomingTotal: 480,
     });
+  });
+
+  it("buildDashboardContractView separa obrigacoes de cartao por tipo", () => {
+    const snapshot = buildSnapshot({
+      cards: {
+        openPurchasesTotal: 320,
+        pendingInvoicesTotal: 780,
+      },
+    });
+
+    const result = buildDashboardContractView(snapshot, new Date("2026-04-15T00:00:00.000Z"));
+
+    const cycleObligations = result.obligations.filter(
+      (obligation) => obligation.obligationType === "credit_card_cycle",
+    );
+    const invoiceObligations = result.obligations.filter(
+      (obligation) => obligation.obligationType === "open_invoice",
+    );
+
+    expect(cycleObligations).toHaveLength(1);
+    expect(invoiceObligations).toHaveLength(1);
+    expect(cycleObligations[0].amount).toBe(320);
+    expect(invoiceObligations[0].amount).toBe(780);
   });
 });

--- a/apps/web/src/services/dashboard.service.ts
+++ b/apps/web/src/services/dashboard.service.ts
@@ -35,6 +35,23 @@ const createObligations = (
   }));
 };
 
+const createCardObligation = (
+  amount: number,
+  obligationType: "credit_card_cycle" | "open_invoice",
+  dueDate: Date,
+): Obligation[] => {
+  if (amount <= 0) {
+    return [];
+  }
+
+  return [{
+    amount,
+    obligationType,
+    dueDate: dueDate.toISOString(),
+    status: "open",
+  }];
+};
+
 export const buildDashboardContractView = (
   snapshot: DashboardSnapshot,
   now: Date = new Date(),
@@ -79,6 +96,16 @@ export const buildDashboardContractView = (
       snapshot.bills.upcomingCount,
       "open",
       new Date(now.getTime() + 30 * DAY_IN_MS),
+    ),
+    ...createCardObligation(
+      snapshot.cards.openPurchasesTotal,
+      "credit_card_cycle",
+      new Date(now.getTime() + 30 * DAY_IN_MS),
+    ),
+    ...createCardObligation(
+      snapshot.cards.pendingInvoicesTotal,
+      "open_invoice",
+      new Date(now.getTime() + 10 * DAY_IN_MS),
     ),
   ];
 


### PR DESCRIPTION
## Contexto
Implementa a Issue 3.2 do Epic 3: separar no card do painel operacional o ciclo atual do cartão das faturas pendentes.

## O que mudou
- no painel operacional, o bloco de cartão agora distingue explicitamente:
  - **Gastos no ciclo** (obligationType: credit_card_cycle)
  - **Faturas a pagar** (obligationType: open_invoice)
- leitura do card passou a usar uildDashboardContractView(...).obligations por tipo, evitando mistura semântica
- contas a pagar continuam calculadas apenas com obligationType: bill (sem contaminar com obrigações de cartão)

## Escopo atendido
- ambos presentes: mostra as duas naturezas separadas
- só ciclo: mostra apenas gasto no ciclo
- só fatura: mostra apenas fatura a pagar
- nenhum: mostra estado vazio do card

## Arquivos alterados
- pps/web/src/components/OperationalSummaryPanel.tsx
- pps/web/src/components/OperationalSummaryPanel.test.tsx
- pps/web/src/services/dashboard.service.ts
- pps/web/src/services/dashboard.service.test.ts

## Garantias
- zero mudança de API
- zero refactor oportunista fora da issue
- sem mistura com 3.3 semantic labels

## Validação
- 
pm -w apps/web run test:run -- src/components/OperationalSummaryPanel.test.tsx src/services/dashboard.service.test.ts
- 
pm -w apps/web run typecheck
- 
pm -w apps/web run lint

## Resultado
O card do painel deixa de misturar obrigação de ciclo corrente com obrigação de fatura já fechada, mantendo leitura operacional clara e previsível.