### PR TITLE
Epic 5 · Issue 5.1 — MonthView extraction

### DIFF
--- a/apps/web/src/components/MonthViewSection.test.tsx
+++ b/apps/web/src/components/MonthViewSection.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import MonthViewSection from "./MonthViewSection";
+
+const buildProps = () => ({
+  sectionRef: { current: null },
+  selectedSummaryMonth: "2026-04",
+  onSummaryMonthChange: vi.fn(),
+  summaryError: "",
+  onRetrySummary: vi.fn(),
+  isLoadingSummary: false,
+  monthlySummary: {
+    month: "2026-04",
+    income: 1200,
+    expense: 600,
+    balance: 600,
+    byCategory: [],
+  },
+  momError: "",
+  hasMonthlySummaryData: true,
+  monthOverMonthMetrics: {
+    balance: { delta: 50, deltaPercent: 9.1, direction: "up" as const, tone: "good" as const },
+    income: { delta: 100, deltaPercent: 11.2, direction: "up" as const, tone: "good" as const },
+    expense: { delta: -80, deltaPercent: -7.5, direction: "down" as const, tone: "good" as const },
+  },
+  formatMonthOverMonthSummary: () => "Vs. mês anterior: subiu 10,0% (+R$ 50,00)",
+  momToneClassNames: {
+    good: "text-green-200",
+    bad: "text-red-200",
+    neutral: "text-ui-200",
+  },
+  money: (value: number) => `R$ ${value.toFixed(2)}`,
+});
+
+describe("MonthViewSection", () => {
+  it("renderiza resumo mensal com labels e valores", () => {
+    render(<MonthViewSection {...buildProps()} />);
+
+    expect(screen.getByText("Visão do mês")).toBeInTheDocument();
+    expect(screen.getByText("Saldo")).toBeInTheDocument();
+    expect(screen.getByText("Entradas")).toBeInTheDocument();
+    expect(screen.getByText("Saídas")).toBeInTheDocument();
+    expect(screen.getByLabelText("Mês do resumo")).toHaveValue("2026-04");
+  });
+
+  it("dispara mudança de mês", () => {
+    const props = buildProps();
+    render(<MonthViewSection {...props} />);
+
+    fireEvent.change(screen.getByLabelText("Mês do resumo"), {
+      target: { value: "2026-05" },
+    });
+
+    expect(props.onSummaryMonthChange).toHaveBeenCalledWith("2026-05");
+  });
+
+  it("exibe erro e permite retry", () => {
+    const props = buildProps();
+    props.summaryError = "Falha ao carregar resumo";
+    render(<MonthViewSection {...props} />);
+
+    expect(screen.getByText("Falha ao carregar resumo")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Tentar novamente" }));
+    expect(props.onRetrySummary).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/MonthViewSection.tsx
+++ b/apps/web/src/components/MonthViewSection.tsx
@@ -1,15 +1,6 @@
 import type { RefObject } from "react";
 import type { MonthlySummary } from "../services/transactions.service";
-
-type MonthOverMonthDirection = "up" | "down" | "flat";
-type MonthOverMonthTone = "good" | "bad" | "neutral";
-
-interface MonthOverMonthMetric {
-  delta: number;
-  deltaPercent: number | null;
-  direction: MonthOverMonthDirection;
-  tone: MonthOverMonthTone;
-}
+import type { MonthOverMonthMetric, MonthOverMonthTone } from "./month-view.types";
 
 interface MonthViewSectionProps {
   sectionRef: RefObject<HTMLElement>;

--- a/apps/web/src/components/MonthViewSection.tsx
+++ b/apps/web/src/components/MonthViewSection.tsx
@@ -1,0 +1,156 @@
+import type { RefObject } from "react";
+import type { MonthlySummary } from "../services/transactions.service";
+
+type MonthOverMonthDirection = "up" | "down" | "flat";
+type MonthOverMonthTone = "good" | "bad" | "neutral";
+
+interface MonthOverMonthMetric {
+  delta: number;
+  deltaPercent: number | null;
+  direction: MonthOverMonthDirection;
+  tone: MonthOverMonthTone;
+}
+
+interface MonthViewSectionProps {
+  sectionRef: RefObject<HTMLElement>;
+  selectedSummaryMonth: string;
+  onSummaryMonthChange: (month: string) => void;
+  summaryError: string;
+  onRetrySummary: () => void | Promise<void>;
+  isLoadingSummary: boolean;
+  monthlySummary: MonthlySummary;
+  momError: string;
+  hasMonthlySummaryData: boolean;
+  monthOverMonthMetrics: {
+    balance: MonthOverMonthMetric;
+    income: MonthOverMonthMetric;
+    expense: MonthOverMonthMetric;
+  };
+  formatMonthOverMonthSummary: (metric: MonthOverMonthMetric) => string;
+  momToneClassNames: Record<MonthOverMonthTone, string>;
+  money: (value: number) => string;
+}
+
+const MonthViewSection = ({
+  sectionRef,
+  selectedSummaryMonth,
+  onSummaryMonthChange,
+  summaryError,
+  onRetrySummary,
+  isLoadingSummary,
+  monthlySummary,
+  momError,
+  hasMonthlySummaryData,
+  monthOverMonthMetrics,
+  formatMonthOverMonthSummary,
+  momToneClassNames,
+  money,
+}: MonthViewSectionProps): JSX.Element => (
+  <section ref={sectionRef}>
+    <div className="mb-2 flex items-center justify-between gap-2">
+      <div>
+        <h3 className="text-sm font-medium text-cf-text-primary">Visão do mês</h3>
+        <p className="mt-1 text-xs text-cf-text-secondary">
+          Saldo, entradas e saídas de movimentações realizadas (sem pendências ou projeções).
+        </p>
+      </div>
+      <input
+        type="month"
+        aria-label="Mês do resumo"
+        value={selectedSummaryMonth}
+        onChange={(event) => onSummaryMonthChange(event.target.value)}
+        className="rounded border border-cf-border bg-cf-surface px-2 py-1 text-sm text-cf-text-primary"
+      />
+    </div>
+    {summaryError ? (
+      <div
+        className="mb-3 flex items-center justify-between gap-3 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+        role="status"
+        aria-live="polite"
+      >
+        <span>{summaryError}</span>
+        <button
+          type="button"
+          onClick={() => void onRetrySummary()}
+          className="rounded border border-red-300 px-2 py-1 text-xs font-semibold text-red-700 hover:bg-red-100"
+        >
+          Tentar novamente
+        </button>
+      </div>
+    ) : null}
+    <div className="grid gap-3 sm:grid-cols-3">
+      <div className="rounded border border-brand-1 bg-cf-bg-subtle px-4 py-3.5">
+        <p className="text-xs font-medium uppercase text-cf-text-secondary">Saldo</p>
+        <p className="text-xl font-semibold text-cf-text-primary">
+          {isLoadingSummary ? "Carregando..." : money(monthlySummary.balance)}
+        </p>
+        <p
+          className={`mt-1 text-xs font-medium ${
+            isLoadingSummary || summaryError || momError
+              ? momToneClassNames.neutral
+              : momToneClassNames[monthOverMonthMetrics.balance.tone]
+          }`}
+          data-testid="mom-balance"
+        >
+          {isLoadingSummary
+            ? "Vs. mês anterior: calculando..."
+            : summaryError || momError
+              ? "Vs. mês anterior: indisponível"
+              : formatMonthOverMonthSummary(monthOverMonthMetrics.balance)}
+        </p>
+      </div>
+      <div className="rounded border border-brand-1 bg-cf-bg-subtle px-4 py-3.5">
+        <p className="text-xs font-medium uppercase text-cf-text-secondary">Entradas</p>
+        <p className="text-xl font-semibold text-cf-text-primary">
+          {isLoadingSummary ? "Carregando..." : money(monthlySummary.income)}
+        </p>
+        <p
+          className={`mt-1 text-xs font-medium ${
+            isLoadingSummary || summaryError || momError
+              ? momToneClassNames.neutral
+              : momToneClassNames[monthOverMonthMetrics.income.tone]
+          }`}
+          data-testid="mom-income"
+        >
+          {isLoadingSummary
+            ? "Vs. mês anterior: calculando..."
+            : summaryError || momError
+              ? "Vs. mês anterior: indisponível"
+              : formatMonthOverMonthSummary(monthOverMonthMetrics.income)}
+        </p>
+      </div>
+      <div className="rounded border border-brand-1 bg-cf-bg-subtle px-4 py-3.5">
+        <p className="text-xs font-medium uppercase text-cf-text-secondary">Saídas</p>
+        <p className="text-xl font-semibold text-cf-text-primary">
+          {isLoadingSummary ? "Carregando..." : money(monthlySummary.expense)}
+        </p>
+        <p
+          className={`mt-1 text-xs font-medium ${
+            isLoadingSummary || summaryError || momError
+              ? momToneClassNames.neutral
+              : momToneClassNames[monthOverMonthMetrics.expense.tone]
+          }`}
+          data-testid="mom-expense"
+        >
+          {isLoadingSummary
+            ? "Vs. mês anterior: calculando..."
+            : summaryError || momError
+              ? "Vs. mês anterior: indisponível"
+              : formatMonthOverMonthSummary(monthOverMonthMetrics.expense)}
+        </p>
+      </div>
+    </div>
+    {!isLoadingSummary && !summaryError && momError ? (
+      <div className="mt-2 rounded border border-cf-border bg-cf-surface px-3 py-2 text-sm text-cf-text-secondary">
+        {momError}
+      </div>
+    ) : null}
+    {!isLoadingSummary && !summaryError && !hasMonthlySummaryData ? (
+      <div className="mt-2 rounded border border-cf-border bg-cf-surface px-3 py-2 text-sm text-cf-text-secondary">
+        Sem dados para o mês selecionado.
+      </div>
+    ) : null}
+  </section>
+);
+
+export default MonthViewSection;

--- a/apps/web/src/components/month-view.types.ts
+++ b/apps/web/src/components/month-view.types.ts
@@ -1,0 +1,9 @@
+export type MonthOverMonthDirection = "up" | "down" | "flat";
+export type MonthOverMonthTone = "good" | "bad" | "neutral";
+
+export interface MonthOverMonthMetric {
+  delta: number;
+  deltaPercent: number | null;
+  direction: MonthOverMonthDirection;
+  tone: MonthOverMonthTone;
+}

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -15,6 +15,7 @@ import CreditCardsSummaryWidget from "../components/CreditCardsSummaryWidget";
 import SalaryWidget from "../components/SalaryWidget";
 import ConsignadoOverviewWidget from "../components/ConsignadoOverviewWidget";
 import OperationalSummaryPanel from "../components/OperationalSummaryPanel";
+import MonthViewSection from "../components/MonthViewSection";
 import TransactionList from "../components/TransactionList";
 import {
   transactionsService,
@@ -2338,111 +2339,21 @@ const App = ({
         </section>
 
         <div className="space-y-6">
-          <section ref={summarySectionRef}>
-            <div className="mb-2 flex items-center justify-between gap-2">
-              <div>
-                <h3 className="text-sm font-medium text-cf-text-primary">Visão do mês</h3>
-                <p className="mt-1 text-xs text-cf-text-secondary">
-                  Saldo, entradas e saídas de movimentações realizadas (sem pendências ou projeções).
-                </p>
-              </div>
-              <input
-                type="month"
-                aria-label="Mês do resumo"
-                value={selectedSummaryMonth}
-                onChange={(event) => setSelectedSummaryMonth(event.target.value)}
-                className="rounded border border-cf-border bg-cf-surface px-2 py-1 text-sm text-cf-text-primary"
-              />
-            </div>
-            {summaryError ? (
-              <div
-                className="mb-3 flex items-center justify-between gap-3 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
-                role="status"
-                aria-live="polite"
-              >
-                <span>{summaryError}</span>
-                <button
-                  type="button"
-                  onClick={loadMonthlySummary}
-                  className="rounded border border-red-300 px-2 py-1 text-xs font-semibold text-red-700 hover:bg-red-100"
-                >
-                  Tentar novamente
-                </button>
-              </div>
-            ) : null}
-            <div className="grid gap-3 sm:grid-cols-3">
-              <div className="rounded border border-brand-1 bg-cf-bg-subtle px-4 py-3.5">
-                <p className="text-xs font-medium uppercase text-cf-text-secondary">Saldo</p>
-                <p className="text-xl font-semibold text-cf-text-primary">
-                  {isLoadingSummary ? "Carregando..." : money(monthlySummary.balance)}
-                </p>
-                <p
-                  className={`mt-1 text-xs font-medium ${
-                    isLoadingSummary || summaryError || momError
-                      ? MOM_TONE_CLASSNAMES.neutral
-                      : MOM_TONE_CLASSNAMES[monthOverMonthMetrics.balance.tone]
-                  }`}
-                  data-testid="mom-balance"
-                >
-                  {isLoadingSummary
-                    ? "Vs. mês anterior: calculando..."
-                    : summaryError || momError
-                      ? "Vs. mês anterior: indisponível"
-                      : formatMonthOverMonthSummary(monthOverMonthMetrics.balance)}
-                </p>
-              </div>
-              <div className="rounded border border-brand-1 bg-cf-bg-subtle px-4 py-3.5">
-                <p className="text-xs font-medium uppercase text-cf-text-secondary">Entradas</p>
-                <p className="text-xl font-semibold text-cf-text-primary">
-                  {isLoadingSummary ? "Carregando..." : money(monthlySummary.income)}
-                </p>
-                <p
-                  className={`mt-1 text-xs font-medium ${
-                    isLoadingSummary || summaryError || momError
-                      ? MOM_TONE_CLASSNAMES.neutral
-                      : MOM_TONE_CLASSNAMES[monthOverMonthMetrics.income.tone]
-                  }`}
-                  data-testid="mom-income"
-                >
-                  {isLoadingSummary
-                    ? "Vs. mês anterior: calculando..."
-                    : summaryError || momError
-                      ? "Vs. mês anterior: indisponível"
-                      : formatMonthOverMonthSummary(monthOverMonthMetrics.income)}
-                </p>
-              </div>
-              <div className="rounded border border-brand-1 bg-cf-bg-subtle px-4 py-3.5">
-                <p className="text-xs font-medium uppercase text-cf-text-secondary">Saídas</p>
-                <p className="text-xl font-semibold text-cf-text-primary">
-                  {isLoadingSummary ? "Carregando..." : money(monthlySummary.expense)}
-                </p>
-                <p
-                  className={`mt-1 text-xs font-medium ${
-                    isLoadingSummary || summaryError || momError
-                      ? MOM_TONE_CLASSNAMES.neutral
-                      : MOM_TONE_CLASSNAMES[monthOverMonthMetrics.expense.tone]
-                  }`}
-                  data-testid="mom-expense"
-                >
-                  {isLoadingSummary
-                    ? "Vs. mês anterior: calculando..."
-                    : summaryError || momError
-                      ? "Vs. mês anterior: indisponível"
-                      : formatMonthOverMonthSummary(monthOverMonthMetrics.expense)}
-                </p>
-              </div>
-            </div>
-            {!isLoadingSummary && !summaryError && momError ? (
-              <div className="mt-2 rounded border border-cf-border bg-cf-surface px-3 py-2 text-sm text-cf-text-secondary">
-                {momError}
-              </div>
-            ) : null}
-            {!isLoadingSummary && !summaryError && !hasMonthlySummaryData ? (
-              <div className="mt-2 rounded border border-cf-border bg-cf-surface px-3 py-2 text-sm text-cf-text-secondary">
-                Sem dados para o mês selecionado.
-              </div>
-            ) : null}
-          </section>
+          <MonthViewSection
+            sectionRef={summarySectionRef}
+            selectedSummaryMonth={selectedSummaryMonth}
+            onSummaryMonthChange={setSelectedSummaryMonth}
+            summaryError={summaryError}
+            onRetrySummary={loadMonthlySummary}
+            isLoadingSummary={isLoadingSummary}
+            monthlySummary={monthlySummary}
+            momError={momError}
+            hasMonthlySummaryData={hasMonthlySummaryData}
+            monthOverMonthMetrics={monthOverMonthMetrics}
+            formatMonthOverMonthSummary={formatMonthOverMonthSummary}
+            momToneClassNames={MOM_TONE_CLASSNAMES}
+            money={money}
+          />
           <section className="space-y-4" aria-labelledby="operational-overview-title">
             <div>
               <h3

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -16,6 +16,11 @@ import SalaryWidget from "../components/SalaryWidget";
 import ConsignadoOverviewWidget from "../components/ConsignadoOverviewWidget";
 import OperationalSummaryPanel from "../components/OperationalSummaryPanel";
 import MonthViewSection from "../components/MonthViewSection";
+import type {
+  MonthOverMonthDirection,
+  MonthOverMonthMetric,
+  MonthOverMonthTone,
+} from "../components/month-view.types";
 import TransactionList from "../components/TransactionList";
 import {
   transactionsService,
@@ -66,8 +71,6 @@ const HealthOverview = lazy(() => import("../components/HealthOverview"));
 const GoalsSection = lazy(() => import("../components/GoalsSection"));
 
 type SummaryMetricKey = "income" | "expense" | "balance";
-type MonthOverMonthDirection = "up" | "down" | "flat";
-type MonthOverMonthTone = "good" | "bad" | "neutral";
 type BudgetAlertStatus = Exclude<MonthlyBudgetStatus, "ok">;
 
 interface PaginationState {
@@ -101,13 +104,6 @@ interface TransactionModalPayload {
   date: string;
   description: string;
   notes: string;
-}
-
-interface MonthOverMonthMetric {
-  delta: number;
-  deltaPercent: number | null;
-  direction: MonthOverMonthDirection;
-  tone: MonthOverMonthTone;
 }
 
 interface AppProps {


### PR DESCRIPTION
## Contexto
Implementa a Issue 5.1 do Epic 5: extrair a composição da Visão do mês do App.tsx para uma unidade própria.

## O que mudou
- extração do bloco de composição MonthView para `MonthViewSection`
- `App.tsx` passa a delegar essa seção para componente dedicado, reduzindo acoplamento e responsabilidade local
- manutenção de contratos, cálculos e comportamento atuais (sem mudança de regra de negócio)
- inclusão de testes focados para o novo componente extraído

## Arquivos alterados
- apps/web/src/pages/App.tsx
- apps/web/src/components/MonthViewSection.tsx
- apps/web/src/components/MonthViewSection.test.tsx

## Garantias de escopo
- sem mudança de API
- sem mistura com 5.2 OperationalWidgets
- sem mistura com 5.3 TransactionsFeed
- sem alteração semântica de domínio

## Validação
- npm -w apps/web run test:run -- src/components/MonthViewSection.test.tsx src/components/OperationalSummaryPanel.test.tsx
- npm -w apps/web run typecheck
- npm -w apps/web run lint

## Resultado
App.tsx fica menor e com fronteira estrutural clara para a Visão do mês, preservando o comportamento funcional existente.