### PR TITLE
feat(aud-007): add deterministic OCR runtime status for scanned invoices

### DIFF
--- a/apps/api/src/credit-card-invoices.test.js
+++ b/apps/api/src/credit-card-invoices.test.js
@@ -9,10 +9,17 @@ import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
 
 // ─── Mock pdf-ocr so tests run without real PDF toolchain ─────────────────────
 
-const mockExtractText = vi.hoisted(() => vi.fn());
+const mockExtractTextWithRuntime = vi.hoisted(() => vi.fn());
 
 vi.mock("./domain/imports/pdf-ocr.js", () => ({
-  extractTextFromPdfWithOcr: mockExtractText,
+  extractTextFromPdfWithOcrRuntime: mockExtractTextWithRuntime,
+  extractTextFromPdfWithOcr: vi.fn(async (...args) => {
+    const result = await mockExtractTextWithRuntime(...args);
+    if (typeof result === "string") {
+      return result;
+    }
+    return String(result?.text || "");
+  }),
   isImportOcrEnabled: () => false,
   shouldRunPdfOcrFallback: () => false,
 }));
@@ -61,6 +68,18 @@ TOTAL DA FATURA    R$ 540,35
 
 const INVALID_TEXT = `Este texto nao tem nenhum dado de fatura.`;
 
+const createOcrRuntimeResult = (text, runtimeOverrides = {}) => ({
+  text,
+  ocrRuntime: {
+    status: "success",
+    reasonCode: "direct_text_sufficient",
+    ocrEnabled: false,
+    ocrAttempted: false,
+    timeoutMs: null,
+    ...runtimeOverrides,
+  },
+});
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const createCard = (token, overrides = {}) =>
@@ -85,7 +104,7 @@ const resetState = async () => {
   resetImportRateLimiterState();
   resetWriteRateLimiterState();
   resetHttpMetricsForTests();
-  mockExtractText.mockReset();
+  mockExtractTextWithRuntime.mockReset();
   await dbQuery("DELETE FROM credit_card_invoices");
   await dbQuery("DELETE FROM credit_card_purchases");
   await dbQuery("DELETE FROM bills");
@@ -124,7 +143,7 @@ describe("credit-card-invoices", () => {
 
   it("POST parse-pdf retorna 201 com campos corretos para fatura valida", async () => {
     const token = await registerAndLogin("inv-parse-ok@test.dev");
-    mockExtractText.mockResolvedValue(VALID_ITAU_TEXT);
+    mockExtractTextWithRuntime.mockResolvedValue(createOcrRuntimeResult(VALID_ITAU_TEXT));
 
     const cardRes = await createCard(token);
     const cardId = cardRes.body.id;
@@ -143,12 +162,13 @@ describe("credit-card-invoices", () => {
     expect(res.body.parseConfidence).toBe("high");
     expect(res.body.needsReview).toBe(false);
     expect(res.body.parseMetadata?.parser?.name).toBe("itau_parser_v1");
+    expect(res.body.parseMetadata?.ocrRuntime?.status).toBe("success");
     expect(res.body.linkedBillId).toBeNull();
   });
 
   it("POST parse-pdf infere periodo quando ausente no PDF (parse_confidence=low)", async () => {
     const token = await registerAndLogin("inv-infer@test.dev");
-    mockExtractText.mockResolvedValue(ITAU_TEXT_NO_PERIOD);
+    mockExtractTextWithRuntime.mockResolvedValue(createOcrRuntimeResult(ITAU_TEXT_NO_PERIOD));
 
     // closing_day=7, dueDate=15/03/2026 → period_end=07/03/2026, period_start=08/02/2026
     const cardRes = await createCard(token, { closingDay: 7, dueDay: 15 });
@@ -168,7 +188,7 @@ describe("credit-card-invoices", () => {
 
   it("POST parse-pdf usa fallback por emissor reconhecido nao-itau com needsReview", async () => {
     const token = await registerAndLogin("inv-nubank-fallback@test.dev");
-    mockExtractText.mockResolvedValue(VALID_NUBANK_TEXT);
+    mockExtractTextWithRuntime.mockResolvedValue(createOcrRuntimeResult(VALID_NUBANK_TEXT));
 
     const cardRes = await createCard(token, { closingDay: 10, dueDay: 20 });
     const cardId = cardRes.body.id;
@@ -189,7 +209,7 @@ describe("credit-card-invoices", () => {
 
   it("POST parse-pdf contabiliza domain metric por emissor", async () => {
     const token = await registerAndLogin("inv-metric-by-issuer@test.dev");
-    mockExtractText.mockResolvedValue(VALID_NUBANK_TEXT);
+    mockExtractTextWithRuntime.mockResolvedValue(createOcrRuntimeResult(VALID_NUBANK_TEXT));
 
     const cardRes = await createCard(token);
     const cardId = cardRes.body.id;
@@ -206,7 +226,7 @@ describe("credit-card-invoices", () => {
 
   it("POST parse-pdf retorna 422 INVOICE_PARSE_FAILED para texto ilegivel", async () => {
     const token = await registerAndLogin("inv-parse-fail@test.dev");
-    mockExtractText.mockResolvedValue(INVALID_TEXT);
+    mockExtractTextWithRuntime.mockResolvedValue(createOcrRuntimeResult(INVALID_TEXT));
 
     const cardRes = await createCard(token);
     const cardId = cardRes.body.id;
@@ -217,10 +237,37 @@ describe("credit-card-invoices", () => {
     expect(res.body.code).toBe("INVOICE_PARSE_FAILED");
   });
 
+  it("POST parse-pdf retorna 422 INVOICE_OCR_TIMEOUT com metrica de timeout", async () => {
+    const token = await registerAndLogin("inv-ocr-timeout@test.dev");
+    mockExtractTextWithRuntime.mockResolvedValue(
+      createOcrRuntimeResult("abc 123", {
+        status: "timeout",
+        reasonCode: "ocr_timeout",
+        ocrEnabled: true,
+        ocrAttempted: true,
+        timeoutMs: 1200,
+      }),
+    );
+
+    const cardRes = await createCard(token);
+    const cardId = cardRes.body.id;
+
+    const res = await uploadInvoice(token, cardId);
+
+    expect(res.status).toBe(422);
+    expect(res.body.code).toBe("INVOICE_OCR_TIMEOUT");
+
+    const metricsRes = await request(app).get("/metrics");
+    expect(metricsRes.status).toBe(200);
+    expect(metricsRes.text).toMatch(
+      /domain_financial_flow_events_total\{flow="credit_card_invoice_ocr_runtime",operation="status_timeout",outcome="error"\}\s+([0-9.]+)/,
+    );
+  });
+
   it("POST parse-pdf retorna 404 para cartao de outro usuario", async () => {
     const token1 = await registerAndLogin("inv-iso-1@test.dev");
     const token2 = await registerAndLogin("inv-iso-2@test.dev");
-    mockExtractText.mockResolvedValue(VALID_ITAU_TEXT);
+    mockExtractTextWithRuntime.mockResolvedValue(createOcrRuntimeResult(VALID_ITAU_TEXT));
 
     const cardRes = await createCard(token1);
     const cardId = cardRes.body.id;
@@ -268,10 +315,10 @@ describe("credit-card-invoices", () => {
     const cardId = cardRes.body.id;
 
     // Upload two invoices with different due_date+total_amount (unique constraint)
-    mockExtractText.mockResolvedValue(VALID_ITAU_TEXT);
+    mockExtractTextWithRuntime.mockResolvedValue(createOcrRuntimeResult(VALID_ITAU_TEXT));
     await uploadInvoice(token, cardId);
 
-    mockExtractText.mockResolvedValue(VALID_ITAU_TEXT_APRIL);
+    mockExtractTextWithRuntime.mockResolvedValue(createOcrRuntimeResult(VALID_ITAU_TEXT_APRIL));
     await uploadInvoice(token, cardId);
 
     const res = await request(app)
@@ -302,7 +349,7 @@ describe("credit-card-invoices", () => {
 
   it("POST link-bill vincula fatura a uma pendencia", async () => {
     const token = await registerAndLogin("inv-link@test.dev");
-    mockExtractText.mockResolvedValue(VALID_ITAU_TEXT);
+    mockExtractTextWithRuntime.mockResolvedValue(createOcrRuntimeResult(VALID_ITAU_TEXT));
 
     const cardRes = await createCard(token);
     const cardId = cardRes.body.id;
@@ -338,7 +385,7 @@ describe("credit-card-invoices", () => {
 
   it("POST link-bill retorna 409 quando fatura ja esta vinculada", async () => {
     const token = await registerAndLogin("inv-link-dup@test.dev");
-    mockExtractText.mockResolvedValue(VALID_ITAU_TEXT);
+    mockExtractTextWithRuntime.mockResolvedValue(createOcrRuntimeResult(VALID_ITAU_TEXT));
 
     const cardRes = await createCard(token);
     const cardId = cardRes.body.id;
@@ -378,7 +425,7 @@ describe("credit-card-invoices", () => {
 
   it("POST link-bill retorna 422 quando valor da pendencia difere do total da fatura", async () => {
     const token = await registerAndLogin("inv-link-amount-mismatch@test.dev");
-    mockExtractText.mockResolvedValue(VALID_ITAU_TEXT);
+    mockExtractTextWithRuntime.mockResolvedValue(createOcrRuntimeResult(VALID_ITAU_TEXT));
 
     const cardRes = await createCard(token);
     const cardId = cardRes.body.id;
@@ -415,10 +462,10 @@ describe("credit-card-invoices", () => {
     const cardRes = await createCard(token);
     const cardId = cardRes.body.id;
 
-    mockExtractText.mockResolvedValue(VALID_ITAU_TEXT);
+    mockExtractTextWithRuntime.mockResolvedValue(createOcrRuntimeResult(VALID_ITAU_TEXT));
     const firstInvoiceRes = await uploadInvoice(token, cardId);
 
-    mockExtractText.mockResolvedValue(VALID_ITAU_TEXT_APRIL_SAME_TOTAL);
+    mockExtractTextWithRuntime.mockResolvedValue(createOcrRuntimeResult(VALID_ITAU_TEXT_APRIL_SAME_TOTAL));
     const secondInvoiceRes = await uploadInvoice(token, cardId);
 
     const billRes = await request(app)
@@ -454,7 +501,7 @@ describe("credit-card-invoices", () => {
   it("POST link-bill retorna 404 para fatura de outro usuario", async () => {
     const token1 = await registerAndLogin("inv-link-iso-1@test.dev");
     const token2 = await registerAndLogin("inv-link-iso-2@test.dev");
-    mockExtractText.mockResolvedValue(VALID_ITAU_TEXT);
+    mockExtractTextWithRuntime.mockResolvedValue(createOcrRuntimeResult(VALID_ITAU_TEXT));
 
     const cardRes = await createCard(token1);
     const cardId = cardRes.body.id;

--- a/apps/api/src/domain/imports/pdf-ocr.js
+++ b/apps/api/src/domain/imports/pdf-ocr.js
@@ -1,6 +1,50 @@
 import { PDFParse } from "pdf-parse";
 
 const OCR_LANGUAGES = "por+eng";
+const DEFAULT_OCR_TIMEOUT_MS = 20000;
+const MIN_OCR_TIMEOUT_MS = 500;
+
+const buildOcrRuntime = ({
+  status,
+  reasonCode,
+  ocrEnabled,
+  ocrAttempted,
+  timeoutMs,
+}) => ({
+  status,
+  reasonCode,
+  ocrEnabled: ocrEnabled === true,
+  ocrAttempted: ocrAttempted === true,
+  timeoutMs,
+});
+
+const createOcrTimeoutError = (timeoutMs) => {
+  const error = new Error(`OCR timeout after ${timeoutMs}ms`);
+  error.code = "OCR_TIMEOUT";
+  return error;
+};
+
+const isOcrTimeoutError = (error) => {
+  const rawValue = `${error?.code || ""} ${error?.name || ""} ${error?.message || ""}`.toLowerCase();
+  return rawValue.includes("timeout") || rawValue.includes("timed out") || rawValue.includes("etimedout");
+};
+
+const withTimeout = async (promise, timeoutMs) => {
+  let timer = null;
+
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(createOcrTimeoutError(timeoutMs)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+};
 
 const loadCreateWorker = async () => {
   const tesseractModule = await import("tesseract.js");
@@ -9,6 +53,17 @@ const loadCreateWorker = async () => {
 
 export const isImportOcrEnabled = (value = process.env.IMPORT_OCR_ENABLED) =>
   String(value || "").trim().toLowerCase() === "true";
+
+export const resolveImportOcrTimeoutMs = (value = process.env.IMPORT_OCR_TIMEOUT_MS) => {
+  const rawValue = String(value || "").trim();
+  const parsed = Number.parseInt(rawValue, 10);
+
+  if (!Number.isInteger(parsed) || parsed < MIN_OCR_TIMEOUT_MS) {
+    return DEFAULT_OCR_TIMEOUT_MS;
+  }
+
+  return parsed;
+};
 
 export const shouldRunPdfOcrFallback = (text) => {
   const normalizedText = String(text || "").replace(/\s+/g, " ").trim();
@@ -26,12 +81,13 @@ export const shouldRunPdfOcrFallback = (text) => {
   return signalCount < 3;
 };
 
-export const extractTextFromPdfWithOcr = async (
+export const extractTextFromPdfWithOcrRuntime = async (
   buffer,
   dependencies = {
     PDFParseCtor: PDFParse,
     loadCreateWorkerFn: loadCreateWorker,
     ocrEnabled: isImportOcrEnabled(),
+    ocrTimeoutMs: resolveImportOcrTimeoutMs(),
   },
 ) => {
   const {
@@ -39,6 +95,7 @@ export const extractTextFromPdfWithOcr = async (
     createWorkerFn,
     loadCreateWorkerFn,
     ocrEnabled = isImportOcrEnabled(),
+    ocrTimeoutMs = resolveImportOcrTimeoutMs(),
   } = dependencies;
   const parser = new PDFParseCtor({ data: buffer });
 
@@ -46,8 +103,30 @@ export const extractTextFromPdfWithOcr = async (
     const textResult = await parser.getText();
     const directText = String(textResult?.text || "");
 
-    if (!shouldRunPdfOcrFallback(directText) || !ocrEnabled) {
-      return directText;
+    if (!shouldRunPdfOcrFallback(directText)) {
+      return {
+        text: directText,
+        ocrRuntime: buildOcrRuntime({
+          status: "success",
+          reasonCode: "direct_text_sufficient",
+          ocrEnabled,
+          ocrAttempted: false,
+          timeoutMs: null,
+        }),
+      };
+    }
+
+    if (!ocrEnabled) {
+      return {
+        text: directText,
+        ocrRuntime: buildOcrRuntime({
+          status: "failed",
+          reasonCode: "ocr_disabled",
+          ocrEnabled,
+          ocrAttempted: false,
+          timeoutMs: ocrTimeoutMs,
+        }),
+      };
     }
 
     const screenshots = await parser.getScreenshot({
@@ -59,7 +138,16 @@ export const extractTextFromPdfWithOcr = async (
     const pages = Array.isArray(screenshots?.pages) ? screenshots.pages : [];
 
     if (pages.length === 0) {
-      return directText;
+      return {
+        text: directText,
+        ocrRuntime: buildOcrRuntime({
+          status: "failed",
+          reasonCode: "ocr_pages_unavailable",
+          ocrEnabled,
+          ocrAttempted: true,
+          timeoutMs: ocrTimeoutMs,
+        }),
+      };
     }
 
     const resolvedCreateWorkerFn =
@@ -72,16 +160,67 @@ export const extractTextFromPdfWithOcr = async (
       const ocrTexts = [];
 
       for (const page of pages) {
-        const result = await worker.recognize(page.data);
+        const result = await withTimeout(worker.recognize(page.data), ocrTimeoutMs);
         ocrTexts.push(String(result?.data?.text || ""));
       }
 
       const combinedOcrText = ocrTexts.join("\n").trim();
-      return combinedOcrText || directText;
+      if (combinedOcrText) {
+        return {
+          text: combinedOcrText,
+          ocrRuntime: buildOcrRuntime({
+            status: "success",
+            reasonCode: "ocr_fallback_applied",
+            ocrEnabled,
+            ocrAttempted: true,
+            timeoutMs: ocrTimeoutMs,
+          }),
+        };
+      }
+
+      return {
+        text: directText,
+        ocrRuntime: buildOcrRuntime({
+          status: "failed",
+          reasonCode: "ocr_empty_result",
+          ocrEnabled,
+          ocrAttempted: true,
+          timeoutMs: ocrTimeoutMs,
+        }),
+      };
+    } catch (error) {
+      if (isOcrTimeoutError(error)) {
+        return {
+          text: directText,
+          ocrRuntime: buildOcrRuntime({
+            status: "timeout",
+            reasonCode: "ocr_timeout",
+            ocrEnabled,
+            ocrAttempted: true,
+            timeoutMs: ocrTimeoutMs,
+          }),
+        };
+      }
+
+      return {
+        text: directText,
+        ocrRuntime: buildOcrRuntime({
+          status: "failed",
+          reasonCode: "ocr_worker_error",
+          ocrEnabled,
+          ocrAttempted: true,
+          timeoutMs: ocrTimeoutMs,
+        }),
+      };
     } finally {
       await worker.terminate();
     }
   } finally {
     await parser.destroy();
   }
+};
+
+export const extractTextFromPdfWithOcr = async (buffer, dependencies) => {
+  const result = await extractTextFromPdfWithOcrRuntime(buffer, dependencies);
+  return result.text;
 };

--- a/apps/api/src/domain/imports/pdf-ocr.test.js
+++ b/apps/api/src/domain/imports/pdf-ocr.test.js
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  extractTextFromPdfWithOcrRuntime,
   extractTextFromPdfWithOcr,
   isImportOcrEnabled,
+  resolveImportOcrTimeoutMs,
   shouldRunPdfOcrFallback,
 } from "./pdf-ocr.js";
 
@@ -10,6 +12,12 @@ describe("pdf OCR fallback", () => {
     expect(isImportOcrEnabled(undefined)).toBe(false);
     expect(isImportOcrEnabled("false")).toBe(false);
     expect(isImportOcrEnabled("true")).toBe(true);
+  });
+
+  it("IMPORT_OCR_TIMEOUT_MS usa default e respeita limite minimo", () => {
+    expect(resolveImportOcrTimeoutMs(undefined)).toBe(20000);
+    expect(resolveImportOcrTimeoutMs("100")).toBe(20000);
+    expect(resolveImportOcrTimeoutMs("2500")).toBe(2500);
   });
 
   it("nao roda OCR quando texto nativo do PDF ja parece utilizavel", () => {
@@ -65,6 +73,26 @@ describe("pdf OCR fallback", () => {
     expect(text).toBe("abc 123");
     expect(fakeParser.getScreenshot).not.toHaveBeenCalled();
     expect(loadCreateWorkerFn).not.toHaveBeenCalled();
+  });
+
+  it("retorna status failed quando OCR seria necessario mas esta desligado", async () => {
+    const fakeParser = {
+      getText: vi.fn().mockResolvedValue({ text: "abc 123" }),
+      getScreenshot: vi.fn(),
+      destroy: vi.fn().mockResolvedValue(undefined),
+    };
+    const PDFParseCtor = vi.fn(() => fakeParser);
+
+    const result = await extractTextFromPdfWithOcrRuntime(Buffer.from("fake-pdf"), {
+      PDFParseCtor,
+      ocrEnabled: false,
+    });
+
+    expect(result.text).toBe("abc 123");
+    expect(result.ocrRuntime.status).toBe("failed");
+    expect(result.ocrRuntime.reasonCode).toBe("ocr_disabled");
+    expect(result.ocrRuntime.ocrAttempted).toBe(false);
+    expect(fakeParser.getScreenshot).not.toHaveBeenCalled();
   });
 
   it("propaga erro quando getText lanca e ainda destroi o parser", async () => {
@@ -151,6 +179,40 @@ describe("pdf OCR fallback", () => {
     expect(text).toContain("PGTO INSS");
     expect(fakeParser.getScreenshot).toHaveBeenCalled();
     expect(createWorkerFn).toHaveBeenCalled();
+    expect(fakeWorker.terminate).toHaveBeenCalled();
+  });
+
+  it("retorna status timeout quando OCR ultrapassa timeout configurado", async () => {
+    const fakeParser = {
+      getText: vi.fn().mockResolvedValue({ text: "abc 123" }),
+      getScreenshot: vi.fn().mockResolvedValue({
+        pages: [{ data: Buffer.from("fake-image") }],
+      }),
+      destroy: vi.fn().mockResolvedValue(undefined),
+    };
+    const fakeWorker = {
+      recognize: vi.fn().mockImplementation(
+        () =>
+          new Promise(() => {
+            // never resolves
+          }),
+      ),
+      terminate: vi.fn().mockResolvedValue(undefined),
+    };
+    const PDFParseCtor = vi.fn(() => fakeParser);
+    const createWorkerFn = vi.fn().mockResolvedValue(fakeWorker);
+
+    const result = await extractTextFromPdfWithOcrRuntime(Buffer.from("fake-pdf"), {
+      PDFParseCtor,
+      createWorkerFn,
+      ocrEnabled: true,
+      ocrTimeoutMs: 5,
+    });
+
+    expect(result.text).toBe("abc 123");
+    expect(result.ocrRuntime.status).toBe("timeout");
+    expect(result.ocrRuntime.reasonCode).toBe("ocr_timeout");
+    expect(result.ocrRuntime.ocrAttempted).toBe(true);
     expect(fakeWorker.terminate).toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/credit-card-invoices.service.js
+++ b/apps/api/src/services/credit-card-invoices.service.js
@@ -1,10 +1,11 @@
 import { dbQuery } from "../db/index.js";
-import { extractTextFromPdfWithOcr } from "../domain/imports/pdf-ocr.js";
+import { extractTextFromPdfWithOcrRuntime } from "../domain/imports/pdf-ocr.js";
 import { parseBRL, parseDMY, parseItauInvoice } from "../domain/imports/itau-invoice.parser.js";
 import { trackDomainFlowError, trackDomainFlowSuccess } from "../observability/domain-metrics.js";
 
 const CREDIT_CARD_INVOICE_BILL_TYPE = "credit_card_invoice";
 const CREDIT_CARD_INVOICE_PARSE_FLOW = "credit_card_invoice_parse";
+const CREDIT_CARD_INVOICE_OCR_RUNTIME_FLOW = "credit_card_invoice_ocr_runtime";
 const KNOWN_INVOICE_ISSUER_METRIC_KEYS = new Set([
   "itau",
   "nubank",
@@ -17,6 +18,7 @@ const KNOWN_INVOICE_ISSUER_METRIC_KEYS = new Set([
   "xp",
   "unknown",
 ]);
+const KNOWN_OCR_RUNTIME_STATUS_KEYS = new Set(["success", "failed", "timeout"]);
 
 const createError = (status, message, extra = {}) => {
   const error = new Error(message);
@@ -64,6 +66,48 @@ const extractRawExcerpt = (text) => collapseWhitespace(text).slice(0, 800);
 const resolveIssuerMetricKey = (issuer) => {
   const normalizedIssuer = String(issuer || "").trim().toLowerCase();
   return KNOWN_INVOICE_ISSUER_METRIC_KEYS.has(normalizedIssuer) ? normalizedIssuer : "unknown";
+};
+
+const resolveOcrRuntimeStatusMetricKey = (status) => {
+  const normalizedStatus = String(status || "").trim().toLowerCase();
+  return KNOWN_OCR_RUNTIME_STATUS_KEYS.has(normalizedStatus) ? normalizedStatus : "failed";
+};
+
+const resolveOcrRuntimeMetadata = (ocrRuntime) => ({
+  status: String(ocrRuntime?.status || "failed").trim().toLowerCase() || "failed",
+  reasonCode: String(ocrRuntime?.reasonCode || "unknown").trim().toLowerCase() || "unknown",
+  ocrEnabled: ocrRuntime?.ocrEnabled === true,
+  ocrAttempted: ocrRuntime?.ocrAttempted === true,
+  timeoutMs: Number.isInteger(ocrRuntime?.timeoutMs) ? ocrRuntime.timeoutMs : null,
+});
+
+const resolveParseErrorFromOcrRuntime = (ocrRuntimeMetadata) => {
+  if (ocrRuntimeMetadata?.status === "timeout") {
+    return {
+      publicCode: "INVOICE_OCR_TIMEOUT",
+      message: "Nao foi possivel extrair dados da fatura porque o OCR excedeu o tempo limite configurado.",
+    };
+  }
+
+  if (ocrRuntimeMetadata?.status !== "failed") {
+    return null;
+  }
+
+  if (ocrRuntimeMetadata.reasonCode === "ocr_disabled") {
+    return {
+      publicCode: "INVOICE_OCR_DISABLED",
+      message: "Nao foi possivel extrair dados da fatura porque o OCR para PDF escaneado esta desativado.",
+    };
+  }
+
+  if (ocrRuntimeMetadata.ocrAttempted) {
+    return {
+      publicCode: "INVOICE_OCR_FAILED",
+      message: "Nao foi possivel extrair dados da fatura porque o OCR falhou ao processar o PDF escaneado.",
+    };
+  }
+
+  return null;
 };
 
 const detectInvoiceIssuer = (rawText) => {
@@ -306,11 +350,29 @@ export const parseCreditCardInvoicePdfForUser = async (rawUserId, rawCardId, fil
   const card = cardRows[0];
 
   // Extract text from PDF
-  let rawText;
+  let extractionResult;
   try {
-    rawText = await extractTextFromPdfWithOcr(fileBuffer);
+    extractionResult = await extractTextFromPdfWithOcrRuntime(fileBuffer);
   } catch {
-    throw createError(422, "Nao foi possivel ler o PDF. Verifique se o arquivo nao esta corrompido.");
+    throw createError(422, "Nao foi possivel ler o PDF. Verifique se o arquivo nao esta corrompido.", {
+      publicCode: "INVOICE_PDF_READ_FAILED",
+    });
+  }
+
+  const rawText = String(extractionResult?.text || "");
+  const ocrRuntimeMetadata = resolveOcrRuntimeMetadata(extractionResult?.ocrRuntime);
+  const ocrRuntimeStatusMetricKey = resolveOcrRuntimeStatusMetricKey(ocrRuntimeMetadata.status);
+
+  if (ocrRuntimeStatusMetricKey === "success") {
+    trackDomainFlowSuccess({
+      flow: CREDIT_CARD_INVOICE_OCR_RUNTIME_FLOW,
+      operation: `status_${ocrRuntimeStatusMetricKey}`,
+    });
+  } else {
+    trackDomainFlowError({
+      flow: CREDIT_CARD_INVOICE_OCR_RUNTIME_FLOW,
+      operation: `status_${ocrRuntimeStatusMetricKey}`,
+    });
   }
 
   const strategyResult = parseCreditCardInvoiceByStrategy(rawText);
@@ -322,6 +384,12 @@ export const parseCreditCardInvoicePdfForUser = async (rawUserId, rawCardId, fil
       flow: CREDIT_CARD_INVOICE_PARSE_FLOW,
       operation: `issuer_${parsedIssuerMetricKey}`,
     });
+    const ocrRuntimeParseError = resolveParseErrorFromOcrRuntime(ocrRuntimeMetadata);
+    if (ocrRuntimeParseError) {
+      throw createError(422, ocrRuntimeParseError.message, {
+        publicCode: ocrRuntimeParseError.publicCode,
+      });
+    }
     throw createError(422, "Nao foi possivel extrair dados da fatura. Verifique se o PDF contem vencimento e total da fatura.", {
       publicCode: "INVOICE_PARSE_FAILED",
     });
@@ -384,6 +452,7 @@ export const parseCreditCardInvoicePdfForUser = async (rawUserId, rawCardId, fil
       strategy: strategyResult.strategy,
       name: strategyResult.parserName,
     },
+    ocrRuntime: ocrRuntimeMetadata,
     issuerDetection: strategyResult.issuerDetection,
     reviewContext: {
       needsReview,

--- a/docs/roadmaps/aud-007-ocr-runtime-governance.md
+++ b/docs/roadmaps/aud-007-ocr-runtime-governance.md
@@ -1,0 +1,38 @@
+# AUD-007 - OCR e PDF escaneado confiavel (Governanca de Slice)
+
+Fonte oficial de sequenciamento: `docs/roadmaps/audit-backlog-executable-plan-2026-04-03.md`.
+
+## Objetivo da fatia
+
+Implementar um slice minimo e verificavel para processamento de PDF escaneado com OCR no runtime atual, com transparencia de status e falha, sem inflar escopo.
+
+## Escopo que entra
+
+- Gate/config controlado para OCR em PDF escaneado.
+- Comportamento explicito para sucesso/falha/timeout no fluxo de parse.
+- Observabilidade basica de OCR (uso/falha/timeout) com cardinalidade controlada.
+- Testes focados do fluxo de OCR escaneado.
+
+## Escopo que nao entra
+
+- Fila assíncrona, job worker, orquestracao em background.
+- UX expandida de acompanhamento de processamento.
+- Novos parsers multiemissor.
+- Tuning amplo de OCR (qualidade/performance/custo) fora de guardrails minimos.
+
+## Rollback
+
+- Reverter para modo sem OCR pesado, com status explicito de nao processado para escaneado.
+- Rollback em um unico commit da fatia, sem migracoes destrutivas.
+
+## Criterios verificaveis minimos
+
+- Documento escaneado com OCR habilitado produz status deterministico de sucesso ou falha explicita.
+- Timeout gera status e codigo de erro explicitos (sem falha silenciosa).
+- Metricas de OCR registram uso e falha sem labels livres.
+- Teste automatizado cobre pelo menos: sucesso OCR e timeout/falha OCR.
+
+## Risco principal e mitigacao
+
+- Risco: crescimento de escopo ao misturar runtime + UX + async.
+- Mitigacao: PR limitada a runtime + status + observabilidade + teste, sem expansoes laterais.

--- a/docs/roadmaps/aud-007-ocr-runtime-governance.md
+++ b/docs/roadmaps/aud-007-ocr-runtime-governance.md
@@ -32,6 +32,18 @@ Implementar um slice minimo e verificavel para processamento de PDF escaneado co
 - Metricas de OCR registram uso e falha sem labels livres.
 - Teste automatizado cobre pelo menos: sucesso OCR e timeout/falha OCR.
 
+## Contrato minimo de status
+
+- Shape esperado em metadados de parse: `ocrRuntime: { status, reasonCode, ocrEnabled, ocrAttempted, timeoutMs }`.
+- Status permitidos nesta fatia: `success | failed | timeout`.
+- Erros tecnicos consumiveis por codigo publico: `INVOICE_OCR_TIMEOUT`, `INVOICE_OCR_FAILED`, `INVOICE_OCR_DISABLED`.
+
+## Tipo de timeout nesta fatia
+
+- Timeout logico/controlado do pipeline OCR no runtime atual.
+- Implementacao por limite configuravel (`IMPORT_OCR_TIMEOUT_MS`) aplicado por pagina durante `worker.recognize`.
+- Nao inclui (nesta fatia) timeout de fila assíncrona ou de infraestrutura externa.
+
 ## Risco principal e mitigacao
 
 - Risco: crescimento de escopo ao misturar runtime + UX + async.


### PR DESCRIPTION
## Governanca (execucao ativa)
- Fonte oficial do sequenciamento: docs/roadmaps/audit-backlog-executable-plan-2026-04-03.md (AUD-007).
- Issue de referencia: #462.
- Slice minimo desta PR: runtime OCR para PDF escaneado com status explicito, observabilidade basica e testes focados.
- Fora de escopo: fila/job assincrono, UX expandida, novos parsers, tuning amplo de OCR.

## Entrega implementada
- Gate/config de OCR mantido por IMPORT_OCR_ENABLED.
- Timeout logico/controlado por IMPORT_OCR_TIMEOUT_MS (aplicado no worker.recognize por pagina).
- Runtime OCR com contrato deterministico em metadados: ocrRuntime { status, reasonCode, ocrEnabled, ocrAttempted, timeoutMs }.
- Status desta fatia: success | failed | timeout.
- Transparencia de erro tecnico por codigo publico: INVOICE_OCR_TIMEOUT, INVOICE_OCR_FAILED, INVOICE_OCR_DISABLED, INVOICE_PDF_READ_FAILED.
- Observabilidade basica por status OCR com cardinalidade controlada no flow credit_card_invoice_ocr_runtime.

## Validacao local
- npm -w apps/api run test -- src/domain/imports/pdf-ocr.test.js src/credit-card-invoices.test.js
- npm -w apps/api run lint -- src/domain/imports/pdf-ocr.js src/domain/imports/pdf-ocr.test.js src/services/credit-card-invoices.service.js src/credit-card-invoices.test.js

## Rollback
- Revert unico do commit funcional da fatia AUD-007.
