### PR TITLE
Nova sequencia - Item 2.3: ingestao/execucao por tipo

### DIFF
--- a/apps/api/src/domain/contracts/contracts.schema.test.ts
+++ b/apps/api/src/domain/contracts/contracts.schema.test.ts
@@ -8,6 +8,7 @@ import {
 import { ForecastResultSchema } from "./forecast.schema";
 import { IncomeEntrySchema } from "./income.schema";
 import { ObligationSchema } from "./obligation.schema";
+import { TaxDocumentIngestionExecutionResponseSchema } from "./tax-document-ingestion-execution-response.schema";
 import { TaxDocumentPreviewResponseSchema } from "./tax-document-preview-response.schema";
 
 describe("financial contracts schemas", () => {
@@ -318,6 +319,102 @@ describe("financial contracts schemas", () => {
           warnings: [],
           textSource: "csv_text",
           textPreviewLines: ["Comprovante de Rendimentos"],
+        },
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("TaxDocumentIngestionExecutionResponseSchema", () => {
+    it("accepts operation payload with ingested and executed flow", () => {
+      const result = TaxDocumentIngestionExecutionResponseSchema.safeParse({
+        preview: {
+          sourceType: "income",
+          detectedState: "ready",
+          blockingRules: [],
+          capabilities: {
+            canExtract: true,
+            canSuggest: true,
+            canExecute: true,
+          },
+          documentType: "income_report_employer",
+          confidenceScore: 0.97,
+          extractorAvailable: true,
+          sourceLabelSuggestion: null,
+          reasons: ["matched_employer_signals"],
+          warnings: [],
+          textSource: "csv_text",
+          textPreviewLines: ["Comprovante de Rendimentos"],
+        },
+        ingestion: {
+          allowed: true,
+          status: "ingested",
+          documentId: 42,
+          blockingRules: [],
+        },
+        suggestion: {
+          allowed: true,
+          sourceLabelSuggestion: "ACME LTDA",
+        },
+        execution: {
+          requested: true,
+          allowed: true,
+          status: "executed",
+          documentId: 42,
+          blockingRules: [],
+        },
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects operation payload with invalid execution status", () => {
+      const result = TaxDocumentIngestionExecutionResponseSchema.safeParse({
+        preview: {
+          sourceType: "support",
+          detectedState: "review_required",
+          blockingRules: [
+            {
+              code: "source_type_requires_manual_review",
+              reason: "Revisao manual obrigatoria",
+            },
+          ],
+          capabilities: {
+            canExtract: false,
+            canSuggest: true,
+            canExecute: false,
+          },
+          documentType: "bank_statement_support",
+          confidenceScore: 0.89,
+          extractorAvailable: false,
+          sourceLabelSuggestion: null,
+          reasons: ["matched_bank_statement_support_signals"],
+          warnings: [],
+          textSource: "csv_text",
+          textPreviewLines: ["Saldo anterior"],
+        },
+        ingestion: {
+          allowed: true,
+          status: "ingested",
+          documentId: 11,
+          blockingRules: [],
+        },
+        suggestion: {
+          allowed: true,
+          sourceLabelSuggestion: null,
+        },
+        execution: {
+          requested: true,
+          allowed: false,
+          status: "blocked",
+          documentId: null,
+          blockingRules: [
+            {
+              code: "execution_not_allowed_for_source_type",
+              reason: "Execucao bloqueada",
+            },
+          ],
         },
       });
 

--- a/apps/api/src/domain/contracts/index.ts
+++ b/apps/api/src/domain/contracts/index.ts
@@ -44,6 +44,15 @@ export {
 } from "./core-financial-semantic-contract.schema";
 
 export {
+  TaxDocumentExecutionDecisionSchema,
+  TaxDocumentExecutionStatusSchema,
+  TaxDocumentIngestionDecisionSchema,
+  TaxDocumentIngestionExecutionResponseSchema,
+  TaxDocumentIngestionStatusSchema,
+  TaxDocumentSuggestionDecisionSchema,
+} from "./tax-document-ingestion-execution-response.schema";
+
+export {
   TaxDocumentPreviewBlockingCodeSchema,
   TaxDocumentPreviewBlockingRuleSchema,
   TaxDocumentPreviewCapabilitiesSchema,
@@ -101,6 +110,15 @@ export type {
   CoreFinancialSemanticContract,
   CoreFinancialSemanticSourceMap,
 } from "./core-financial-semantic-contract.schema";
+
+export type {
+  TaxDocumentExecutionDecision,
+  TaxDocumentExecutionStatus,
+  TaxDocumentIngestionDecision,
+  TaxDocumentIngestionExecutionResponse,
+  TaxDocumentIngestionStatus,
+  TaxDocumentSuggestionDecision,
+} from "./tax-document-ingestion-execution-response.schema";
 
 export type {
   TaxDocumentPreviewBlockingCode,

--- a/apps/api/src/domain/contracts/tax-document-ingestion-execution-response.schema.ts
+++ b/apps/api/src/domain/contracts/tax-document-ingestion-execution-response.schema.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+import {
+  TaxDocumentPreviewBlockingRuleSchema,
+  TaxDocumentPreviewSchema,
+} from "./tax-document-preview-response.schema";
+
+export const TaxDocumentIngestionStatusSchema = z.enum([
+  "ingested",
+  "blocked",
+]);
+
+export const TaxDocumentExecutionStatusSchema = z.enum([
+  "executed",
+  "not_requested",
+  "not_allowed",
+]);
+
+export const TaxDocumentIngestionDecisionSchema = z.object({
+  allowed: z.boolean(),
+  status: TaxDocumentIngestionStatusSchema,
+  documentId: z.number().int().positive().nullable(),
+  blockingRules: z.array(TaxDocumentPreviewBlockingRuleSchema),
+});
+
+export const TaxDocumentSuggestionDecisionSchema = z.object({
+  allowed: z.boolean(),
+  sourceLabelSuggestion: z.string().nullable(),
+});
+
+export const TaxDocumentExecutionDecisionSchema = z.object({
+  requested: z.boolean(),
+  allowed: z.boolean(),
+  status: TaxDocumentExecutionStatusSchema,
+  documentId: z.number().int().positive().nullable(),
+  blockingRules: z.array(TaxDocumentPreviewBlockingRuleSchema),
+});
+
+export const TaxDocumentIngestionExecutionResponseSchema = z.object({
+  preview: TaxDocumentPreviewSchema,
+  ingestion: TaxDocumentIngestionDecisionSchema,
+  suggestion: TaxDocumentSuggestionDecisionSchema,
+  execution: TaxDocumentExecutionDecisionSchema,
+});
+
+export type TaxDocumentIngestionStatus = z.infer<
+  typeof TaxDocumentIngestionStatusSchema
+>;
+export type TaxDocumentExecutionStatus = z.infer<
+  typeof TaxDocumentExecutionStatusSchema
+>;
+export type TaxDocumentIngestionDecision = z.infer<
+  typeof TaxDocumentIngestionDecisionSchema
+>;
+export type TaxDocumentSuggestionDecision = z.infer<
+  typeof TaxDocumentSuggestionDecisionSchema
+>;
+export type TaxDocumentExecutionDecision = z.infer<
+  typeof TaxDocumentExecutionDecisionSchema
+>;
+export type TaxDocumentIngestionExecutionResponse = z.infer<
+  typeof TaxDocumentIngestionExecutionResponseSchema
+>;

--- a/apps/api/src/domain/contracts/types.ts
+++ b/apps/api/src/domain/contracts/types.ts
@@ -46,6 +46,15 @@ export type {
 } from "./core-financial-semantic-contract.schema";
 
 export type {
+  TaxDocumentExecutionDecision,
+  TaxDocumentExecutionStatus,
+  TaxDocumentIngestionDecision,
+  TaxDocumentIngestionExecutionResponse,
+  TaxDocumentIngestionStatus,
+  TaxDocumentSuggestionDecision,
+} from "./tax-document-ingestion-execution-response.schema";
+
+export type {
   TaxDocumentPreviewBlockingCode,
   TaxDocumentPreviewBlockingRule,
   TaxDocumentPreviewCapabilities,

--- a/apps/api/src/routes/tax.routes.js
+++ b/apps/api/src/routes/tax.routes.js
@@ -2,8 +2,10 @@ import { Router } from "express";
 import path from "node:path";
 import multer from "multer";
 import { authMiddleware } from "../middlewares/auth.middleware.js";
+import { TaxDocumentIngestionExecutionResponseSchema } from "../domain/contracts/tax-document-ingestion-execution-response.schema.ts";
 import { TaxDocumentPreviewResponseSchema } from "../domain/contracts/tax-document-preview-response.schema.ts";
 import { getTaxBootstrapByUser } from "../services/tax-bootstrap.service.js";
+import { ingestAndExecuteTaxDocumentBySourceType } from "../services/tax-document-ingestion-execution.service.js";
 import {
   createTaxDocumentForUser,
   deleteTaxDocumentByIdForUser,
@@ -150,6 +152,38 @@ router.post("/documents/preview", (req, res, next) => {
         req,
         res,
         { routeLabel: "POST /tax/documents/preview" },
+      );
+    } catch (serviceError) {
+      return next(serviceError);
+    }
+  });
+});
+
+router.post("/documents/ingest-execute", (req, res, next) => {
+  upload.single("file")(req, res, async (error) => {
+    if (error) {
+      let normalizedError = error;
+
+      if (error instanceof multer.MulterError && error.code === "LIMIT_FILE_SIZE") {
+        normalizedError = createError(413, "Arquivo muito grande.");
+      }
+
+      return next(normalizedError);
+    }
+
+    try {
+      ensureValidTaxDocumentFile(req.file);
+      const operation = await ingestAndExecuteTaxDocumentBySourceType({
+        userId: req.user.id,
+        payload: req.body ?? {},
+        file: req.file,
+      });
+      return respondValidated(
+        TaxDocumentIngestionExecutionResponseSchema,
+        operation,
+        req,
+        res,
+        { routeLabel: "POST /tax/documents/ingest-execute" },
       );
     } catch (serviceError) {
       return next(serviceError);

--- a/apps/api/src/services/tax-document-ingestion-execution.service.js
+++ b/apps/api/src/services/tax-document-ingestion-execution.service.js
@@ -1,0 +1,131 @@
+import { createTaxError } from "../domain/tax/tax.validation.js";
+import { createTaxDocumentForUser } from "./tax-documents.service.js";
+import { previewTaxDocumentBySourceType } from "./tax-document-preview.service.js";
+import { processTaxDocumentByIdForUser } from "./tax-extraction.service.js";
+
+const EXECUTION_BLOCKING_CODES = new Set([
+  "document_type_not_identified",
+  "source_type_requires_manual_review",
+  "source_type_not_supported_for_extraction",
+  "text_extraction_unavailable",
+  "execution_not_allowed_for_source_type",
+]);
+
+const normalizeExecuteWhenAllowed = (value) => {
+  if (typeof value === "undefined" || value === null || String(value).trim() === "") {
+    return true;
+  }
+
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  const normalizedValue = String(value).trim().toLowerCase();
+
+  if (["true", "1", "sim", "yes"].includes(normalizedValue)) {
+    return true;
+  }
+
+  if (["false", "0", "nao", "no"].includes(normalizedValue)) {
+    return false;
+  }
+
+  throw createTaxError(400, "executeWhenAllowed invalido. Use true ou false.");
+};
+
+const selectExecutionBlockingRules = (preview) =>
+  preview.blockingRules.filter((rule) => EXECUTION_BLOCKING_CODES.has(rule.code));
+
+const buildIngestionPayload = (payload = {}, preview) => {
+  const normalizedPayload = payload && typeof payload === "object" ? { ...payload } : {};
+  const hasSourceLabel =
+    typeof normalizedPayload.sourceLabel === "string" && normalizedPayload.sourceLabel.trim();
+
+  delete normalizedPayload.executeWhenAllowed;
+
+  if (!hasSourceLabel && preview.capabilities.canSuggest && preview.sourceLabelSuggestion) {
+    normalizedPayload.sourceLabel = preview.sourceLabelSuggestion;
+  }
+
+  return normalizedPayload;
+};
+
+export const ingestAndExecuteTaxDocumentBySourceType = async ({
+  userId,
+  payload = {},
+  file,
+}) => {
+  const executionRequested = normalizeExecuteWhenAllowed(payload.executeWhenAllowed);
+  const preview = await previewTaxDocumentBySourceType(file);
+  const ingestionAllowed = preview.detectedState !== "blocked";
+
+  if (!ingestionAllowed) {
+    return {
+      preview,
+      ingestion: {
+        allowed: false,
+        status: "blocked",
+        documentId: null,
+        blockingRules: [...preview.blockingRules],
+      },
+      suggestion: {
+        allowed: preview.capabilities.canSuggest,
+        sourceLabelSuggestion: preview.capabilities.canSuggest
+          ? preview.sourceLabelSuggestion
+          : null,
+      },
+      execution: {
+        requested: executionRequested,
+        allowed: false,
+        status: "not_allowed",
+        documentId: null,
+        blockingRules: selectExecutionBlockingRules(preview),
+      },
+    };
+  }
+
+  const ingestedDocument = await createTaxDocumentForUser(
+    userId,
+    buildIngestionPayload(payload, preview),
+    file,
+  );
+
+  const executionAllowed = preview.capabilities.canExecute;
+  let executionStatus = "not_requested";
+  let executionDocumentId = null;
+  let executionBlockingRules = [];
+
+  if (executionRequested && executionAllowed) {
+    const processedDocument = await processTaxDocumentByIdForUser(userId, ingestedDocument.id);
+    executionStatus = "executed";
+    executionDocumentId = Number(processedDocument?.document?.id || ingestedDocument.id);
+  }
+
+  if (executionRequested && !executionAllowed) {
+    executionStatus = "not_allowed";
+    executionBlockingRules = selectExecutionBlockingRules(preview);
+  }
+
+  return {
+    preview,
+    ingestion: {
+      allowed: true,
+      status: "ingested",
+      documentId: Number(ingestedDocument.id),
+      blockingRules: [],
+    },
+    suggestion: {
+      allowed: preview.capabilities.canSuggest,
+      sourceLabelSuggestion: preview.capabilities.canSuggest
+        ? preview.sourceLabelSuggestion
+        : null,
+    },
+    execution: {
+      requested: executionRequested,
+      allowed: executionAllowed,
+      status: executionStatus,
+      documentId: executionDocumentId,
+      blockingRules: executionBlockingRules,
+    },
+  };
+};

--- a/apps/api/src/tax.test.js
+++ b/apps/api/src/tax.test.js
@@ -13,6 +13,7 @@ import {
 import { resetLoginProtectionState } from "./middlewares/login-protection.middleware.js";
 import { resetImportRateLimiterState, resetWriteRateLimiterState } from "./middlewares/rate-limit.middleware.js";
 import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
+import { TaxDocumentIngestionExecutionResponseSchema } from "./domain/contracts/tax-document-ingestion-execution-response.schema.ts";
 import { TaxDocumentPreviewResponseSchema } from "./domain/contracts/tax-document-preview-response.schema.ts";
 import { resolveTaxDocumentAbsolutePath } from "./services/tax-document-storage.service.js";
 
@@ -126,6 +127,22 @@ describe("Tax API foundation", () => {
   it("POST /tax/documents/preview retorna 401 sem token", async () => {
     const response = await request(app)
       .post("/tax/documents/preview")
+      .attach("file", Buffer.from("preview", "utf8"), {
+        filename: "preview.csv",
+        contentType: "text/csv",
+      });
+
+    expectErrorResponseWithRequestId(
+      response,
+      401,
+      "Token de autenticacao ausente ou invalido.",
+    );
+  });
+
+  it("POST /tax/documents/ingest-execute retorna 401 sem token", async () => {
+    const response = await request(app)
+      .post("/tax/documents/ingest-execute")
+      .field("taxYear", "2026")
       .attach("file", Buffer.from("preview", "utf8"), {
         filename: "preview.csv",
         contentType: "text/csv",
@@ -639,6 +656,155 @@ describe("Tax API foundation", () => {
     const blockingCodes = response.body.preview.blockingRules.map((rule) => rule.code);
     expect(blockingCodes).toContain("document_type_not_identified");
     expect(blockingCodes).toContain("execution_not_allowed_for_source_type");
+  });
+
+  it("POST /tax/documents/ingest-execute retorna 400 quando arquivo fiscal nao e enviado", async () => {
+    const token = await registerAndLogin("tax-ingest-execute-missing-file@test.dev");
+
+    const response = await request(app)
+      .post("/tax/documents/ingest-execute")
+      .set("Authorization", `Bearer ${token}`)
+      .field("taxYear", "2026");
+
+    expectErrorResponseWithRequestId(response, 400, "Arquivo fiscal (file) e obrigatorio.");
+  });
+
+  it("POST /tax/documents/ingest-execute bloqueia ingestao para sourceType unknown", async () => {
+    const token = await registerAndLogin("tax-ingest-execute-unknown@test.dev");
+
+    const response = await request(app)
+      .post("/tax/documents/ingest-execute")
+      .set("Authorization", `Bearer ${token}`)
+      .field("taxYear", "2026")
+      .attach("file", Buffer.from("qualquer conteudo sem pistas fiscais claras", "utf8"), {
+        filename: "ingest-unknown.pdf",
+        contentType: "application/pdf",
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.ingestion).toMatchObject({
+      allowed: false,
+      status: "blocked",
+      documentId: null,
+    });
+    expect(response.body.execution).toMatchObject({
+      requested: true,
+      allowed: false,
+      status: "not_allowed",
+      documentId: null,
+    });
+    const ingestionBlockingCodes = response.body.ingestion.blockingRules.map((rule) => rule.code);
+    expect(ingestionBlockingCodes).toContain("document_type_not_identified");
+
+    const parsed = TaxDocumentIngestionExecutionResponseSchema.safeParse(response.body);
+    expect(parsed.success).toBe(true);
+
+    const documentsResponse = await request(app)
+      .get("/tax/documents?taxYear=2026")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(documentsResponse.status).toBe(200);
+    expect(documentsResponse.body.total).toBe(0);
+  });
+
+  it("POST /tax/documents/ingest-execute ingere support e bloqueia execucao automatica", async () => {
+    const token = await registerAndLogin("tax-ingest-execute-support@test.dev");
+
+    const response = await request(app)
+      .post("/tax/documents/ingest-execute")
+      .set("Authorization", `Bearer ${token}`)
+      .field("taxYear", "2026")
+      .attach(
+        "file",
+        Buffer.from(
+          [
+            "Data;Historico;Valor",
+            "05/02/2026;Saldo anterior;100,00",
+            "06/02/2026;Lancamentos;20,00",
+          ].join("\n"),
+          "utf8",
+        ),
+        {
+          filename: "ingest-support.csv",
+          contentType: "text/csv",
+        },
+      );
+
+    expect(response.status).toBe(200);
+    expect(response.body.preview).toMatchObject({
+      sourceType: "support",
+      detectedState: "review_required",
+    });
+    expect(response.body.ingestion).toMatchObject({
+      allowed: true,
+      status: "ingested",
+    });
+    expect(response.body.execution).toMatchObject({
+      requested: true,
+      allowed: false,
+      status: "not_allowed",
+      documentId: null,
+    });
+    expect(response.body.suggestion.allowed).toBe(true);
+
+    const detailResponse = await request(app)
+      .get(`/tax/documents/${response.body.ingestion.documentId}`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(detailResponse.status).toBe(200);
+    expect(detailResponse.body.document.processingStatus).toBe("uploaded");
+  });
+
+  it("POST /tax/documents/ingest-execute ingere e executa automaticamente para sourceType ready", async () => {
+    const token = await registerAndLogin("tax-ingest-execute-income@test.dev");
+
+    const response = await request(app)
+      .post("/tax/documents/ingest-execute")
+      .set("Authorization", `Bearer ${token}`)
+      .field("taxYear", "2026")
+      .attach(
+        "file",
+        Buffer.from(
+          [
+            "Comprovante de Rendimentos Pagos e de Imposto sobre a Renda Retido na Fonte",
+            "Fonte pagadora ACME LTDA",
+            "CNPJ 12.345.678/0001-90",
+            "Rendimentos tributaveis R$ 54.321,00",
+          ].join("\n"),
+          "utf8",
+        ),
+        {
+          filename: "ingest-income.csv",
+          contentType: "text/csv",
+        },
+      );
+
+    expect(response.status).toBe(200);
+    expect(response.body.preview).toMatchObject({
+      sourceType: "income",
+      detectedState: "ready",
+      documentType: "income_report_employer",
+    });
+    expect(response.body.ingestion).toMatchObject({
+      allowed: true,
+      status: "ingested",
+    });
+    expect(response.body.execution).toMatchObject({
+      requested: true,
+      allowed: true,
+      status: "executed",
+    });
+
+    const detailResponse = await request(app)
+      .get(`/tax/documents/${response.body.ingestion.documentId}`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(detailResponse.status).toBe(200);
+    expect(detailResponse.body.document.processingStatus).toBe("normalized");
+    expect(detailResponse.body.document.documentType).toBe("income_report_employer");
+
+    const parsed = TaxDocumentIngestionExecutionResponseSchema.safeParse(response.body);
+    expect(parsed.success).toBe(true);
   });
 
   it("GET /tax/documents retorna documentos enviados pelo usuario autenticado", async () => {

--- a/docs/architecture/v1.6.20-document-ingestion-execution-by-type.md
+++ b/docs/architecture/v1.6.20-document-ingestion-execution-by-type.md
@@ -1,0 +1,73 @@
+# v1.6.20 - Document Ingestion And Execution By Type
+
+## Context
+
+Item 2.3 extends the operational path after preview.
+
+After Item 2.2, preview already exposes state, blocking rules and capabilities by source type. This slice adds an explicit API flow for ingestion and execution decisions by `sourceType`.
+
+## What Was Added
+
+### Canonical operation response contract
+
+File: apps/api/src/domain/contracts/tax-document-ingestion-execution-response.schema.ts
+
+Response payload now makes ingestion and execution explicit:
+
+- preview: canonical preview payload from Item 2.2
+- ingestion:
+  - allowed
+  - status (`ingested | blocked`)
+  - documentId
+  - blockingRules
+- suggestion:
+  - allowed
+  - sourceLabelSuggestion
+- execution:
+  - requested
+  - allowed
+  - status (`executed | not_requested | not_allowed`)
+  - documentId
+  - blockingRules
+
+### Operational service by source type
+
+File: apps/api/src/services/tax-document-ingestion-execution.service.js
+
+New orchestration service:
+
+1. Runs preview classification by source type.
+2. Applies Item 2.2 state/blocking semantics.
+3. Decides if ingestion is allowed.
+4. Executes ingestion when allowed.
+5. Executes processing only when requested and allowed.
+
+Behavior by state:
+
+- blocked: ingestion blocked, execution blocked.
+- review_required: ingestion allowed, execution blocked, suggestion remains explicit.
+- ready: ingestion allowed and execution can run when requested.
+
+### Explicit endpoint
+
+Route: POST /tax/documents/ingest-execute
+
+- Uses same upload guardrails (required file, allowed mime/extension, size limit).
+- Returns validated contract payload via respondValidated.
+- Keeps UI and copy untouched.
+
+## Out Of Scope
+
+- No UI changes.
+- No copy changes.
+- No extractor expansion for source types still marked as manual review.
+
+## Validation
+
+- Contract tests updated for the new ingestion/execution response schema.
+- Tax API tests cover:
+  - auth protection
+  - missing file validation
+  - blocked flow (unknown)
+  - ingested + execution blocked flow (support)
+  - ingested + executed flow (income)


### PR DESCRIPTION
Implement Item 2.3 to add explicit ingestion and execution flow by source type.

Scope:
- add canonical operation response contract for ingestion/execution decisions;
- add orchestration service that applies 2.2 states/blocking rules to operational flow;
- add POST /tax/documents/ingest-execute endpoint with validated response;
- add focused contract and route tests for blocked/review_required/ready flows;
- add architecture note v1.6.20.

Out of scope:
- UI changes;
- copy changes;
- extractor expansion for blocked manual-review types.