### PR TITLE
Nova sequencia - Item 1.1: contrato semantico canonico do core financeiro

### DIFF
--- a/apps/api/src/domain/contracts/contracts.schema.test.ts
+++ b/apps/api/src/domain/contracts/contracts.schema.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import { BalanceSnapshotSchema } from "./balance.schema";
+import {
+  CoreFinancialSemanticContractSchema,
+  CoreFinancialSemanticSourceMapSchema,
+} from "./core-financial-semantic-contract.schema";
 import { ForecastResultSchema } from "./forecast.schema";
 import { IncomeEntrySchema } from "./income.schema";
 import { ObligationSchema } from "./obligation.schema";
@@ -169,6 +173,74 @@ describe("financial contracts schemas", () => {
         },
         confidence: "high",
         periodEnd: "2026-04-30T23:59:59.000Z",
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("CoreFinancialSemanticContractSchema", () => {
+    it("accepts canonical payload with realized/current/projection separation", () => {
+      const result = CoreFinancialSemanticContractSchema.safeParse({
+        semanticsVersion: "v1",
+        realized: {
+          confirmedInflowTotal: 5000,
+          settledOutflowTotal: 3200,
+          netAmount: 1800,
+          referenceMonth: "2026-04",
+        },
+        currentPosition: {
+          bankBalance: 2100,
+          technicalBalance: 1750,
+          asOf: "2026-04-03T12:00:00.000Z",
+        },
+        projection: {
+          referenceMonth: "2026-04",
+          projectedBalance: 950,
+          adjustedProjectedBalance: 600,
+          expectedInflow: 2400,
+        },
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects payload without mandatory semantic group", () => {
+      const result = CoreFinancialSemanticContractSchema.safeParse({
+        semanticsVersion: "v1",
+        realized: {
+          confirmedInflowTotal: 5000,
+          settledOutflowTotal: 3200,
+          netAmount: 1800,
+          referenceMonth: "2026-04",
+        },
+        currentPosition: {
+          bankBalance: 2100,
+          technicalBalance: 1750,
+          asOf: "2026-04-03T12:00:00.000Z",
+        },
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("CoreFinancialSemanticSourceMapSchema", () => {
+    it("accepts non-overlapping source mapping across semantic scopes", () => {
+      const result = CoreFinancialSemanticSourceMapSchema.safeParse({
+        realized: ["dashboard.income.receivedThisMonth"],
+        currentPosition: ["dashboard.bankBalance"],
+        projection: ["forecast.adjustedProjectedBalance"],
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects overlapping source mapping between scopes", () => {
+      const result = CoreFinancialSemanticSourceMapSchema.safeParse({
+        realized: ["dashboard.bankBalance"],
+        currentPosition: ["dashboard.bankBalance"],
+        projection: ["forecast.adjustedProjectedBalance"],
       });
 
       expect(result.success).toBe(false);

--- a/apps/api/src/domain/contracts/core-financial-semantic-contract.schema.ts
+++ b/apps/api/src/domain/contracts/core-financial-semantic-contract.schema.ts
@@ -1,0 +1,111 @@
+import { z } from "zod";
+
+const YearMonthSchema = z.string().regex(/^\d{4}-\d{2}$/);
+
+const AsOfSchema = z.union([
+  z.string().datetime({ offset: true }),
+  z.date(),
+]);
+
+export const CoreFinancialRealizedSchema = z.object({
+  confirmedInflowTotal: z.number(),
+  settledOutflowTotal: z.number(),
+  netAmount: z.number(),
+  referenceMonth: YearMonthSchema,
+});
+
+export const CoreFinancialCurrentPositionSchema = z.object({
+  bankBalance: z.number(),
+  technicalBalance: z.number(),
+  asOf: AsOfSchema,
+});
+
+export const CoreFinancialProjectionSchema = z.object({
+  referenceMonth: YearMonthSchema,
+  projectedBalance: z.number(),
+  adjustedProjectedBalance: z.number(),
+  expectedInflow: z.number().nullable(),
+});
+
+export const CoreFinancialSemanticContractSchema = z.object({
+  semanticsVersion: z.literal("v1"),
+  realized: CoreFinancialRealizedSchema,
+  currentPosition: CoreFinancialCurrentPositionSchema,
+  projection: CoreFinancialProjectionSchema,
+});
+
+const CoreFinancialSemanticSourcePathSchema = z.enum([
+  "dashboard.bankBalance",
+  "dashboard.income.receivedThisMonth",
+  "dashboard.income.pendingThisMonth",
+  "dashboard.forecast.projectedBalance",
+  "forecast.spendingToDate",
+  "forecast.projectedBalance",
+  "forecast.adjustedProjectedBalance",
+  "forecast.incomeExpected",
+]);
+
+export const CoreFinancialSemanticSourceMapSchema = z
+  .object({
+    realized: z.array(CoreFinancialSemanticSourcePathSchema).min(1),
+    currentPosition: z.array(CoreFinancialSemanticSourcePathSchema).min(1),
+    projection: z.array(CoreFinancialSemanticSourcePathSchema).min(1),
+  })
+  .superRefine((value, ctx) => {
+    const owners = new Map<string, "realized" | "currentPosition" | "projection">();
+
+    const register = (
+      semanticScope: "realized" | "currentPosition" | "projection",
+      sourcePath: string,
+      path: ["realized" | "currentPosition" | "projection", number],
+    ) => {
+      const existing = owners.get(sourcePath);
+      if (existing && existing !== semanticScope) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `source path '${sourcePath}' cannot belong to both ${existing} and ${semanticScope}`,
+          path,
+        });
+        return;
+      }
+      owners.set(sourcePath, semanticScope);
+    };
+
+    value.realized.forEach((sourcePath, index) => {
+      register("realized", sourcePath, ["realized", index]);
+    });
+    value.currentPosition.forEach((sourcePath, index) => {
+      register("currentPosition", sourcePath, ["currentPosition", index]);
+    });
+    value.projection.forEach((sourcePath, index) => {
+      register("projection", sourcePath, ["projection", index]);
+    });
+  });
+
+export const CORE_FINANCIAL_SEMANTIC_SOURCE_MAP =
+  CoreFinancialSemanticSourceMapSchema.parse({
+    realized: [
+      "dashboard.income.receivedThisMonth",
+      "forecast.spendingToDate",
+    ],
+    currentPosition: ["dashboard.bankBalance"],
+    projection: [
+      "dashboard.income.pendingThisMonth",
+      "dashboard.forecast.projectedBalance",
+      "forecast.projectedBalance",
+      "forecast.adjustedProjectedBalance",
+      "forecast.incomeExpected",
+    ],
+  });
+
+export type CoreFinancialRealized = z.infer<typeof CoreFinancialRealizedSchema>;
+export type CoreFinancialCurrentPosition = z.infer<
+  typeof CoreFinancialCurrentPositionSchema
+>;
+export type CoreFinancialProjection = z.infer<typeof CoreFinancialProjectionSchema>;
+export type CoreFinancialSemanticContract = z.infer<
+  typeof CoreFinancialSemanticContractSchema
+>;
+export type CoreFinancialSemanticSourceMap = z.infer<
+  typeof CoreFinancialSemanticSourceMapSchema
+>;

--- a/apps/api/src/domain/contracts/index.ts
+++ b/apps/api/src/domain/contracts/index.ts
@@ -34,6 +34,15 @@ export {
   ForecastRecomputeResponseSchema,
 } from "./forecast-response.schema";
 
+export {
+  CORE_FINANCIAL_SEMANTIC_SOURCE_MAP,
+  CoreFinancialCurrentPositionSchema,
+  CoreFinancialProjectionSchema,
+  CoreFinancialRealizedSchema,
+  CoreFinancialSemanticContractSchema,
+  CoreFinancialSemanticSourceMapSchema,
+} from "./core-financial-semantic-contract.schema";
+
 export type {
   BalanceSnapshot,
   BalanceSource,
@@ -72,3 +81,11 @@ export type {
   ForecastResponseMeta,
   ForecastRecomputeResponse,
 } from "./forecast-response.schema";
+
+export type {
+  CoreFinancialCurrentPosition,
+  CoreFinancialProjection,
+  CoreFinancialRealized,
+  CoreFinancialSemanticContract,
+  CoreFinancialSemanticSourceMap,
+} from "./core-financial-semantic-contract.schema";

--- a/apps/api/src/domain/contracts/types.ts
+++ b/apps/api/src/domain/contracts/types.ts
@@ -36,3 +36,11 @@ export type {
   ForecastResponseMeta,
   ForecastRecomputeResponse,
 } from "./forecast-response.schema";
+
+export type {
+  CoreFinancialCurrentPosition,
+  CoreFinancialProjection,
+  CoreFinancialRealized,
+  CoreFinancialSemanticContract,
+  CoreFinancialSemanticSourceMap,
+} from "./core-financial-semantic-contract.schema";

--- a/docs/architecture/v1.6.15-core-financial-semantic-contract-canonical.md
+++ b/docs/architecture/v1.6.15-core-financial-semantic-contract-canonical.md
@@ -1,0 +1,60 @@
+# v1.6.15 - Core Financial Semantic Contract (Canonical)
+
+## Context
+
+Item 1.1 of the new official sequence defines a single canonical contract for the financial core semantics with explicit separation between:
+
+- `realized`
+- `currentPosition`
+- `projection`
+
+This slice is intentionally structural. It does not change dashboard rendering, copy, or document ingestion flow.
+
+## What Was Added
+
+File: `apps/api/src/domain/contracts/core-financial-semantic-contract.schema.ts`
+
+- `CoreFinancialSemanticContractSchema`
+- `CoreFinancialRealizedSchema`
+- `CoreFinancialCurrentPositionSchema`
+- `CoreFinancialProjectionSchema`
+- `CoreFinancialSemanticSourceMapSchema`
+- `CORE_FINANCIAL_SEMANTIC_SOURCE_MAP`
+
+The source map is validated to prevent semantic overlap (a field cannot belong to two scopes).
+
+## Canonical Semantics (v1)
+
+- `realized`: confirmed and settled month values.
+- `currentPosition`: current balance position at an `asOf` instant.
+- `projection`: expected future position for the reference month.
+
+## Source Mapping (Current Surfaces)
+
+`realized`
+
+- `dashboard.income.receivedThisMonth`
+- `forecast.spendingToDate`
+
+`currentPosition`
+
+- `dashboard.bankBalance`
+
+`projection`
+
+- `dashboard.income.pendingThisMonth`
+- `dashboard.forecast.projectedBalance`
+- `forecast.projectedBalance`
+- `forecast.adjustedProjectedBalance`
+- `forecast.incomeExpected`
+
+## Out Of Scope
+
+- No API payload format migration (planned for Item 1.2).
+- No dashboard consumption refactor (planned for Item 1.3).
+- No document ingestion or copy adjustments.
+
+## Validation
+
+- Contract schema tests cover canonical payload acceptance and overlap rejection.
+- Contract and types are exported through `index.ts` and `types.ts` for reuse.


### PR DESCRIPTION
Define o contrato semantico canonico do core financeiro com separacao explicita entre realized, currentPosition e projection.

Inclui:
- mapa de origem semantica para dashboard/forecast com validacao anti-sobreposicao;
- exportacoes de tipos/schemas no barrel de contratos;
- testes focados de contratos para o novo contrato e source map.

Fora de escopo:
- migracao de payload das APIs;
- refactor visual do dashboard;
- fluxo documental;
- copy de produto.