### PR TITLE
AUD-002: hard fail de JWT no bootstrap/config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,10 @@ VITE_API_URL=http://localhost:3001
 # apps/api/.env
 PORT=3001
 NODE_ENV=development
-JWT_SECRET=troque-isto
+# JWT hardening:
+# - production exige segredo explicito, nao-placeholder e com 32+ caracteres
+# - local/test (sem valor) usa fallback deterministico somente para desenvolvimento
+JWT_SECRET=troque-isto-por-um-segredo-com-32-ou-mais-caracteres
 JWT_EXPIRES_IN=24h
 TRUST_PROXY=1
 # Exemplo local:

--- a/README.md
+++ b/README.md
@@ -212,6 +212,11 @@ CORS_ORIGIN=http://localhost:5173
 TRUST_PROXY=1
 ```
 
+Regras de JWT:
+
+* em `production`, o boot falha se `JWT_SECRET` estiver ausente, placeholder ou com menos de 32 caracteres
+* em `development/test`, sem `JWT_SECRET` explicito o runtime usa fallback deterministico apenas para manter ambiente local/CI previsivel
+
 ### Hardening de auth
 
 ```env

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -4,7 +4,10 @@ NODE_ENV=development
 # APP_VERSION=1.6.3
 # APP_COMMIT=2eb3f64
 # Render auto-populates RENDER_GIT_COMMIT (version fallback: sha-<commit-curto>)
-JWT_SECRET=troque-isto
+# JWT hardening:
+# - production exige segredo explicito, nao-placeholder e com 32+ caracteres
+# - local/test (sem valor) usa fallback deterministico somente para desenvolvimento
+JWT_SECRET=troque-isto-por-um-segredo-com-32-ou-mais-caracteres
 JWT_EXPIRES_IN=24h
 TRUST_PROXY=1
 # Exemplo local:

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -2,6 +2,7 @@ import express from "express";
 import cors from "cors";
 import cookieParser from "cookie-parser";
 import dotenv from "dotenv";
+import { assertJwtEnvironmentConsistency } from "./config/jwt-env-guard.js";
 import healthRoutes from "./routes/health.routes.js";
 import metricsRoutes from "./routes/metrics.routes.js";
 import authRoutes from "./routes/auth.routes.js";
@@ -30,6 +31,7 @@ import { requestLoggingMiddleware } from "./middlewares/request-logging.middlewa
 import { httpMetricsMiddleware } from "./observability/http-metrics.js";
 
 dotenv.config();
+assertJwtEnvironmentConsistency();
 
 const app = express();
 

--- a/apps/api/src/config/jwt-env-guard.js
+++ b/apps/api/src/config/jwt-env-guard.js
@@ -1,0 +1,85 @@
+const normalizeEnvValue = (value) =>
+  typeof value === "string" ? value.trim().toLowerCase() : "";
+
+const normalizeSecretValue = (value) =>
+  typeof value === "string" ? value.trim() : "";
+
+const MIN_PRODUCTION_JWT_SECRET_LENGTH = 32;
+const DEFAULT_DEV_JWT_SECRET = "control-finance-dev-only-jwt-secret";
+const DEFAULT_TEST_JWT_SECRET = "control-finance-test-only-jwt-secret";
+
+const PLACEHOLDER_SECRETS = new Set([
+  "secret",
+  "default",
+  "changeme",
+  "change-me",
+  "troque-isto",
+  "your_jwt_secret",
+  "jwt_secret",
+  "control-finance-dev-secret",
+  DEFAULT_DEV_JWT_SECRET,
+  DEFAULT_TEST_JWT_SECRET,
+]);
+
+const createJwtEnvError = (message, code = "JWT_SECRET_INVALID") => {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+};
+
+const isPlaceholderSecret = (secret) => {
+  const normalizedSecret = normalizeEnvValue(secret);
+
+  if (!normalizedSecret) {
+    return true;
+  }
+
+  if (PLACEHOLDER_SECRETS.has(normalizedSecret)) {
+    return true;
+  }
+
+  return normalizedSecret.includes("changeme") || normalizedSecret.includes("troque");
+};
+
+const resolveDefaultSecretForNodeEnv = (nodeEnv) =>
+  nodeEnv === "test" ? DEFAULT_TEST_JWT_SECRET : DEFAULT_DEV_JWT_SECRET;
+
+export const resolveJwtSecretForRuntime = (env = process.env) => {
+  const nodeEnv = normalizeEnvValue(env.NODE_ENV || "development");
+  const configuredSecret = normalizeSecretValue(env.JWT_SECRET || "");
+
+  if (nodeEnv === "production") {
+    if (!configuredSecret) {
+      throw createJwtEnvError(
+        "Invalid JWT environment: NODE_ENV=production requires JWT_SECRET to be explicitly configured.",
+        "JWT_SECRET_MISSING",
+      );
+    }
+
+    if (isPlaceholderSecret(configuredSecret)) {
+      throw createJwtEnvError(
+        "Invalid JWT environment: NODE_ENV=production does not allow placeholder/default JWT_SECRET values.",
+      );
+    }
+
+    if (configuredSecret.length < MIN_PRODUCTION_JWT_SECRET_LENGTH) {
+      throw createJwtEnvError(
+        `Invalid JWT environment: NODE_ENV=production requires JWT_SECRET with at least ${MIN_PRODUCTION_JWT_SECRET_LENGTH} characters.`,
+      );
+    }
+
+    return configuredSecret;
+  }
+
+  if (configuredSecret) {
+    return configuredSecret;
+  }
+
+  const fallbackSecret = resolveDefaultSecretForNodeEnv(nodeEnv);
+  env.JWT_SECRET = fallbackSecret;
+  return fallbackSecret;
+};
+
+export const assertJwtEnvironmentConsistency = (env = process.env) => {
+  resolveJwtSecretForRuntime(env);
+};

--- a/apps/api/src/config/jwt-env-guard.test.js
+++ b/apps/api/src/config/jwt-env-guard.test.js
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertJwtEnvironmentConsistency,
+  resolveJwtSecretForRuntime,
+} from "./jwt-env-guard.js";
+
+describe("jwt env guard", () => {
+  it("falha em producao sem JWT_SECRET", () => {
+    expect(() =>
+      assertJwtEnvironmentConsistency({
+        NODE_ENV: "production",
+      }),
+    ).toThrow("NODE_ENV=production requires JWT_SECRET");
+  });
+
+  it("falha em producao com placeholder", () => {
+    expect(() =>
+      assertJwtEnvironmentConsistency({
+        NODE_ENV: "production",
+        JWT_SECRET: "troque-isto",
+      }),
+    ).toThrow("does not allow placeholder/default JWT_SECRET");
+  });
+
+  it("falha em producao com segredo curto", () => {
+    expect(() =>
+      assertJwtEnvironmentConsistency({
+        NODE_ENV: "production",
+        JWT_SECRET: "abc123",
+      }),
+    ).toThrow("requires JWT_SECRET with at least 32 characters");
+  });
+
+  it("aceita producao com segredo valido", () => {
+    expect(() =>
+      assertJwtEnvironmentConsistency({
+        NODE_ENV: "production",
+        JWT_SECRET: "prod-super-secret-jwt-key-with-32-plus",
+      }),
+    ).not.toThrow();
+  });
+
+  it("define fallback deterministico em test quando JWT_SECRET nao existe", () => {
+    const env = {
+      NODE_ENV: "test",
+    };
+
+    const secret = resolveJwtSecretForRuntime(env);
+
+    expect(secret).toBe("control-finance-test-only-jwt-secret");
+    expect(env.JWT_SECRET).toBe("control-finance-test-only-jwt-secret");
+  });
+
+  it("define fallback deterministico em development quando JWT_SECRET nao existe", () => {
+    const env = {
+      NODE_ENV: "development",
+    };
+
+    const secret = resolveJwtSecretForRuntime(env);
+
+    expect(secret).toBe("control-finance-dev-only-jwt-secret");
+    expect(env.JWT_SECRET).toBe("control-finance-dev-only-jwt-secret");
+  });
+});

--- a/apps/api/src/me.test.js
+++ b/apps/api/src/me.test.js
@@ -108,9 +108,11 @@ describe("GET /me", () => {
     // Get token by logging via the profile directly (no password, use the google-only route manually)
     // We test by directly checking the service behavior via GET /me using a valid JWT
     const jwt = await import("jsonwebtoken");
+    const jwtSecret = String(process.env.JWT_SECRET || "");
+    expect(jwtSecret.length).toBeGreaterThan(0);
     const token = jwt.default.sign(
       { sub: String(userId), email },
-      process.env.JWT_SECRET || "control-finance-dev-secret",
+      jwtSecret,
       { expiresIn: "1h" },
     );
 

--- a/apps/api/src/paywall.test.js
+++ b/apps/api/src/paywall.test.js
@@ -299,18 +299,20 @@ describe("paywall bypass (PAYWALL_BYPASS_ENABLED)", () => {
   });
 
   it("bypass NAO se aplica quando NODE_ENV=production", async () => {
-    const token = await registerAndLogin(BYPASS_EMAIL);
-    const userId = await getUserIdByEmail(BYPASS_EMAIL);
-    await dbQuery(`UPDATE users SET trial_ends_at = NOW() - INTERVAL '1 day' WHERE id = $1`, [userId]);
-
     const originalEnabled = process.env.PAYWALL_BYPASS_ENABLED;
     const originalEmails  = process.env.PAYWALL_BYPASS_EMAILS;
     const originalEnv     = process.env.NODE_ENV;
+    const originalJwtSecret = process.env.JWT_SECRET;
     process.env.PAYWALL_BYPASS_ENABLED = "true";
     process.env.PAYWALL_BYPASS_EMAILS  = BYPASS_EMAIL;
     process.env.NODE_ENV = "production";
+    process.env.JWT_SECRET = "control-finance-production-jwt-secret-123456";
 
     try {
+      const token = await registerAndLogin(BYPASS_EMAIL);
+      const userId = await getUserIdByEmail(BYPASS_EMAIL);
+      await dbQuery(`UPDATE users SET trial_ends_at = NOW() - INTERVAL '1 day' WHERE id = $1`, [userId]);
+
       const res = await request(testApp)
         .get("/trial-gated")
         .set("Authorization", `Bearer ${token}`);
@@ -319,6 +321,7 @@ describe("paywall bypass (PAYWALL_BYPASS_ENABLED)", () => {
       process.env.PAYWALL_BYPASS_ENABLED = originalEnabled;
       process.env.PAYWALL_BYPASS_EMAILS  = originalEmails;
       process.env.NODE_ENV = originalEnv;
+      process.env.JWT_SECRET = originalJwtSecret;
     }
   });
 });

--- a/apps/api/src/server.js
+++ b/apps/api/src/server.js
@@ -1,4 +1,5 @@
 import app from "./app.js";
+import { assertJwtEnvironmentConsistency } from "./config/jwt-env-guard.js";
 import { assertStripeEnvironmentConsistency } from "./config/stripe-env-guard.js";
 import { getDatabaseConnectionDiagnostics } from "./db/index.js";
 import { runMigrations } from "./db/migrate.js";
@@ -8,6 +9,7 @@ import { logError, logInfo } from "./observability/logger.js";
 const port = Number(process.env.PORT) || 3001;
 
 const startServer = async () => {
+  assertJwtEnvironmentConsistency();
   assertStripeEnvironmentConsistency();
   await runMigrations();
   startImportSessionsCleanupJob();

--- a/apps/api/src/services/auth.service.js
+++ b/apps/api/src/services/auth.service.js
@@ -2,9 +2,9 @@ import { randomBytes, createHash, randomUUID } from "node:crypto";
 import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
 import { OAuth2Client } from "google-auth-library";
+import { resolveJwtSecretForRuntime } from "../config/jwt-env-guard.js";
 import { dbQuery } from "../db/index.js";
 
-const DEFAULT_JWT_SECRET = "control-finance-dev-secret";
 const DEFAULT_ACCESS_TOKEN_EXPIRES_IN = "15m";
 const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d).{8,}$/;
 const WEAK_PASSWORD_MESSAGE =
@@ -22,7 +22,7 @@ const sanitizeUser = (user) => ({
   email: user.email,
 });
 
-const getJwtSecret = () => process.env.JWT_SECRET || DEFAULT_JWT_SECRET;
+const getJwtSecret = () => resolveJwtSecretForRuntime(process.env);
 
 const getAccessTokenExpiresIn = () =>
   process.env.ACCESS_TOKEN_EXPIRES_IN ||


### PR DESCRIPTION
## Contexto
AUD-002 (P0): hard fail de JWT no bootstrap/config, removendo fallback inseguro no auth service sem quebrar previsibilidade de dev/test/CI.

## O que mudou
- Novo guard de ambiente: `apps/api/src/config/jwt-env-guard.js`.
- Regra de produção (`NODE_ENV=production`):
  - falha se `JWT_SECRET` ausente;
  - falha para placeholders/defaults óbvios;
  - falha se segredo tiver menos de 32 caracteres.
- Non-production (`development/test`):
  - sem `JWT_SECRET`, aplica fallback determinístico controlado para manter ambiente local/CI previsível.
- Bootstrap endurecido:
  - `assertJwtEnvironmentConsistency()` executado no bootstrap da app e no startup do server.
- Auth service:
  - removido fallback permissivo local;
  - segredo JWT agora resolvido exclusivamente via guard central.
- Testes:
  - suíte dedicada para o guard de JWT cobrindo produção e non-production.
  - ajuste em `me.test.js` para uso explícito do segredo ativo.
- Documentação/env:
  - atualização em `.env.example`, `apps/api/.env.example` e README com regra operacional de JWT.

## Escopo fora
- Sem alterações de contrato HTTP além do endurecimento de startup/config.
- Sem mudanças de flows de refresh/login além da origem do segredo JWT.

## Validação executada
- `npm -w apps/api run test:run -- src/config/jwt-env-guard.test.js src/me.test.js src/auth.test.js`

## Critério de aceite atendido
- Produção não sobe sem `JWT_SECRET` explícito e válido.
- Fallback permissivo removido do auth service.
- Dev/test permanecem determinísticos e operacionais.
- Testes cobrem hard fail de produção e comportamento non-production.
