### PR TITLE
fix(imports): require explicit confirmation for ambiguous document classification

### DIFF
--- a/apps/api/src/credit-card-invoices.test.js
+++ b/apps/api/src/credit-card-invoices.test.js
@@ -161,6 +161,10 @@ describe("credit-card-invoices", () => {
     expect(res.body.minimumPayment).toBe(124.78);
     expect(res.body.parseConfidence).toBe("high");
     expect(res.body.needsReview).toBe(false);
+    expect(res.body.classificationConfidence).toBe(0.9);
+    expect(res.body.classificationAmbiguous).toBe(false);
+    expect(res.body.reasonCode).toBe("not_ambiguous");
+    expect(res.body.requiresUserConfirmation).toBe(false);
     expect(res.body.parseMetadata?.parser?.name).toBe("itau_parser_v1");
     expect(res.body.parseMetadata?.ocrRuntime?.status).toBe("success");
     expect(res.body.linkedBillId).toBeNull();
@@ -179,6 +183,10 @@ describe("credit-card-invoices", () => {
     expect(res.status).toBe(201);
     expect(res.body.parseConfidence).toBe("low");
     expect(res.body.needsReview).toBe(true);
+    expect(res.body.classificationConfidence).toBe(0.45);
+    expect(res.body.classificationAmbiguous).toBe(true);
+    expect(res.body.reasonCode).toBe("period_inferred_from_closing_day");
+    expect(res.body.requiresUserConfirmation).toBe(true);
     expect(res.body.periodStart).not.toBeNull();
     expect(res.body.periodEnd).not.toBeNull();
     expect(res.body.parseMetadata.fieldsSources.periodStart).toBe("inference:closing_day");
@@ -455,6 +463,62 @@ describe("credit-card-invoices", () => {
 
     expect(res.status).toBe(422);
     expect(res.body.message).toBe("Valor da pendencia difere do total da fatura.");
+  });
+
+  it("POST link-bill exige confirmacao explicita para fatura ambigua", async () => {
+    const token = await registerAndLogin("inv-link-ambiguous-confirm@test.dev");
+    mockExtractTextWithRuntime.mockResolvedValue(createOcrRuntimeResult(ITAU_TEXT_NO_PERIOD));
+
+    const cardRes = await createCard(token, { closingDay: 7, dueDay: 15 });
+    const cardId = cardRes.body.id;
+
+    const invoiceRes = await uploadInvoice(token, cardId);
+    expect(invoiceRes.status).toBe(201);
+    expect(invoiceRes.body.classificationAmbiguous).toBe(true);
+    expect(invoiceRes.body.requiresUserConfirmation).toBe(true);
+
+    const billRes = await request(app)
+      .post("/bills")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        title: "Fatura ambigua",
+        amount: 850,
+        dueDate: "2026-03-15",
+        billType: "credit_card_invoice",
+      });
+
+    await dbQuery(
+      `UPDATE bills SET credit_card_id = $1, bill_type = 'credit_card_invoice' WHERE id = $2`,
+      [cardId, billRes.body.id],
+    );
+
+    const linkWithoutConfirmationRes = await request(app)
+      .post(`/credit-cards/${cardId}/invoices/${invoiceRes.body.id}/link-bill`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ billId: billRes.body.id });
+
+    expect(linkWithoutConfirmationRes.status).toBe(422);
+    expect(linkWithoutConfirmationRes.body.code).toBe("AMBIGUOUS_CLASSIFICATION_CONFIRMATION_REQUIRED");
+
+    const linkWithConfirmationRes = await request(app)
+      .post(`/credit-cards/${cardId}/invoices/${invoiceRes.body.id}/link-bill`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        billId: billRes.body.id,
+        confirmAmbiguousClassification: true,
+      });
+
+    expect(linkWithConfirmationRes.status).toBe(200);
+    expect(linkWithConfirmationRes.body.linkedBillId).toBe(billRes.body.id);
+
+    const metricsRes = await request(app).get("/metrics");
+    expect(metricsRes.status).toBe(200);
+    expect(metricsRes.text).toMatch(
+      /domain_financial_flow_events_total\{flow="credit_card_invoice_classification_confirmation",operation="auto_accept_blocked",outcome="error"\}\s+([0-9.]+)/,
+    );
+    expect(metricsRes.text).toMatch(
+      /domain_financial_flow_events_total\{flow="credit_card_invoice_classification_confirmation",operation="manual_confirmation",outcome="success"\}\s+([0-9.]+)/,
+    );
   });
 
   it("POST link-bill retorna 409 quando a mesma pendencia ja esta vinculada a outra fatura", async () => {

--- a/apps/api/src/services/credit-card-invoices.service.js
+++ b/apps/api/src/services/credit-card-invoices.service.js
@@ -6,6 +6,9 @@ import { trackDomainFlowError, trackDomainFlowSuccess } from "../observability/d
 const CREDIT_CARD_INVOICE_BILL_TYPE = "credit_card_invoice";
 const CREDIT_CARD_INVOICE_PARSE_FLOW = "credit_card_invoice_parse";
 const CREDIT_CARD_INVOICE_OCR_RUNTIME_FLOW = "credit_card_invoice_ocr_runtime";
+const CREDIT_CARD_INVOICE_CLASSIFICATION_CONFIRMATION_FLOW = "credit_card_invoice_classification_confirmation";
+const HIGH_CONFIDENCE_SCORE = 0.9;
+const LOW_CONFIDENCE_SCORE = 0.45;
 const KNOWN_INVOICE_ISSUER_METRIC_KEYS = new Set([
   "itau",
   "nubank",
@@ -25,6 +28,25 @@ const createError = (status, message, extra = {}) => {
   error.status = status;
   Object.assign(error, extra);
   return error;
+};
+
+const normalizeJsonObject = (value) => {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed;
+      }
+    } catch {
+      return {};
+    }
+  }
+
+  return {};
 };
 
 const normalizeUserId = (value) => {
@@ -108,6 +130,32 @@ const resolveParseErrorFromOcrRuntime = (ocrRuntimeMetadata) => {
   }
 
   return null;
+};
+
+const resolveInvoiceClassificationSignals = ({ parseConfidence, parseMetadata }) => {
+  const normalizedParseConfidence = String(parseConfidence || "").trim().toLowerCase() === "high" ? "high" : "low";
+  const normalizedParseMetadata = normalizeJsonObject(parseMetadata);
+  const reviewContext = normalizeJsonObject(normalizedParseMetadata.reviewContext);
+  const reasonCodes = Array.isArray(reviewContext.reasonCodes)
+    ? reviewContext.reasonCodes
+      .map((value) => String(value || "").trim().toLowerCase())
+      .filter(Boolean)
+    : [];
+
+  const classificationAmbiguous =
+    reviewContext.needsReview === true || normalizedParseConfidence !== "high" || reasonCodes.length > 0;
+
+  const reasonCode = classificationAmbiguous
+    ? reasonCodes[0] || (normalizedParseConfidence === "low" ? "parse_confidence_low" : "manual_review_required")
+    : "not_ambiguous";
+
+  return {
+    classificationConfidence: normalizedParseConfidence === "high" ? HIGH_CONFIDENCE_SCORE : LOW_CONFIDENCE_SCORE,
+    classificationAmbiguous,
+    reasonCode,
+    requiresUserConfirmation: classificationAmbiguous,
+    parseMetadata: normalizedParseMetadata,
+  };
 };
 
 const detectInvoiceIssuer = (rawText) => {
@@ -308,32 +356,42 @@ const inferPeriod = (dueDate, closingDay) => {
 
 // ─── Formatters ───────────────────────────────────────────────────────────────
 
-const formatInvoice = (row) => ({
-  id: Number(row.id),
-  userId: Number(row.user_id),
-  creditCardId: Number(row.credit_card_id),
-  issuer: row.issuer,
-  cardLast4: row.card_last4 ?? null,
-  periodStart: typeof row.period_start === "string"
-    ? row.period_start
-    : row.period_start?.toISOString().slice(0, 10) ?? null,
-  periodEnd: typeof row.period_end === "string"
-    ? row.period_end
-    : row.period_end?.toISOString().slice(0, 10) ?? null,
-  dueDate: typeof row.due_date === "string"
-    ? row.due_date
-    : row.due_date?.toISOString().slice(0, 10) ?? null,
-  totalAmount: Number(row.total_amount),
-  minimumPayment: row.minimum_payment != null ? Number(row.minimum_payment) : null,
-  financedBalance: row.financed_balance != null ? Number(row.financed_balance) : null,
-  parseConfidence: row.parse_confidence,
-  parseMetadata: row.parse_metadata ?? {},
-  needsReview:
-    row.parse_metadata?.reviewContext?.needsReview === true || row.parse_confidence === "low",
-  linkedBillId: row.linked_bill_id ? Number(row.linked_bill_id) : null,
-  createdAt: typeof row.created_at === "string" ? row.created_at : row.created_at?.toISOString(),
-  updatedAt: typeof row.updated_at === "string" ? row.updated_at : row.updated_at?.toISOString(),
-});
+const formatInvoice = (row) => {
+  const classificationSignals = resolveInvoiceClassificationSignals({
+    parseConfidence: row.parse_confidence,
+    parseMetadata: row.parse_metadata,
+  });
+
+  return {
+    id: Number(row.id),
+    userId: Number(row.user_id),
+    creditCardId: Number(row.credit_card_id),
+    issuer: row.issuer,
+    cardLast4: row.card_last4 ?? null,
+    periodStart: typeof row.period_start === "string"
+      ? row.period_start
+      : row.period_start?.toISOString().slice(0, 10) ?? null,
+    periodEnd: typeof row.period_end === "string"
+      ? row.period_end
+      : row.period_end?.toISOString().slice(0, 10) ?? null,
+    dueDate: typeof row.due_date === "string"
+      ? row.due_date
+      : row.due_date?.toISOString().slice(0, 10) ?? null,
+    totalAmount: Number(row.total_amount),
+    minimumPayment: row.minimum_payment != null ? Number(row.minimum_payment) : null,
+    financedBalance: row.financed_balance != null ? Number(row.financed_balance) : null,
+    parseConfidence: row.parse_confidence,
+    parseMetadata: classificationSignals.parseMetadata,
+    needsReview: classificationSignals.classificationAmbiguous,
+    classificationConfidence: classificationSignals.classificationConfidence,
+    classificationAmbiguous: classificationSignals.classificationAmbiguous,
+    reasonCode: classificationSignals.reasonCode,
+    requiresUserConfirmation: classificationSignals.requiresUserConfirmation,
+    linkedBillId: row.linked_bill_id ? Number(row.linked_bill_id) : null,
+    createdAt: typeof row.created_at === "string" ? row.created_at : row.created_at?.toISOString(),
+    updatedAt: typeof row.updated_at === "string" ? row.updated_at : row.updated_at?.toISOString(),
+  };
+};
 
 // ─── Parse PDF ────────────────────────────────────────────────────────────────
 
@@ -525,12 +583,28 @@ export const linkBillToInvoiceForUser = async (rawUserId, rawCardId, rawInvoiceI
 
   // Invoice ownership
   const { rows: invRows } = await dbQuery(
-    `SELECT id, linked_bill_id, total_amount FROM credit_card_invoices
+    `SELECT id, linked_bill_id, total_amount, parse_confidence, parse_metadata FROM credit_card_invoices
       WHERE id = $1 AND credit_card_id = $2 AND user_id = $3`,
     [invoiceId, cardId, userId]
   );
   if (!invRows.length) throw createError(404, "Fatura nao encontrada.");
   if (invRows[0].linked_bill_id) throw createError(409, "Fatura ja esta vinculada a uma pendencia.");
+
+  const classificationSignals = resolveInvoiceClassificationSignals({
+    parseConfidence: invRows[0].parse_confidence,
+    parseMetadata: invRows[0].parse_metadata,
+  });
+  const explicitAmbiguousConfirmation = input?.confirmAmbiguousClassification === true;
+
+  if (classificationSignals.requiresUserConfirmation && !explicitAmbiguousConfirmation) {
+    trackDomainFlowError({
+      flow: CREDIT_CARD_INVOICE_CLASSIFICATION_CONFIRMATION_FLOW,
+      operation: "auto_accept_blocked",
+    });
+    throw createError(422, "Confirmacao explicita obrigatoria para fatura com classificacao ambigua.", {
+      publicCode: "AMBIGUOUS_CLASSIFICATION_CONFIRMATION_REQUIRED",
+    });
+  }
 
   // Bill ownership + same card
   const { rows: billRows } = await dbQuery(
@@ -577,6 +651,11 @@ export const linkBillToInvoiceForUser = async (rawUserId, rawCardId, rawInvoiceI
       RETURNING *`,
     [billId, invoiceId, userId]
   );
+
+  trackDomainFlowSuccess({
+    flow: CREDIT_CARD_INVOICE_CLASSIFICATION_CONFIRMATION_FLOW,
+    operation: classificationSignals.requiresUserConfirmation ? "manual_confirmation" : "auto_accept",
+  });
 
   return formatInvoice(updated[0]);
 };

--- a/apps/web/src/services/credit-cards.service.ts
+++ b/apps/web/src/services/credit-cards.service.ts
@@ -114,9 +114,17 @@ export interface CreditCardInvoicePdf {
   parseConfidence: InvoiceParseConfidence;
   parseMetadata: Record<string, unknown>;
   needsReview?: boolean;
+  classificationConfidence?: number;
+  classificationAmbiguous?: boolean;
+  reasonCode?: string;
+  requiresUserConfirmation?: boolean;
   linkedBillId: number | null;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface LinkBillToInvoicePdfOptions {
+  confirmAmbiguousClassification?: boolean;
 }
 
 const normalizeString = (value: unknown) => (typeof value === "string" ? value.trim() : "");
@@ -293,11 +301,17 @@ export const creditCardsService = {
   linkBillToInvoicePdf: async (
     cardId: number,
     invoiceId: number,
-    billId: number
+    billId: number,
+    options: LinkBillToInvoicePdfOptions = {},
   ): Promise<CreditCardInvoicePdf> => {
     const { data } = await api.post<CreditCardInvoicePdf>(
       `/credit-cards/${cardId}/invoices/${invoiceId}/link-bill`,
-      { billId }
+      {
+        billId,
+        ...(options.confirmAmbiguousClassification === true
+          ? { confirmAmbiguousClassification: true }
+          : {}),
+      }
     );
     return data;
   },

--- a/docs/roadmaps/aud-008-ambiguity-confidence-governance.md
+++ b/docs/roadmaps/aud-008-ambiguity-confidence-governance.md
@@ -30,3 +30,15 @@ Quando a classificacao for ambigua, o sistema nao decide sozinho; ele sinaliza e
 - Ambiguidade produz status explicitamente revisavel e nao auto-decisionado.
 - Contrato permanece aditivo para consumidores existentes.
 - Teste automatizado cobre ao menos um caso de auto-aceite e um caso de confirmacao manual obrigatoria.
+
+## Shape minimo esperado do contrato
+
+- `classificationConfidence`: score numerico normalizado para decisao operacional.
+- `classificationAmbiguous`: sinal booleano de ambiguidade.
+- `reasonCode`: motivo tecnico principal da classificacao ambigua.
+- `requiresUserConfirmation`: gate booleano para confirmacao explicita.
+
+## Fallback seguro desta fatia
+
+- Em ambiguidade, bloquear auto-aceite.
+- Exigir confirmacao explicita do usuario para seguir com o vinculo/acao.

--- a/docs/roadmaps/aud-008-ambiguity-confidence-governance.md
+++ b/docs/roadmaps/aud-008-ambiguity-confidence-governance.md
@@ -1,0 +1,32 @@
+# AUD-008 - Confidence e Confirmacao Ambigua (Governanca de Slice)
+
+Fonte oficial de sequenciamento: `docs/roadmaps/audit-backlog-executable-plan-2026-04-03.md`.
+
+## Contrato semantico da fatia
+
+Quando a classificacao for ambigua, o sistema nao decide sozinho; ele sinaliza e exige confirmacao explicita.
+
+## Escopo que entra
+
+- Sinal de ambiguidade/confidence com reason codes em contrato aditivo FE/BE.
+- Fallback seguro: sem auto-aceite em classificacao ambigua.
+- Testes focados de limiar e confirmacao obrigatoria.
+- Metricas basicas de auto-accept vs manual-confirmation com cardinalidade controlada.
+
+## Escopo que nao entra
+
+- Expansao de parser documental.
+- UX complexa (wizards, novos fluxos longos, estados extensivos).
+- Fila/background e orquestracao assíncrona.
+- Tuning amplo de heuristica fora do limiar minimo da fatia.
+
+## Rollback
+
+- Reverter para comportamento anterior de limiar/confirmacao por revert unico da fatia.
+- Sem migracoes destrutivas.
+
+## Criterios verificaveis minimos
+
+- Ambiguidade produz status explicitamente revisavel e nao auto-decisionado.
+- Contrato permanece aditivo para consumidores existentes.
+- Teste automatizado cobre ao menos um caso de auto-aceite e um caso de confirmacao manual obrigatoria.


### PR DESCRIPTION
## Governanca (execucao ativa)
- Fonte oficial do sequenciamento: docs/roadmaps/audit-backlog-executable-plan-2026-04-03.md (AUD-008).
- Issue de referencia: #464.
- Contrato da fatia: quando a classificacao for ambigua, o sistema nao decide sozinho; ele sinaliza e exige confirmacao explicita.
- Fora de escopo: expansao de parser, UX complexa, fila/background, tuning amplo de heuristica.

## Entrega minima implementada
- Sinal aditivo FE/BE no contrato de fatura: `classificationConfidence`, `classificationAmbiguous`, `reasonCode`, `requiresUserConfirmation`.
- Fallback seguro: bloqueio de auto-aceite para classificacao ambigua no link da fatura.
- Confirmacao explicita no backend via `confirmAmbiguousClassification=true` para permitir vinculo em caso ambiguo.
- Metricas basicas com cardinalidade controlada no fluxo `credit_card_invoice_classification_confirmation`:
  - `auto_accept_blocked` (error)
  - `manual_confirmation` (success)

## Validacao local
- npm -w apps/api run test -- src/credit-card-invoices.test.js
- npm -w apps/api run lint -- src/services/credit-card-invoices.service.js src/credit-card-invoices.test.js
- npm -w apps/web run typecheck
- npm -w apps/web run lint -- src/services/credit-cards.service.ts

## Rollback
- Revert unico do commit funcional da fatia AUD-008.
