### PR TITLE
Nova sequencia - Item 1.3: alinhar consumo do dashboard ao semantic core

### DIFF
--- a/apps/web/src/components/OperationalSummaryPanel.test.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.test.tsx
@@ -17,6 +17,15 @@ vi.mock("../services/dashboard.service", async (importOriginal) => {
 
 const buildSnapshot = (overrides: Partial<DashboardSnapshot> = {}): DashboardSnapshot => {
   const bankBalance = overrides.bankBalance ?? 1000;
+  const bills = {
+    overdueCount: 0,
+    overdueTotal: 0,
+    dueSoonCount: 0,
+    dueSoonTotal: 0,
+    upcomingCount: 0,
+    upcomingTotal: 0,
+    ...(overrides.bills ?? {}),
+  };
   const income = {
     receivedThisMonth: 0,
     pendingThisMonth: 0,
@@ -27,15 +36,7 @@ const buildSnapshot = (overrides: Partial<DashboardSnapshot> = {}): DashboardSna
 
   return {
     bankBalance,
-    bills: {
-      overdueCount: 0,
-      overdueTotal: 0,
-      dueSoonCount: 0,
-      dueSoonTotal: 0,
-      upcomingCount: 0,
-      upcomingTotal: 0,
-      ...(overrides.bills ?? {}),
-    },
+    bills,
     cards: {
       openPurchasesTotal: 0,
       pendingInvoicesTotal: 0,
@@ -53,7 +54,7 @@ const buildSnapshot = (overrides: Partial<DashboardSnapshot> = {}): DashboardSna
       },
       currentPosition: {
         bankBalance,
-        technicalBalance: bankBalance,
+        technicalBalance: bankBalance - bills.overdueTotal,
         asOf: "2026-04-15T00:00:00.000Z",
       },
       projection: {
@@ -358,5 +359,63 @@ describe("OperationalSummaryPanel", () => {
     expect(screen.getByText("R$ 0,00")).toBeInTheDocument();
     expect(screen.getByText("Realizado no mês")).toBeInTheDocument();
     expect(screen.getByText("Previsto no mês: R$ 900,00")).toBeInTheDocument();
+  });
+
+  it("prioriza semanticCore no consumo de saldo e renda", async () => {
+    vi.mocked(dashboardService.getSnapshot).mockResolvedValueOnce(
+      buildSnapshot({
+        bankBalance: 1000,
+        income: {
+          receivedThisMonth: 50,
+          pendingThisMonth: 20,
+          referenceMonth: "2026-04",
+        },
+        forecast: {
+          projectedBalance: 400,
+          month: "2026-04",
+        },
+        bills: {
+          overdueCount: 1,
+          overdueTotal: 120,
+          dueSoonCount: 0,
+          dueSoonTotal: 0,
+          upcomingCount: 0,
+          upcomingTotal: 0,
+        },
+        semanticCore: {
+          semanticsVersion: "v1",
+          realized: {
+            confirmedInflowTotal: 1200,
+            settledOutflowTotal: 300,
+            netAmount: 900,
+            referenceMonth: "2026-04",
+          },
+          currentPosition: {
+            bankBalance: 850,
+            technicalBalance: 730,
+            asOf: "2026-04-15T00:00:00.000Z",
+          },
+          projection: {
+            referenceMonth: "2026-04",
+            projectedBalance: 200,
+            adjustedProjectedBalance: 150,
+            expectedInflow: 350,
+          },
+        },
+      }),
+    );
+
+    render(<OperationalSummaryPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Saldo realizado após vencidas: R$ 730,00")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("R$ 850,00")).toBeInTheDocument();
+    expect(screen.getByText("R$ 1.200,00")).toBeInTheDocument();
+    expect(screen.getByText("Previsto no mês: R$ 350,00")).toBeInTheDocument();
+    expect(screen.getByText("R$ 200,00")).toBeInTheDocument();
+    expect(screen.queryByText("R$ 50,00")).not.toBeInTheDocument();
+    expect(screen.queryByText("R$ 400,00")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/OperationalSummaryPanel.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.tsx
@@ -162,8 +162,8 @@ const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanel
     );
   }
 
-  const { forecast, consignado } = snapshot;
-  const { balanceSnapshot, obligations } = buildDashboardContractView(snapshot);
+  const { forecast, consignado, semanticCore } = snapshot;
+  const { obligations } = buildDashboardContractView(snapshot);
 
   const nowTimestamp = Date.now();
   const dueSoonLimit = nowTimestamp + 7 * DAY_IN_MS;
@@ -190,8 +190,8 @@ const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanel
   const dueSoonTotal = sumAmounts(dueSoonObligations);
   const upcomingCount = upcomingObligations.length;
   const upcomingTotal = sumAmounts(upcomingObligations);
-  const receivedThisMonth = snapshot.income.receivedThisMonth;
-  const projectedThisMonth = snapshot.income.pendingThisMonth;
+  const receivedThisMonth = semanticCore.realized.confirmedInflowTotal;
+  const projectedThisMonth = semanticCore.projection.expectedInflow ?? 0;
   const cardCycleTotal = sumAmounts(
     obligations.filter((obligation) => obligation.obligationType === "credit_card_cycle"),
   );
@@ -200,10 +200,10 @@ const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanel
   );
 
   // ── Tile 1: Bank balance ──────────────────────────────────────────────────
-  const bankBalance = balanceSnapshot.bankBalance;
+  const bankBalance = semanticCore.currentPosition.bankBalance;
   const hasOverdueBills = overdueCount > 0;
   const hasDueSoonBills = dueSoonCount > 0;
-  const technicalBalance = balanceSnapshot.technicalBalance;
+  const technicalBalance = semanticCore.currentPosition.technicalBalance;
   const shortTermBalance = technicalBalance - dueSoonTotal;
   const shouldShowShortTermBalance = hasDueSoonBills && !hasOverdueBills;
 
@@ -316,12 +316,13 @@ const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanel
   };
 
   // ── Tile 5: Forecast ──────────────────────────────────────────────────────
+  const projectionBalance = semanticCore.projection.projectedBalance;
   const forecastTile: TileProps = forecast
     ? {
         label: "Saldo projetado",
-        primary: money(forecast.projectedBalance),
+        primary: money(projectionBalance),
         secondary: "Fechamento previsto do mês",
-        accent: forecast.projectedBalance < 0 ? "danger" : forecast.projectedBalance < 200 ? "warning" : "default",
+        accent: projectionBalance < 0 ? "danger" : projectionBalance < 200 ? "warning" : "default",
       }
     : {
         label: "Saldo projetado",

--- a/apps/web/src/services/dashboard.service.test.ts
+++ b/apps/web/src/services/dashboard.service.test.ts
@@ -13,6 +13,15 @@ const getMock = vi.mocked(api.get);
 
 const buildSnapshot = (overrides: Partial<DashboardSnapshot> = {}): DashboardSnapshot => {
   const bankBalance = overrides.bankBalance ?? 1200;
+  const bills = {
+    overdueCount: 0,
+    overdueTotal: 0,
+    dueSoonCount: 0,
+    dueSoonTotal: 0,
+    upcomingCount: 0,
+    upcomingTotal: 0,
+    ...(overrides.bills ?? {}),
+  };
   const income = {
     receivedThisMonth: 0,
     pendingThisMonth: 0,
@@ -23,15 +32,7 @@ const buildSnapshot = (overrides: Partial<DashboardSnapshot> = {}): DashboardSna
 
   return {
     bankBalance,
-    bills: {
-      overdueCount: 0,
-      overdueTotal: 0,
-      dueSoonCount: 0,
-      dueSoonTotal: 0,
-      upcomingCount: 0,
-      upcomingTotal: 0,
-      ...(overrides.bills ?? {}),
-    },
+    bills,
     cards: {
       openPurchasesTotal: 0,
       pendingInvoicesTotal: 0,
@@ -49,7 +50,7 @@ const buildSnapshot = (overrides: Partial<DashboardSnapshot> = {}): DashboardSna
       },
       currentPosition: {
         bankBalance,
-        technicalBalance: bankBalance,
+        technicalBalance: bankBalance - bills.overdueTotal,
         asOf: "2026-04-15T00:00:00.000Z",
       },
       projection: {
@@ -141,5 +142,54 @@ describe("dashboardService", () => {
     expect(invoiceObligations).toHaveLength(1);
     expect(cycleObligations[0].amount).toBe(320);
     expect(invoiceObligations[0].amount).toBe(780);
+  });
+
+  it("buildDashboardContractView prioriza semanticCore para renda e posicao atual", () => {
+    const snapshot = buildSnapshot({
+      bankBalance: 1200,
+      income: {
+        receivedThisMonth: 10,
+        pendingThisMonth: 20,
+        referenceMonth: "2026-03",
+      },
+      semanticCore: {
+        semanticsVersion: "v1",
+        realized: {
+          confirmedInflowTotal: 2300,
+          settledOutflowTotal: 700,
+          netAmount: 1600,
+          referenceMonth: "2026-04",
+        },
+        currentPosition: {
+          bankBalance: 850,
+          technicalBalance: 640,
+          asOf: "2026-04-20T00:00:00.000Z",
+        },
+        projection: {
+          referenceMonth: "2026-04",
+          projectedBalance: 900,
+          adjustedProjectedBalance: 500,
+          expectedInflow: 300,
+        },
+      },
+    });
+
+    const result = buildDashboardContractView(snapshot, new Date("2026-04-15T00:00:00.000Z"));
+
+    expect(result.balanceSnapshot.bankBalance).toBe(850);
+    expect(result.balanceSnapshot.technicalBalance).toBe(640);
+    expect(result.balanceSnapshot.asOf).toBe("2026-04-20T00:00:00.000Z");
+    expect(result.incomes).toEqual([
+      expect.objectContaining({
+        netAmount: 2300,
+        status: "confirmed",
+        sourceId: "2026-04",
+      }),
+      expect.objectContaining({
+        netAmount: 300,
+        status: "pending",
+        sourceId: "2026-04",
+      }),
+    ]);
   });
 });

--- a/apps/web/src/services/dashboard.service.ts
+++ b/apps/web/src/services/dashboard.service.ts
@@ -1,6 +1,7 @@
 import { api, withApiRequestContext, type ApiRequestContext } from "./api";
 import type {
   BalanceSnapshot,
+  CoreFinancialSemanticContract,
   DashboardSnapshotResponse,
   IncomeEntry,
   Obligation,
@@ -15,6 +16,10 @@ export interface DashboardFinancialContractView {
 }
 
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+const toAsOfISOString = (
+  asOf: CoreFinancialSemanticContract["currentPosition"]["asOf"],
+): string => (typeof asOf === "string" ? asOf : asOf.toISOString());
 
 const createObligations = (
   totalAmount: number,
@@ -56,25 +61,29 @@ export const buildDashboardContractView = (
   snapshot: DashboardSnapshot,
   now: Date = new Date(),
 ): DashboardFinancialContractView => {
+  const semanticCore = snapshot.semanticCore;
+  const confirmedInflow = semanticCore.realized.confirmedInflowTotal;
+  const expectedInflow = semanticCore.projection.expectedInflow ?? 0;
+
   const incomes: IncomeEntry[] = [];
-  if (snapshot.income.receivedThisMonth > 0) {
+  if (confirmedInflow > 0) {
     incomes.push({
-      grossAmount: snapshot.income.receivedThisMonth,
-      netAmount: snapshot.income.receivedThisMonth,
+      grossAmount: confirmedInflow,
+      netAmount: confirmedInflow,
       status: "confirmed",
       incomeType: "salary",
       isInferred: true,
-      sourceId: snapshot.income.referenceMonth,
+      sourceId: semanticCore.realized.referenceMonth,
     });
   }
-  if (snapshot.income.pendingThisMonth > 0) {
+  if (expectedInflow > 0) {
     incomes.push({
-      grossAmount: snapshot.income.pendingThisMonth,
-      netAmount: snapshot.income.pendingThisMonth,
+      grossAmount: expectedInflow,
+      netAmount: expectedInflow,
       status: "pending",
       incomeType: "salary",
       isInferred: true,
-      sourceId: snapshot.income.referenceMonth,
+      sourceId: semanticCore.projection.referenceMonth,
     });
   }
 
@@ -110,10 +119,10 @@ export const buildDashboardContractView = (
   ];
 
   const balanceSnapshot: BalanceSnapshot = {
-    bankBalance: snapshot.bankBalance,
-    technicalBalance: snapshot.bankBalance - snapshot.bills.overdueTotal,
+    bankBalance: semanticCore.currentPosition.bankBalance,
+    technicalBalance: semanticCore.currentPosition.technicalBalance,
     source: "bank_account",
-    asOf: now.toISOString(),
+    asOf: toAsOfISOString(semanticCore.currentPosition.asOf),
   };
 
   return {

--- a/docs/architecture/v1.6.17-core-financial-semantic-dashboard-consumption.md
+++ b/docs/architecture/v1.6.17-core-financial-semantic-dashboard-consumption.md
@@ -1,0 +1,48 @@
+# v1.6.17 - Core Financial Semantic Dashboard Consumption
+
+## Context
+
+Item 1.3 aligns dashboard consumption to the semantic contract introduced in v1.6.15 and applied to API payloads in v1.6.16.
+
+Goal: make dashboard widgets consume `semanticCore` explicitly (`realized`, `currentPosition`, `projection`) and remove ambiguous semantic inference.
+
+## What Changed
+
+### Web service contract view
+
+File: `apps/web/src/services/dashboard.service.ts`
+
+- `buildDashboardContractView` now prioritizes `snapshot.semanticCore` as source of truth for:
+  - confirmed income (`realized.confirmedInflowTotal`)
+  - expected income (`projection.expectedInflow`)
+  - current balance (`currentPosition.bankBalance`)
+  - technical balance (`currentPosition.technicalBalance`)
+  - `asOf` timestamp (`currentPosition.asOf`)
+
+Obligations composition remains unchanged (derived from bills/cards exposure fields).
+
+### Dashboard widget consumption
+
+File: `apps/web/src/components/OperationalSummaryPanel.tsx`
+
+- Income tile now consumes semantic values directly:
+  - realized = `semanticCore.realized.confirmedInflowTotal`
+  - projected = `semanticCore.projection.expectedInflow`
+- Balance tile now consumes semantic position values:
+  - bank balance = `semanticCore.currentPosition.bankBalance`
+  - technical balance = `semanticCore.currentPosition.technicalBalance`
+- Forecast tile uses `semanticCore.projection.projectedBalance` when forecast is available.
+
+## Scope Guardrails
+
+- No API changes.
+- No document flow changes.
+- No copy/product text redesign.
+- Functional behavior preserved while replacing semantic source.
+
+## Validation
+
+- Added regression coverage to ensure semantic source precedence:
+  - `apps/web/src/services/dashboard.service.test.ts`
+  - `apps/web/src/components/OperationalSummaryPanel.test.tsx`
+- Existing dashboard behavior checks remain green.


### PR DESCRIPTION
Alinha o consumo do dashboard ao contrato semantico core (semanticCore), sem reabrir API.

Escopo:
- service e widget passam a consumir explicitamente realized/currentPosition/projection;
- remove leitura ambigua de renda/saldo quando semanticCore existe;
- testes do web atualizados com cobertura de precedencia semantica;
- documentacao arquitetural v1.6.17.

Fora de escopo:
- fluxo documental;
- copy de produto;
- novas mudancas de API.