### PR TITLE
Backlog · B.3 — freeze JS boundaries

### DIFF
--- a/docs/architecture/v1.6.12-freeze-js-boundaries.md
+++ b/docs/architecture/v1.6.12-freeze-js-boundaries.md
@@ -1,0 +1,41 @@
+# v1.6.12 - freeze JS boundaries
+
+Data: 2026-04-03
+Status: entregue
+
+## Objetivo
+
+Congelar fronteiras JavaScript apos a migracao parcial para TypeScript (Epic 6), reduzindo risco de regressao silenciosa de linguagem.
+
+## Fronteiras congeladas
+
+1. `apps/web/src`
+- Permitido em JS apenas:
+  - `apps/web/src/services/api.test.js`
+  - `apps/web/src/test/setup.js`
+- Qualquer novo `.js` em `apps/web/src` deve falhar no guard rail.
+
+2. `apps/api/src/domain/contracts`
+- Zona TS-only.
+- Arquivos `.js` nessa pasta sao bloqueados.
+
+3. Services da API migrados para TS
+- Nao podem voltar para contraparte `.js`:
+  - `apps/api/src/services/forecast.service.ts`
+  - `apps/api/src/services/dashboard.service.ts`
+  - `apps/api/src/services/transactions-import.service.ts`
+- Imports para `*.service.js` desses tres services sao bloqueados.
+
+## Enforcement
+
+Novo guard rail: `scripts/check-js-boundaries.mjs`
+
+Comandos:
+- `npm run check:js-boundaries`
+- `npm run lint` (executa o check antes do lint web/api)
+
+## Fora de escopo
+
+- Sem migracao funcional de novos modulos JS para TS.
+- Sem alteracao de regras de negocio.
+- Sem mexer em metricas de dominio (B.4).

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   ],
   "scripts": {
     "dev": "concurrently \"npm -w apps/api run dev\" \"npm -w apps/web run dev\"",
-    "lint": "npm -w apps/web run lint && npm -w apps/api run lint",
+    "check:js-boundaries": "node scripts/check-js-boundaries.mjs",
+    "lint": "npm run check:js-boundaries && npm -w apps/web run lint && npm -w apps/api run lint",
     "typecheck:web": "npm -w apps/web run typecheck",
     "typecheck": "npm run typecheck:web",
     "test": "npm -w apps/web run test:run && npm -w apps/api run test:run",

--- a/scripts/check-js-boundaries.mjs
+++ b/scripts/check-js-boundaries.mjs
@@ -1,0 +1,80 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const MIGRATED_API_SERVICE_JS_PATHS = [
+  "apps/api/src/services/forecast.service.js",
+  "apps/api/src/services/dashboard.service.js",
+  "apps/api/src/services/transactions-import.service.js",
+];
+
+const ALLOWED_WEB_SRC_JS_FILES = new Set([
+  "apps/web/src/services/api.test.js",
+  "apps/web/src/test/setup.js",
+]);
+
+const normalizePath = (value) => value.replace(/\\/g, "/");
+
+const runGitList = (patterns) => {
+  const output = execFileSync("git", ["ls-files", ...patterns], { encoding: "utf8" });
+  return output
+    .split(/\r?\n/)
+    .map((line) => normalizePath(line.trim()))
+    .filter(Boolean);
+};
+
+const trackedJsFiles = runGitList(["*.js"]);
+const trackedSourceFiles = runGitList(["apps/api/src/**/*.js", "apps/api/src/**/*.ts"]);
+const violations = [];
+
+for (const filePath of trackedJsFiles) {
+  if (filePath.startsWith("apps/web/src/") && !ALLOWED_WEB_SRC_JS_FILES.has(filePath)) {
+    violations.push(
+      `${filePath} -> JS em apps/web/src fora da allowlist (freeze ativo).`,
+    );
+  }
+
+  if (filePath.startsWith("apps/api/src/domain/contracts/")) {
+    violations.push(
+      `${filePath} -> JS em contracts nao permitido (deve permanecer TypeScript).`,
+    );
+  }
+}
+
+for (const forbiddenPath of MIGRATED_API_SERVICE_JS_PATHS) {
+  if (trackedJsFiles.includes(forbiddenPath)) {
+    violations.push(
+      `${forbiddenPath} -> contraparte JS de service migrado nao pode voltar.`,
+    );
+  }
+}
+
+const restrictedImportPattern =
+  /(?:from\s+['"]|import\s*\(\s*['"])(?:[^'"]*\/(?:forecast|dashboard|transactions-import)\.service\.js)['"]/;
+
+for (const sourcePath of trackedSourceFiles) {
+  const content = readFileSync(sourcePath, "utf8");
+  if (restrictedImportPattern.test(content)) {
+    violations.push(
+      `${sourcePath} -> import legado .js para service migrado detectado.`,
+    );
+  }
+}
+
+if (violations.length > 0) {
+  console.error("[freeze-js] Violacoes detectadas:");
+  for (const violation of violations) {
+    console.error(`- ${violation}`);
+  }
+  process.exit(1);
+}
+
+const webSrcJsFiles = trackedJsFiles.filter((path) => path.startsWith("apps/web/src/"));
+const apiContractsJsFiles = trackedJsFiles.filter((path) =>
+  path.startsWith("apps/api/src/domain/contracts/"),
+);
+
+console.log("[freeze-js] OK");
+console.log(
+  `[freeze-js] web/src js allowlist: ${webSrcJsFiles.length}/${ALLOWED_WEB_SRC_JS_FILES.size} encontrados`,
+);
+console.log(`[freeze-js] contracts js files: ${apiContractsJsFiles.length}`);


### PR DESCRIPTION
Congela fronteiras JavaScript remanescentes apos a migracao parcial para TypeScript, para impedir regressao silenciosa de linguagem.

Escopo:
- Novo guard rail `scripts/check-js-boundaries.mjs` com validacoes de fronteira JS/TS.
- `package.json` (root): adiciona `check:js-boundaries` e executa o check antes do lint web/api.
- Documentacao de fronteiras congeladas em `docs/architecture/v1.6.12-freeze-js-boundaries.md`.

Regras aplicadas no guard rail:
- Bloqueia novos `.js` em `apps/web/src` fora da allowlist atual.
- Bloqueia `.js` em `apps/api/src/domain/contracts` (zona TS-only).
- Bloqueia retorno dos services migrados para contraparte `.js`.
- Bloqueia imports legados para `forecast/dashboard/transactions-import.service.js`.

Validacao executada:
- `npm run check:js-boundaries`
- `npm run lint`
