### PR TITLE
Nova sequencia - Item 2.1: contrato de preview documental por tipo

### DIFF
--- a/apps/api/src/domain/contracts/contracts.schema.test.ts
+++ b/apps/api/src/domain/contracts/contracts.schema.test.ts
@@ -8,6 +8,7 @@ import {
 import { ForecastResultSchema } from "./forecast.schema";
 import { IncomeEntrySchema } from "./income.schema";
 import { ObligationSchema } from "./obligation.schema";
+import { TaxDocumentPreviewResponseSchema } from "./tax-document-preview-response.schema";
 
 describe("financial contracts schemas", () => {
   describe("BalanceSnapshotSchema", () => {
@@ -241,6 +242,44 @@ describe("financial contracts schemas", () => {
         realized: ["dashboard.bankBalance"],
         currentPosition: ["dashboard.bankBalance"],
         projection: ["forecast.adjustedProjectedBalance"],
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("TaxDocumentPreviewResponseSchema", () => {
+    it("accepts preview payload grouped by source type", () => {
+      const result = TaxDocumentPreviewResponseSchema.safeParse({
+        preview: {
+          sourceType: "income",
+          documentType: "income_report_employer",
+          confidenceScore: 0.97,
+          extractorAvailable: true,
+          sourceLabelSuggestion: null,
+          reasons: ["matched_employer_signals"],
+          warnings: [],
+          textSource: "csv_text",
+          textPreviewLines: ["Comprovante de Rendimentos"],
+        },
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects preview payload with invalid source type", () => {
+      const result = TaxDocumentPreviewResponseSchema.safeParse({
+        preview: {
+          sourceType: "other",
+          documentType: "income_report_employer",
+          confidenceScore: 0.97,
+          extractorAvailable: true,
+          sourceLabelSuggestion: null,
+          reasons: ["matched_employer_signals"],
+          warnings: [],
+          textSource: "csv_text",
+          textPreviewLines: ["Comprovante de Rendimentos"],
+        },
       });
 
       expect(result.success).toBe(false);

--- a/apps/api/src/domain/contracts/index.ts
+++ b/apps/api/src/domain/contracts/index.ts
@@ -43,6 +43,14 @@ export {
   CoreFinancialSemanticSourceMapSchema,
 } from "./core-financial-semantic-contract.schema";
 
+export {
+  TaxDocumentPreviewDocumentTypeSchema,
+  TaxDocumentPreviewResponseSchema,
+  TaxDocumentPreviewSchema,
+  TaxDocumentPreviewSourceTypeSchema,
+  TaxDocumentPreviewTextSourceSchema,
+} from "./tax-document-preview-response.schema";
+
 export type {
   BalanceSnapshot,
   BalanceSource,
@@ -89,3 +97,11 @@ export type {
   CoreFinancialSemanticContract,
   CoreFinancialSemanticSourceMap,
 } from "./core-financial-semantic-contract.schema";
+
+export type {
+  TaxDocumentPreview,
+  TaxDocumentPreviewDocumentType,
+  TaxDocumentPreviewResponse,
+  TaxDocumentPreviewSourceType,
+  TaxDocumentPreviewTextSource,
+} from "./tax-document-preview-response.schema";

--- a/apps/api/src/domain/contracts/tax-document-preview-response.schema.ts
+++ b/apps/api/src/domain/contracts/tax-document-preview-response.schema.ts
@@ -1,0 +1,59 @@
+import { z } from "zod";
+
+export const TaxDocumentPreviewSourceTypeSchema = z.enum([
+  "income",
+  "deduction",
+  "debt",
+  "support",
+  "unknown",
+]);
+
+export const TaxDocumentPreviewDocumentTypeSchema = z.enum([
+  "unknown",
+  "income_report_bank",
+  "income_report_employer",
+  "clt_payslip",
+  "income_report_inss",
+  "medical_statement",
+  "education_receipt",
+  "loan_statement",
+  "bank_statement_support",
+]);
+
+export const TaxDocumentPreviewTextSourceSchema = z.enum([
+  "csv_text",
+  "pdf_text",
+  "pdf_text_error",
+  "image_text_pending",
+  "unsupported_text_source",
+]);
+
+export const TaxDocumentPreviewSchema = z.object({
+  sourceType: TaxDocumentPreviewSourceTypeSchema,
+  documentType: TaxDocumentPreviewDocumentTypeSchema,
+  confidenceScore: z.number().min(0).max(1),
+  extractorAvailable: z.boolean(),
+  sourceLabelSuggestion: z.string().nullable(),
+  reasons: z.array(z.string()),
+  warnings: z.array(z.string()),
+  textSource: TaxDocumentPreviewTextSourceSchema,
+  textPreviewLines: z.array(z.string()),
+});
+
+export const TaxDocumentPreviewResponseSchema = z.object({
+  preview: TaxDocumentPreviewSchema,
+});
+
+export type TaxDocumentPreviewSourceType = z.infer<
+  typeof TaxDocumentPreviewSourceTypeSchema
+>;
+export type TaxDocumentPreviewDocumentType = z.infer<
+  typeof TaxDocumentPreviewDocumentTypeSchema
+>;
+export type TaxDocumentPreviewTextSource = z.infer<
+  typeof TaxDocumentPreviewTextSourceSchema
+>;
+export type TaxDocumentPreview = z.infer<typeof TaxDocumentPreviewSchema>;
+export type TaxDocumentPreviewResponse = z.infer<
+  typeof TaxDocumentPreviewResponseSchema
+>;

--- a/apps/api/src/domain/contracts/types.ts
+++ b/apps/api/src/domain/contracts/types.ts
@@ -44,3 +44,11 @@ export type {
   CoreFinancialSemanticContract,
   CoreFinancialSemanticSourceMap,
 } from "./core-financial-semantic-contract.schema";
+
+export type {
+  TaxDocumentPreview,
+  TaxDocumentPreviewDocumentType,
+  TaxDocumentPreviewResponse,
+  TaxDocumentPreviewSourceType,
+  TaxDocumentPreviewTextSource,
+} from "./tax-document-preview-response.schema";

--- a/apps/api/src/routes/tax.routes.js
+++ b/apps/api/src/routes/tax.routes.js
@@ -2,6 +2,7 @@ import { Router } from "express";
 import path from "node:path";
 import multer from "multer";
 import { authMiddleware } from "../middlewares/auth.middleware.js";
+import { TaxDocumentPreviewResponseSchema } from "../domain/contracts/tax-document-preview-response.schema.ts";
 import { getTaxBootstrapByUser } from "../services/tax-bootstrap.service.js";
 import {
   createTaxDocumentForUser,
@@ -11,6 +12,7 @@ import {
 } from "../services/tax-documents.service.js";
 import { exportTaxDossierByYear } from "../services/tax-export.service.js";
 import { processTaxDocumentByIdForUser } from "../services/tax-extraction.service.js";
+import { previewTaxDocumentBySourceType } from "../services/tax-document-preview.service.js";
 import { syncAppTaxFactsByYear } from "../services/tax-app-sync.service.js";
 import { createManualTaxFactByUser, listTaxFactsByUser } from "../services/tax-facts.service.js";
 import { getTaxObligationByYear } from "../services/tax-obligation.service.js";
@@ -22,6 +24,7 @@ import {
   previewTaxSummaryByYear,
   rebuildTaxSummaryByYear,
 } from "../services/tax-summary.service.js";
+import { respondValidated } from "./respond-validated.js";
 
 const router = Router();
 const TAX_DOCUMENT_MAX_FILE_SIZE_BYTES = Number(
@@ -120,6 +123,34 @@ router.post("/documents", (req, res, next) => {
       ensureValidTaxDocumentFile(req.file);
       const document = await createTaxDocumentForUser(req.user.id, req.body ?? {}, req.file);
       return res.status(201).json({ document });
+    } catch (serviceError) {
+      return next(serviceError);
+    }
+  });
+});
+
+router.post("/documents/preview", (req, res, next) => {
+  upload.single("file")(req, res, async (error) => {
+    if (error) {
+      let normalizedError = error;
+
+      if (error instanceof multer.MulterError && error.code === "LIMIT_FILE_SIZE") {
+        normalizedError = createError(413, "Arquivo muito grande.");
+      }
+
+      return next(normalizedError);
+    }
+
+    try {
+      ensureValidTaxDocumentFile(req.file);
+      const preview = await previewTaxDocumentBySourceType(req.file);
+      return respondValidated(
+        TaxDocumentPreviewResponseSchema,
+        { preview },
+        req,
+        res,
+        { routeLabel: "POST /tax/documents/preview" },
+      );
     } catch (serviceError) {
       return next(serviceError);
     }

--- a/apps/api/src/services/tax-document-preview.service.js
+++ b/apps/api/src/services/tax-document-preview.service.js
@@ -1,0 +1,38 @@
+import { hasTaxExtractorForDocumentType } from "../domain/tax/tax-document-extractors.js";
+import { classifyTaxDocumentBuffer } from "./tax-classification.service.js";
+
+const SOURCE_TYPE_BY_DOCUMENT_TYPE = Object.freeze({
+  income_report_bank: "income",
+  income_report_employer: "income",
+  clt_payslip: "income",
+  income_report_inss: "income",
+  medical_statement: "deduction",
+  education_receipt: "deduction",
+  loan_statement: "debt",
+  bank_statement_support: "support",
+  unknown: "unknown",
+});
+
+export const resolveTaxDocumentSourceType = (documentType) =>
+  SOURCE_TYPE_BY_DOCUMENT_TYPE[String(documentType || "").trim()] || "unknown";
+
+export const previewTaxDocumentBySourceType = async (file) => {
+  const classification = await classifyTaxDocumentBuffer({
+    buffer: file.buffer,
+    originalFileName: file.originalname,
+  });
+
+  return {
+    sourceType: resolveTaxDocumentSourceType(classification.documentType),
+    documentType: classification.documentType,
+    confidenceScore: classification.confidenceScore,
+    extractorAvailable: hasTaxExtractorForDocumentType(classification.documentType),
+    sourceLabelSuggestion: classification.sourceLabelSuggestion,
+    reasons: [...classification.reasons],
+    warnings: [...classification.warnings],
+    textSource: classification.textSource,
+    textPreviewLines: [
+      ...(classification.classificationPayload?.textPreviewLines || []),
+    ],
+  };
+};

--- a/apps/api/src/tax.test.js
+++ b/apps/api/src/tax.test.js
@@ -13,6 +13,7 @@ import {
 import { resetLoginProtectionState } from "./middlewares/login-protection.middleware.js";
 import { resetImportRateLimiterState, resetWriteRateLimiterState } from "./middlewares/rate-limit.middleware.js";
 import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
+import { TaxDocumentPreviewResponseSchema } from "./domain/contracts/tax-document-preview-response.schema.ts";
 import { resolveTaxDocumentAbsolutePath } from "./services/tax-document-storage.service.js";
 
 const TEST_TAX_STORAGE_DIR = path.join(os.tmpdir(), "control-finance-tax-documents-tests");
@@ -113,6 +114,21 @@ describe("Tax API foundation", () => {
       .attach("file", Buffer.from("%PDF-1.4\nfake", "utf8"), {
         filename: "informe.pdf",
         contentType: "application/pdf",
+      });
+
+    expectErrorResponseWithRequestId(
+      response,
+      401,
+      "Token de autenticacao ausente ou invalido.",
+    );
+  });
+
+  it("POST /tax/documents/preview retorna 401 sem token", async () => {
+    const response = await request(app)
+      .post("/tax/documents/preview")
+      .attach("file", Buffer.from("preview", "utf8"), {
+        filename: "preview.csv",
+        contentType: "text/csv",
       });
 
     expectErrorResponseWithRequestId(
@@ -497,6 +513,53 @@ describe("Tax API foundation", () => {
       pageSize: 20,
       total: 0,
     });
+  });
+
+  it("POST /tax/documents/preview retorna 400 quando arquivo fiscal nao e enviado", async () => {
+    const token = await registerAndLogin("tax-preview-missing-file@test.dev");
+
+    const response = await request(app)
+      .post("/tax/documents/preview")
+      .set("Authorization", `Bearer ${token}`);
+
+    expectErrorResponseWithRequestId(response, 400, "Arquivo fiscal (file) e obrigatorio.");
+  });
+
+  it("POST /tax/documents/preview classifica documento e retorna sourceType canonico", async () => {
+    const token = await registerAndLogin("tax-preview-employer@test.dev");
+
+    const response = await request(app)
+      .post("/tax/documents/preview")
+      .set("Authorization", `Bearer ${token}`)
+      .attach(
+        "file",
+        Buffer.from(
+          [
+            "Comprovante de Rendimentos Pagos e de Imposto sobre a Renda Retido na Fonte",
+            "Fonte pagadora ACME LTDA",
+            "CNPJ 12.345.678/0001-90",
+            "Rendimentos tributaveis R$ 54.321,00",
+          ].join("\n"),
+          "utf8",
+        ),
+        {
+          filename: "preview-employer.csv",
+          contentType: "text/csv",
+        },
+      );
+
+    expect(response.status).toBe(200);
+    expect(response.body.preview).toMatchObject({
+      sourceType: "income",
+      documentType: "income_report_employer",
+      extractorAvailable: true,
+      textSource: "csv_text",
+    });
+    expect(Array.isArray(response.body.preview.reasons)).toBe(true);
+    expect(Array.isArray(response.body.preview.textPreviewLines)).toBe(true);
+
+    const parsed = TaxDocumentPreviewResponseSchema.safeParse(response.body);
+    expect(parsed.success).toBe(true);
   });
 
   it("GET /tax/documents retorna documentos enviados pelo usuario autenticado", async () => {

--- a/docs/architecture/v1.6.18-document-preview-contract-by-type.md
+++ b/docs/architecture/v1.6.18-document-preview-contract-by-type.md
@@ -1,0 +1,55 @@
+# v1.6.18 - Document Preview Contract By Source Type
+
+## Context
+
+Item 2.1 starts the new sequence for document preview and ingestion by type.
+
+This slice introduces only the canonical preview contract and a dedicated API response for classification by source type. It does not change persisted ingestion behavior.
+
+## What Was Added
+
+### Canonical response contract
+
+File: `apps/api/src/domain/contracts/tax-document-preview-response.schema.ts`
+
+Response shape:
+
+- `preview.sourceType`: `income | deduction | debt | support | unknown`
+- `preview.documentType`: canonical tax document type
+- `preview.confidenceScore`
+- `preview.extractorAvailable`
+- `preview.sourceLabelSuggestion`
+- `preview.reasons`
+- `preview.warnings`
+- `preview.textSource`
+- `preview.textPreviewLines`
+
+Contract exported through contract barrels (`index.ts`, `types.ts`).
+
+### Preview endpoint
+
+Route: `POST /tax/documents/preview`
+
+- Uses upload guardrails already applied to document upload (file required, supported extensions/mime, size limit).
+- Classifies uploaded document without persisting it.
+- Returns validated payload through `respondValidated` using the canonical preview contract.
+
+### Source type mapping
+
+File: `apps/api/src/services/tax-document-preview.service.js`
+
+`documentType -> sourceType` mapping is explicit and centralized, becoming the source of truth for preview semantics.
+
+## Out Of Scope
+
+- No ingestion flow rewrite.
+- No normalization/extraction pipeline change.
+- No dashboard/copy/document UI change.
+
+## Validation
+
+- Contract tests updated for preview schema.
+- Tax API tests cover:
+  - auth protection for preview endpoint
+  - missing file validation
+  - successful preview response and contract compliance


### PR DESCRIPTION
Introduce canonical API contract for tax document preview grouped by source type.

Scope:
- new response schema for document preview by source type;
- new POST /tax/documents/preview endpoint with response validation;
- source type mapping service from detected document type;
- focused tax tests and contract tests;
- architecture note v1.6.18.

Out of scope:
- ingestion pipeline changes;
- dashboard/copy/doc flow UI.