### PR TITLE
Nova sequencia - Item 2.4: trilha auditavel e transparencia por tipo

### DIFF
--- a/apps/api/src/domain/contracts/contracts.schema.test.ts
+++ b/apps/api/src/domain/contracts/contracts.schema.test.ts
@@ -364,6 +364,47 @@ describe("financial contracts schemas", () => {
           documentId: 42,
           blockingRules: [],
         },
+        transparency: {
+          detected: {
+            sourceType: "income",
+            documentType: "income_report_employer",
+            detectedState: "ready",
+            reasonCodes: ["matched_employer_signals"],
+          },
+          blocked: {
+            hasBlockingRules: false,
+            rules: [],
+          },
+          suggested: {
+            allowed: true,
+            sourceLabelSuggestion: "ACME LTDA",
+            reasonCodes: ["source_label_suggestion_available"],
+          },
+          executed: {
+            requested: true,
+            allowed: true,
+            status: "executed",
+            reasonCodes: ["execution_completed"],
+          },
+        },
+        auditTrail: [
+          {
+            step: "detected",
+            outcome: "allowed",
+            sourceType: "income",
+            documentId: null,
+            reasonCodes: ["matched_employer_signals"],
+            reasonMessage: "Documento detectado como income_report_employer no sourceType income.",
+          },
+          {
+            step: "executed",
+            outcome: "executed",
+            sourceType: "income",
+            documentId: 42,
+            reasonCodes: ["execution_completed"],
+            reasonMessage: "Execucao automatica concluida para o tipo detectado.",
+          },
+        ],
       });
 
       expect(result.success).toBe(true);
@@ -416,6 +457,119 @@ describe("financial contracts schemas", () => {
             },
           ],
         },
+        transparency: {
+          detected: {
+            sourceType: "support",
+            documentType: "bank_statement_support",
+            detectedState: "review_required",
+            reasonCodes: ["matched_bank_statement_support_signals"],
+          },
+          blocked: {
+            hasBlockingRules: true,
+            rules: [
+              {
+                code: "source_type_requires_manual_review",
+                reason: "Revisao manual obrigatoria",
+              },
+            ],
+          },
+          suggested: {
+            allowed: true,
+            sourceLabelSuggestion: null,
+            reasonCodes: ["source_label_suggestion_not_available"],
+          },
+          executed: {
+            requested: true,
+            allowed: false,
+            status: "not_allowed",
+            reasonCodes: ["execution_not_allowed_for_source_type"],
+          },
+        },
+        auditTrail: [
+          {
+            step: "detected",
+            outcome: "allowed",
+            sourceType: "support",
+            documentId: null,
+            reasonCodes: ["matched_bank_statement_support_signals"],
+            reasonMessage: "Documento detectado como bank_statement_support no sourceType support.",
+          },
+        ],
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects operation payload with invalid audit step", () => {
+      const result = TaxDocumentIngestionExecutionResponseSchema.safeParse({
+        preview: {
+          sourceType: "income",
+          detectedState: "ready",
+          blockingRules: [],
+          capabilities: {
+            canExtract: true,
+            canSuggest: true,
+            canExecute: true,
+          },
+          documentType: "income_report_employer",
+          confidenceScore: 0.97,
+          extractorAvailable: true,
+          sourceLabelSuggestion: null,
+          reasons: ["matched_employer_signals"],
+          warnings: [],
+          textSource: "csv_text",
+          textPreviewLines: ["Comprovante de Rendimentos"],
+        },
+        ingestion: {
+          allowed: true,
+          status: "ingested",
+          documentId: 42,
+          blockingRules: [],
+        },
+        suggestion: {
+          allowed: true,
+          sourceLabelSuggestion: "ACME LTDA",
+        },
+        execution: {
+          requested: true,
+          allowed: true,
+          status: "executed",
+          documentId: 42,
+          blockingRules: [],
+        },
+        transparency: {
+          detected: {
+            sourceType: "income",
+            documentType: "income_report_employer",
+            detectedState: "ready",
+            reasonCodes: ["matched_employer_signals"],
+          },
+          blocked: {
+            hasBlockingRules: false,
+            rules: [],
+          },
+          suggested: {
+            allowed: true,
+            sourceLabelSuggestion: "ACME LTDA",
+            reasonCodes: ["source_label_suggestion_available"],
+          },
+          executed: {
+            requested: true,
+            allowed: true,
+            status: "executed",
+            reasonCodes: ["execution_completed"],
+          },
+        },
+        auditTrail: [
+          {
+            step: "classified",
+            outcome: "allowed",
+            sourceType: "income",
+            documentId: 42,
+            reasonCodes: ["matched_employer_signals"],
+            reasonMessage: "Etapa invalida.",
+          },
+        ],
       });
 
       expect(result.success).toBe(false);

--- a/apps/api/src/domain/contracts/index.ts
+++ b/apps/api/src/domain/contracts/index.ts
@@ -44,12 +44,20 @@ export {
 } from "./core-financial-semantic-contract.schema";
 
 export {
+  TaxDocumentAuditEntrySchema,
+  TaxDocumentAuditOutcomeSchema,
+  TaxDocumentAuditStepSchema,
   TaxDocumentExecutionDecisionSchema,
   TaxDocumentExecutionStatusSchema,
   TaxDocumentIngestionDecisionSchema,
   TaxDocumentIngestionExecutionResponseSchema,
   TaxDocumentIngestionStatusSchema,
   TaxDocumentSuggestionDecisionSchema,
+  TaxDocumentTransparencyBlockedSchema,
+  TaxDocumentTransparencyDetectedSchema,
+  TaxDocumentTransparencyExecutedSchema,
+  TaxDocumentTransparencySchema,
+  TaxDocumentTransparencySuggestedSchema,
 } from "./tax-document-ingestion-execution-response.schema";
 
 export {
@@ -112,12 +120,20 @@ export type {
 } from "./core-financial-semantic-contract.schema";
 
 export type {
+  TaxDocumentAuditEntry,
+  TaxDocumentAuditOutcome,
+  TaxDocumentAuditStep,
   TaxDocumentExecutionDecision,
   TaxDocumentExecutionStatus,
   TaxDocumentIngestionDecision,
   TaxDocumentIngestionExecutionResponse,
   TaxDocumentIngestionStatus,
   TaxDocumentSuggestionDecision,
+  TaxDocumentTransparency,
+  TaxDocumentTransparencyBlocked,
+  TaxDocumentTransparencyDetected,
+  TaxDocumentTransparencyExecuted,
+  TaxDocumentTransparencySuggested,
 } from "./tax-document-ingestion-execution-response.schema";
 
 export type {

--- a/apps/api/src/domain/contracts/tax-document-ingestion-execution-response.schema.ts
+++ b/apps/api/src/domain/contracts/tax-document-ingestion-execution-response.schema.ts
@@ -35,11 +35,68 @@ export const TaxDocumentExecutionDecisionSchema = z.object({
   blockingRules: z.array(TaxDocumentPreviewBlockingRuleSchema),
 });
 
+export const TaxDocumentAuditStepSchema = z.enum([
+  "detected",
+  "blocked",
+  "suggested",
+  "executed",
+]);
+
+export const TaxDocumentAuditOutcomeSchema = z.enum([
+  "allowed",
+  "blocked",
+  "skipped",
+  "executed",
+]);
+
+export const TaxDocumentAuditEntrySchema = z.object({
+  step: TaxDocumentAuditStepSchema,
+  outcome: TaxDocumentAuditOutcomeSchema,
+  sourceType: TaxDocumentPreviewSchema.shape.sourceType,
+  documentId: z.number().int().positive().nullable(),
+  reasonCodes: z.array(z.string()),
+  reasonMessage: z.string().min(1),
+});
+
+export const TaxDocumentTransparencyDetectedSchema = z.object({
+  sourceType: TaxDocumentPreviewSchema.shape.sourceType,
+  documentType: TaxDocumentPreviewSchema.shape.documentType,
+  detectedState: TaxDocumentPreviewSchema.shape.detectedState,
+  reasonCodes: z.array(z.string()),
+});
+
+export const TaxDocumentTransparencyBlockedSchema = z.object({
+  hasBlockingRules: z.boolean(),
+  rules: z.array(TaxDocumentPreviewBlockingRuleSchema),
+});
+
+export const TaxDocumentTransparencySuggestedSchema = z.object({
+  allowed: z.boolean(),
+  sourceLabelSuggestion: z.string().nullable(),
+  reasonCodes: z.array(z.string()),
+});
+
+export const TaxDocumentTransparencyExecutedSchema = z.object({
+  requested: z.boolean(),
+  allowed: z.boolean(),
+  status: TaxDocumentExecutionStatusSchema,
+  reasonCodes: z.array(z.string()),
+});
+
+export const TaxDocumentTransparencySchema = z.object({
+  detected: TaxDocumentTransparencyDetectedSchema,
+  blocked: TaxDocumentTransparencyBlockedSchema,
+  suggested: TaxDocumentTransparencySuggestedSchema,
+  executed: TaxDocumentTransparencyExecutedSchema,
+});
+
 export const TaxDocumentIngestionExecutionResponseSchema = z.object({
   preview: TaxDocumentPreviewSchema,
   ingestion: TaxDocumentIngestionDecisionSchema,
   suggestion: TaxDocumentSuggestionDecisionSchema,
   execution: TaxDocumentExecutionDecisionSchema,
+  transparency: TaxDocumentTransparencySchema,
+  auditTrail: z.array(TaxDocumentAuditEntrySchema),
 });
 
 export type TaxDocumentIngestionStatus = z.infer<
@@ -56,6 +113,26 @@ export type TaxDocumentSuggestionDecision = z.infer<
 >;
 export type TaxDocumentExecutionDecision = z.infer<
   typeof TaxDocumentExecutionDecisionSchema
+>;
+export type TaxDocumentAuditStep = z.infer<typeof TaxDocumentAuditStepSchema>;
+export type TaxDocumentAuditOutcome = z.infer<
+  typeof TaxDocumentAuditOutcomeSchema
+>;
+export type TaxDocumentAuditEntry = z.infer<typeof TaxDocumentAuditEntrySchema>;
+export type TaxDocumentTransparencyDetected = z.infer<
+  typeof TaxDocumentTransparencyDetectedSchema
+>;
+export type TaxDocumentTransparencyBlocked = z.infer<
+  typeof TaxDocumentTransparencyBlockedSchema
+>;
+export type TaxDocumentTransparencySuggested = z.infer<
+  typeof TaxDocumentTransparencySuggestedSchema
+>;
+export type TaxDocumentTransparencyExecuted = z.infer<
+  typeof TaxDocumentTransparencyExecutedSchema
+>;
+export type TaxDocumentTransparency = z.infer<
+  typeof TaxDocumentTransparencySchema
 >;
 export type TaxDocumentIngestionExecutionResponse = z.infer<
   typeof TaxDocumentIngestionExecutionResponseSchema

--- a/apps/api/src/domain/contracts/types.ts
+++ b/apps/api/src/domain/contracts/types.ts
@@ -46,12 +46,20 @@ export type {
 } from "./core-financial-semantic-contract.schema";
 
 export type {
+  TaxDocumentAuditEntry,
+  TaxDocumentAuditOutcome,
+  TaxDocumentAuditStep,
   TaxDocumentExecutionDecision,
   TaxDocumentExecutionStatus,
   TaxDocumentIngestionDecision,
   TaxDocumentIngestionExecutionResponse,
   TaxDocumentIngestionStatus,
   TaxDocumentSuggestionDecision,
+  TaxDocumentTransparency,
+  TaxDocumentTransparencyBlocked,
+  TaxDocumentTransparencyDetected,
+  TaxDocumentTransparencyExecuted,
+  TaxDocumentTransparencySuggested,
 } from "./tax-document-ingestion-execution-response.schema";
 
 export type {

--- a/apps/api/src/services/tax-document-ingestion-execution.service.js
+++ b/apps/api/src/services/tax-document-ingestion-execution.service.js
@@ -36,6 +36,122 @@ const normalizeExecuteWhenAllowed = (value) => {
 const selectExecutionBlockingRules = (preview) =>
   preview.blockingRules.filter((rule) => EXECUTION_BLOCKING_CODES.has(rule.code));
 
+const mapRuleCodes = (rules = []) => rules.map((rule) => rule.code);
+
+const buildTransparency = ({
+  preview,
+  suggestion,
+  execution,
+  blockedRules,
+}) => ({
+  detected: {
+    sourceType: preview.sourceType,
+    documentType: preview.documentType,
+    detectedState: preview.detectedState,
+    reasonCodes: [...preview.reasons],
+  },
+  blocked: {
+    hasBlockingRules: blockedRules.length > 0,
+    rules: blockedRules,
+  },
+  suggested: {
+    allowed: suggestion.allowed,
+    sourceLabelSuggestion: suggestion.sourceLabelSuggestion,
+    reasonCodes: suggestion.allowed
+      ? suggestion.sourceLabelSuggestion
+        ? ["source_label_suggestion_available"]
+        : ["source_label_suggestion_not_available"]
+      : ["suggestion_not_allowed_for_source_type"],
+  },
+  executed: {
+    requested: execution.requested,
+    allowed: execution.allowed,
+    status: execution.status,
+    reasonCodes:
+      execution.status === "executed"
+        ? ["execution_completed"]
+        : execution.status === "not_requested"
+          ? ["execution_not_requested"]
+          : mapRuleCodes(execution.blockingRules),
+  },
+});
+
+const buildAuditTrail = ({
+  preview,
+  ingestion,
+  suggestion,
+  execution,
+}) => {
+  const entries = [
+    {
+      step: "detected",
+      outcome: preview.detectedState === "blocked" ? "blocked" : "allowed",
+      sourceType: preview.sourceType,
+      documentId: null,
+      reasonCodes: [...preview.reasons],
+      reasonMessage: `Documento detectado como ${preview.documentType} no sourceType ${preview.sourceType}.`,
+    },
+  ];
+
+  if (ingestion.blockingRules.length > 0 || execution.blockingRules.length > 0) {
+    const blockedCodes = [
+      ...mapRuleCodes(ingestion.blockingRules),
+      ...mapRuleCodes(execution.blockingRules),
+    ];
+    const uniqueBlockedCodes = [...new Set(blockedCodes)];
+
+    entries.push({
+      step: "blocked",
+      outcome: "blocked",
+      sourceType: preview.sourceType,
+      documentId: ingestion.documentId,
+      reasonCodes: uniqueBlockedCodes,
+      reasonMessage: "Fluxo documental teve bloqueios operacionais para o tipo detectado.",
+    });
+  }
+
+  entries.push({
+    step: "suggested",
+    outcome: suggestion.allowed ? "allowed" : "skipped",
+    sourceType: preview.sourceType,
+    documentId: ingestion.documentId,
+    reasonCodes: suggestion.allowed
+      ? suggestion.sourceLabelSuggestion
+        ? ["source_label_suggestion_available"]
+        : ["source_label_suggestion_not_available"]
+      : ["suggestion_not_allowed_for_source_type"],
+    reasonMessage: suggestion.allowed
+      ? "Sugestao operacional avaliada para o tipo detectado."
+      : "Sugestao nao permitida para o tipo detectado.",
+  });
+
+  entries.push({
+    step: "executed",
+    outcome:
+      execution.status === "executed"
+        ? "executed"
+        : execution.status === "not_allowed"
+          ? "blocked"
+          : "skipped",
+    sourceType: preview.sourceType,
+    documentId: execution.documentId || ingestion.documentId,
+    reasonCodes:
+      execution.status === "executed"
+        ? ["execution_completed"]
+        : execution.status === "not_requested"
+          ? ["execution_not_requested"]
+          : mapRuleCodes(execution.blockingRules),
+    reasonMessage:
+      execution.status === "executed"
+        ? "Execucao automatica concluida para o tipo detectado."
+        : execution.status === "not_requested"
+          ? "Execucao automatica nao requisitada para esta operacao."
+          : "Execucao automatica bloqueada pelas regras do tipo detectado.",
+  });
+
+  return entries;
+};
+
 const buildIngestionPayload = (payload = {}, preview) => {
   const normalizedPayload = payload && typeof payload === "object" ? { ...payload } : {};
   const hasSourceLabel =
@@ -60,27 +176,43 @@ export const ingestAndExecuteTaxDocumentBySourceType = async ({
   const ingestionAllowed = preview.detectedState !== "blocked";
 
   if (!ingestionAllowed) {
+    const suggestion = {
+      allowed: preview.capabilities.canSuggest,
+      sourceLabelSuggestion: preview.capabilities.canSuggest
+        ? preview.sourceLabelSuggestion
+        : null,
+    };
+    const execution = {
+      requested: executionRequested,
+      allowed: false,
+      status: "not_allowed",
+      documentId: null,
+      blockingRules: selectExecutionBlockingRules(preview),
+    };
+    const ingestion = {
+      allowed: false,
+      status: "blocked",
+      documentId: null,
+      blockingRules: [...preview.blockingRules],
+    };
+
     return {
       preview,
-      ingestion: {
-        allowed: false,
-        status: "blocked",
-        documentId: null,
-        blockingRules: [...preview.blockingRules],
-      },
-      suggestion: {
-        allowed: preview.capabilities.canSuggest,
-        sourceLabelSuggestion: preview.capabilities.canSuggest
-          ? preview.sourceLabelSuggestion
-          : null,
-      },
-      execution: {
-        requested: executionRequested,
-        allowed: false,
-        status: "not_allowed",
-        documentId: null,
-        blockingRules: selectExecutionBlockingRules(preview),
-      },
+      ingestion,
+      suggestion,
+      execution,
+      transparency: buildTransparency({
+        preview,
+        suggestion,
+        execution,
+        blockedRules: [...ingestion.blockingRules],
+      }),
+      auditTrail: buildAuditTrail({
+        preview,
+        ingestion,
+        suggestion,
+        execution,
+      }),
     };
   }
 
@@ -106,26 +238,42 @@ export const ingestAndExecuteTaxDocumentBySourceType = async ({
     executionBlockingRules = selectExecutionBlockingRules(preview);
   }
 
+  const ingestion = {
+    allowed: true,
+    status: "ingested",
+    documentId: Number(ingestedDocument.id),
+    blockingRules: [],
+  };
+  const suggestion = {
+    allowed: preview.capabilities.canSuggest,
+    sourceLabelSuggestion: preview.capabilities.canSuggest
+      ? preview.sourceLabelSuggestion
+      : null,
+  };
+  const execution = {
+    requested: executionRequested,
+    allowed: executionAllowed,
+    status: executionStatus,
+    documentId: executionDocumentId,
+    blockingRules: executionBlockingRules,
+  };
+
   return {
     preview,
-    ingestion: {
-      allowed: true,
-      status: "ingested",
-      documentId: Number(ingestedDocument.id),
-      blockingRules: [],
-    },
-    suggestion: {
-      allowed: preview.capabilities.canSuggest,
-      sourceLabelSuggestion: preview.capabilities.canSuggest
-        ? preview.sourceLabelSuggestion
-        : null,
-    },
-    execution: {
-      requested: executionRequested,
-      allowed: executionAllowed,
-      status: executionStatus,
-      documentId: executionDocumentId,
-      blockingRules: executionBlockingRules,
-    },
+    ingestion,
+    suggestion,
+    execution,
+    transparency: buildTransparency({
+      preview,
+      suggestion,
+      execution,
+      blockedRules: [...execution.blockingRules],
+    }),
+    auditTrail: buildAuditTrail({
+      preview,
+      ingestion,
+      suggestion,
+      execution,
+    }),
   };
 };

--- a/apps/api/src/tax.test.js
+++ b/apps/api/src/tax.test.js
@@ -693,6 +693,17 @@ describe("Tax API foundation", () => {
       status: "not_allowed",
       documentId: null,
     });
+    expect(response.body.transparency.detected).toMatchObject({
+      sourceType: "unknown",
+      documentType: "unknown",
+      detectedState: "blocked",
+    });
+    expect(response.body.transparency.blocked.hasBlockingRules).toBe(true);
+    expect(response.body.transparency.executed.reasonCodes).toContain(
+      "execution_not_allowed_for_source_type",
+    );
+    expect(Array.isArray(response.body.auditTrail)).toBe(true);
+    expect(response.body.auditTrail.map((entry) => entry.step)).toContain("blocked");
     const ingestionBlockingCodes = response.body.ingestion.blockingRules.map((rule) => rule.code);
     expect(ingestionBlockingCodes).toContain("document_type_not_identified");
 
@@ -746,6 +757,16 @@ describe("Tax API foundation", () => {
       documentId: null,
     });
     expect(response.body.suggestion.allowed).toBe(true);
+    expect(response.body.transparency.detected).toMatchObject({
+      sourceType: "support",
+      documentType: "bank_statement_support",
+      detectedState: "review_required",
+    });
+    expect(response.body.transparency.blocked.hasBlockingRules).toBe(true);
+    expect(response.body.transparency.executed.reasonCodes).toContain(
+      "execution_not_allowed_for_source_type",
+    );
+    expect(response.body.auditTrail.map((entry) => entry.step)).toContain("blocked");
 
     const detailResponse = await request(app)
       .get(`/tax/documents/${response.body.ingestion.documentId}`)
@@ -794,6 +815,14 @@ describe("Tax API foundation", () => {
       allowed: true,
       status: "executed",
     });
+    expect(response.body.transparency.detected).toMatchObject({
+      sourceType: "income",
+      documentType: "income_report_employer",
+      detectedState: "ready",
+    });
+    expect(response.body.transparency.blocked.hasBlockingRules).toBe(false);
+    expect(response.body.transparency.executed.reasonCodes).toContain("execution_completed");
+    expect(response.body.auditTrail.map((entry) => entry.step)).toContain("executed");
 
     const detailResponse = await request(app)
       .get(`/tax/documents/${response.body.ingestion.documentId}`)

--- a/docs/architecture/v1.6.21-document-audit-trail-by-type.md
+++ b/docs/architecture/v1.6.21-document-audit-trail-by-type.md
@@ -1,0 +1,52 @@
+# v1.6.21 - Document Audit Trail And Transparency By Type
+
+## Context
+
+Item 2.4 closes the document operational block by making the flow auditable and transparent per `sourceType`.
+
+Item 2.3 already introduced explicit ingestion and execution decisions by type. This slice adds a minimum auditable trail that explains what was detected, blocked, suggested, and executed, including reasons.
+
+## What Was Added
+
+### Canonical transparency and audit-trail contract
+
+File: apps/api/src/domain/contracts/tax-document-ingestion-execution-response.schema.ts
+
+The operation response now includes:
+
+- `transparency`:
+  - `detected`: source type, document type, state, reason codes
+  - `blocked`: blocking presence + blocking rules
+  - `suggested`: suggestion allowance + suggested label + reason codes
+  - `executed`: requested/allowed/status + reason codes
+- `auditTrail[]`:
+  - ordered entries by step (`detected`, `blocked`, `suggested`, `executed`)
+  - outcome
+  - sourceType
+  - documentId
+  - reasonCodes
+  - reasonMessage
+
+Contract barrels were updated to export the new schemas and types.
+
+### Service-level audit trail generation
+
+File: apps/api/src/services/tax-document-ingestion-execution.service.js
+
+The orchestration service now produces deterministic transparency and audit entries for each decision path:
+
+- blocked (`unknown`): explicit blocked reasons and no ingestion side effects.
+- review_required (`support`/`debt`): ingestion allowed, execution blocked with reason codes.
+- ready (`income`/`deduction`): ingestion and execution path with execution completion evidence.
+
+## Out Of Scope
+
+- No UI changes.
+- No copy changes.
+- No ingestion/extractor expansion beyond existing state/blocking policy.
+
+## Validation
+
+- Contract tests updated for `TaxDocumentIngestionExecutionResponseSchema` with transparency and audit trail constraints.
+- API tests validated with focused scenarios for blocked/support/ready operational paths.
+- API lint and focused test suite passed.


### PR DESCRIPTION
Implement Item 2.4 to close Item 2 with auditable transparency by source type.

Scope:
- extend ingest/execute contract with transparency and auditTrail sections;
- generate deterministic audit trail entries (detected/blocked/suggested/executed) in orchestration service;
- expose explicit reason codes and messages by source type decisions;
- update focused contract and tax route tests;
- add architecture note v1.6.21.

Out of scope:
- UI changes;
- copy changes.