### PR TITLE
AUD-001: matriz real de suporte documental e product truth guardrails

### DIFF
--- a/apps/api/src/domain/tax/tax-document-support-matrix.js
+++ b/apps/api/src/domain/tax/tax-document-support-matrix.js
@@ -1,0 +1,69 @@
+import { TAX_DOCUMENT_TYPES } from "./tax.constants.js";
+
+export const TAX_DOCUMENT_SUPPORT_MATRIX_VERSION = "2026-04-03.aud-001";
+
+export const SOURCE_TYPE_BY_DOCUMENT_TYPE = Object.freeze({
+  income_report_bank: "income",
+  income_report_employer: "income",
+  clt_payslip: "income",
+  income_report_inss: "income",
+  medical_statement: "deduction",
+  education_receipt: "deduction",
+  loan_statement: "debt",
+  bank_statement_support: "support",
+  unknown: "unknown",
+});
+
+export const SOURCE_TYPE_POLICY = Object.freeze({
+  income: {
+    supportLevel: "supported",
+    supportsExtraction: true,
+    allowsSuggestion: true,
+    allowsExecution: true,
+  },
+  deduction: {
+    supportLevel: "supported",
+    supportsExtraction: true,
+    allowsSuggestion: true,
+    allowsExecution: true,
+  },
+  debt: {
+    supportLevel: "restricted",
+    supportsExtraction: false,
+    allowsSuggestion: true,
+    allowsExecution: false,
+  },
+  support: {
+    supportLevel: "restricted",
+    supportsExtraction: false,
+    allowsSuggestion: true,
+    allowsExecution: false,
+  },
+  unknown: {
+    supportLevel: "not_supported",
+    supportsExtraction: false,
+    allowsSuggestion: false,
+    allowsExecution: false,
+  },
+});
+
+export const resolveTaxDocumentSourceType = (documentType) =>
+  SOURCE_TYPE_BY_DOCUMENT_TYPE[String(documentType || "").trim()] || "unknown";
+
+export const resolvePolicyBySourceType = (sourceType) =>
+  SOURCE_TYPE_POLICY[String(sourceType || "").trim()] || SOURCE_TYPE_POLICY.unknown;
+
+export const listTaxDocumentSupportMatrix = () =>
+  TAX_DOCUMENT_TYPES.map((documentType) => {
+    const sourceType = resolveTaxDocumentSourceType(documentType);
+    const policy = resolvePolicyBySourceType(sourceType);
+
+    return {
+      documentType,
+      sourceType,
+      supportLevel: policy.supportLevel,
+      supportsExtraction: policy.supportsExtraction,
+      allowsSuggestion: policy.allowsSuggestion,
+      allowsExecution: policy.allowsExecution,
+    };
+  });

--- a/apps/api/src/domain/tax/tax-document-support-matrix.test.js
+++ b/apps/api/src/domain/tax/tax-document-support-matrix.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  listTaxDocumentSupportMatrix,
+  resolvePolicyBySourceType,
+  resolveTaxDocumentSourceType,
+} from "./tax-document-support-matrix.js";
+
+describe("tax document support matrix", () => {
+  it("mantem sourceType e politica coerentes para cada documentType", () => {
+    const matrix = listTaxDocumentSupportMatrix();
+
+    expect(matrix.length).toBeGreaterThan(0);
+
+    matrix.forEach((item) => {
+      const expectedSourceType = resolveTaxDocumentSourceType(item.documentType);
+      const expectedPolicy = resolvePolicyBySourceType(expectedSourceType);
+
+      expect(item.sourceType).toBe(expectedSourceType);
+      expect(item.supportLevel).toBe(expectedPolicy.supportLevel);
+      expect(item.supportsExtraction).toBe(expectedPolicy.supportsExtraction);
+      expect(item.allowsSuggestion).toBe(expectedPolicy.allowsSuggestion);
+      expect(item.allowsExecution).toBe(expectedPolicy.allowsExecution);
+    });
+  });
+});

--- a/apps/api/src/services/tax-bootstrap.service.js
+++ b/apps/api/src/services/tax-bootstrap.service.js
@@ -6,19 +6,26 @@ import {
   TAX_FACT_TYPES,
   TAX_RULE_FAMILIES,
 } from "../domain/tax/tax.constants.js";
+import {
+  listTaxDocumentSupportMatrix,
+  TAX_DOCUMENT_SUPPORT_MATRIX_VERSION,
+} from "../domain/tax/tax-document-support-matrix.js";
 import { listTaxRuleSeedYears } from "../domain/tax/tax-rules.engine.js";
 import { normalizeTaxUserId } from "../domain/tax/tax.validation.js";
 
 export const getTaxBootstrapByUser = async (userId) => {
   normalizeTaxUserId(userId);
   const supportedTaxYears = listTaxRuleSeedYears();
+  const documentSupportMatrix = listTaxDocumentSupportMatrix();
 
   return {
     module: "tax",
     scope: "irpf_mvp",
     apiVersion: resolveApiVersion(),
+    documentSupportMatrixVersion: TAX_DOCUMENT_SUPPORT_MATRIX_VERSION,
     supportedTaxYears,
     documentTypes: [...TAX_DOCUMENT_TYPES],
+    documentSupportMatrix,
     documentProcessingStatuses: [...TAX_DOCUMENT_PROCESSING_STATUSES],
     factTypes: [...TAX_FACT_TYPES],
     reviewStatuses: [...TAX_FACT_REVIEW_STATUSES],

--- a/apps/api/src/services/tax-document-preview.service.js
+++ b/apps/api/src/services/tax-document-preview.service.js
@@ -1,54 +1,15 @@
 import { hasTaxExtractorForDocumentType } from "../domain/tax/tax-document-extractors.js";
+import {
+  resolvePolicyBySourceType as resolveDocumentPolicyBySourceType,
+  resolveTaxDocumentSourceType as resolveDocumentSourceType,
+} from "../domain/tax/tax-document-support-matrix.js";
 import { classifyTaxDocumentBuffer } from "./tax-classification.service.js";
-
-const SOURCE_TYPE_BY_DOCUMENT_TYPE = Object.freeze({
-  income_report_bank: "income",
-  income_report_employer: "income",
-  clt_payslip: "income",
-  income_report_inss: "income",
-  medical_statement: "deduction",
-  education_receipt: "deduction",
-  loan_statement: "debt",
-  bank_statement_support: "support",
-  unknown: "unknown",
-});
-
-const SOURCE_TYPE_POLICY = Object.freeze({
-  income: {
-    supportsExtraction: true,
-    allowsSuggestion: true,
-    allowsExecution: true,
-  },
-  deduction: {
-    supportsExtraction: true,
-    allowsSuggestion: true,
-    allowsExecution: true,
-  },
-  debt: {
-    supportsExtraction: false,
-    allowsSuggestion: true,
-    allowsExecution: false,
-  },
-  support: {
-    supportsExtraction: false,
-    allowsSuggestion: true,
-    allowsExecution: false,
-  },
-  unknown: {
-    supportsExtraction: false,
-    allowsSuggestion: false,
-    allowsExecution: false,
-  },
-});
 
 const BLOCKED_TEXT_SOURCES = new Set([
   "pdf_text_error",
   "image_text_pending",
   "unsupported_text_source",
 ]);
-
-const resolvePolicyBySourceType = (sourceType) =>
-  SOURCE_TYPE_POLICY[String(sourceType || "").trim()] || SOURCE_TYPE_POLICY.unknown;
 
 const buildBlockingRules = ({
   sourceType,
@@ -98,7 +59,7 @@ const buildBlockingRules = ({
 };
 
 export const resolveTaxDocumentSourceType = (documentType) =>
-  SOURCE_TYPE_BY_DOCUMENT_TYPE[String(documentType || "").trim()] || "unknown";
+  resolveDocumentSourceType(documentType);
 
 export const previewTaxDocumentBySourceType = async (file) => {
   const classification = await classifyTaxDocumentBuffer({
@@ -107,7 +68,7 @@ export const previewTaxDocumentBySourceType = async (file) => {
   });
 
   const sourceType = resolveTaxDocumentSourceType(classification.documentType);
-  const policy = resolvePolicyBySourceType(sourceType);
+  const policy = resolveDocumentPolicyBySourceType(sourceType);
   const extractorAvailable = hasTaxExtractorForDocumentType(classification.documentType);
   const canExtract =
     policy.supportsExtraction &&

--- a/apps/api/src/tax.test.js
+++ b/apps/api/src/tax.test.js
@@ -515,6 +515,35 @@ describe("Tax API foundation", () => {
     expect(response.body.supportedTaxYears).toContain(2026);
     expect(typeof response.body.apiVersion).toBe("string");
     expect(response.body.apiVersion.length).toBeGreaterThan(0);
+    expect(typeof response.body.documentSupportMatrixVersion).toBe("string");
+    expect(response.body.documentSupportMatrixVersion.length).toBeGreaterThan(0);
+    expect(Array.isArray(response.body.documentSupportMatrix)).toBe(true);
+    expect(response.body.documentSupportMatrix).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          documentType: "income_report_bank",
+          sourceType: "income",
+          supportLevel: "supported",
+          supportsExtraction: true,
+          allowsExecution: true,
+        }),
+        expect.objectContaining({
+          documentType: "bank_statement_support",
+          sourceType: "support",
+          supportLevel: "restricted",
+          supportsExtraction: false,
+          allowsExecution: false,
+        }),
+        expect.objectContaining({
+          documentType: "unknown",
+          sourceType: "unknown",
+          supportLevel: "not_supported",
+          supportsExtraction: false,
+          allowsSuggestion: false,
+          allowsExecution: false,
+        }),
+      ]),
+    );
   });
 
   it("GET /tax/documents retorna lista paginada vazia para o exercicio informado", async () => {

--- a/apps/web/src/components/TaxUploadModal.test.tsx
+++ b/apps/web/src/components/TaxUploadModal.test.tsx
@@ -67,6 +67,51 @@ describe("TaxUploadModal", () => {
     );
   });
 
+  it("expõe matriz de suporte com estados suportado, restrito e não suportado", () => {
+    render(
+      <TaxUploadModal
+        isOpen
+        taxYear={2026}
+        stage="idle"
+        supportMatrixVersion="2026-04-03.aud-001"
+        supportMatrix={[
+          {
+            documentType: "income_report_bank",
+            sourceType: "income",
+            supportLevel: "supported",
+            supportsExtraction: true,
+            allowsSuggestion: true,
+            allowsExecution: true,
+          },
+          {
+            documentType: "bank_statement_support",
+            sourceType: "support",
+            supportLevel: "restricted",
+            supportsExtraction: false,
+            allowsSuggestion: true,
+            allowsExecution: false,
+          },
+          {
+            documentType: "unknown",
+            sourceType: "unknown",
+            supportLevel: "not_supported",
+            supportsExtraction: false,
+            allowsSuggestion: false,
+            allowsExecution: false,
+          },
+        ]}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Matriz real de suporte documental")).toBeInTheDocument();
+    expect(screen.getByText("v2026-04-03.aud-001")).toBeInTheDocument();
+    expect(screen.getByText("Suportado (1)")).toBeInTheDocument();
+    expect(screen.getByText("Restrito (1)")).toBeInTheDocument();
+    expect(screen.getByText("Não suportado (0)")).toBeInTheDocument();
+  });
+
   // ─── Preview step ──────────────────────────────────────────────────────────
 
   it("renderiza o step de preview com nome do arquivo, tipo e contagem de fatos", () => {

--- a/apps/web/src/components/TaxUploadModal.test.tsx
+++ b/apps/web/src/components/TaxUploadModal.test.tsx
@@ -67,6 +67,26 @@ describe("TaxUploadModal", () => {
     );
   });
 
+  it("mostra fallback restritivo quando a matriz de suporte está indisponível", () => {
+    render(
+      <TaxUploadModal
+        isOpen
+        taxYear={2026}
+        stage="idle"
+        supportMatrix={[]}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Matriz de suporte indisponível")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Matriz de suporte indisponível no momento. Siga com revisão manual: documentos podem ser bloqueados para extração e execução automática nesta fatia.",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("expõe matriz de suporte com estados suportado, restrito e não suportado", () => {
     render(
       <TaxUploadModal

--- a/apps/web/src/components/TaxUploadModal.tsx
+++ b/apps/web/src/components/TaxUploadModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState, type FormEvent, type MouseEvent } from "react";
-import type { TaxDocumentDetail } from "../services/tax.service";
+import type { TaxDocumentDetail, TaxDocumentSupportMatrixItem } from "../services/tax.service";
 
 export type TaxUploadStage = "idle" | "uploading" | "processing" | "preview" | "success" | "error";
 
@@ -11,6 +11,8 @@ interface TaxUploadModalProps {
   errorMessage?: string;
   previewDocument?: TaxDocumentDetail | null;
   previewFactCount?: number;
+  supportMatrix?: TaxDocumentSupportMatrixItem[];
+  supportMatrixVersion?: string;
   onClose: () => void;
   onSubmit: (payload: {
     file: File;
@@ -61,6 +63,18 @@ const PREVIEW_STATUS_LABELS: Record<string, string> = {
   failed: "Falhou",
 };
 
+const SUPPORT_LEVEL_LABELS: Record<string, string> = {
+  supported: "Suportado",
+  restricted: "Restrito",
+  not_supported: "Não suportado",
+};
+
+const SUPPORT_LEVEL_HINTS: Record<string, string> = {
+  supported: "Extração e execução automática liberadas.",
+  restricted: "Aceita ingestão para revisão manual, sem execução automática nesta fatia.",
+  not_supported: "Sem fluxo operacional nesta fatia do produto.",
+};
+
 const extractFileExtension = (fileName: string) => {
   const lastDotIndex = fileName.lastIndexOf(".");
 
@@ -104,6 +118,8 @@ const TaxUploadModal = ({
   errorMessage = "",
   previewDocument = null,
   previewFactCount = 0,
+  supportMatrix = [],
+  supportMatrixVersion = "",
   onClose,
   onSubmit,
   onConfirmPreview,
@@ -139,6 +155,39 @@ const TaxUploadModal = ({
 
     return "";
   }, [stage, statusMessage]);
+
+  const groupedSupportMatrix = useMemo(() => {
+    const groups: Record<string, TaxDocumentSupportMatrixItem[]> = {
+      supported: [],
+      restricted: [],
+      not_supported: [],
+    };
+
+    supportMatrix.forEach((item) => {
+      const level =
+        item.supportLevel === "supported" ||
+        item.supportLevel === "restricted" ||
+        item.supportLevel === "not_supported"
+          ? item.supportLevel
+          : "not_supported";
+
+      if (item.documentType === "unknown") {
+        return;
+      }
+
+      groups[level].push(item);
+    });
+
+    (Object.keys(groups) as Array<keyof typeof groups>).forEach((level) => {
+      groups[level].sort((left, right) => {
+        const leftLabel = PREVIEW_DOCUMENT_TYPE_LABELS[left.documentType] ?? left.documentType;
+        const rightLabel = PREVIEW_DOCUMENT_TYPE_LABELS[right.documentType] ?? right.documentType;
+        return leftLabel.localeCompare(rightLabel, "pt-BR");
+      });
+    });
+
+    return groups;
+  }, [supportMatrix]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -333,6 +382,44 @@ const TaxUploadModal = ({
                 <div className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-3">
                   <p className="text-sm text-cf-text-primary">{helperText}</p>
                 </div>
+
+                {supportMatrix.length > 0 ? (
+                  <section className="rounded border border-cf-border bg-cf-surface px-3 py-3" aria-label="Matriz de suporte documental">
+                    <div className="flex items-center justify-between gap-3">
+                      <p className="text-sm font-semibold text-cf-text-primary">Matriz real de suporte documental</p>
+                      {supportMatrixVersion ? (
+                        <span className="rounded border border-cf-border bg-cf-bg-subtle px-2 py-0.5 text-[11px] font-medium text-cf-text-secondary">
+                          v{supportMatrixVersion}
+                        </span>
+                      ) : null}
+                    </div>
+                    <p className="mt-1 text-xs text-cf-text-secondary">
+                      Transparência da fatia atual: suportado, restrito e não suportado.
+                    </p>
+
+                    <div className="mt-3 space-y-3">
+                      {(["supported", "restricted", "not_supported"] as const).map((level) => {
+                        const items = groupedSupportMatrix[level];
+
+                        return (
+                          <div key={level} className="rounded border border-cf-border bg-cf-bg-subtle px-3 py-2.5">
+                            <p className="text-xs font-semibold uppercase tracking-wide text-cf-text-primary">
+                              {SUPPORT_LEVEL_LABELS[level]} ({items.length})
+                            </p>
+                            <p className="mt-0.5 text-xs text-cf-text-secondary">{SUPPORT_LEVEL_HINTS[level]}</p>
+                            <p className="mt-1.5 text-xs text-cf-text-primary">
+                              {items.length > 0
+                                ? items
+                                    .map((item) => PREVIEW_DOCUMENT_TYPE_LABELS[item.documentType] ?? item.documentType)
+                                    .join("; ")
+                                : "Nenhum tipo nesta categoria."}
+                            </p>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </section>
+                ) : null}
 
                 <div className="flex flex-col gap-2">
                   <label htmlFor="tax-document-file" className="text-sm font-semibold text-cf-text-primary">

--- a/apps/web/src/components/TaxUploadModal.tsx
+++ b/apps/web/src/components/TaxUploadModal.tsx
@@ -75,6 +75,9 @@ const SUPPORT_LEVEL_HINTS: Record<string, string> = {
   not_supported: "Sem fluxo operacional nesta fatia do produto.",
 };
 
+const SUPPORT_MATRIX_UNAVAILABLE_MESSAGE =
+  "Matriz de suporte indisponível no momento. Siga com revisão manual: documentos podem ser bloqueados para extração e execução automática nesta fatia.";
+
 const extractFileExtension = (fileName: string) => {
   const lastDotIndex = fileName.lastIndexOf(".");
 
@@ -419,7 +422,16 @@ const TaxUploadModal = ({
                       })}
                     </div>
                   </section>
-                ) : null}
+                ) : (
+                  <section
+                    className="rounded border border-amber-200 bg-amber-50 px-3 py-3"
+                    role="alert"
+                    aria-label="Matriz de suporte indisponível"
+                  >
+                    <p className="text-sm font-semibold text-amber-800">Matriz de suporte indisponível</p>
+                    <p className="mt-1 text-xs text-amber-700">{SUPPORT_MATRIX_UNAVAILABLE_MESSAGE}</p>
+                  </section>
+                )}
 
                 <div className="flex flex-col gap-2">
                   <label htmlFor="tax-document-file" className="text-sm font-semibold text-cf-text-primary">

--- a/apps/web/src/pages/TaxPage.test.tsx
+++ b/apps/web/src/pages/TaxPage.test.tsx
@@ -15,6 +15,7 @@ import {
 
 vi.mock("../services/tax.service", () => ({
   taxService: {
+    getBootstrap: vi.fn(),
     listDocuments: vi.fn(),
     uploadDocument: vi.fn(),
     reprocessDocument: vi.fn(),
@@ -181,6 +182,36 @@ const renderPage = (
 describe("TaxPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(taxService.getBootstrap).mockResolvedValue({
+      module: "tax",
+      scope: "irpf_mvp",
+      apiVersion: "1.0.0-test",
+      documentSupportMatrixVersion: "2026-04-03.aud-001",
+      supportedTaxYears: [2026],
+      documentTypes: ["income_report_bank", "income_report_employer", "clt_payslip", "income_report_inss", "medical_statement", "education_receipt", "loan_statement", "bank_statement_support", "unknown"],
+      documentSupportMatrix: [
+        {
+          documentType: "income_report_bank",
+          sourceType: "income",
+          supportLevel: "supported",
+          supportsExtraction: true,
+          allowsSuggestion: true,
+          allowsExecution: true,
+        },
+        {
+          documentType: "bank_statement_support",
+          sourceType: "support",
+          supportLevel: "restricted",
+          supportsExtraction: false,
+          allowsSuggestion: true,
+          allowsExecution: false,
+        },
+      ],
+      documentProcessingStatuses: ["uploaded", "classified", "extracted", "normalized", "failed"],
+      factTypes: ["taxable_income"],
+      reviewStatuses: ["pending", "approved", "corrected", "rejected"],
+      ruleFamilies: ["obligation"],
+    });
     vi.mocked(taxService.listDocuments).mockResolvedValue({
       items: [buildDocument()],
       page: 1,

--- a/apps/web/src/pages/TaxPage.tsx
+++ b/apps/web/src/pages/TaxPage.tsx
@@ -5,6 +5,7 @@ import TaxManualFactModal from "../components/TaxManualFactModal";
 import { profileService } from "../services/profile.service";
 import {
   taxService,
+  type TaxDocumentSupportMatrixItem,
   type TaxDocument,
   type TaxDocumentDetail,
   type TaxDocumentsListResult,
@@ -477,6 +478,8 @@ const TaxPage = ({ onBack = undefined, onOpenProfileSettings = undefined }: TaxP
   const [uploadErrorMessage, setUploadErrorMessage] = useState("");
   const [uploadPreviewDocument, setUploadPreviewDocument] = useState<TaxDocumentDetail | null>(null);
   const [uploadPreviewFactCount, setUploadPreviewFactCount] = useState(0);
+  const [documentSupportMatrix, setDocumentSupportMatrix] = useState<TaxDocumentSupportMatrixItem[]>([]);
+  const [documentSupportMatrixVersion, setDocumentSupportMatrixVersion] = useState("");
   const [manualFactErrorMessage, setManualFactErrorMessage] = useState("");
   const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Guard: fire auto-sync at most once per mount (StrictMode + dep-change safety)
@@ -539,7 +542,7 @@ const TaxPage = ({ onBack = undefined, onOpenProfileSettings = undefined }: TaxP
     setIsLoadingPage(true);
     setPageError("");
 
-    const [summaryResult, obligationResult, documentsResult, factsResult, profileResult] = await Promise.allSettled([
+    const [summaryResult, obligationResult, documentsResult, factsResult, profileResult, bootstrapResult] = await Promise.allSettled([
       taxService.getSummary(taxYear),
       taxService.getObligation(taxYear),
       taxService.listDocuments({
@@ -554,6 +557,7 @@ const TaxPage = ({ onBack = undefined, onOpenProfileSettings = undefined }: TaxP
         pageSize: DEFAULT_FACTS_PAGE_SIZE,
       }),
       profileService.getMe(),
+      taxService.getBootstrap(),
     ]);
 
     const nextErrors: string[] = [];
@@ -595,6 +599,11 @@ const TaxPage = ({ onBack = undefined, onOpenProfileSettings = undefined }: TaxP
 
     if (profileResult.status === "fulfilled") {
       setTaxpayerCpf(profileResult.value.profile?.taxpayerCpf ?? null);
+    }
+
+    if (bootstrapResult.status === "fulfilled") {
+      setDocumentSupportMatrix(bootstrapResult.value.documentSupportMatrix);
+      setDocumentSupportMatrixVersion(bootstrapResult.value.documentSupportMatrixVersion);
     }
 
     setPageError(nextErrors[0] || "");
@@ -2102,6 +2111,8 @@ const TaxPage = ({ onBack = undefined, onOpenProfileSettings = undefined }: TaxP
         errorMessage={uploadErrorMessage}
         previewDocument={uploadPreviewDocument}
         previewFactCount={uploadPreviewFactCount}
+        supportMatrix={documentSupportMatrix}
+        supportMatrixVersion={documentSupportMatrixVersion}
         onClose={handleCloseUploadModal}
         onSubmit={handleUploadDocument}
         onConfirmPreview={handleConfirmUploadPreview}

--- a/apps/web/src/services/tax.service.ts
+++ b/apps/web/src/services/tax.service.ts
@@ -4,12 +4,36 @@ export type TaxFactReviewStatus = "pending" | "approved" | "corrected" | "reject
 export type TaxFactReviewAction = "approve" | "correct" | "reject";
 export type TaxExportFormat = "json" | "csv";
 export type TaxFactSourceFilter = "with_document" | "without_document";
+export type TaxDocumentSupportLevel = "supported" | "restricted" | "not_supported";
 export type TaxDocumentProcessingStatus =
   | "uploaded"
   | "classified"
   | "extracted"
   | "normalized"
   | "failed";
+
+export interface TaxDocumentSupportMatrixItem {
+  documentType: string;
+  sourceType: string;
+  supportLevel: TaxDocumentSupportLevel;
+  supportsExtraction: boolean;
+  allowsSuggestion: boolean;
+  allowsExecution: boolean;
+}
+
+export interface TaxBootstrap {
+  module: string;
+  scope: string;
+  apiVersion: string;
+  documentSupportMatrixVersion: string;
+  supportedTaxYears: number[];
+  documentTypes: string[];
+  documentSupportMatrix: TaxDocumentSupportMatrixItem[];
+  documentProcessingStatuses: string[];
+  factTypes: string[];
+  reviewStatuses: string[];
+  ruleFamilies: string[];
+}
 
 export interface TaxDocumentLatestExtraction {
   extractorName: string;
@@ -303,6 +327,30 @@ const normalizeNullableString = (value: unknown): string | null => {
   return normalizedValue || null;
 };
 
+const normalizeStringArray = (value: unknown): string[] =>
+  Array.isArray(value) ? value.map((item) => normalizeString(item)).filter(Boolean) : [];
+
+const normalizeNumberArray = (value: unknown): number[] =>
+  Array.isArray(value)
+    ? value
+        .map((item) => normalizeNumber(item))
+        .filter((item) => Number.isFinite(item))
+    : [];
+
+const normalizeTaxDocumentSupportLevel = (value: unknown): TaxDocumentSupportLevel => {
+  const normalizedValue = normalizeString(value);
+
+  if (
+    normalizedValue === "supported" ||
+    normalizedValue === "restricted" ||
+    normalizedValue === "not_supported"
+  ) {
+    return normalizedValue;
+  }
+
+  return "not_supported";
+};
+
 const normalizeObject = (value: unknown): Record<string, unknown> => {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return {};
@@ -336,6 +384,39 @@ const normalizeLatestExtraction = (value: unknown): TaxDocumentLatestExtraction 
       ? raw.warnings.map((warning) => normalizeString(warning)).filter(Boolean)
       : [],
     createdAt: normalizeNullableString(raw.createdAt),
+  };
+};
+
+const normalizeDocumentSupportMatrixItem = (value: unknown): TaxDocumentSupportMatrixItem => {
+  const raw = normalizeObject(value);
+
+  return {
+    documentType: normalizeString(raw.documentType),
+    sourceType: normalizeString(raw.sourceType),
+    supportLevel: normalizeTaxDocumentSupportLevel(raw.supportLevel),
+    supportsExtraction: Boolean(raw.supportsExtraction),
+    allowsSuggestion: Boolean(raw.allowsSuggestion),
+    allowsExecution: Boolean(raw.allowsExecution),
+  };
+};
+
+const normalizeTaxBootstrap = (value: unknown): TaxBootstrap => {
+  const raw = normalizeObject(value);
+
+  return {
+    module: normalizeString(raw.module),
+    scope: normalizeString(raw.scope),
+    apiVersion: normalizeString(raw.apiVersion),
+    documentSupportMatrixVersion: normalizeString(raw.documentSupportMatrixVersion),
+    supportedTaxYears: normalizeNumberArray(raw.supportedTaxYears),
+    documentTypes: normalizeStringArray(raw.documentTypes),
+    documentSupportMatrix: Array.isArray(raw.documentSupportMatrix)
+      ? raw.documentSupportMatrix.map(normalizeDocumentSupportMatrixItem)
+      : [],
+    documentProcessingStatuses: normalizeStringArray(raw.documentProcessingStatuses),
+    factTypes: normalizeStringArray(raw.factTypes),
+    reviewStatuses: normalizeStringArray(raw.reviewStatuses),
+    ruleFamilies: normalizeStringArray(raw.ruleFamilies),
   };
 };
 
@@ -676,6 +757,11 @@ const normalizeBlobApiError = async (error: unknown) => {
 };
 
 export const taxService = {
+  getBootstrap: async (): Promise<TaxBootstrap> => {
+    const { data } = await api.get("/tax");
+    return normalizeTaxBootstrap(data);
+  },
+
   listDocuments: async (params: {
     taxYear: number;
     status?: TaxDocumentProcessingStatus;


### PR DESCRIPTION
## Contexto
Entrega da AUD-001 com escopo estrito: explicitar a verdade de produto sobre suporte documental (suportado/restrito/nao suportado), sem ampliar promessa funcional.

## O que mudou
- API: matriz de suporte documental versionada exposta em `GET /tax` (`documentSupportMatrixVersion` + `documentSupportMatrix`).
- API: preview passa a reutilizar a mesma politica/mapeamento centralizado para evitar drift de contrato.
- Web: consumo do bootstrap fiscal (`taxService.getBootstrap`) e repasse da matriz para o modal de upload.
- UX: modal de envio fiscal agora mostra matriz real de suporte com categorias explicitas: Suportado / Restrito / Nao suportado.
- Testes: cobertura adicionada/atualizada para contrato e UX.

## Escopo fora
- Sem expansao de parser para boleto generico (AUD-005).
- Sem mudanca de runtime OCR (AUD-007).

## Validacao executada
- `npm -w apps/api run test:run -- src/tax.test.js -t "catalogo inicial do dominio fiscal"`
- `npm -w apps/web run test:run -- src/components/TaxUploadModal.test.tsx src/pages/TaxPage.test.tsx`

## Critério de aceite atendido
- Contrato de suporte versionado e visivel no bootstrap.
- UX explicita com suporte/restricao/nao-suporte na tela de envio fiscal.
- Coerencia FE/BE reduzindo risco de promessa implicita divergente.
