### PR TITLE
Epic 3 · Issue 3.3 — semantic labels do painel operacional

### DIFF
--- a/apps/web/src/components/OperationalSummaryPanel.test.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.test.tsx
@@ -71,7 +71,7 @@ describe("OperationalSummaryPanel", () => {
     render(<OperationalSummaryPanel />);
 
     await waitFor(() => {
-      expect(screen.getByText("Saldo técnico: R$ 700,00")).toBeInTheDocument();
+      expect(screen.getByText("Saldo realizado após vencidas: R$ 700,00")).toBeInTheDocument();
     });
 
     expect(screen.getByText("2 vencidas somam R$ 300,00")).toBeInTheDocument();
@@ -95,16 +95,16 @@ describe("OperationalSummaryPanel", () => {
     render(<OperationalSummaryPanel />);
 
     await waitFor(() => {
-      expect(screen.getByText("Saldo em 7 dias: R$ 920,00")).toBeInTheDocument();
+      expect(screen.getByText("Saldo projetado em 7 dias: R$ 920,00")).toBeInTheDocument();
     });
 
-    expect(screen.getByText("1 em 7 dias somam R$ 80,00")).toBeInTheDocument();
+    expect(screen.getByText("1 obrigação em 7 dias somam R$ 80,00")).toBeInTheDocument();
     expect(
       screen.getByText(
-        (content) => content.includes("Urgência 7d: 1 conta") && content.includes("80,00"),
+        (content) => content.includes("Urgência 7d: 1 obrigação") && content.includes("80,00"),
       ),
     ).toBeInTheDocument();
-    expect(screen.queryByText("Saldo disponível")).not.toBeInTheDocument();
+    expect(screen.queryByText("Saldo realizado")).not.toBeInTheDocument();
   });
 
   it("dispara CTA de contas em 7 dias quando callback é fornecido", async () => {
@@ -150,10 +150,10 @@ describe("OperationalSummaryPanel", () => {
     render(<OperationalSummaryPanel />);
 
     await waitFor(() => {
-      expect(screen.getByText("Saldo disponível")).toBeInTheDocument();
+      expect(screen.getByText("Saldo realizado")).toBeInTheDocument();
     });
 
-    expect(screen.queryByText(/Saldo em 7 dias:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Saldo projetado em 7 dias:/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Saldo técnico:/)).not.toBeInTheDocument();
   });
 
@@ -174,11 +174,11 @@ describe("OperationalSummaryPanel", () => {
     render(<OperationalSummaryPanel />);
 
     await waitFor(() => {
-      expect(screen.getByText("Contas a pagar")).toBeInTheDocument();
+      expect(screen.getByText("Obrigações de contas")).toBeInTheDocument();
     });
 
     expect(screen.getByText(/480[,.]00/)).toBeInTheDocument();
-    expect(screen.getByText("2 próximas")).toBeInTheDocument();
+    expect(screen.getByText("2 obrigações futuras")).toBeInTheDocument();
   });
 
   it("mantem foco em urgencia imediata e sinaliza proximas no contexto", async () => {
@@ -204,10 +204,10 @@ describe("OperationalSummaryPanel", () => {
     expect(screen.getByText(/300[,.]00/)).toBeInTheDocument();
     expect(
       screen.getByText(
-        (content) => content.includes("Urgência 7d: 1 conta") && content.includes("200,00"),
+        (content) => content.includes("Urgência 7d: 1 obrigação") && content.includes("200,00"),
       ),
     ).toBeInTheDocument();
-    expect(screen.getByText(/2 próximas/)).toBeInTheDocument();
+    expect(screen.getByText(/2 obrigações futuras/)).toBeInTheDocument();
   });
 
   it("cartao separa ciclo atual e faturas pendentes quando ambos existem", async () => {
@@ -223,7 +223,7 @@ describe("OperationalSummaryPanel", () => {
     render(<OperationalSummaryPanel />);
 
     await waitFor(() => {
-      expect(screen.getByText("Cartão")).toBeInTheDocument();
+      expect(screen.getByText("Obrigações de cartão")).toBeInTheDocument();
     });
 
     expect(screen.getByText("Faturas a pagar: R$ 900,00")).toBeInTheDocument();
@@ -243,7 +243,7 @@ describe("OperationalSummaryPanel", () => {
     render(<OperationalSummaryPanel />);
 
     await waitFor(() => {
-      expect(screen.getByText("Cartão")).toBeInTheDocument();
+      expect(screen.getByText("Obrigações de cartão")).toBeInTheDocument();
     });
 
     expect(screen.getByText("Gastos no ciclo: R$ 280,00")).toBeInTheDocument();
@@ -263,7 +263,7 @@ describe("OperationalSummaryPanel", () => {
     render(<OperationalSummaryPanel />);
 
     await waitFor(() => {
-      expect(screen.getByText("Cartão")).toBeInTheDocument();
+      expect(screen.getByText("Obrigações de cartão")).toBeInTheDocument();
     });
 
     expect(screen.getByText("Faturas a pagar: R$ 610,00")).toBeInTheDocument();
@@ -283,10 +283,10 @@ describe("OperationalSummaryPanel", () => {
     render(<OperationalSummaryPanel />);
 
     await waitFor(() => {
-      expect(screen.getByText("Cartão")).toBeInTheDocument();
+      expect(screen.getByText("Obrigações de cartão")).toBeInTheDocument();
     });
 
-    expect(screen.getByText("Sem movimentação")).toBeInTheDocument();
+    expect(screen.getByText("Sem ciclo e sem fatura")).toBeInTheDocument();
   });
 
   it("separa renda recebida e prevista sem somar no valor principal", async () => {
@@ -303,12 +303,12 @@ describe("OperationalSummaryPanel", () => {
     render(<OperationalSummaryPanel />);
 
     await waitFor(() => {
-      expect(screen.getByText("Renda do mês")).toBeInTheDocument();
+      expect(screen.getByText("Renda do mês (realizada e prevista)")).toBeInTheDocument();
     });
 
     expect(screen.getByText("R$ 1.200,00")).toBeInTheDocument();
-    expect(screen.getByText("Recebido")).toBeInTheDocument();
-    expect(screen.getByText("Previsto: R$ 350,00")).toBeInTheDocument();
+    expect(screen.getByText("Realizado no mês")).toBeInTheDocument();
+    expect(screen.getByText("Previsto no mês: R$ 350,00")).toBeInTheDocument();
     expect(screen.queryByText("R$ 1.550,00")).not.toBeInTheDocument();
   });
 
@@ -326,11 +326,11 @@ describe("OperationalSummaryPanel", () => {
     render(<OperationalSummaryPanel />);
 
     await waitFor(() => {
-      expect(screen.getByText("Renda do mês")).toBeInTheDocument();
+      expect(screen.getByText("Renda do mês (realizada e prevista)")).toBeInTheDocument();
     });
 
     expect(screen.getByText("R$ 0,00")).toBeInTheDocument();
-    expect(screen.getByText("Recebido")).toBeInTheDocument();
-    expect(screen.getByText("Previsto: R$ 900,00")).toBeInTheDocument();
+    expect(screen.getByText("Realizado no mês")).toBeInTheDocument();
+    expect(screen.getByText("Previsto no mês: R$ 900,00")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/OperationalSummaryPanel.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.tsx
@@ -208,10 +208,10 @@ const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanel
   const shouldShowShortTermBalance = hasDueSoonBills && !hasOverdueBills;
 
   const bankTileSecondary = hasOverdueBills
-    ? `Saldo técnico: ${money(technicalBalance)}`
+    ? `Saldo realizado após vencidas: ${money(technicalBalance)}`
     : shouldShowShortTermBalance
-      ? `Saldo em 7 dias: ${money(shortTermBalance)}`
-      : "Saldo disponível";
+      ? `Saldo projetado em 7 dias: ${money(shortTermBalance)}`
+      : "Saldo realizado";
 
   const bankTileDetails: string[] = [];
   if (hasOverdueBills) {
@@ -221,12 +221,12 @@ const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanel
   }
   if (hasDueSoonBills) {
     bankTileDetails.push(
-      `${dueSoonCount} em 7 dias somam ${money(dueSoonTotal)}`,
+      `${dueSoonCount} ${dueSoonCount > 1 ? "obrigações" : "obrigação"} em 7 dias somam ${money(dueSoonTotal)}`,
     );
   }
 
   const bankTile: TileProps = {
-    label: "Conta",
+    label: "Saldo em conta",
     primary: money(bankBalance),
     secondary: bankTileSecondary,
     tertiary: bankTileDetails.length > 0 ? bankTileDetails.join(" • ") : undefined,
@@ -255,16 +255,16 @@ const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanel
   const billsTertiaryTokens: string[] = [];
   if (dueSoonCount > 0) {
     billsTertiaryTokens.push(
-      `Urgência 7d: ${dueSoonCount} conta${dueSoonCount > 1 ? "s" : ""} • ${money(dueSoonTotal)}`,
+      `Urgência 7d: ${dueSoonCount} ${dueSoonCount > 1 ? "obrigações" : "obrigação"} • ${money(dueSoonTotal)}`,
     );
   }
   if (hasUpcomingBills) {
     billsTertiaryTokens.push(
-      `${upcomingCount} próxima${upcomingCount > 1 ? "s" : ""}`,
+      `${upcomingCount} ${upcomingCount > 1 ? "obrigações" : "obrigação"} futura${upcomingCount > 1 ? "s" : ""}`,
     );
   }
   const billsTile: TileProps = {
-    label: "Contas a pagar",
+    label: "Obrigações de contas",
     primary: shouldHighlightImmediateBills || hasUpcomingBills ? money(billsPrimaryAmount) : "—",
     secondary:
       overdueCount > 0
@@ -272,8 +272,8 @@ const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanel
         : dueSoonCount > 0
           ? `${dueSoonCount} em 7 dias`
           : hasUpcomingBills
-            ? `${upcomingCount} próxima${upcomingCount > 1 ? "s" : ""}`
-          : "Nenhuma pendente",
+            ? `${upcomingCount} ${upcomingCount > 1 ? "obrigações" : "obrigação"} futura${upcomingCount > 1 ? "s" : ""}`
+          : "Sem obrigação pendente",
     tertiary: billsTertiaryTokens.length > 0 ? `+ ${billsTertiaryTokens.join(" • ")}` : undefined,
     actionLabel: dueSoonCount > 0 && onOpenDueSoonBills ? "Ver contas em 7 dias" : undefined,
     onActionClick: dueSoonCount > 0 && onOpenDueSoonBills ? onOpenDueSoonBills : undefined,
@@ -284,14 +284,14 @@ const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanel
   const hasCardCycle = cardCycleTotal > 0;
   const hasOpenInvoices = openInvoicesTotal > 0;
   const cardTile: TileProps = {
-    label: "Cartão",
+    label: "Obrigações de cartão",
     primary: hasOpenInvoices ? money(openInvoicesTotal) : hasCardCycle ? money(cardCycleTotal) : "—",
     secondary:
       hasOpenInvoices
         ? `Faturas a pagar: ${money(openInvoicesTotal)}`
         : hasCardCycle
           ? `Gastos no ciclo: ${money(cardCycleTotal)}`
-          : "Sem movimentação",
+          : "Sem ciclo e sem fatura",
     tertiary:
       hasOpenInvoices && hasCardCycle
         ? `Gastos no ciclo: ${money(cardCycleTotal)}`
@@ -303,10 +303,10 @@ const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanel
   const hasConfirmedIncome = receivedThisMonth > 0;
   const hasProjectedIncome = projectedThisMonth > 0;
   const incomeTile: TileProps = {
-    label: "Renda do mês",
+    label: "Renda do mês (realizada e prevista)",
     primary: money(receivedThisMonth),
-    secondary: "Recebido",
-    tertiary: `Previsto: ${money(projectedThisMonth)}`,
+    secondary: "Realizado no mês",
+    tertiary: `Previsto no mês: ${money(projectedThisMonth)}`,
     accent:
       hasConfirmedIncome
         ? "success"
@@ -318,15 +318,15 @@ const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanel
   // ── Tile 5: Forecast ──────────────────────────────────────────────────────
   const forecastTile: TileProps = forecast
     ? {
-        label: "Projeção",
+        label: "Saldo projetado",
         primary: money(forecast.projectedBalance),
-        secondary: "Fechamento do mês",
+        secondary: "Fechamento previsto do mês",
         accent: forecast.projectedBalance < 0 ? "danger" : forecast.projectedBalance < 200 ? "warning" : "default",
       }
     : {
-        label: "Projeção",
+        label: "Saldo projetado",
         primary: "—",
-        secondary: "Sem dados suficientes",
+        secondary: "Sem base para projeção",
         accent: "muted",
       };
 


### PR DESCRIPTION
## Contexto
Implementa a Issue 3.3 do Epic 3: alinhar os labels do painel operacional com a semântica financeira real dos dados.

## O que mudou
- atualização de labels/microcopy no OperationalSummaryPanel para explicitar natureza de cada bloco:
  - **Saldo em conta** (realizado)
  - **Obrigações de contas**
  - **Obrigações de cartão**
  - **Renda do mês (realizada e prevista)**
  - **Saldo projetado**
- ajustes de textos auxiliares para reduzir ambiguidade semântica (realizado, previsto, obrigação, ciclo, fatura)
- atualização dos testes do componente para travar os novos labels e evitar regressão de microcopy semântica

## Arquivos alterados
- pps/web/src/components/OperationalSummaryPanel.tsx
- pps/web/src/components/OperationalSummaryPanel.test.tsx

## Garantias de escopo
- sem mudança de API
- sem reabrir forecast
- sem mistura com recomposição de home/App.tsx
- sem abrir outra frente em paralelo

## Validação
- 
pm -w apps/web run test:run -- src/components/OperationalSummaryPanel.test.tsx
- 
pm -w apps/web run typecheck
- 
pm -w apps/web run lint

## Resultado
Os rótulos do painel operacional passam a refletir com precisão o que é realizado, previsto e obrigação, reduzindo risco de leitura ambígua em contexto financeiro.