### PR TITLE
Nova sequencia - Item 2.2: estados e bloqueios por tipo

### DIFF
--- a/apps/api/src/domain/contracts/contracts.schema.test.ts
+++ b/apps/api/src/domain/contracts/contracts.schema.test.ts
@@ -253,6 +253,13 @@ describe("financial contracts schemas", () => {
       const result = TaxDocumentPreviewResponseSchema.safeParse({
         preview: {
           sourceType: "income",
+          detectedState: "ready",
+          blockingRules: [],
+          capabilities: {
+            canExtract: true,
+            canSuggest: true,
+            canExecute: true,
+          },
           documentType: "income_report_employer",
           confidenceScore: 0.97,
           extractorAvailable: true,
@@ -271,6 +278,38 @@ describe("financial contracts schemas", () => {
       const result = TaxDocumentPreviewResponseSchema.safeParse({
         preview: {
           sourceType: "other",
+          detectedState: "ready",
+          blockingRules: [],
+          capabilities: {
+            canExtract: true,
+            canSuggest: true,
+            canExecute: true,
+          },
+          documentType: "income_report_employer",
+          confidenceScore: 0.97,
+          extractorAvailable: true,
+          sourceLabelSuggestion: null,
+          reasons: ["matched_employer_signals"],
+          warnings: [],
+          textSource: "csv_text",
+          textPreviewLines: ["Comprovante de Rendimentos"],
+        },
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects preview payload with invalid detected state", () => {
+      const result = TaxDocumentPreviewResponseSchema.safeParse({
+        preview: {
+          sourceType: "income",
+          detectedState: "in_progress",
+          blockingRules: [],
+          capabilities: {
+            canExtract: true,
+            canSuggest: true,
+            canExecute: true,
+          },
           documentType: "income_report_employer",
           confidenceScore: 0.97,
           extractorAvailable: true,

--- a/apps/api/src/domain/contracts/index.ts
+++ b/apps/api/src/domain/contracts/index.ts
@@ -44,6 +44,10 @@ export {
 } from "./core-financial-semantic-contract.schema";
 
 export {
+  TaxDocumentPreviewBlockingCodeSchema,
+  TaxDocumentPreviewBlockingRuleSchema,
+  TaxDocumentPreviewCapabilitiesSchema,
+  TaxDocumentPreviewDetectedStateSchema,
   TaxDocumentPreviewDocumentTypeSchema,
   TaxDocumentPreviewResponseSchema,
   TaxDocumentPreviewSchema,
@@ -99,7 +103,11 @@ export type {
 } from "./core-financial-semantic-contract.schema";
 
 export type {
+  TaxDocumentPreviewBlockingCode,
+  TaxDocumentPreviewBlockingRule,
+  TaxDocumentPreviewCapabilities,
   TaxDocumentPreview,
+  TaxDocumentPreviewDetectedState,
   TaxDocumentPreviewDocumentType,
   TaxDocumentPreviewResponse,
   TaxDocumentPreviewSourceType,

--- a/apps/api/src/domain/contracts/tax-document-preview-response.schema.ts
+++ b/apps/api/src/domain/contracts/tax-document-preview-response.schema.ts
@@ -28,8 +28,36 @@ export const TaxDocumentPreviewTextSourceSchema = z.enum([
   "unsupported_text_source",
 ]);
 
+export const TaxDocumentPreviewDetectedStateSchema = z.enum([
+  "ready",
+  "review_required",
+  "blocked",
+]);
+
+export const TaxDocumentPreviewBlockingCodeSchema = z.enum([
+  "document_type_not_identified",
+  "source_type_requires_manual_review",
+  "source_type_not_supported_for_extraction",
+  "text_extraction_unavailable",
+  "execution_not_allowed_for_source_type",
+]);
+
+export const TaxDocumentPreviewBlockingRuleSchema = z.object({
+  code: TaxDocumentPreviewBlockingCodeSchema,
+  reason: z.string().min(1),
+});
+
+export const TaxDocumentPreviewCapabilitiesSchema = z.object({
+  canExtract: z.boolean(),
+  canSuggest: z.boolean(),
+  canExecute: z.boolean(),
+});
+
 export const TaxDocumentPreviewSchema = z.object({
   sourceType: TaxDocumentPreviewSourceTypeSchema,
+  detectedState: TaxDocumentPreviewDetectedStateSchema,
+  blockingRules: z.array(TaxDocumentPreviewBlockingRuleSchema),
+  capabilities: TaxDocumentPreviewCapabilitiesSchema,
   documentType: TaxDocumentPreviewDocumentTypeSchema,
   confidenceScore: z.number().min(0).max(1),
   extractorAvailable: z.boolean(),
@@ -52,6 +80,18 @@ export type TaxDocumentPreviewDocumentType = z.infer<
 >;
 export type TaxDocumentPreviewTextSource = z.infer<
   typeof TaxDocumentPreviewTextSourceSchema
+>;
+export type TaxDocumentPreviewDetectedState = z.infer<
+  typeof TaxDocumentPreviewDetectedStateSchema
+>;
+export type TaxDocumentPreviewBlockingCode = z.infer<
+  typeof TaxDocumentPreviewBlockingCodeSchema
+>;
+export type TaxDocumentPreviewBlockingRule = z.infer<
+  typeof TaxDocumentPreviewBlockingRuleSchema
+>;
+export type TaxDocumentPreviewCapabilities = z.infer<
+  typeof TaxDocumentPreviewCapabilitiesSchema
 >;
 export type TaxDocumentPreview = z.infer<typeof TaxDocumentPreviewSchema>;
 export type TaxDocumentPreviewResponse = z.infer<

--- a/apps/api/src/domain/contracts/types.ts
+++ b/apps/api/src/domain/contracts/types.ts
@@ -46,7 +46,11 @@ export type {
 } from "./core-financial-semantic-contract.schema";
 
 export type {
+  TaxDocumentPreviewBlockingCode,
+  TaxDocumentPreviewBlockingRule,
+  TaxDocumentPreviewCapabilities,
   TaxDocumentPreview,
+  TaxDocumentPreviewDetectedState,
   TaxDocumentPreviewDocumentType,
   TaxDocumentPreviewResponse,
   TaxDocumentPreviewSourceType,

--- a/apps/api/src/services/tax-document-preview.service.js
+++ b/apps/api/src/services/tax-document-preview.service.js
@@ -13,6 +13,90 @@ const SOURCE_TYPE_BY_DOCUMENT_TYPE = Object.freeze({
   unknown: "unknown",
 });
 
+const SOURCE_TYPE_POLICY = Object.freeze({
+  income: {
+    supportsExtraction: true,
+    allowsSuggestion: true,
+    allowsExecution: true,
+  },
+  deduction: {
+    supportsExtraction: true,
+    allowsSuggestion: true,
+    allowsExecution: true,
+  },
+  debt: {
+    supportsExtraction: false,
+    allowsSuggestion: true,
+    allowsExecution: false,
+  },
+  support: {
+    supportsExtraction: false,
+    allowsSuggestion: true,
+    allowsExecution: false,
+  },
+  unknown: {
+    supportsExtraction: false,
+    allowsSuggestion: false,
+    allowsExecution: false,
+  },
+});
+
+const BLOCKED_TEXT_SOURCES = new Set([
+  "pdf_text_error",
+  "image_text_pending",
+  "unsupported_text_source",
+]);
+
+const resolvePolicyBySourceType = (sourceType) =>
+  SOURCE_TYPE_POLICY[String(sourceType || "").trim()] || SOURCE_TYPE_POLICY.unknown;
+
+const buildBlockingRules = ({
+  sourceType,
+  documentType,
+  textSource,
+  supportsExtraction,
+  allowsExecution,
+}) => {
+  const rules = [];
+
+  if (sourceType === "unknown" || documentType === "unknown") {
+    rules.push({
+      code: "document_type_not_identified",
+      reason: "Documento nao identificado com confianca para fluxo automatizado.",
+    });
+  }
+
+  if (sourceType === "support" || sourceType === "debt") {
+    rules.push({
+      code: "source_type_requires_manual_review",
+      reason: "Tipo documental exige revisao manual antes de qualquer execucao.",
+    });
+  }
+
+  if (!supportsExtraction) {
+    rules.push({
+      code: "source_type_not_supported_for_extraction",
+      reason: "Tipo documental ainda sem extrator operacional nesta fatia.",
+    });
+  }
+
+  if (BLOCKED_TEXT_SOURCES.has(textSource)) {
+    rules.push({
+      code: "text_extraction_unavailable",
+      reason: "Texto indisponivel para extracao automatica nesta tentativa.",
+    });
+  }
+
+  if (!allowsExecution) {
+    rules.push({
+      code: "execution_not_allowed_for_source_type",
+      reason: "Execucao automatica bloqueada para o tipo documental detectado.",
+    });
+  }
+
+  return rules;
+};
+
 export const resolveTaxDocumentSourceType = (documentType) =>
   SOURCE_TYPE_BY_DOCUMENT_TYPE[String(documentType || "").trim()] || "unknown";
 
@@ -22,11 +106,36 @@ export const previewTaxDocumentBySourceType = async (file) => {
     originalFileName: file.originalname,
   });
 
+  const sourceType = resolveTaxDocumentSourceType(classification.documentType);
+  const policy = resolvePolicyBySourceType(sourceType);
+  const extractorAvailable = hasTaxExtractorForDocumentType(classification.documentType);
+  const canExtract =
+    policy.supportsExtraction &&
+    extractorAvailable &&
+    !BLOCKED_TEXT_SOURCES.has(classification.textSource);
+  const canSuggest = policy.allowsSuggestion;
+  const canExecute = canExtract && policy.allowsExecution;
+  const blockingRules = buildBlockingRules({
+    sourceType,
+    documentType: classification.documentType,
+    textSource: classification.textSource,
+    supportsExtraction: policy.supportsExtraction,
+    allowsExecution: policy.allowsExecution,
+  });
+
   return {
-    sourceType: resolveTaxDocumentSourceType(classification.documentType),
+    sourceType,
+    detectedState:
+      sourceType === "unknown" ? "blocked" : canExecute ? "ready" : "review_required",
+    blockingRules,
+    capabilities: {
+      canExtract,
+      canSuggest,
+      canExecute,
+    },
     documentType: classification.documentType,
     confidenceScore: classification.confidenceScore,
-    extractorAvailable: hasTaxExtractorForDocumentType(classification.documentType),
+    extractorAvailable,
     sourceLabelSuggestion: classification.sourceLabelSuggestion,
     reasons: [...classification.reasons],
     warnings: [...classification.warnings],

--- a/apps/api/src/tax.test.js
+++ b/apps/api/src/tax.test.js
@@ -525,7 +525,7 @@ describe("Tax API foundation", () => {
     expectErrorResponseWithRequestId(response, 400, "Arquivo fiscal (file) e obrigatorio.");
   });
 
-  it("POST /tax/documents/preview classifica documento e retorna sourceType canonico", async () => {
+  it("POST /tax/documents/preview classifica documento e retorna estado operacional por tipo", async () => {
     const token = await registerAndLogin("tax-preview-employer@test.dev");
 
     const response = await request(app)
@@ -551,15 +551,94 @@ describe("Tax API foundation", () => {
     expect(response.status).toBe(200);
     expect(response.body.preview).toMatchObject({
       sourceType: "income",
+      detectedState: "ready",
       documentType: "income_report_employer",
       extractorAvailable: true,
       textSource: "csv_text",
+      capabilities: {
+        canExtract: true,
+        canSuggest: true,
+        canExecute: true,
+      },
     });
+    expect(response.body.preview.blockingRules).toEqual([]);
     expect(Array.isArray(response.body.preview.reasons)).toBe(true);
     expect(Array.isArray(response.body.preview.textPreviewLines)).toBe(true);
 
     const parsed = TaxDocumentPreviewResponseSchema.safeParse(response.body);
     expect(parsed.success).toBe(true);
+  });
+
+  it("POST /tax/documents/preview retorna review_required para sourceType support", async () => {
+    const token = await registerAndLogin("tax-preview-support@test.dev");
+
+    const response = await request(app)
+      .post("/tax/documents/preview")
+      .set("Authorization", `Bearer ${token}`)
+      .attach(
+        "file",
+        Buffer.from(
+          [
+            "Data;Historico;Valor",
+            "05/02/2026;Saldo anterior;100,00",
+            "06/02/2026;Lancamentos;20,00",
+          ].join("\n"),
+          "utf8",
+        ),
+        {
+          filename: "preview-support.csv",
+          contentType: "text/csv",
+        },
+      );
+
+    expect(response.status).toBe(200);
+    expect(response.body.preview).toMatchObject({
+      sourceType: "support",
+      detectedState: "review_required",
+      documentType: "bank_statement_support",
+      capabilities: {
+        canExtract: false,
+        canSuggest: true,
+        canExecute: false,
+      },
+    });
+
+    const blockingCodes = response.body.preview.blockingRules.map((rule) => rule.code);
+    expect(blockingCodes).toContain("source_type_requires_manual_review");
+    expect(blockingCodes).toContain("source_type_not_supported_for_extraction");
+    expect(blockingCodes).toContain("execution_not_allowed_for_source_type");
+  });
+
+  it("POST /tax/documents/preview retorna blocked para documento unknown", async () => {
+    const token = await registerAndLogin("tax-preview-unknown@test.dev");
+
+    const response = await request(app)
+      .post("/tax/documents/preview")
+      .set("Authorization", `Bearer ${token}`)
+      .attach(
+        "file",
+        Buffer.from("qualquer conteudo sem pistas fiscais claras", "utf8"),
+        {
+          filename: "preview-unknown.pdf",
+          contentType: "application/pdf",
+        },
+      );
+
+    expect(response.status).toBe(200);
+    expect(response.body.preview).toMatchObject({
+      sourceType: "unknown",
+      detectedState: "blocked",
+      documentType: "unknown",
+      capabilities: {
+        canExtract: false,
+        canSuggest: false,
+        canExecute: false,
+      },
+    });
+
+    const blockingCodes = response.body.preview.blockingRules.map((rule) => rule.code);
+    expect(blockingCodes).toContain("document_type_not_identified");
+    expect(blockingCodes).toContain("execution_not_allowed_for_source_type");
   });
 
   it("GET /tax/documents retorna documentos enviados pelo usuario autenticado", async () => {

--- a/docs/architecture/v1.6.19-document-preview-states-by-type.md
+++ b/docs/architecture/v1.6.19-document-preview-states-by-type.md
@@ -1,0 +1,67 @@
+# v1.6.19 - Document Preview States And Blocking Rules By Type
+
+## Context
+
+Item 2.2 makes preview operational by exposing explicit state and blocking semantics by `sourceType`.
+
+This slice keeps ingestion unchanged and does not introduce UI changes.
+
+## What Was Added
+
+### Operational state in preview contract
+
+File: `apps/api/src/domain/contracts/tax-document-preview-response.schema.ts`
+
+New fields under `preview`:
+
+- `detectedState`: `ready | review_required | blocked`
+- `blockingRules[]`: explicit blocking code and reason
+- `capabilities`:
+  - `canExtract`
+  - `canSuggest`
+  - `canExecute`
+
+Blocking code vocabulary:
+
+- `document_type_not_identified`
+- `source_type_requires_manual_review`
+- `source_type_not_supported_for_extraction`
+- `text_extraction_unavailable`
+- `execution_not_allowed_for_source_type`
+
+### Source-type policy and blocking matrix
+
+File: `apps/api/src/services/tax-document-preview.service.js`
+
+A centralized policy now defines behavior by `sourceType`:
+
+- `income` and `deduction`: extraction and execution allowed when text/extractor are available.
+- `support` and `debt`: manual-review state with execution blocked in this slice.
+- `unknown`: blocked state with explicit identification block.
+
+The service now computes:
+
+- `detectedState`
+- `blockingRules`
+- `capabilities`
+
+and keeps existing preview metadata (`documentType`, confidence, reasons, warnings, text source, preview lines).
+
+### Test coverage
+
+- Contract tests validate new mandatory fields and enum guardrails.
+- Tax route tests validate:
+  - `ready` flow for `income`
+  - `review_required` flow for `support`
+  - `blocked` flow for `unknown`
+
+## Out Of Scope
+
+- No ingestion rewrite.
+- No extraction pipeline expansion for unsupported types.
+- No UI or copy changes.
+
+## Validation
+
+- Focused API tests for preview route and contract parsing.
+- API lint and contract tests.


### PR DESCRIPTION
Implement Item 2.2 for tax document preview operational semantics by source type.

Scope:
- extend canonical preview contract with detected state, blocking rules and capabilities;
- add source-type policy matrix in preview service;
- expose explicit canExtract/canSuggest/canExecute semantics;
- add focused contract and route tests for ready/review_required/blocked paths;
- add architecture note v1.6.19.

Out of scope:
- ingestion rewrite;
- UI changes.