### PR TITLE
Nova sequencia - Item 1.2: aplicar contrato semantico nas respostas centrais da API

### DIFF
--- a/apps/api/src/dashboard.test.js
+++ b/apps/api/src/dashboard.test.js
@@ -79,6 +79,7 @@ const DASHBOARD_TOP_LEVEL_KEYS = [
   "cards",
   "income",
   "forecast",
+  "semanticCore",
   "consignado",
 ].sort();
 
@@ -96,6 +97,33 @@ const DASHBOARD_CARDS_KEYS = ["openPurchasesTotal", "pendingInvoicesTotal"].sort
 const DASHBOARD_INCOME_KEYS = ["receivedThisMonth", "pendingThisMonth", "referenceMonth"].sort();
 
 const DASHBOARD_CONSIGNADO_KEYS = ["monthlyTotal", "contractsCount", "comprometimentoPct"].sort();
+
+const DASHBOARD_SEMANTIC_CORE_KEYS = [
+  "semanticsVersion",
+  "realized",
+  "currentPosition",
+  "projection",
+].sort();
+
+const DASHBOARD_SEMANTIC_REALIZED_KEYS = [
+  "confirmedInflowTotal",
+  "settledOutflowTotal",
+  "netAmount",
+  "referenceMonth",
+].sort();
+
+const DASHBOARD_SEMANTIC_CURRENT_POSITION_KEYS = [
+  "bankBalance",
+  "technicalBalance",
+  "asOf",
+].sort();
+
+const DASHBOARD_SEMANTIC_PROJECTION_KEYS = [
+  "referenceMonth",
+  "projectedBalance",
+  "adjustedProjectedBalance",
+  "expectedInflow",
+].sort();
 
 const getUserIdByEmail = async (email) => {
   const userRes = await dbQuery("SELECT id FROM users WHERE email = $1 LIMIT 1", [email]);
@@ -434,6 +462,16 @@ describe("dashboard snapshot", () => {
     expect(Object.keys(res.body.cards).sort()).toEqual(DASHBOARD_CARDS_KEYS);
     expect(Object.keys(res.body.income).sort()).toEqual(DASHBOARD_INCOME_KEYS);
     expect(Object.keys(res.body.consignado).sort()).toEqual(DASHBOARD_CONSIGNADO_KEYS);
+    expect(Object.keys(res.body.semanticCore).sort()).toEqual(DASHBOARD_SEMANTIC_CORE_KEYS);
+    expect(Object.keys(res.body.semanticCore.realized).sort()).toEqual(
+      DASHBOARD_SEMANTIC_REALIZED_KEYS,
+    );
+    expect(Object.keys(res.body.semanticCore.currentPosition).sort()).toEqual(
+      DASHBOARD_SEMANTIC_CURRENT_POSITION_KEYS,
+    );
+    expect(Object.keys(res.body.semanticCore.projection).sort()).toEqual(
+      DASHBOARD_SEMANTIC_PROJECTION_KEYS,
+    );
 
     expect(res.body).toStrictEqual({
       bankBalance: 0,
@@ -455,6 +493,26 @@ describe("dashboard snapshot", () => {
         referenceMonth: currentMonth(),
       },
       forecast: null,
+      semanticCore: {
+        semanticsVersion: "v1",
+        realized: {
+          confirmedInflowTotal: 0,
+          settledOutflowTotal: 0,
+          netAmount: 0,
+          referenceMonth: currentMonth(),
+        },
+        currentPosition: {
+          bankBalance: 0,
+          technicalBalance: 0,
+          asOf: expect.any(String),
+        },
+        projection: {
+          referenceMonth: currentMonth(),
+          projectedBalance: 0,
+          adjustedProjectedBalance: 0,
+          expectedInflow: null,
+        },
+      },
       consignado: {
         monthlyTotal: 0,
         contractsCount: 0,
@@ -510,6 +568,7 @@ describe("dashboard snapshot", () => {
     expect(Object.keys(res.body.cards).sort()).toEqual(DASHBOARD_CARDS_KEYS);
     expect(Object.keys(res.body.income).sort()).toEqual(DASHBOARD_INCOME_KEYS);
     expect(Object.keys(res.body.consignado).sort()).toEqual(DASHBOARD_CONSIGNADO_KEYS);
+    expect(Object.keys(res.body.semanticCore).sort()).toEqual(DASHBOARD_SEMANTIC_CORE_KEYS);
 
     expect(typeof res.body.bankBalance).toBe("number");
     expect(typeof res.body.bills.overdueTotal).toBe("number");
@@ -520,6 +579,17 @@ describe("dashboard snapshot", () => {
     expect(typeof res.body.income.pendingThisMonth).toBe("number");
     expect(typeof res.body.consignado.monthlyTotal).toBe("number");
     expect(typeof res.body.consignado.contractsCount).toBe("number");
+    expect(res.body.semanticCore.semanticsVersion).toBe("v1");
+    expect(res.body.semanticCore.realized.confirmedInflowTotal).toBe(
+      res.body.income.receivedThisMonth,
+    );
+    expect(res.body.semanticCore.currentPosition.bankBalance).toBe(res.body.bankBalance);
+    expect(res.body.semanticCore.projection.projectedBalance).toBe(
+      res.body.forecast ? res.body.forecast.projectedBalance : res.body.bankBalance,
+    );
+    expect(res.body.semanticCore.projection.expectedInflow).toBe(
+      res.body.income.pendingThisMonth > 0 ? res.body.income.pendingThisMonth : null,
+    );
     expect(
       res.body.consignado.comprometimentoPct === null
         ? true
@@ -694,6 +764,7 @@ describe("dashboard snapshot", () => {
     expect(Object.keys(res.body.cards).sort()).toEqual(DASHBOARD_CARDS_KEYS);
     expect(Object.keys(res.body.income).sort()).toEqual(DASHBOARD_INCOME_KEYS);
     expect(Object.keys(res.body.consignado).sort()).toEqual(DASHBOARD_CONSIGNADO_KEYS);
+    expect(Object.keys(res.body.semanticCore).sort()).toEqual(DASHBOARD_SEMANTIC_CORE_KEYS);
 
     const bankIsPositive = res.body.bankBalance > 0;
     expect(bankIsPositive).toBe(scenario.expected.bankSign === "positive");
@@ -713,6 +784,14 @@ describe("dashboard snapshot", () => {
 
     const cardExposure = res.body.cards.openPurchasesTotal + res.body.cards.pendingInvoicesTotal;
     expect(cardExposure > 0).toBe(scenario.expected.cardImpacts);
+
+    expect(res.body.semanticCore.realized.confirmedInflowTotal).toBe(
+      res.body.income.receivedThisMonth,
+    );
+    expect(res.body.semanticCore.currentPosition.bankBalance).toBe(res.body.bankBalance);
+    expect(res.body.semanticCore.projection.referenceMonth).toBe(
+      res.body.forecast ? res.body.forecast.month : res.body.income.referenceMonth,
+    );
 
     if (scenario.expected.forecastMode === "available") {
       expect(res.body.forecast).not.toBeNull();

--- a/apps/api/src/domain/contracts/dashboard-response.schema.ts
+++ b/apps/api/src/domain/contracts/dashboard-response.schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { CoreFinancialSemanticContractSchema } from "./core-financial-semantic-contract.schema";
 
 const DashboardBillsSchema = z.object({
   overdueCount: z.number().int().nonnegative(),
@@ -37,6 +38,7 @@ export const DashboardSnapshotResponseSchema = z.object({
   cards: DashboardCardsSchema,
   income: DashboardIncomeSchema,
   forecast: DashboardForecastSchema.nullable(),
+  semanticCore: CoreFinancialSemanticContractSchema,
   consignado: DashboardConsignadoSchema,
 });
 

--- a/apps/api/src/domain/contracts/forecast-response.schema.ts
+++ b/apps/api/src/domain/contracts/forecast-response.schema.ts
@@ -4,6 +4,7 @@ import {
   ForecastIncomeBasisSchema,
   ForecastPendingItemsSchema,
 } from "./forecast.schema";
+import { CoreFinancialSemanticContractSchema } from "./core-financial-semantic-contract.schema";
 
 const YearMonthSchema = z.string().regex(/^\d{4}-\d{2}$/);
 
@@ -45,6 +46,7 @@ const ForecastHttpPayloadSchema = z.object({
   adjustedProjectedBalance: z.number(),
   bankLimit: ForecastBankLimitProjectionSchema.nullable(),
   _meta: ForecastResponseMetaSchema,
+  semanticCore: CoreFinancialSemanticContractSchema,
 });
 
 export const ForecastCurrentResponseSchema = ForecastHttpPayloadSchema.nullable();

--- a/apps/api/src/forecast.test.js
+++ b/apps/api/src/forecast.test.js
@@ -75,6 +75,22 @@ describe("GET /forecasts/current", () => {
     expect(res.body).not.toBeNull();
     expect(typeof res.body.projectedBalance).toBe("number");
     expect(typeof res.body.month).toBe("string");
+    expect(res.body.semanticCore).toMatchObject({
+      semanticsVersion: "v1",
+      realized: {
+        referenceMonth: res.body.month,
+      },
+      currentPosition: {
+        bankBalance: expect.any(Number),
+        technicalBalance: expect.any(Number),
+        asOf: expect.any(String),
+      },
+      projection: {
+        referenceMonth: res.body.month,
+        projectedBalance: res.body.projectedBalance,
+        adjustedProjectedBalance: res.body.adjustedProjectedBalance,
+      },
+    });
   });
 });
 
@@ -111,6 +127,26 @@ describe("POST /forecasts/recompute", () => {
         bills: 0,
         invoices: 0,
         creditCardCycles: 0,
+      },
+    });
+    expect(res.body.semanticCore).toMatchObject({
+      semanticsVersion: "v1",
+      realized: {
+        confirmedInflowTotal: 0,
+        settledOutflowTotal: 0,
+        netAmount: 0,
+        referenceMonth: res.body.month,
+      },
+      currentPosition: {
+        bankBalance: 0,
+        technicalBalance: 0,
+        asOf: expect.any(String),
+      },
+      projection: {
+        referenceMonth: res.body.month,
+        projectedBalance: res.body.projectedBalance,
+        adjustedProjectedBalance: res.body.adjustedProjectedBalance,
+        expectedInflow: null,
       },
     });
     expect(Array.isArray(res.body._meta.fallbacksUsed)).toBe(true);
@@ -690,6 +726,11 @@ describe("forecast — bills integration", () => {
       used: 80,
       status: "using",
     });
+    expect(res.body.semanticCore.realized.settledOutflowTotal).toBe(res.body.spendingToDate);
+    expect(res.body.semanticCore.projection.adjustedProjectedBalance).toBe(
+      res.body.adjustedProjectedBalance,
+    );
+    expect(res.body.semanticCore.projection.expectedInflow).toBe(res.body.incomeExpected);
   });
 
   it("recompute com multiplas bills soma corretamente", async () => {

--- a/apps/api/src/services/dashboard.service.ts
+++ b/apps/api/src/services/dashboard.service.ts
@@ -50,12 +50,34 @@ interface DashboardSnapshot {
     projectedBalance: number;
     month: string;
   } | null;
+  semanticCore: {
+    semanticsVersion: "v1";
+    realized: {
+      confirmedInflowTotal: number;
+      settledOutflowTotal: number;
+      netAmount: number;
+      referenceMonth: string;
+    };
+    currentPosition: {
+      bankBalance: number;
+      technicalBalance: number;
+      asOf: string;
+    };
+    projection: {
+      referenceMonth: string;
+      projectedBalance: number;
+      adjustedProjectedBalance: number;
+      expectedInflow: number | null;
+    };
+  };
   consignado: {
     monthlyTotal: number;
     contractsCount: number;
     comprometimentoPct: number | null;
   };
 }
+
+type DashboardSnapshotBase = Omit<DashboardSnapshot, "semanticCore">;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -67,6 +89,78 @@ const toISODate = (dateValue: Date): string => dateValue.toISOString().slice(0, 
 
 // Returns YYYY-MM from a Date
 const toYearMonth = (dateValue: Date): string => dateValue.toISOString().slice(0, 7);
+
+const normalizeYearMonth = (value: string | Date | null | undefined): string | null => {
+  if (value == null) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return toYearMonth(value);
+  }
+
+  const raw = String(value).trim();
+  if (!raw) {
+    return null;
+  }
+
+  const fromDate = new Date(raw);
+  if (!Number.isNaN(fromDate.getTime())) {
+    return toYearMonth(fromDate);
+  }
+
+  if (/^\d{4}-\d{2}/.test(raw)) {
+    return raw.slice(0, 7);
+  }
+
+  return null;
+};
+
+const buildDashboardSemanticCore = (
+  snapshot: DashboardSnapshotBase,
+  asOf: Date,
+): DashboardSnapshot["semanticCore"] => {
+  const confirmedInflowTotal = Number(snapshot.income.receivedThisMonth.toFixed(2));
+  const settledOutflowTotal = 0;
+  const netAmount = Number((confirmedInflowTotal - settledOutflowTotal).toFixed(2));
+
+  const projectionReferenceMonth = snapshot.forecast?.month ?? snapshot.income.referenceMonth;
+  const projectedBalanceBase = snapshot.forecast?.projectedBalance ?? snapshot.bankBalance;
+  const pendingObligationsTotal =
+    snapshot.bills.overdueTotal +
+    snapshot.bills.dueSoonTotal +
+    snapshot.bills.upcomingTotal +
+    snapshot.cards.openPurchasesTotal +
+    snapshot.cards.pendingInvoicesTotal;
+  const expectedInflow =
+    snapshot.income.pendingThisMonth > 0 ? snapshot.income.pendingThisMonth : null;
+  const adjustedProjectedBalance = Number(
+    (projectedBalanceBase + (expectedInflow ?? 0) - pendingObligationsTotal).toFixed(2),
+  );
+
+  return {
+    semanticsVersion: "v1",
+    realized: {
+      confirmedInflowTotal,
+      settledOutflowTotal,
+      netAmount,
+      referenceMonth: snapshot.income.referenceMonth,
+    },
+    currentPosition: {
+      bankBalance: snapshot.bankBalance,
+      technicalBalance: Number(
+        (snapshot.bankBalance - snapshot.bills.overdueTotal).toFixed(2),
+      ),
+      asOf: asOf.toISOString(),
+    },
+    projection: {
+      referenceMonth: projectionReferenceMonth,
+      projectedBalance: Number(projectedBalanceBase.toFixed(2)),
+      adjustedProjectedBalance,
+      expectedInflow,
+    },
+  };
+};
 
 // ─── Snapshot ─────────────────────────────────────────────────────────────────
 
@@ -166,8 +260,9 @@ export const getDashboardSnapshot = async (
   const bills = (billsRes.rows[0] ?? {}) as BillsRow;
   const income = (incomeRes.rows[0] ?? {}) as IncomeRow;
   const forecastRow = (forecastRes.rows[0] ?? null) as ForecastRow | null;
+  const forecastMonth = normalizeYearMonth(forecastRow?.month);
 
-  return {
+  const baseSnapshot: DashboardSnapshotBase = {
     bankBalance: toNum(bankRes.rows[0]?.total as NumericLike),
     bills: {
       overdueCount: toInt(bills.overdue_count),
@@ -189,7 +284,7 @@ export const getDashboardSnapshot = async (
     forecast: forecastRow
       ? {
           projectedBalance: toNum(forecastRow.projected_balance),
-          month: String(forecastRow.month),
+          month: forecastMonth ?? currentMonth,
         }
       : null,
     consignado: (() => {
@@ -203,5 +298,10 @@ export const getDashboardSnapshot = async (
           : null;
       return { monthlyTotal, contractsCount, comprometimentoPct };
     })(),
+  };
+
+  return {
+    ...baseSnapshot,
+    semanticCore: buildDashboardSemanticCore(baseSnapshot, now),
   };
 };

--- a/apps/api/src/services/forecast.service.ts
+++ b/apps/api/src/services/forecast.service.ts
@@ -48,6 +48,26 @@ interface ForecastPayload {
   adjustedProjectedBalance: number;
   bankLimit: ForecastBankLimitProjection | null;
   _meta: ForecastMeta;
+  semanticCore: {
+    semanticsVersion: "v1";
+    realized: {
+      confirmedInflowTotal: number;
+      settledOutflowTotal: number;
+      netAmount: number;
+      referenceMonth: string;
+    };
+    currentPosition: {
+      bankBalance: number;
+      technicalBalance: number;
+      asOf: string;
+    };
+    projection: {
+      referenceMonth: string;
+      projectedBalance: number;
+      adjustedProjectedBalance: number;
+      expectedInflow: number | null;
+    };
+  };
 }
 
 interface ForecastRow {
@@ -223,6 +243,52 @@ const buildForecastMeta = async ({
     incomeBasis,
     pendingItems,
     fallbacksUsed,
+  };
+};
+
+const buildForecastSemanticCore = ({
+  referenceMonth,
+  incomeToDate,
+  spendingToDate,
+  currentPositionBalance,
+  projectedBalance,
+  adjustedProjectedBalance,
+  expectedInflow,
+  asOf,
+}: {
+  referenceMonth: string;
+  incomeToDate: number;
+  spendingToDate: number;
+  currentPositionBalance: number;
+  projectedBalance: number;
+  adjustedProjectedBalance: number;
+  expectedInflow: number | null;
+  asOf: Date;
+}): ForecastPayload["semanticCore"] => {
+  const confirmedInflowTotal = Number(incomeToDate.toFixed(2));
+  const settledOutflowTotal = Number(spendingToDate.toFixed(2));
+  const netAmount = Number((confirmedInflowTotal - settledOutflowTotal).toFixed(2));
+  const normalizedCurrentPositionBalance = Number(currentPositionBalance.toFixed(2));
+
+  return {
+    semanticsVersion: "v1",
+    realized: {
+      confirmedInflowTotal,
+      settledOutflowTotal,
+      netAmount,
+      referenceMonth,
+    },
+    currentPosition: {
+      bankBalance: normalizedCurrentPositionBalance,
+      technicalBalance: normalizedCurrentPositionBalance,
+      asOf: asOf.toISOString(),
+    },
+    projection: {
+      referenceMonth,
+      projectedBalance: Number(projectedBalance.toFixed(2)),
+      adjustedProjectedBalance: Number(adjustedProjectedBalance.toFixed(2)),
+      expectedInflow,
+    },
   };
 };
 
@@ -416,6 +482,16 @@ export const computeForecast = async (
     balanceBasis,
     incomeBasis,
   });
+  const semanticCore = buildForecastSemanticCore({
+    referenceMonth: currentMonth,
+    incomeToDate,
+    spendingToDate,
+    currentPositionBalance: realBalanceBase,
+    projectedBalance: pb,
+    adjustedProjectedBalance,
+    expectedInflow: incomeExpected,
+    asOf: now,
+  });
 
   return {
     month: mStart.slice(0, 7),
@@ -433,6 +509,7 @@ export const computeForecast = async (
     adjustedProjectedBalance,
     bankLimit: buildBankLimitProjection(effectiveBankLimitTotal, adjustedProjectedBalance),
     _meta: meta,
+    semanticCore,
   };
 };
 
@@ -445,6 +522,7 @@ export const getLatestForecast = async (
 ): Promise<ForecastPayload | null> => {
   const uid = normalizeUserId(userId);
   const mStart = monthStartStr(now);
+  const todayStr = now.toISOString().slice(0, 10);
 
   const result = await dbQuery(
     `SELECT * FROM user_forecasts WHERE user_id = $1 AND month = $2 LIMIT 1`,
@@ -477,6 +555,7 @@ export const getLatestForecast = async (
 
   const bankLimitResult = await dbQuery(
     `SELECT
+       COALESCE(SUM(balance), 0)::numeric AS total_balance,
        COALESCE(SUM(limit_total), 0)::numeric AS total_limit_total,
        COUNT(*)::int AS active_accounts_count
      FROM bank_accounts
@@ -484,10 +563,24 @@ export const getLatestForecast = async (
        AND is_active = true`,
     [uid],
   );
+  const totalBankBalance = Number(bankLimitResult.rows[0]?.total_balance || 0);
   const totalBankLimitTotal = Number(bankLimitResult.rows[0]?.total_limit_total || 0);
   const activeAccountsCount = Number(bankLimitResult.rows[0]?.active_accounts_count || 0);
   const effectiveBankLimitTotal =
     activeAccountsCount > 0 ? totalBankLimitTotal : profileBankLimitTotal;
+
+  const monthlyResult = await dbQuery(
+    `SELECT
+       COALESCE(SUM(CASE WHEN type = 'Saida' THEN value ELSE 0 END), 0) AS spending_to_date,
+       COALESCE(SUM(CASE WHEN type = 'Entrada' THEN value ELSE 0 END), 0) AS income_to_date
+     FROM transactions
+     WHERE user_id = $1
+       AND deleted_at IS NULL
+       AND date >= $2
+       AND date <= $3`,
+    [uid, mStart, todayStr],
+  );
+  const incomeToDate = Number(monthlyResult.rows[0]?.income_to_date || 0);
 
   const stmtExpectedResult = await dbQuery(
     `SELECT COALESCE(SUM(st.net_amount), 0) AS total
@@ -509,6 +602,20 @@ export const getLatestForecast = async (
     balanceBasis,
     incomeBasis,
   });
+  const currentPositionBalance =
+    activeAccountsCount > 0
+      ? totalBankBalance
+      : Number((incomeToDate - forecast.spendingToDate).toFixed(2));
+  const semanticCore = buildForecastSemanticCore({
+    referenceMonth: forecast.month,
+    incomeToDate,
+    spendingToDate: forecast.spendingToDate,
+    currentPositionBalance,
+    projectedBalance: forecast.projectedBalance,
+    adjustedProjectedBalance,
+    expectedInflow: forecast.incomeExpected,
+    asOf: now,
+  });
 
   return {
     ...forecast,
@@ -520,5 +627,6 @@ export const getLatestForecast = async (
       adjustedProjectedBalance,
     ),
     _meta: meta,
+    semanticCore,
   };
 };

--- a/apps/web/src/components/OperationalSummaryPanel.test.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.test.tsx
@@ -15,37 +15,63 @@ vi.mock("../services/dashboard.service", async (importOriginal) => {
   };
 });
 
-const buildSnapshot = (overrides: Partial<DashboardSnapshot> = {}): DashboardSnapshot => ({
-  bankBalance: 1000,
-  bills: {
-    overdueCount: 0,
-    overdueTotal: 0,
-    dueSoonCount: 0,
-    dueSoonTotal: 0,
-    upcomingCount: 0,
-    upcomingTotal: 0,
-    ...(overrides.bills ?? {}),
-  },
-  cards: {
-    openPurchasesTotal: 0,
-    pendingInvoicesTotal: 0,
-    ...(overrides.cards ?? {}),
-  },
-  income: {
+const buildSnapshot = (overrides: Partial<DashboardSnapshot> = {}): DashboardSnapshot => {
+  const bankBalance = overrides.bankBalance ?? 1000;
+  const income = {
     receivedThisMonth: 0,
     pendingThisMonth: 0,
     referenceMonth: "2026-04",
     ...(overrides.income ?? {}),
-  },
-  forecast: overrides.forecast ?? null,
-  consignado: {
-    monthlyTotal: 0,
-    contractsCount: 0,
-    comprometimentoPct: null,
-    ...(overrides.consignado ?? {}),
-  },
-  ...overrides,
-});
+  };
+  const forecast = overrides.forecast ?? null;
+
+  return {
+    bankBalance,
+    bills: {
+      overdueCount: 0,
+      overdueTotal: 0,
+      dueSoonCount: 0,
+      dueSoonTotal: 0,
+      upcomingCount: 0,
+      upcomingTotal: 0,
+      ...(overrides.bills ?? {}),
+    },
+    cards: {
+      openPurchasesTotal: 0,
+      pendingInvoicesTotal: 0,
+      ...(overrides.cards ?? {}),
+    },
+    income,
+    forecast,
+    semanticCore: overrides.semanticCore ?? {
+      semanticsVersion: "v1",
+      realized: {
+        confirmedInflowTotal: income.receivedThisMonth,
+        settledOutflowTotal: 0,
+        netAmount: income.receivedThisMonth,
+        referenceMonth: income.referenceMonth,
+      },
+      currentPosition: {
+        bankBalance,
+        technicalBalance: bankBalance,
+        asOf: "2026-04-15T00:00:00.000Z",
+      },
+      projection: {
+        referenceMonth: forecast?.month ?? income.referenceMonth,
+        projectedBalance: forecast?.projectedBalance ?? bankBalance,
+        adjustedProjectedBalance: forecast?.projectedBalance ?? bankBalance,
+        expectedInflow:
+          income.pendingThisMonth > 0 ? income.pendingThisMonth : null,
+      },
+    },
+    consignado: {
+      monthlyTotal: 0,
+      contractsCount: 0,
+      comprometimentoPct: null,
+      ...(overrides.consignado ?? {}),
+    },
+  };
+};
 
 describe("OperationalSummaryPanel", () => {
   beforeEach(() => {

--- a/apps/web/src/services/dashboard.service.test.ts
+++ b/apps/web/src/services/dashboard.service.test.ts
@@ -11,37 +11,63 @@ vi.mock("./api", () => ({
 
 const getMock = vi.mocked(api.get);
 
-const buildSnapshot = (overrides: Partial<DashboardSnapshot> = {}): DashboardSnapshot => ({
-  bankBalance: 1200,
-  bills: {
-    overdueCount: 0,
-    overdueTotal: 0,
-    dueSoonCount: 0,
-    dueSoonTotal: 0,
-    upcomingCount: 0,
-    upcomingTotal: 0,
-    ...(overrides.bills ?? {}),
-  },
-  cards: {
-    openPurchasesTotal: 0,
-    pendingInvoicesTotal: 0,
-    ...(overrides.cards ?? {}),
-  },
-  income: {
+const buildSnapshot = (overrides: Partial<DashboardSnapshot> = {}): DashboardSnapshot => {
+  const bankBalance = overrides.bankBalance ?? 1200;
+  const income = {
     receivedThisMonth: 0,
     pendingThisMonth: 0,
     referenceMonth: "2026-04",
     ...(overrides.income ?? {}),
-  },
-  forecast: overrides.forecast ?? null,
-  consignado: {
-    monthlyTotal: 0,
-    contractsCount: 0,
-    comprometimentoPct: null,
-    ...(overrides.consignado ?? {}),
-  },
-  ...overrides,
-});
+  };
+  const forecast = overrides.forecast ?? null;
+
+  return {
+    bankBalance,
+    bills: {
+      overdueCount: 0,
+      overdueTotal: 0,
+      dueSoonCount: 0,
+      dueSoonTotal: 0,
+      upcomingCount: 0,
+      upcomingTotal: 0,
+      ...(overrides.bills ?? {}),
+    },
+    cards: {
+      openPurchasesTotal: 0,
+      pendingInvoicesTotal: 0,
+      ...(overrides.cards ?? {}),
+    },
+    income,
+    forecast,
+    semanticCore: overrides.semanticCore ?? {
+      semanticsVersion: "v1",
+      realized: {
+        confirmedInflowTotal: income.receivedThisMonth,
+        settledOutflowTotal: 0,
+        netAmount: income.receivedThisMonth,
+        referenceMonth: income.referenceMonth,
+      },
+      currentPosition: {
+        bankBalance,
+        technicalBalance: bankBalance,
+        asOf: "2026-04-15T00:00:00.000Z",
+      },
+      projection: {
+        referenceMonth: forecast?.month ?? income.referenceMonth,
+        projectedBalance: forecast?.projectedBalance ?? bankBalance,
+        adjustedProjectedBalance: forecast?.projectedBalance ?? bankBalance,
+        expectedInflow:
+          income.pendingThisMonth > 0 ? income.pendingThisMonth : null,
+      },
+    },
+    consignado: {
+      monthlyTotal: 0,
+      contractsCount: 0,
+      comprometimentoPct: null,
+      ...(overrides.consignado ?? {}),
+    },
+  };
+};
 
 describe("dashboardService", () => {
   beforeEach(() => {

--- a/docs/architecture/v1.6.16-core-financial-semantic-api-responses.md
+++ b/docs/architecture/v1.6.16-core-financial-semantic-api-responses.md
@@ -1,0 +1,53 @@
+# v1.6.16 - Core Financial Semantic Contract Applied to API Responses
+
+## Context
+
+Item 1.2 applies the canonical semantic contract from v1.6.15 to the central API responses:
+
+- `GET /dashboard/snapshot`
+- `GET /forecasts/current`
+- `POST /forecasts/recompute`
+
+Goal: remove semantic ambiguity by exposing `realized`, `currentPosition`, and `projection` explicitly in payloads.
+
+## Changes
+
+### Contracts
+
+- `DashboardSnapshotResponseSchema` now includes `semanticCore`.
+- `ForecastHttpPayloadSchema` now includes `semanticCore`.
+
+`semanticCore` follows `CoreFinancialSemanticContractSchema` (`semanticsVersion = "v1"`).
+
+### Dashboard response
+
+`semanticCore` is derived from the dashboard snapshot fields:
+
+- `realized.confirmedInflowTotal` <- `income.receivedThisMonth`
+- `currentPosition.bankBalance` <- `bankBalance`
+- `projection.projectedBalance` <- `forecast.projectedBalance` or `bankBalance` fallback
+- `projection.expectedInflow` <- `income.pendingThisMonth` (nullable)
+
+### Forecast responses
+
+`semanticCore` is now emitted in both recompute/current flows:
+
+- `realized.settledOutflowTotal` <- `spendingToDate`
+- `projection.projectedBalance` <- `projectedBalance`
+- `projection.adjustedProjectedBalance` <- `adjustedProjectedBalance`
+- `projection.expectedInflow` <- `incomeExpected`
+
+Current position uses active bank balances when available, with deterministic fallback to realized net month position.
+
+## Scope and Guardrails
+
+- Functional behavior preserved.
+- No dashboard visual refactor.
+- No document ingestion changes.
+- No product copy changes.
+
+## Validation
+
+- Dashboard regression tests updated for canonical `semanticCore` output.
+- Forecast endpoint tests updated for semantic alignment.
+- API lint and focused suites green.


### PR DESCRIPTION
Aplicacao do contrato semantico canonico (v1) nas respostas centrais da API.

Escopo:
- dashboard/forecast passam a expor semanticCore com realized/currentPosition/projection;
- alinhamento com o contrato definido na 1.1;
- atualizacao de testes focados e validacoes de contrato;
- documentacao arquitetural v1.6.16.

Fora de escopo:
- dashboard visual;
- fluxo documental;
- copy de produto.