### PR TITLE
Backlog · B.5 — import dedup guardrails

### DIFF
--- a/apps/api/src/import.test.js
+++ b/apps/api/src/import.test.js
@@ -1259,6 +1259,33 @@ describe("transaction imports", () => {
     expect(second.body.rows[0].normalized).toBeNull();
   });
 
+  it("POST /transactions/import/dry-run marca duplicate para linhas equivalentes repetidas no mesmo arquivo", async () => {
+    const token = await registerAndLogin("import-dedupe-in-file@controlfinance.dev");
+    await makeProUser("import-dedupe-in-file@controlfinance.dev");
+
+    const csv = csvFile(
+      [
+        "date,type,value,description,notes,category",
+        "2026-03-01,Entrada,850,Freelance,PIX 123,",
+        "2026-03-01,Entrada,850,Freelance,PIX 123,",
+      ].join("\n"),
+    );
+
+    const response = await request(app)
+      .post("/transactions/import/dry-run")
+      .set("Authorization", `Bearer ${token}`)
+      .attach("file", csv.buffer, { filename: csv.fileName, contentType: "text/csv" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.summary.totalRows).toBe(2);
+    expect(response.body.summary.validRows).toBe(1);
+    expect(response.body.summary.duplicateRows).toBe(1);
+
+    const duplicateRow = response.body.rows.find((row) => row.status === "duplicate");
+    expect(duplicateRow).toBeTruthy();
+    expect(duplicateRow.statusDetail).toBe("Ja existe uma linha equivalente no arquivo de importacao.");
+  });
+
   it("POST /transactions/import/dry-run marca conflito quando credito bancario bate com historico de renda", async () => {
     const email = "import-income-conflict@controlfinance.dev";
     const token = await registerAndLogin(email);
@@ -1375,8 +1402,16 @@ describe("transaction imports", () => {
       .send({ importId: dryB.body.importId });
 
     expect(commitB.status).toBe(200);
-    // a linha duplicada foi inserida (sessao B nao sabia da A no momento do dry-run)
-    // mas o fingerprint agora esta no banco — proximo dry-run vai detectar
+    expect(commitB.body.imported).toBe(0);
+
+    const persisted = await dbQuery(
+      `SELECT COUNT(*)::int AS count FROM transactions WHERE user_id = (SELECT id FROM users WHERE email = $1) AND deleted_at IS NULL`,
+      ["import-dedupe-commit@controlfinance.dev"],
+    );
+
+    expect(Number(persisted.rows[0].count)).toBe(1);
+
+    // proximo dry-run continua detectando o lancamento como duplicado
     const check = await request(app)
       .post("/transactions/import/dry-run")
       .set("Authorization", `Bearer ${token}`)

--- a/apps/api/src/services/transactions-import.service.ts
+++ b/apps/api/src/services/transactions-import.service.ts
@@ -138,6 +138,24 @@ const loadExistingFingerprints = async (
   return new Set(result.rows.map((row) => row.import_fingerprint));
 };
 
+const loadExistingFingerprintsWithClient = async (
+  transactionClient: { query: (sql: string, params?: unknown[]) => Promise<{ rows: Array<{ import_fingerprint: string }> }> },
+  userId: number | string,
+  fingerprints: string[],
+): Promise<Set<string>> => {
+  if (fingerprints.length === 0) {
+    return new Set();
+  }
+
+  const result = await transactionClient.query(
+    `SELECT import_fingerprint FROM transactions
+     WHERE user_id = $1 AND deleted_at IS NULL AND import_fingerprint = ANY($2)`,
+    [userId, fingerprints],
+  );
+
+  return new Set(result.rows.map((row) => row.import_fingerprint));
+};
+
 const toMoneyNumber = (value: unknown): number => {
   const parsedValue = Number(value);
   return Number.isFinite(parsedValue) ? Number(parsedValue.toFixed(2)) : 0;
@@ -1106,10 +1124,28 @@ export const dryRunTransactionsImportForUser = async (
     loadExistingFingerprints(userId, [...fingerprintMap.values()]),
     loadStructuredIncomeStatementsForUser(userId),
   ]);
+  const seenFingerprintsInFile = new Set<string>();
 
   const rows = validatedRows.map((row) => {
     if (row.status !== "valid" || !row.normalized) return row;
-    const fp = fingerprintMap.get(row.line);
+    const fp = String(fingerprintMap.get(row.line) || "").trim();
+
+    if (!fp) {
+      return row;
+    }
+
+    if (seenFingerprintsInFile.has(fp)) {
+      return {
+        ...row,
+        status: "duplicate",
+        statusDetail: "Ja existe uma linha equivalente no arquivo de importacao.",
+        fingerprint: fp,
+        normalized: null,
+      };
+    }
+
+    seenFingerprintsInFile.add(fp);
+
     if (existingSet.has(fp)) {
       return {
         ...row,
@@ -1393,10 +1429,45 @@ export const commitTransactionsImportForUser = async (
         imported: 0,
         income: 0,
         expense: 0,
+        createdTransactions: [],
       };
     }
 
-    const insertValuesPlaceholders = normalizedRows
+    const fingerprintCandidates = normalizedRows
+      .map((row) => (typeof row.fingerprint === "string" ? row.fingerprint.trim() : ""))
+      .filter(Boolean);
+    const existingFingerprints = await loadExistingFingerprintsWithClient(
+      transactionClient,
+      userId,
+      [...new Set(fingerprintCandidates)],
+    );
+    const seenFingerprints = new Set(existingFingerprints);
+
+    const dedupedRows = normalizedRows.filter((row) => {
+      const fingerprint = typeof row.fingerprint === "string" ? row.fingerprint.trim() : "";
+
+      if (!fingerprint) {
+        return true;
+      }
+
+      if (seenFingerprints.has(fingerprint)) {
+        return false;
+      }
+
+      seenFingerprints.add(fingerprint);
+      return true;
+    });
+
+    if (dedupedRows.length === 0) {
+      return {
+        imported: 0,
+        income: 0,
+        expense: 0,
+        createdTransactions: [],
+      };
+    }
+
+    const insertValuesPlaceholders = dedupedRows
       .map((_, rowIndex) => {
         const p = rowIndex * 10 + 2;
         return `($1, $${p}, $${p + 1}, $${p + 2}::date, $${p + 3}, $${p + 4}, $${p + 5}, $${p + 6}, $${p + 7}, NOW(), $${p + 8}, $${p + 9})`;
@@ -1405,7 +1476,7 @@ export const commitTransactionsImportForUser = async (
 
     const insertParams = [userId];
 
-    normalizedRows.forEach((row) => {
+    dedupedRows.forEach((row) => {
       insertParams.push(
         row.type,
         row.value,
@@ -1449,7 +1520,7 @@ export const commitTransactionsImportForUser = async (
     // transaction id with the original CSV line number.
     const createdTransactions = insertResult.rows.map((row, i) => ({
       id: Number(row.id),
-      line: normalizedRows[i]?.line ?? null,
+      line: dedupedRows[i]?.line ?? null,
       type: String(row.type),
       value: Number(row.value),
       date: toISODateOnly(row.date),

--- a/docs/architecture/v1.6.14-import-dedup-guardrails.md
+++ b/docs/architecture/v1.6.14-import-dedup-guardrails.md
@@ -1,0 +1,37 @@
+# v1.6.14 - import dedup guardrails
+
+Data: 2026-04-03
+Status: entregue
+
+## Objetivo
+
+Endurecer deduplicacao no fluxo de importacao de transacoes para evitar reimport silencioso de lancamentos equivalentes, sem alterar regra funcional fora da importacao.
+
+## Guard rails aplicados
+
+1. Dry-run: duplicidade no proprio arquivo
+- Linhas validas com o mesmo fingerprint no mesmo arquivo passam a ser marcadas como `duplicate`.
+- Mensagem: `Ja existe uma linha equivalente no arquivo de importacao.`
+
+2. Commit: rechecagem de fingerprint no banco
+- Antes do insert, o commit revalida fingerprints contra transacoes ativas do usuario.
+- Linhas que ficaram duplicadas entre o dry-run e o commit (ex.: sessoes paralelas criadas antes do primeiro commit) sao ignoradas no insert.
+
+3. Commit: dedup final do lote
+- Mesmo dentro do payload de commit, fingerprints repetidos nao sao reinseridos.
+
+## Resultado esperado
+
+- Reimport de sessao stale nao cria duplicata silenciosa.
+- Dry-run passa a explicitar duplicata intra-arquivo.
+- Contratos de resposta e fluxo de commit/undo permanecem estaveis.
+
+## Arquivos impactados
+
+- `apps/api/src/services/transactions-import.service.ts`
+- `apps/api/src/import.test.js`
+
+## Validacao
+
+- `npm -w apps/api run test:run -- src/import.test.js src/import-utility-dry-run.test.js`
+- `npm -w apps/api run lint`


### PR DESCRIPTION
Endurece guard rails de deduplicacao no fluxo de importacao de transacoes, sem alterar UI e sem misturar outras frentes.

Escopo:
- `apps/api/src/services/transactions-import.service.ts`
  - dry-run marca duplicata intra-arquivo (mesmo fingerprint no mesmo CSV/OFX/PDF parseado)
  - commit revalida fingerprints no banco antes do insert para bloquear reimport silencioso de sessoes stale
  - commit evita insercao duplicada mesmo com fingerprints repetidos no payload
- `apps/api/src/import.test.js`
  - cobre duplicata intra-arquivo no dry-run
  - valida que commit de sessao stale nao reinsere lancamento equivalente
- `docs/architecture/v1.6.14-import-dedup-guardrails.md`
  - documenta guard rails e contrato operacional

Validacao executada:
- `npm -w apps/api run test:run -- src/import.test.js src/import-utility-dry-run.test.js`
- `npm -w apps/api run lint`

Fora de escopo:
- sem mudanca de regra de negocio fora da importacao
- sem UI
- sem analytics/domain metrics
