### PR TITLE
Backlog · B.4 — domain metrics baseline

### DIFF
--- a/apps/api/src/health-observability.test.js
+++ b/apps/api/src/health-observability.test.js
@@ -10,7 +10,11 @@ import {
   resetWriteRateLimiterState,
 } from "./middlewares/rate-limit.middleware.js";
 import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
-import { expectErrorResponseWithRequestId, setupTestDb } from "./test-helpers.js";
+import {
+  expectErrorResponseWithRequestId,
+  registerAndLogin,
+  setupTestDb,
+} from "./test-helpers.js";
 
 let testDbPool;
 
@@ -187,5 +191,47 @@ describe("health and observability", () => {
         process.env.METRICS_AUTH_TOKEN = envSnapshot.METRICS_AUTH_TOKEN;
       }
     }
+  });
+
+  it("GET /metrics expõe baseline de domain metrics para fluxo financeiro de transacoes", async () => {
+    const token = await registerAndLogin("domain-metrics-finance@test.dev");
+
+    const successResponse = await request(app)
+      .post("/transactions")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        type: "Entrada",
+        value: 150,
+        date: "2026-04-03",
+        description: "Recebimento baseline",
+      });
+
+    const errorResponse = await request(app)
+      .post("/transactions")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        type: "Entrada",
+      });
+
+    const metricsResponse = await request(app).get("/metrics");
+
+    expect(successResponse.status).toBe(201);
+    expect(errorResponse.status).toBe(400);
+    expect(metricsResponse.status).toBe(200);
+    expect(metricsResponse.text).toContain("# HELP domain_financial_flow_events_total");
+    expect(metricsResponse.text).toContain("# HELP domain_financial_flow_records_total");
+    expect(metricsResponse.text).toMatch(
+      /domain_financial_flow_events_total\{[^}]*flow="transactions"[^}]*operation="create"[^}]*outcome="success"[^}]*\}\s+([0-9.]+)/,
+    );
+    expect(metricsResponse.text).toMatch(
+      /domain_financial_flow_events_total\{[^}]*flow="transactions"[^}]*operation="create"[^}]*outcome="error"[^}]*\}\s+([0-9.]+)/,
+    );
+
+    const recordsMatch = metricsResponse.text.match(
+      /domain_financial_flow_records_total\{[^}]*flow="transactions"[^}]*operation="create"[^}]*\}\s+([0-9.]+)/,
+    );
+
+    expect(recordsMatch).not.toBeNull();
+    expect(Number(recordsMatch[1])).toBeGreaterThanOrEqual(1);
   });
 });

--- a/apps/api/src/observability/domain-metrics.js
+++ b/apps/api/src/observability/domain-metrics.js
@@ -1,0 +1,57 @@
+import { Counter } from "prom-client";
+import { metricsRegistry } from "./http-metrics.js";
+
+const domainFinancialFlowEventsCounter = new Counter({
+  name: "domain_financial_flow_events_total",
+  help: "Total de eventos de dominio nos fluxos financeiros por operacao e resultado.",
+  labelNames: ["flow", "operation", "outcome"],
+  registers: [metricsRegistry],
+});
+
+const domainFinancialFlowRecordsCounter = new Counter({
+  name: "domain_financial_flow_records_total",
+  help: "Total de registros afetados por operacoes de dominio nos fluxos financeiros.",
+  labelNames: ["flow", "operation"],
+  registers: [metricsRegistry],
+});
+
+const toSafeMetricValue = (value) => {
+  const parsed = Number(value);
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return 0;
+  }
+
+  return parsed;
+};
+
+export const trackDomainFlowEvent = ({ flow, operation, outcome }) => {
+  if (!flow || !operation || !outcome) {
+    return;
+  }
+
+  domainFinancialFlowEventsCounter.inc({ flow, operation, outcome });
+};
+
+export const trackDomainFlowRecords = ({ flow, operation, records = 1 }) => {
+  if (!flow || !operation) {
+    return;
+  }
+
+  const safeRecords = toSafeMetricValue(records);
+
+  if (safeRecords === 0) {
+    return;
+  }
+
+  domainFinancialFlowRecordsCounter.inc({ flow, operation }, safeRecords);
+};
+
+export const trackDomainFlowSuccess = ({ flow, operation, records = 1 }) => {
+  trackDomainFlowEvent({ flow, operation, outcome: "success" });
+  trackDomainFlowRecords({ flow, operation, records });
+};
+
+export const trackDomainFlowError = ({ flow, operation }) => {
+  trackDomainFlowEvent({ flow, operation, outcome: "error" });
+};

--- a/apps/api/src/observability/http-metrics.js
+++ b/apps/api/src/observability/http-metrics.js
@@ -3,7 +3,7 @@ import { Counter, Histogram, Registry } from "prom-client";
 const METRICS_ENDPOINT_PATH = "/metrics";
 const CRITICAL_ENDPOINTS = new Set(["/transactions", "/categories", "/auth/login"]);
 
-const metricsRegistry = new Registry();
+export const metricsRegistry = new Registry();
 
 const httpRequestsTotalCounter = new Counter({
   name: "http_requests_total",

--- a/apps/api/src/routes/bills.routes.js
+++ b/apps/api/src/routes/bills.routes.js
@@ -16,6 +16,10 @@ import {
   confirmBillMatch,
   unmatchBill,
 } from "../services/reconciliation.service.js";
+import {
+  trackDomainFlowError,
+  trackDomainFlowSuccess,
+} from "../observability/domain-metrics.js";
 
 const router = Router();
 
@@ -56,8 +60,10 @@ router.get("/", async (req, res, next) => {
 router.post("/", billsWriteRateLimiter, async (req, res, next) => {
   try {
     const bill = await createBillForUser(req.user.id, req.body || {});
+    trackDomainFlowSuccess({ flow: "bills", operation: "create" });
     res.status(201).json(bill);
   } catch (error) {
+    trackDomainFlowError({ flow: "bills", operation: "create" });
     next(error);
   }
 });
@@ -66,8 +72,14 @@ router.post("/", billsWriteRateLimiter, async (req, res, next) => {
 router.post("/batch", billsWriteRateLimiter, async (req, res, next) => {
   try {
     const bills = await createBillsBatchForUser(req.user.id, req.body?.bills ?? []);
+    trackDomainFlowSuccess({
+      flow: "bills",
+      operation: "create_batch",
+      records: Array.isArray(bills) ? bills.length : 0,
+    });
     res.status(201).json({ bills });
   } catch (error) {
+    trackDomainFlowError({ flow: "bills", operation: "create_batch" });
     next(error);
   }
 });
@@ -75,8 +87,10 @@ router.post("/batch", billsWriteRateLimiter, async (req, res, next) => {
 router.patch("/:id/mark-paid", billsWriteRateLimiter, async (req, res, next) => {
   try {
     const result = await markBillAsPaidForUser(req.user.id, req.params.id, req.body || {});
+    trackDomainFlowSuccess({ flow: "bills", operation: "mark_paid" });
     res.status(200).json(result);
   } catch (error) {
+    trackDomainFlowError({ flow: "bills", operation: "mark_paid" });
     next(error);
   }
 });
@@ -84,8 +98,10 @@ router.patch("/:id/mark-paid", billsWriteRateLimiter, async (req, res, next) => 
 router.patch("/:id", billsWriteRateLimiter, async (req, res, next) => {
   try {
     const bill = await updateBillForUser(req.user.id, req.params.id, req.body || {});
+    trackDomainFlowSuccess({ flow: "bills", operation: "update" });
     res.status(200).json(bill);
   } catch (error) {
+    trackDomainFlowError({ flow: "bills", operation: "update" });
     next(error);
   }
 });
@@ -93,8 +109,10 @@ router.patch("/:id", billsWriteRateLimiter, async (req, res, next) => {
 router.delete("/:id", billsWriteRateLimiter, async (req, res, next) => {
   try {
     await deleteBillForUser(req.user.id, req.params.id);
+    trackDomainFlowSuccess({ flow: "bills", operation: "delete" });
     res.status(204).send();
   } catch (error) {
+    trackDomainFlowError({ flow: "bills", operation: "delete" });
     next(error);
   }
 });
@@ -113,8 +131,10 @@ router.get("/:id/match-candidates", async (req, res, next) => {
 router.post("/:id/confirm-match", billsWriteRateLimiter, async (req, res, next) => {
   try {
     const result = await confirmBillMatch(req.user.id, req.params.id, req.body || {});
+    trackDomainFlowSuccess({ flow: "bills", operation: "confirm_match" });
     res.status(200).json(result);
   } catch (error) {
+    trackDomainFlowError({ flow: "bills", operation: "confirm_match" });
     if (error.publicCode === "DIVERGENCE_CONFIRMATION_REQUIRED") {
       return res.status(422).json({
         message: error.message,
@@ -129,8 +149,10 @@ router.post("/:id/confirm-match", billsWriteRateLimiter, async (req, res, next) 
 router.delete("/:id/match", billsWriteRateLimiter, async (req, res, next) => {
   try {
     const result = await unmatchBill(req.user.id, req.params.id);
+    trackDomainFlowSuccess({ flow: "bills", operation: "unmatch" });
     res.status(200).json(result);
   } catch (error) {
+    trackDomainFlowError({ flow: "bills", operation: "unmatch" });
     next(error);
   }
 });

--- a/apps/api/src/routes/budgets.routes.js
+++ b/apps/api/src/routes/budgets.routes.js
@@ -6,6 +6,10 @@ import {
   listMonthlyBudgetsByUser,
   upsertMonthlyBudgetForUser,
 } from "../services/budgets.service.js";
+import {
+  trackDomainFlowError,
+  trackDomainFlowSuccess,
+} from "../observability/domain-metrics.js";
 
 const router = Router();
 
@@ -23,8 +27,10 @@ router.get("/", async (req, res, next) => {
 router.post("/", budgetsWriteRateLimiter, async (req, res, next) => {
   try {
     const budget = await upsertMonthlyBudgetForUser(req.user.id, req.body || {});
+    trackDomainFlowSuccess({ flow: "budgets", operation: "upsert" });
     res.status(200).json(budget);
   } catch (error) {
+    trackDomainFlowError({ flow: "budgets", operation: "upsert" });
     next(error);
   }
 });
@@ -32,8 +38,10 @@ router.post("/", budgetsWriteRateLimiter, async (req, res, next) => {
 router.delete("/:id", budgetsWriteRateLimiter, async (req, res, next) => {
   try {
     await deleteMonthlyBudgetForUser(req.user.id, req.params.id);
+    trackDomainFlowSuccess({ flow: "budgets", operation: "delete" });
     res.status(204).send();
   } catch (error) {
+    trackDomainFlowError({ flow: "budgets", operation: "delete" });
     next(error);
   }
 });

--- a/apps/api/src/routes/goals.routes.js
+++ b/apps/api/src/routes/goals.routes.js
@@ -8,6 +8,10 @@ import {
   updateGoalForUser,
   deleteGoalForUser,
 } from "../services/goals.service.js";
+import {
+  trackDomainFlowError,
+  trackDomainFlowSuccess,
+} from "../observability/domain-metrics.js";
 
 const router = Router();
 
@@ -27,8 +31,10 @@ router.get("/", async (req, res, next) => {
 router.post("/", goalsWriteRateLimiter, async (req, res, next) => {
   try {
     const goal = await createGoalForUser(req.user.id, req.body ?? {});
+    trackDomainFlowSuccess({ flow: "goals", operation: "create" });
     res.status(201).json(goal);
   } catch (error) {
+    trackDomainFlowError({ flow: "goals", operation: "create" });
     next(error);
   }
 });
@@ -37,8 +43,10 @@ router.post("/", goalsWriteRateLimiter, async (req, res, next) => {
 router.patch("/:id", goalsWriteRateLimiter, async (req, res, next) => {
   try {
     const goal = await updateGoalForUser(req.user.id, req.params.id, req.body ?? {});
+    trackDomainFlowSuccess({ flow: "goals", operation: "update" });
     res.status(200).json(goal);
   } catch (error) {
+    trackDomainFlowError({ flow: "goals", operation: "update" });
     next(error);
   }
 });
@@ -47,8 +55,10 @@ router.patch("/:id", goalsWriteRateLimiter, async (req, res, next) => {
 router.delete("/:id", goalsWriteRateLimiter, async (req, res, next) => {
   try {
     await deleteGoalForUser(req.user.id, req.params.id);
+    trackDomainFlowSuccess({ flow: "goals", operation: "delete" });
     res.status(204).send();
   } catch (error) {
+    trackDomainFlowError({ flow: "goals", operation: "delete" });
     next(error);
   }
 });

--- a/apps/api/src/routes/transactions.routes.js
+++ b/apps/api/src/routes/transactions.routes.js
@@ -17,6 +17,10 @@ import {
   trackDryRunSemanticDriftMetrics,
 } from "../observability/import-observability.js";
 import {
+  trackDomainFlowError,
+  trackDomainFlowSuccess,
+} from "../observability/domain-metrics.js";
+import {
   createTransactionForUser,
   deleteTransactionForUser,
   exportTransactionsCsvByUser,
@@ -361,8 +365,10 @@ router.get("/", async (req, res, next) => {
 router.post("/", transactionsWriteRateLimiter, async (req, res, next) => {
   try {
     const transaction = await createTransactionForUser(req.user.id, req.body || {});
+    trackDomainFlowSuccess({ flow: "transactions", operation: "create" });
     res.status(201).json(transaction);
   } catch (error) {
+    trackDomainFlowError({ flow: "transactions", operation: "create" });
     next(error);
   }
 });
@@ -382,8 +388,14 @@ router.post("/bulk-delete", transactionsWriteRateLimiter, async (req, res, next)
     ensureDestructiveActionConfirmation(req.body?.confirm ?? req.query?.confirm);
     const ids = Array.isArray(req.body?.transactionIds) ? req.body.transactionIds : [];
     const result = await bulkDeleteTransactionsForUser(req.user.id, ids);
+    trackDomainFlowSuccess({
+      flow: "transactions",
+      operation: "bulk_delete",
+      records: result.deletedCount,
+    });
     res.status(200).json(result);
   } catch (error) {
+    trackDomainFlowError({ flow: "transactions", operation: "bulk_delete" });
     next(error);
   }
 });
@@ -395,8 +407,10 @@ router.patch("/:id", transactionsWriteRateLimiter, async (req, res, next) => {
       req.params.id,
       req.body || {},
     );
+    trackDomainFlowSuccess({ flow: "transactions", operation: "update" });
     res.status(200).json(updatedTransaction);
   } catch (error) {
+    trackDomainFlowError({ flow: "transactions", operation: "update" });
     next(error);
   }
 });
@@ -404,11 +418,13 @@ router.patch("/:id", transactionsWriteRateLimiter, async (req, res, next) => {
 router.delete("/:id", transactionsWriteRateLimiter, async (req, res, next) => {
   try {
     const removedTransaction = await deleteTransactionForUser(req.user.id, req.params.id);
+    trackDomainFlowSuccess({ flow: "transactions", operation: "delete" });
     res.status(200).json({
       id: removedTransaction.id,
       success: true,
     });
   } catch (error) {
+    trackDomainFlowError({ flow: "transactions", operation: "delete" });
     next(error);
   }
 });
@@ -416,8 +432,10 @@ router.delete("/:id", transactionsWriteRateLimiter, async (req, res, next) => {
 router.post("/:id/restore", transactionsWriteRateLimiter, async (req, res, next) => {
   try {
     const restoredTransaction = await restoreTransactionForUser(req.user.id, req.params.id);
+    trackDomainFlowSuccess({ flow: "transactions", operation: "restore" });
     res.status(200).json(restoredTransaction);
   } catch (error) {
+    trackDomainFlowError({ flow: "transactions", operation: "restore" });
     next(error);
   }
 });
@@ -486,6 +504,12 @@ router.post("/import/dry-run", importRateLimiter, requireFeature("csv_import"), 
         statusCode: 200,
       });
 
+      trackDomainFlowSuccess({
+        flow: "transactions_import",
+        operation: "dry_run",
+        records: rowsTotal,
+      });
+
       return res.status(200).json(dryRunResult);
     } catch (serviceError) {
       logImportEvent("import.dry_run.error", {
@@ -499,6 +523,8 @@ router.post("/import/dry-run", importRateLimiter, requireFeature("csv_import"), 
         statusCode: Number.isInteger(serviceError?.status) ? serviceError.status : 500,
         message: serviceError?.message || "Unexpected error.",
       });
+
+      trackDomainFlowError({ flow: "transactions_import", operation: "dry_run" });
 
       return next(serviceError);
     }
@@ -528,6 +554,11 @@ router.post("/import/commit", importRateLimiter, requireFeature("csv_import"), a
     const invalidRows = Number(observability.invalidRows) || 0;
 
     trackCommitSuccessMetrics({ rowsImported: commitResult.imported });
+    trackDomainFlowSuccess({
+      flow: "transactions_import",
+      operation: "commit",
+      records: Number(commitResult.imported) || 0,
+    });
     logImportEvent("import.commit.success", {
       requestId,
       userId,
@@ -567,6 +598,8 @@ router.post("/import/commit", importRateLimiter, requireFeature("csv_import"), a
       statusCode,
       message: error?.message || "Unexpected error.",
     });
+
+    trackDomainFlowError({ flow: "transactions_import", operation: "commit" });
 
     next(error);
   }

--- a/docs/architecture/v1.6.13-domain-metrics-baseline.md
+++ b/docs/architecture/v1.6.13-domain-metrics-baseline.md
@@ -1,0 +1,46 @@
+# v1.6.13 - domain metrics baseline
+
+Data: 2026-04-03
+Status: entregue
+
+## Objetivo
+
+Adicionar um baseline de metricas de dominio para fluxos financeiros, sem alterar regras de negocio.
+
+## Metricas adicionadas
+
+1. `domain_financial_flow_events_total{flow,operation,outcome}`
+- Conta eventos de operacao de dominio por fluxo financeiro.
+- `outcome`: `success` ou `error`.
+
+2. `domain_financial_flow_records_total{flow,operation}`
+- Conta registros afetados por operacao.
+- Para operacoes em lote, usa quantidade efetiva de itens afetados.
+
+## Fluxos instrumentados
+
+- `transactions`
+  - create, update, delete, restore, bulk_delete
+- `transactions_import`
+  - dry_run, commit
+- `budgets`
+  - upsert, delete
+- `goals`
+  - create, update, delete
+- `bills`
+  - create, create_batch, mark_paid, update, delete, confirm_match, unmatch
+
+## Exposicao
+
+- As series sao registradas no mesmo registry Prometheus ja exposto em `GET /metrics`.
+
+## Validacao
+
+- Teste focado: `npm -w apps/api run test:run -- src/health-observability.test.js`
+- Lint API: `npm -w apps/api run lint`
+
+## Fora de escopo
+
+- Sem alteracao de regras de negocio.
+- Sem dedupe/import (Backlog B.5).
+- Sem mudanca de semantica de resposta das rotas existentes.


### PR DESCRIPTION
Baseline de metricas de dominio para fluxos financeiros da API, sem mudanca funcional.

Escopo:
- Novo modulo `apps/api/src/observability/domain-metrics.js`.
- Reuso do mesmo registry Prometheus exposto em `GET /metrics`.
- Instrumentacao de eventos e registros afetados nas operacoes:
  - transactions: create, update, delete, restore, bulk_delete
  - transactions_import: dry_run, commit
  - budgets: upsert, delete
  - goals: create, update, delete
  - bills: create, create_batch, mark_paid, update, delete, confirm_match, unmatch
- Documentacao em `docs/architecture/v1.6.13-domain-metrics-baseline.md`.

Validacao executada:
- `npm -w apps/api run test:run -- src/health-observability.test.js`
- `npm -w apps/api run lint`

Sem alteracao de regra de negocio e sem incluir dedupe/import (B.5).