### PR TITLE
feat(audit): enforce binary gate for generic boleto support decision

### DIFF
--- a/apps/api/src/import-utility-dry-run.test.js
+++ b/apps/api/src/import-utility-dry-run.test.js
@@ -97,6 +97,11 @@ describe("transaction imports utility bills dry-run", () => {
 
     expect(response.status).toBe(200);
     expect(response.body.documentType).toBe("utility_bill_telecom");
+    expect(response.body.utilityBillImportDecision).toEqual({
+      scope: "generic_boleto",
+      decision: "blocked",
+      reasonCode: "unsupported_auto_transaction_import",
+    });
     expect(response.body.summary).toEqual({
       totalRows: 0,
       validRows: 0,
@@ -124,6 +129,8 @@ describe("transaction imports utility bills dry-run", () => {
 
     const metrics = getImportMetricsSnapshot();
     expect(metrics.import_dry_run_semantic_drift_total).toBe(0);
+    expect(metrics.import_dry_run_utility_gate_blocked_total).toBe(1);
+    expect(metrics.import_dry_run_utility_gate_supported_total).toBe(0);
   });
 
   it("POST /transactions/import/dry-run retorna documentType e suggestion para utility_bill_gas", async () => {
@@ -151,6 +158,11 @@ describe("transaction imports utility bills dry-run", () => {
 
     expect(response.status).toBe(200);
     expect(response.body.documentType).toBe("utility_bill_gas");
+    expect(response.body.utilityBillImportDecision).toEqual({
+      scope: "generic_boleto",
+      decision: "blocked",
+      reasonCode: "unsupported_auto_transaction_import",
+    });
     expect(response.body.summary).toEqual({
       totalRows: 0,
       validRows: 0,
@@ -178,6 +190,8 @@ describe("transaction imports utility bills dry-run", () => {
 
     const metrics = getImportMetricsSnapshot();
     expect(metrics.import_dry_run_semantic_drift_total).toBe(0);
+    expect(metrics.import_dry_run_utility_gate_blocked_total).toBe(1);
+    expect(metrics.import_dry_run_utility_gate_supported_total).toBe(0);
   });
 
   it("POST /transactions/import/dry-run incrementa metrica quando suggestion diverge do documentType utilitario", async () => {
@@ -205,6 +219,11 @@ describe("transaction imports utility bills dry-run", () => {
 
     expect(response.status).toBe(200);
     expect(response.body.documentType).toBe("utility_bill_gas");
+    expect(response.body.utilityBillImportDecision).toEqual({
+      scope: "generic_boleto",
+      decision: "blocked",
+      reasonCode: "unsupported_auto_transaction_import",
+    });
     expect(response.body.suggestion).toMatchObject({
       billType: "water",
     });
@@ -212,5 +231,7 @@ describe("transaction imports utility bills dry-run", () => {
     const metrics = getImportMetricsSnapshot();
     expect(metrics.import_dry_run_total).toBe(1);
     expect(metrics.import_dry_run_semantic_drift_total).toBe(1);
+    expect(metrics.import_dry_run_utility_gate_blocked_total).toBe(1);
+    expect(metrics.import_dry_run_utility_gate_supported_total).toBe(0);
   });
 });

--- a/apps/api/src/observability/import-observability.js
+++ b/apps/api/src/observability/import-observability.js
@@ -3,6 +3,8 @@ import { logError, logInfo } from "./logger.js";
 const METRIC_NAMES = {
   dryRunTotal: "import_dry_run_total",
   dryRunSemanticDriftTotal: "import_dry_run_semantic_drift_total",
+  dryRunUtilityGateBlockedTotal: "import_dry_run_utility_gate_blocked_total",
+  dryRunUtilityGateSupportedTotal: "import_dry_run_utility_gate_supported_total",
   commitTotal: "import_commit_total",
   commitSuccessTotal: "import_commit_success_total",
   commitFailTotal: "import_commit_fail_total",
@@ -13,6 +15,8 @@ const METRIC_NAMES = {
 const importMetricsState = {
   [METRIC_NAMES.dryRunTotal]: 0,
   [METRIC_NAMES.dryRunSemanticDriftTotal]: 0,
+  [METRIC_NAMES.dryRunUtilityGateBlockedTotal]: 0,
+  [METRIC_NAMES.dryRunUtilityGateSupportedTotal]: 0,
   [METRIC_NAMES.commitTotal]: 0,
   [METRIC_NAMES.commitSuccessTotal]: 0,
   [METRIC_NAMES.commitFailTotal]: 0,
@@ -60,6 +64,10 @@ export const getImportMetricsSnapshot = () => {
     import_dry_run_total: importMetricsState[METRIC_NAMES.dryRunTotal],
     import_dry_run_semantic_drift_total:
       importMetricsState[METRIC_NAMES.dryRunSemanticDriftTotal],
+    import_dry_run_utility_gate_blocked_total:
+      importMetricsState[METRIC_NAMES.dryRunUtilityGateBlockedTotal],
+    import_dry_run_utility_gate_supported_total:
+      importMetricsState[METRIC_NAMES.dryRunUtilityGateSupportedTotal],
     import_commit_total: importMetricsState[METRIC_NAMES.commitTotal],
     import_commit_success_total: importMetricsState[METRIC_NAMES.commitSuccessTotal],
     import_commit_fail_total: importMetricsState[METRIC_NAMES.commitFailTotal],
@@ -86,6 +94,17 @@ export const trackDryRunSemanticDriftMetrics = ({ driftDetected = false } = {}) 
   }
 
   incrementMetric(METRIC_NAMES.dryRunSemanticDriftTotal);
+};
+
+export const trackDryRunUtilityGateDecisionMetrics = ({ decision = null } = {}) => {
+  if (decision === "blocked") {
+    incrementMetric(METRIC_NAMES.dryRunUtilityGateBlockedTotal);
+    return;
+  }
+
+  if (decision === "supported") {
+    incrementMetric(METRIC_NAMES.dryRunUtilityGateSupportedTotal);
+  }
 };
 
 export const trackCommitAttemptMetrics = () => {

--- a/apps/api/src/routes/transactions.routes.js
+++ b/apps/api/src/routes/transactions.routes.js
@@ -15,6 +15,7 @@ import {
   trackCommitSuccessMetrics,
   trackDryRunMetrics,
   trackDryRunSemanticDriftMetrics,
+  trackDryRunUtilityGateDecisionMetrics,
 } from "../observability/import-observability.js";
 import {
   trackDomainFlowError,
@@ -475,9 +476,16 @@ router.post("/import/dry-run", importRateLimiter, requireFeature("csv_import"), 
       const validRows = Number(dryRunResult.summary?.validRows) || 0;
       const invalidRows = Number(dryRunResult.summary?.invalidRows) || 0;
       const semanticDrift = detectUtilityDryRunSemanticDrift(dryRunResult);
+      const utilityGateDecision =
+        dryRunResult?.utilityBillImportDecision?.decision === "supported"
+          ? "supported"
+          : dryRunResult?.utilityBillImportDecision?.decision === "blocked"
+            ? "blocked"
+            : null;
 
       trackDryRunMetrics({ rowsTotal });
       trackDryRunSemanticDriftMetrics({ driftDetected: semanticDrift.driftDetected });
+      trackDryRunUtilityGateDecisionMetrics({ decision: utilityGateDecision });
 
       if (semanticDrift.driftDetected) {
         logImportEvent("import.dry_run.semantic_drift", {
@@ -500,6 +508,7 @@ router.post("/import/dry-run", importRateLimiter, requireFeature("csv_import"), 
         rowsTotal,
         validRows,
         invalidRows,
+        utilityBillImportDecision: dryRunResult?.utilityBillImportDecision || null,
         elapsedMs: elapsedTimer(),
         statusCode: 200,
       });

--- a/apps/api/src/services/transactions-import.service.ts
+++ b/apps/api/src/services/transactions-import.service.ts
@@ -80,6 +80,12 @@ type ImportFile = {
   mimetype?: string;
 };
 
+type UtilityBillImportDecision = {
+  scope: "generic_boleto";
+  decision: "blocked" | "supported";
+  reasonCode: string;
+};
+
 const CATEGORY_ENTRY = TRANSACTION_TYPE_ENTRY;
 const CATEGORY_EXIT = TRANSACTION_TYPE_EXIT;
 const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
@@ -97,6 +103,27 @@ const HEADER_ERROR_MESSAGE =
   "CSV invalido. Cabecalho esperado: date,type,value,description,notes,category";
 const IMPORT_FORMAT_ERROR_MESSAGE =
   "Arquivo nao reconhecido. Envie um CSV manual com cabecalho date,type,value,description,notes,category ou um CSV, OFX ou PDF de extrato.";
+const UTILITY_BILL_DOCUMENT_TYPES = new Set([
+  "utility_bill_energy",
+  "utility_bill_water",
+  "utility_bill_gas",
+  "utility_bill_telecom",
+]);
+
+const resolveUtilityBillImportDecision = (documentType: unknown): UtilityBillImportDecision | null => {
+  const normalizedDocumentType =
+    typeof documentType === "string" ? documentType.trim().toLowerCase() : "";
+
+  if (!normalizedDocumentType || !UTILITY_BILL_DOCUMENT_TYPES.has(normalizedDocumentType)) {
+    return null;
+  }
+
+  return {
+    scope: "generic_boleto",
+    decision: "blocked",
+    reasonCode: "unsupported_auto_transaction_import",
+  };
+};
 
 const extractFitId = (notes: unknown): string | null => {
   const match = String(notes || "").match(/^FITID\s+(\S+)/);
@@ -1097,6 +1124,7 @@ export const dryRunTransactionsImportForUser = async (
     suggestion,
     suggestions = [],
   } = await parseImportFileRows(importFile);
+  const utilityBillImportDecision = resolveUtilityBillImportDecision(documentType);
   const [categoryMap, categories, importRules] = await Promise.all([
     loadCategoryMapForUser(userId),
     loadCategoriesForUser(userId),
@@ -1186,12 +1214,14 @@ export const dryRunTransactionsImportForUser = async (
     summary,
     fileName: importFile?.originalname || null,
     documentType,
+    utilityBillImportDecision,
   });
 
   return {
     importId: persistedSession.importId,
     expiresAt: persistedSession.expiresAt,
     documentType,
+    utilityBillImportDecision,
     suggestion: suggestion || null,
     suggestions,
     summary,

--- a/apps/web/src/components/ImportCsvModal.jsx
+++ b/apps/web/src/components/ImportCsvModal.jsx
@@ -296,6 +296,20 @@ const ImportCsvModal = ({
     );
   }, [dryRunResult]);
 
+  const isUtilityBillAutoImportBlocked = useMemo(() => {
+    if (!isUtilityBill) {
+      return false;
+    }
+
+    const decision = dryRunResult?.utilityBillImportDecision?.decision;
+
+    if (decision === "supported") {
+      return false;
+    }
+
+    return true;
+  }, [dryRunResult, isUtilityBill]);
+
   const profileSuggestions = useMemo(() => {
     const suggestionsFromResponse = Array.isArray(dryRunResult?.suggestions)
       ? dryRunResult.suggestions
@@ -1040,9 +1054,9 @@ const ImportCsvModal = ({
               </div>
             ) : null}
 
-            {isUtilityBill ? (
+            {isUtilityBillAutoImportBlocked ? (
               <div className="rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-400">
-                Boleto detectado. O suporte completo à importação de contas de energia, água, gás, internet, telefone e TV chegará em breve. Por enquanto, nenhuma transação é extraída.
+                Boleto utilitário detectado. A importação automática de transações para boleto genérico está bloqueada por gate binário nesta versão. Use os dados detectados abaixo para criar a pendência manualmente.
               </div>
             ) : null}
 

--- a/apps/web/src/components/ImportCsvModal.test.jsx
+++ b/apps/web/src/components/ImportCsvModal.test.jsx
@@ -206,6 +206,11 @@ describe("ImportCsvModal", () => {
     transactionsService.dryRunImportCsv.mockResolvedValueOnce(
       buildDryRunResponse({
         documentType: "utility_bill_telecom",
+        utilityBillImportDecision: {
+          scope: "generic_boleto",
+          decision: "blocked",
+          reasonCode: "unsupported_auto_transaction_import",
+        },
         summary: {
           totalRows: 0,
           validRows: 0,
@@ -238,7 +243,7 @@ describe("ImportCsvModal", () => {
     });
 
     expect(
-      screen.getByText(/energia, água, gás, internet, telefone e TV/i),
+      screen.getByText(/importação automática de transações para boleto genérico está bloqueada/i),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Criar pendência" })).toBeInTheDocument();
   });

--- a/apps/web/src/services/transactions.service.test.ts
+++ b/apps/web/src/services/transactions.service.test.ts
@@ -98,4 +98,26 @@ describe("transactions service import dry-run", () => {
       billType: null,
     });
   });
+
+  it("normaliza utilityBillImportDecision quando o backend retorna gate binario", async () => {
+    postMock.mockResolvedValueOnce({
+      data: {
+        ...BASE_DRY_RUN_RESPONSE,
+        utilityBillImportDecision: {
+          scope: "generic_boleto",
+          decision: "blocked",
+          reasonCode: "unsupported_auto_transaction_import",
+        },
+      },
+    });
+
+    const file = new File(["dummy"], "telecom.pdf", { type: "application/pdf" });
+    const result = await transactionsService.dryRunImportCsv(file);
+
+    expect(result.utilityBillImportDecision).toEqual({
+      scope: "generic_boleto",
+      decision: "blocked",
+      reasonCode: "unsupported_auto_transaction_import",
+    });
+  });
 });

--- a/apps/web/src/services/transactions.service.ts
+++ b/apps/web/src/services/transactions.service.ts
@@ -213,6 +213,12 @@ export interface ImportDryRunBillSuggestion {
   customerCode?: string | null;
 }
 
+export interface ImportDryRunUtilityBillImportDecision {
+  scope: "generic_boleto";
+  decision: "blocked" | "supported";
+  reasonCode: string;
+}
+
 const IMPORT_DRY_RUN_BILL_TYPES = new Set([
   "energy",
   "water",
@@ -230,6 +236,7 @@ export interface ImportDryRunResult {
   summary: ImportDryRunSummary;
   rows: ImportDryRunRow[];
   documentType?: string | null;
+  utilityBillImportDecision?: ImportDryRunUtilityBillImportDecision | null;
   suggestion?: ImportDryRunSuggestion | null;
   suggestions?: ImportDryRunSuggestion[];
 }
@@ -393,6 +400,11 @@ interface ImportDryRunApiResponse {
   importId?: unknown;
   expiresAt?: unknown;
   documentType?: unknown;
+  utilityBillImportDecision?: {
+    scope?: unknown;
+    decision?: unknown;
+    reasonCode?: unknown;
+  } | null;
   suggestion?: unknown;
   suggestions?: unknown[];
   summary?: {
@@ -562,6 +574,42 @@ const normalizeImportDryRunProfileDeduction = (
       normalizedType === "loan" || normalizedType === "card" || normalizedType === "other"
         ? normalizedType
         : null,
+  };
+};
+
+const normalizeImportDryRunUtilityBillImportDecision = (
+  raw: unknown,
+): ImportDryRunUtilityBillImportDecision | null => {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return null;
+  }
+
+  const parsed = raw as {
+    scope?: unknown;
+    decision?: unknown;
+    reasonCode?: unknown;
+  };
+
+  const scope = String(parsed.scope || "").trim();
+  const decision = String(parsed.decision || "").trim();
+  const reasonCode = String(parsed.reasonCode || "").trim();
+
+  if (scope !== "generic_boleto") {
+    return null;
+  }
+
+  if (decision !== "blocked" && decision !== "supported") {
+    return null;
+  }
+
+  if (!reasonCode) {
+    return null;
+  }
+
+  return {
+    scope: "generic_boleto",
+    decision,
+    reasonCode,
   };
 };
 
@@ -1046,6 +1094,9 @@ export const transactionsService = {
         typeof responseBody.documentType === "string" && responseBody.documentType.trim()
           ? responseBody.documentType.trim()
           : null,
+      utilityBillImportDecision: normalizeImportDryRunUtilityBillImportDecision(
+        responseBody.utilityBillImportDecision,
+      ),
       suggestion: normalizeImportDryRunSuggestion(responseBody.suggestion),
       suggestions: Array.isArray(responseBody.suggestions)
         ? responseBody.suggestions


### PR DESCRIPTION
## Contexto
AUD-005 (gate binário de produto/contrato para boleto genérico) a partir da main atualizada.

## Escopo desta fatia
- Define decisão binária explícita no dry-run de importação para documentos utilitários de boleto.
- Remove copy de meio-termo na UX (sem promessa "chegará em breve").
- Mantém escopo limitado: sem parser novo, sem extração automática de transações para boleto genérico.

## O que mudou
### API
- `dryRunTransactionsImportForUser` passa a retornar `utilityBillImportDecision` quando `documentType` é utilitário.
- Decisão atual do gate: `blocked` com `reasonCode=unsupported_auto_transaction_import`.
- Observabilidade: métricas novas de decisão
  - `import_dry_run_utility_gate_blocked_total`
  - `import_dry_run_utility_gate_supported_total`
- Rota de dry-run passa a contabilizar a decisão no observability.

### Web
- Contrato tipado de `utilityBillImportDecision` no `transactions.service`.
- Modal de importação troca mensagem ambígua por bloqueio explícito de gate binário.
- Fluxo de pendência manual permanece explícito como alternativa operacional.

### Testes
- API: `import-utility-dry-run.test.js` valida payload de decisão + métricas.
- Web: `transactions.service.test.ts` valida normalização do novo campo.
- Web: `ImportCsvModal.test.jsx` valida copy de bloqueio explícito.

## Governança (início)
- Owner: @JrValerio (product + api + web)
- Rollback: voltar ao contrato/copy anterior removendo `utilityBillImportDecision` e a copy de bloqueio.
- Gate binário explícito desta fatia:
  - **Suportado**: apenas o que já está comprovado por parser+corpus+testes.
  - **Bloqueado**: importação automática de transações para boleto genérico.
- Critério verificável:
  1. dry-run utilitário retorna `utilityBillImportDecision.decision=blocked`.
  2. métricas de decisão são incrementadas.
  3. UI exibe bloqueio explícito, sem promessa ambígua.

## Evidências
- `npm --prefix apps/api run test -- src/import-utility-dry-run.test.js` ✅
- `npm --prefix apps/web run test:run -- src/services/transactions.service.test.ts src/components/ImportCsvModal.test.jsx` ✅
- `npm --prefix apps/api run lint` ✅
- `npm --prefix apps/web run lint -- src/services/transactions.service.ts src/services/transactions.service.test.ts src/components/ImportCsvModal.jsx src/components/ImportCsvModal.test.jsx` ✅
