### PR TITLE
AUD-003 (fase A): contrato, politica e adapter para storage sensivel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,9 @@ CORS_ORIGIN=http://localhost:5173
 # Enable only on hosts with at least 1GB RAM available to the API service.
 IMPORT_OCR_ENABLED=false
 # Central do Leão (IRPF)
+# Storage adapter policy (AUD-003 fase A): keep local until explicit cutover plan.
+# Supported values: local
+# TAX_DOCUMENTS_STORAGE_ADAPTER=local
 # Persist fiscal uploads outside the temp directory in production.
 # TAX_DOCUMENTS_STORAGE_DIR=/var/data/control-finance/tax-documents
 # Optional max upload size in bytes (default: 10 MB)

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ AUTH_RATE_LIMIT_WINDOW_MS=
 AUTH_BRUTE_FORCE_MAX_ATTEMPTS=
 AUTH_BRUTE_FORCE_WINDOW_MS=
 AUTH_BRUTE_FORCE_LOCK_MS=
+TAX_DOCUMENTS_STORAGE_ADAPTER=local
 TAX_DOCUMENTS_STORAGE_DIR=
 TAX_DOCUMENT_MAX_FILE_SIZE_BYTES=10485760
 ```
@@ -276,6 +277,7 @@ Configuração recomendada:
 * login e registro funcionam
 * `VITE_API_URL` aponta para a API pública
 * `ANTHROPIC_API_KEY` está configurada na API se a camada de IA estiver habilitada
+* `TAX_DOCUMENTS_STORAGE_ADAPTER` permanece `local` ate existir plano explicito de cutover
 * `TAX_DOCUMENTS_STORAGE_DIR` aponta para storage persistente se a Central do Leão estiver habilitada em produção
 
 ## Scripts

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -49,6 +49,9 @@ AUTH_BRUTE_FORCE_LOCK_MS=900000
 # AI_RATE_LIMIT_MAX=10
 # AI_RATE_LIMIT_WINDOW_MS=600000
 # Central do Leão (IRPF)
+# Storage adapter policy (AUD-003 fase A): keep local until explicit cutover plan.
+# Supported values: local
+# TAX_DOCUMENTS_STORAGE_ADAPTER=local
 # Persist fiscal uploads outside the temp directory in production.
 # TAX_DOCUMENTS_STORAGE_DIR=/var/data/control-finance/tax-documents
 # Optional max upload size in bytes (default: 10 MB)

--- a/apps/api/src/services/tax-document-storage-local.adapter.js
+++ b/apps/api/src/services/tax-document-storage-local.adapter.js
@@ -1,0 +1,50 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { normalizeTaxDocumentStorageSegments } from "./tax-document-storage.policy.js";
+
+const DEFAULT_STORAGE_DIR = path.join(os.tmpdir(), "control-finance", "tax-documents");
+
+export const resolveLocalTaxDocumentsStorageDir = (env = process.env) => {
+  const configuredDirectory = String(env.TAX_DOCUMENTS_STORAGE_DIR || "").trim();
+
+  if (!configuredDirectory) {
+    return DEFAULT_STORAGE_DIR;
+  }
+
+  return path.resolve(configuredDirectory);
+};
+
+export const createLocalTaxDocumentStorageAdapter = (env = process.env) => {
+  const resolveAbsolutePath = (storageKey) => {
+    const storageRoot = resolveLocalTaxDocumentsStorageDir(env);
+    const segments = normalizeTaxDocumentStorageSegments(storageKey);
+
+    return path.join(storageRoot, ...segments);
+  };
+
+  return {
+    name: "local",
+    resolveAbsolutePath,
+    async saveDocument({ storageKey, buffer }) {
+      const absolutePath = resolveAbsolutePath(storageKey);
+      await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+      await fs.writeFile(absolutePath, buffer);
+      return { absolutePath };
+    },
+    async readDocument({ storageKey }) {
+      return fs.readFile(resolveAbsolutePath(storageKey));
+    },
+    async deleteDocument({ storageKey }) {
+      const absolutePath = resolveAbsolutePath(storageKey);
+
+      try {
+        await fs.unlink(absolutePath);
+      } catch (error) {
+        if (error?.code !== "ENOENT") {
+          throw error;
+        }
+      }
+    },
+  };
+};

--- a/apps/api/src/services/tax-document-storage.policy.js
+++ b/apps/api/src/services/tax-document-storage.policy.js
@@ -1,0 +1,67 @@
+const sanitizeEnvValue = (value) =>
+  typeof value === "string" ? value.trim().toLowerCase() : "";
+
+const STORAGE_KEY_SEGMENT_REGEX = /^[a-zA-Z0-9._-]{1,120}$/;
+const MAX_STORAGE_KEY_SEGMENTS = 8;
+const MAX_STORAGE_KEY_LENGTH = 512;
+
+export const TAX_DOCUMENT_STORAGE_POLICY_VERSION = "aud-003-phase-a-v1";
+export const TAX_DOCUMENT_STORAGE_ADAPTER_LOCAL = "local";
+export const TAX_DOCUMENT_STORAGE_DEFAULT_ADAPTER = TAX_DOCUMENT_STORAGE_ADAPTER_LOCAL;
+export const TAX_DOCUMENT_STORAGE_SUPPORTED_ADAPTERS = new Set([
+  TAX_DOCUMENT_STORAGE_ADAPTER_LOCAL,
+]);
+
+export const sanitizeTaxDocumentFileExtension = (originalFileName) => {
+  const extension = (String(originalFileName || "").match(/\.[^./\\]+$/)?.[0] || "").toLowerCase();
+
+  if (!extension) {
+    return ".bin";
+  }
+
+  return /^[.][a-z0-9]{1,10}$/.test(extension) ? extension : ".bin";
+};
+
+export const normalizeTaxDocumentStorageSegments = (storageKey) => {
+  const normalizedKey = String(storageKey || "").replaceAll("\\", "/");
+
+  if (!normalizedKey || normalizedKey.length > MAX_STORAGE_KEY_LENGTH) {
+    throw new Error("storageKey invalido.");
+  }
+
+  const segments = normalizedKey.split("/").filter(Boolean);
+
+  if (segments.length === 0 || segments.length > MAX_STORAGE_KEY_SEGMENTS) {
+    throw new Error("storageKey invalido.");
+  }
+
+  if (
+    segments.some(
+      (segment) =>
+        segment === "." ||
+        segment === ".." ||
+        !STORAGE_KEY_SEGMENT_REGEX.test(segment),
+    )
+  ) {
+    throw new Error("storageKey invalido.");
+  }
+
+  return segments;
+};
+
+export const resolveTaxDocumentStorageAdapterName = (env = process.env) => {
+  const rawAdapterName = sanitizeEnvValue(
+    env.TAX_DOCUMENTS_STORAGE_ADAPTER || TAX_DOCUMENT_STORAGE_DEFAULT_ADAPTER,
+  );
+
+  const adapterName = rawAdapterName || TAX_DOCUMENT_STORAGE_DEFAULT_ADAPTER;
+
+  if (!TAX_DOCUMENT_STORAGE_SUPPORTED_ADAPTERS.has(adapterName)) {
+    const supportedValues = [...TAX_DOCUMENT_STORAGE_SUPPORTED_ADAPTERS].join(", ");
+    throw new Error(
+      `Unsupported TAX_DOCUMENTS_STORAGE_ADAPTER '${adapterName}'. Supported values: ${supportedValues}.`,
+    );
+  }
+
+  return adapterName;
+};

--- a/apps/api/src/services/tax-document-storage.service.js
+++ b/apps/api/src/services/tax-document-storage.service.js
@@ -1,38 +1,74 @@
-import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
+import { trackDomainFlowError, trackDomainFlowSuccess } from "../observability/domain-metrics.js";
+import {
+  TAX_DOCUMENT_STORAGE_ADAPTER_LOCAL,
+  TAX_DOCUMENT_STORAGE_POLICY_VERSION,
+  TAX_DOCUMENT_STORAGE_SUPPORTED_ADAPTERS,
+  resolveTaxDocumentStorageAdapterName,
+  sanitizeTaxDocumentFileExtension,
+} from "./tax-document-storage.policy.js";
+import {
+  createLocalTaxDocumentStorageAdapter,
+  resolveLocalTaxDocumentsStorageDir,
+} from "./tax-document-storage-local.adapter.js";
 
-const DEFAULT_STORAGE_DIR = path.join(os.tmpdir(), "control-finance", "tax-documents");
+const STORAGE_FLOW = "tax_documents_storage";
 
-const sanitizeFileExtension = (originalFileName) => {
-  const extension = path.extname(String(originalFileName || "")).toLowerCase();
+const assertStorageAdapterContract = (adapter, adapterName) => {
+  const requiredMethods = [
+    "resolveAbsolutePath",
+    "saveDocument",
+    "readDocument",
+    "deleteDocument",
+  ];
 
-  if (!extension) {
-    return ".bin";
+  for (const methodName of requiredMethods) {
+    if (typeof adapter?.[methodName] !== "function") {
+      throw new Error(
+        `Invalid tax storage adapter '${adapterName}': missing method '${methodName}'.`,
+      );
+    }
   }
 
-  return /^[.][a-z0-9]{1,10}$/.test(extension) ? extension : ".bin";
+  return adapter;
 };
 
-const normalizeStorageSegments = (storageKey) => {
-  const normalizedKey = String(storageKey || "").replaceAll("\\", "/");
-  const segments = normalizedKey.split("/").filter(Boolean);
-
-  if (segments.some((segment) => segment === "." || segment === "..")) {
-    throw new Error("storageKey invalido.");
+const createStorageAdapter = (adapterName, env = process.env) => {
+  if (adapterName === TAX_DOCUMENT_STORAGE_ADAPTER_LOCAL) {
+    return createLocalTaxDocumentStorageAdapter(env);
   }
 
-  return segments;
+  throw new Error(
+    `Unsupported TAX_DOCUMENTS_STORAGE_ADAPTER '${adapterName}'. Supported values: ${[
+      ...TAX_DOCUMENT_STORAGE_SUPPORTED_ADAPTERS,
+    ].join(", ")}.`,
+  );
 };
 
-export const resolveTaxDocumentsStorageDir = () => {
-  const configuredDirectory = String(process.env.TAX_DOCUMENTS_STORAGE_DIR || "").trim();
+const resolveTaxDocumentStorageAdapter = (env = process.env) => {
+  const adapterName = resolveTaxDocumentStorageAdapterName(env);
+  const adapter = assertStorageAdapterContract(createStorageAdapter(adapterName, env), adapterName);
 
-  if (!configuredDirectory) {
-    return DEFAULT_STORAGE_DIR;
+  return {
+    adapterName,
+    adapter,
+  };
+};
+
+export const resolveTaxDocumentStoragePolicy = (env = process.env) => ({
+  version: TAX_DOCUMENT_STORAGE_POLICY_VERSION,
+  adapterName: resolveTaxDocumentStorageAdapterName(env),
+  supportedAdapters: [...TAX_DOCUMENT_STORAGE_SUPPORTED_ADAPTERS],
+});
+
+export const resolveTaxDocumentsStorageDir = (env = process.env) => {
+  const adapterName = resolveTaxDocumentStorageAdapterName(env);
+
+  if (adapterName === TAX_DOCUMENT_STORAGE_ADAPTER_LOCAL) {
+    return resolveLocalTaxDocumentsStorageDir(env);
   }
 
-  return path.resolve(configuredDirectory);
+  return path.resolve(resolveLocalTaxDocumentsStorageDir(env));
 };
 
 export const buildTaxDocumentStorageDescriptor = ({
@@ -40,7 +76,7 @@ export const buildTaxDocumentStorageDescriptor = ({
   sha256,
   originalFileName,
 }) => {
-  const storedFileName = `${sha256}${sanitizeFileExtension(originalFileName)}`;
+  const storedFileName = `${sha256}${sanitizeTaxDocumentFileExtension(originalFileName)}`;
   const storageKey = path.posix.join(String(userId), storedFileName);
 
   return {
@@ -50,10 +86,8 @@ export const buildTaxDocumentStorageDescriptor = ({
 };
 
 export const resolveTaxDocumentAbsolutePath = (storageKey) => {
-  const storageRoot = resolveTaxDocumentsStorageDir();
-  const segments = normalizeStorageSegments(storageKey);
-
-  return path.join(storageRoot, ...segments);
+  const { adapter } = resolveTaxDocumentStorageAdapter();
+  return adapter.resolveAbsolutePath(storageKey);
 };
 
 export const saveTaxDocumentBuffer = async ({
@@ -62,35 +96,55 @@ export const saveTaxDocumentBuffer = async ({
   originalFileName,
   buffer,
 }) => {
+  const { adapter } = resolveTaxDocumentStorageAdapter();
   const descriptor = buildTaxDocumentStorageDescriptor({
     userId,
     sha256,
     originalFileName,
   });
-  const absolutePath = resolveTaxDocumentAbsolutePath(descriptor.storageKey);
 
-  await fs.mkdir(path.dirname(absolutePath), { recursive: true });
-  await fs.writeFile(absolutePath, buffer);
+  try {
+    const persisted = await adapter.saveDocument({
+      storageKey: descriptor.storageKey,
+      buffer,
+    });
 
-  return {
-    ...descriptor,
-    absolutePath,
-  };
+    trackDomainFlowSuccess({ flow: STORAGE_FLOW, operation: "save" });
+
+    return {
+      ...descriptor,
+      absolutePath:
+        typeof persisted?.absolutePath === "string"
+          ? persisted.absolutePath
+          : adapter.resolveAbsolutePath(descriptor.storageKey),
+    };
+  } catch (error) {
+    trackDomainFlowError({ flow: STORAGE_FLOW, operation: "save" });
+    throw error;
+  }
 };
 
 export const readStoredTaxDocumentBuffer = async (storageKey) => {
-  const absolutePath = resolveTaxDocumentAbsolutePath(storageKey);
-  return fs.readFile(absolutePath);
+  const { adapter } = resolveTaxDocumentStorageAdapter();
+
+  try {
+    const buffer = await adapter.readDocument({ storageKey });
+    trackDomainFlowSuccess({ flow: STORAGE_FLOW, operation: "read" });
+    return buffer;
+  } catch (error) {
+    trackDomainFlowError({ flow: STORAGE_FLOW, operation: "read" });
+    throw error;
+  }
 };
 
 export const deleteStoredTaxDocument = async (storageKey) => {
-  const absolutePath = resolveTaxDocumentAbsolutePath(storageKey);
+  const { adapter } = resolveTaxDocumentStorageAdapter();
 
   try {
-    await fs.unlink(absolutePath);
+    await adapter.deleteDocument({ storageKey });
+    trackDomainFlowSuccess({ flow: STORAGE_FLOW, operation: "delete" });
   } catch (error) {
-    if (error?.code !== "ENOENT") {
-      throw error;
-    }
+    trackDomainFlowError({ flow: STORAGE_FLOW, operation: "delete" });
+    throw error;
   }
 };

--- a/apps/api/src/services/tax-document-storage.service.test.js
+++ b/apps/api/src/services/tax-document-storage.service.test.js
@@ -1,0 +1,110 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  buildTaxDocumentStorageDescriptor,
+  deleteStoredTaxDocument,
+  readStoredTaxDocumentBuffer,
+  resolveTaxDocumentAbsolutePath,
+  resolveTaxDocumentStoragePolicy,
+  saveTaxDocumentBuffer,
+} from "./tax-document-storage.service.js";
+
+const TEST_STORAGE_DIR = path.join(
+  os.tmpdir(),
+  "control-finance-tax-documents-storage-service-tests",
+);
+
+const ENV_KEYS = [
+  "TAX_DOCUMENTS_STORAGE_DIR",
+  "TAX_DOCUMENTS_STORAGE_ADAPTER",
+];
+
+const envSnapshot = {};
+
+const restoreEnv = () => {
+  for (const key of ENV_KEYS) {
+    if (typeof envSnapshot[key] === "undefined") {
+      delete process.env[key];
+    } else {
+      process.env[key] = envSnapshot[key];
+    }
+  }
+};
+
+describe("tax-document-storage.service", () => {
+  beforeEach(async () => {
+    for (const key of ENV_KEYS) {
+      envSnapshot[key] = process.env[key];
+    }
+
+    process.env.TAX_DOCUMENTS_STORAGE_DIR = TEST_STORAGE_DIR;
+    delete process.env.TAX_DOCUMENTS_STORAGE_ADAPTER;
+
+    await fs.rm(TEST_STORAGE_DIR, { recursive: true, force: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(TEST_STORAGE_DIR, { recursive: true, force: true });
+    restoreEnv();
+  });
+
+  it("expoe politica de storage com adapter local por padrao", () => {
+    const policy = resolveTaxDocumentStoragePolicy();
+
+    expect(policy).toMatchObject({
+      version: "aud-003-phase-a-v1",
+      adapterName: "local",
+    });
+    expect(policy.supportedAdapters).toContain("local");
+  });
+
+  it("rejeita adapter nao suportado", () => {
+    process.env.TAX_DOCUMENTS_STORAGE_ADAPTER = "blob";
+
+    expect(() => resolveTaxDocumentStoragePolicy()).toThrow(
+      "Unsupported TAX_DOCUMENTS_STORAGE_ADAPTER",
+    );
+  });
+
+  it("mantem contrato de descriptor e saneia extensao insegura", () => {
+    const descriptor = buildTaxDocumentStorageDescriptor({
+      userId: 99,
+      sha256: "a".repeat(64),
+      originalFileName: "arquivo.exe;rm -rf",
+    });
+
+    expect(descriptor.storedFileName).toBe(`${"a".repeat(64)}.bin`);
+    expect(descriptor.storageKey).toBe(`99/${"a".repeat(64)}.bin`);
+  });
+
+  it("salva, le e remove documento com adapter local", async () => {
+    const payload = Buffer.from("fiscal-document-content", "utf8");
+
+    const stored = await saveTaxDocumentBuffer({
+      userId: 7,
+      sha256: "b".repeat(64),
+      originalFileName: "documento.pdf",
+      buffer: payload,
+    });
+
+    expect(stored.storageKey).toBe(`7/${"b".repeat(64)}.pdf`);
+    expect(stored.absolutePath).toBe(resolveTaxDocumentAbsolutePath(stored.storageKey));
+
+    const loaded = await readStoredTaxDocumentBuffer(stored.storageKey);
+    expect(Buffer.compare(loaded, payload)).toBe(0);
+
+    await deleteStoredTaxDocument(stored.storageKey);
+
+    await expect(readStoredTaxDocumentBuffer(stored.storageKey)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("bloqueia path traversal no storageKey", () => {
+    expect(() => resolveTaxDocumentAbsolutePath("../escape.txt")).toThrow(
+      "storageKey invalido",
+    );
+  });
+});


### PR DESCRIPTION
## Contexto
Implementa a fase A obrigatoria da AUD-003 (storage sensivel hardening) com escopo estrito: contrato/politica/adapter.

## Escopo desta fatia (fase A)
- contrato explicito de adapter de storage para documentos fiscais
- politica versionada de storage (adapter suportado + validacao de storageKey)
- adapter local separado e selecionado por configuracao (TAX_DOCUMENTS_STORAGE_ADAPTER, default local)
- instrumentacao de metricas de operacoes save/read/delete no fluxo de storage
- docs/env atualizados para explicitar guardrail de cutover

## Fora de escopo (fase B)
- cutover para backend remoto (blob/s3/etc)
- migracao de artefatos existentes
- alteracao de runtime para strategy multi-backend em producao

Se o cutover crescer, abrir AUD-003B (nao expandir esta PR).

## Owner
- platform + security + api (execucao: @JrValerio)

## Rollback
- rollback limpo por revert do commit desta PR
- TAX_DOCUMENTS_STORAGE_ADAPTER permanece local por padrao (sem cutover)

## Criterio verificavel
- contrato/politica/adapter presentes no codigo
- testes de save/read/delete via adapter
- suite fiscal principal sem regressao
- sem alteracao de comportamento de upload atual

## Dependencia de infraestrutura
- fase A: nenhuma nova dependencia obrigatoria
- futuras fases de cutover: exigem plano explicito de infraestrutura + rollback

## Validacao executada
- npm --prefix apps/api run lint
- npm --prefix apps/api run test -- src/services/tax-document-storage.service.test.js
- npm --prefix apps/api run test -- src/tax.test.js