### PR TITLE
fix(security): minimize sensitive raw excerpt persistence in document metadata

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,11 @@ IMPORT_OCR_ENABLED=false
 # TAX_DOCUMENTS_STORAGE_DIR=/var/data/control-finance/tax-documents
 # Optional max upload size in bytes (default: 10 MB)
 # TAX_DOCUMENT_MAX_FILE_SIZE_BYTES=10485760
+# AUD-004: redige previews textuais sensiveis de raw_json.classification no momento da persistencia.
+# true (default): remove textPreviewLines de tax_document_extractions.raw_json.classification
+# false: rollback controlado para comportamento legado sem redacao
+# Em producao, usar false apenas de forma excepcional, temporaria e com registro operacional.
+# TAX_SENSITIVE_EXCERPT_REDACTION_ENABLED=true
 # Ops endpoint guard (non-production only; required for /ops/force-plan)
 # OPS_TOKEN=troque-isto-por-um-token-forte
 # Stripe checkout (billing)

--- a/README.md
+++ b/README.md
@@ -228,7 +228,15 @@ AUTH_BRUTE_FORCE_LOCK_MS=
 TAX_DOCUMENTS_STORAGE_ADAPTER=local
 TAX_DOCUMENTS_STORAGE_DIR=
 TAX_DOCUMENT_MAX_FILE_SIZE_BYTES=10485760
+TAX_SENSITIVE_EXCERPT_REDACTION_ENABLED=true
 ```
+
+`TAX_SENSITIVE_EXCERPT_REDACTION_ENABLED` controla a redacao de trechos textuais sensiveis em `tax_document_extractions.raw_json.classification`:
+
+* `true` (padrao): remove `textPreviewLines` na persistencia
+* `false`: rollback controlado para manter payload legado sem redacao
+
+Em producao, manter `true` como padrao e usar `false` apenas de forma excepcional, temporaria e com registro operacional.
 
 ### IA
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -56,3 +56,8 @@ AUTH_BRUTE_FORCE_LOCK_MS=900000
 # TAX_DOCUMENTS_STORAGE_DIR=/var/data/control-finance/tax-documents
 # Optional max upload size in bytes (default: 10 MB)
 # TAX_DOCUMENT_MAX_FILE_SIZE_BYTES=10485760
+# AUD-004: redige previews textuais sensiveis de raw_json.classification no momento da persistencia.
+# true (default): remove textPreviewLines de tax_document_extractions.raw_json.classification
+# false: rollback controlado para comportamento legado sem redacao
+# Em producao, usar false apenas de forma excepcional, temporaria e com registro operacional.
+# TAX_SENSITIVE_EXCERPT_REDACTION_ENABLED=true

--- a/apps/api/src/services/tax-extraction.service.js
+++ b/apps/api/src/services/tax-extraction.service.js
@@ -1,6 +1,7 @@
 import { dbQuery, withDbTransaction } from "../db/index.js";
 import { runTaxExtractorForDocument } from "../domain/tax/tax-document-extractors.js";
 import { createTaxError, normalizeTaxUserId } from "../domain/tax/tax.validation.js";
+import { trackDomainFlowRecords } from "../observability/domain-metrics.js";
 import { classifyStoredTaxDocument } from "./tax-classification.service.js";
 import { getTaxDocumentByIdForUser } from "./tax-documents.service.js";
 import {
@@ -10,6 +11,24 @@ import {
 
 const CLASSIFIER_ONLY_EXTRACTOR_NAME = "classifier-only";
 const CLASSIFIER_ONLY_EXTRACTOR_VERSION = "1.0.0";
+const EXTRACTION_FLOW = "tax_documents_extraction";
+const REDACTION_OPERATION = "redact_text_preview_lines";
+
+const isSensitiveExcerptRedactionEnabled = (env = process.env) => {
+  const flagValue = env.TAX_SENSITIVE_EXCERPT_REDACTION_ENABLED;
+
+  if (typeof flagValue === "undefined") {
+    return true;
+  }
+
+  const normalizedFlagValue = String(flagValue).trim().toLowerCase();
+
+  if (["false", "0", "no", "nao", "off"].includes(normalizedFlagValue)) {
+    return false;
+  }
+
+  return true;
+};
 
 const normalizeDocumentId = (value) => {
   const parsedValue = Number(value);
@@ -61,6 +80,31 @@ const mapPersistedExtraction = (row) => ({
   warnings: Array.isArray(row.warnings_json) ? row.warnings_json : [],
 });
 
+const buildPersistedClassificationPayload = (
+  classificationPayload,
+  { env = process.env } = {},
+) => {
+  if (!classificationPayload || typeof classificationPayload !== "object") {
+    return {};
+  }
+
+  if (!isSensitiveExcerptRedactionEnabled(env)) {
+    return { ...classificationPayload };
+  }
+
+  const { textPreviewLines, ...safePayload } = classificationPayload;
+
+  if (Array.isArray(textPreviewLines) && textPreviewLines.length > 0) {
+    trackDomainFlowRecords({
+      flow: EXTRACTION_FLOW,
+      operation: REDACTION_OPERATION,
+      records: textPreviewLines.length,
+    });
+  }
+
+  return safePayload;
+};
+
 const buildExtractionPreview = ({
   classification,
   extractorResult,
@@ -74,11 +118,11 @@ const buildExtractionPreview = ({
   confidenceScore: classification.confidenceScore,
   rawJson: extractorResult
     ? {
-        classification: classification.classificationPayload,
+        classification: buildPersistedClassificationPayload(classification.classificationPayload),
         extraction: extractorResult.payload,
       }
     : {
-        classification: classification.classificationPayload,
+        classification: buildPersistedClassificationPayload(classification.classificationPayload),
       },
   warnings,
 });
@@ -96,11 +140,11 @@ const persistSuccessfulProcessing = async ({
     extractorResult?.extractorVersion || CLASSIFIER_ONLY_EXTRACTOR_VERSION;
   const rawJson = extractorResult
     ? {
-        classification: classification.classificationPayload,
+        classification: buildPersistedClassificationPayload(classification.classificationPayload),
         extraction: extractorResult.payload,
       }
     : {
-        classification: classification.classificationPayload,
+        classification: buildPersistedClassificationPayload(classification.classificationPayload),
       };
 
   let persistedExtraction = null;

--- a/apps/api/src/tax.test.js
+++ b/apps/api/src/tax.test.js
@@ -1390,6 +1390,7 @@ describe("Tax API foundation", () => {
       fgtsBase: 8500,
     });
     expect(Array.isArray(extractionResult.rows[0]?.raw_json?.extraction?.rubrics)).toBe(true);
+    expect(extractionResult.rows[0]?.raw_json?.classification?.textPreviewLines).toBeUndefined();
 
     const factsResult = await dbQuery(
       `SELECT fact_type, subcategory, amount, dedupe_strength, conflict_code
@@ -1443,6 +1444,73 @@ describe("Tax API foundation", () => {
         conflict_code: null,
       }),
     ]);
+  });
+
+  it("POST /tax/documents/:id/reprocess permite rollback da redacao sensivel por feature flag", async () => {
+    const previousRedactionFlag = process.env.TAX_SENSITIVE_EXCERPT_REDACTION_ENABLED;
+    process.env.TAX_SENSITIVE_EXCERPT_REDACTION_ENABLED = "false";
+
+    try {
+      const token = await registerAndLogin("tax-documents-reprocess-clt-redaction-flag@test.dev");
+      const uploadResponse = await request(app)
+        .post("/tax/documents")
+        .set("Authorization", `Bearer ${token}`)
+        .field("taxYear", "2026")
+        .attach(
+          "file",
+          Buffer.from(
+            [
+              "CONTRACHEQUE MARCO 2025",
+              "Empregador ACME TECNOLOGIA LTDA",
+              "CNPJ 12.345.678/0001-90",
+              "Empregado JOAO DA SILVA",
+              "CPF 123.456.789-00",
+              "Admissao 01/02/2020",
+              "Cargo ANALISTA DE SISTEMAS",
+              "Competencia 03/2025",
+              "Vencimentos",
+              "Salario Base 7.500,00",
+              "Horas Extras 1.000,00",
+              "Descontos",
+              "INSS 876,00",
+              "IRRF 423,35",
+              "Liquido 7.200,65",
+            ].join("\n"),
+            "utf8",
+          ),
+          {
+            filename: "holerite-clt-flag-off.csv",
+            contentType: "text/csv",
+          },
+        );
+
+      expect(uploadResponse.status).toBe(201);
+
+      const reprocessResponse = await request(app)
+        .post(`/tax/documents/${uploadResponse.body.document.id}/reprocess`)
+        .set("Authorization", `Bearer ${token}`);
+
+      expect(reprocessResponse.status).toBe(200);
+
+      const extractionResult = await dbQuery(
+        `SELECT raw_json
+         FROM tax_document_extractions
+         WHERE document_id = $1
+         ORDER BY id DESC
+         LIMIT 1`,
+        [uploadResponse.body.document.id],
+      );
+
+      expect(Array.isArray(extractionResult.rows[0]?.raw_json?.classification?.textPreviewLines)).toBe(
+        true,
+      );
+    } finally {
+      if (typeof previousRedactionFlag === "undefined") {
+        delete process.env.TAX_SENSITIVE_EXCERPT_REDACTION_ENABLED;
+      } else {
+        process.env.TAX_SENSITIVE_EXCERPT_REDACTION_ENABLED = previousRedactionFlag;
+      }
+    }
   });
 
   it("GET /tax/income-statement-clt/:taxYear agrega meses aprovados de holerite CLT", async () => {


### PR DESCRIPTION
## Contexto
Implementa a fatia AUD-004 com minimizacao de persistencia sensivel no fluxo fiscal, sem cutover de storage e sem refactor amplo.

## Escopo exato
- Redacao de `textPreviewLines` em `tax_document_extractions.raw_json.classification` no momento da persistencia.
- Mantem retorno de preview em memoria (sem impacto no UX de analise imediata).

## O que mudou
- `apps/api/src/services/tax-extraction.service.js`
  - remove `textPreviewLines` do payload persistido por padrao.
  - adiciona feature flag de rollback: `TAX_SENSITIVE_EXCERPT_REDACTION_ENABLED`.
  - registra metrica de redaction com:
    - `flow=tax_documents_extraction`
    - `operation=redact_text_preview_lines`
    - `records=<quantidade removida>`
- `apps/api/src/tax.test.js`
  - cobre caminho padrao (campo nao persistido).
  - cobre rollback por flag (`false`) com comportamento legado.
- `.env.example`, `apps/api/.env.example`, `README.md`
  - documentacao da flag e disciplina operacional.

## Governanca
- Owner: @JrValerio (security/api)
- Rollback: setar `TAX_SENSITIVE_EXCERPT_REDACTION_ENABLED=false` de forma **excepcional**, temporaria e rastreavel.
- Criterios verificaveis:
  1. `raw_json.classification.textPreviewLines` ausente por padrao apos reprocessamento.
  2. Com flag em `false`, campo volta a ser persistido (rollback controlado).
  3. Suite fiscal focada passa.
  4. Lint dos arquivos alterados passa.

## Evidencias
- `npm --prefix apps/api run test -- src/tax.test.js` -> 74 passed.
- `npm --prefix apps/api run lint -- src/services/tax-extraction.service.js src/tax.test.js` -> sem erros.

## Nota de escopo
Esta PR resolve um recorte especifico e relevante de minimizacao (`textPreviewLines`).
Nao declara cobertura completa de todo payload sensivel historico (`metadata_json`, hints e similares), que seguem para fatias futuras.
