### PR TITLE
test(import): add anonymized corpus golden-tests guardrails

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,6 +14,7 @@
     "db:backfill:categories-normalized": "node src/db/backfill-categories-normalized.js",
     "db:seed": "node src/db/seed.js",
     "lint": "eslint src --max-warnings 0",
+    "test:golden": "vitest run src/credit-card-invoices.golden.test.js",
     "test": "vitest run",
     "test:run": "vitest run"
   },

--- a/apps/api/src/credit-card-invoices.golden.test.js
+++ b/apps/api/src/credit-card-invoices.golden.test.js
@@ -1,0 +1,168 @@
+import fs from "node:fs/promises";
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from "vitest";
+import request from "supertest";
+import app from "./app.js";
+import { clearDbClientForTests, dbQuery } from "./db/index.js";
+import { setupTestDb, registerAndLogin } from "./test-helpers.js";
+import { resetLoginProtectionState } from "./middlewares/login-protection.middleware.js";
+import { resetImportRateLimiterState, resetWriteRateLimiterState } from "./middlewares/rate-limit.middleware.js";
+import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
+
+const mockExtractTextWithRuntime = vi.hoisted(() => vi.fn());
+
+vi.mock("./domain/imports/pdf-ocr.js", () => ({
+  extractTextFromPdfWithOcrRuntime: mockExtractTextWithRuntime,
+  extractTextFromPdfWithOcr: vi.fn(async (...args) => {
+    const result = await mockExtractTextWithRuntime(...args);
+    if (typeof result === "string") {
+      return result;
+    }
+    return String(result?.text || "");
+  }),
+  isImportOcrEnabled: () => false,
+  shouldRunPdfOcrFallback: () => false,
+}));
+
+const GOLDEN_FIXTURE_PATH = new URL(
+  "./domain/imports/corpus/credit-card-invoices/golden-v1.json",
+  import.meta.url,
+);
+
+const sensitivePatterns = [
+  /\b\d{3}\.\d{3}\.\d{3}-\d{2}\b/, // CPF formatado
+  /\b\d{11}\b/, // CPF sem formatacao
+  /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i, // email
+  /\b\d{13,19}\b/, // possivel numero de cartao completo
+];
+
+const createOcrRuntimeResult = (text) => ({
+  text,
+  ocrRuntime: {
+    status: "success",
+    reasonCode: "direct_text_sufficient",
+    ocrEnabled: false,
+    ocrAttempted: false,
+    timeoutMs: null,
+  },
+});
+
+const createCard = (token, overrides = {}) =>
+  request(app)
+    .post("/credit-cards")
+    .set("Authorization", `Bearer ${token}`)
+    .send({ name: "Cartao Teste", limitTotal: 5000, closingDay: 7, dueDay: 15, ...overrides });
+
+const uploadInvoice = (token, cardId) =>
+  request(app)
+    .post(`/credit-cards/${cardId}/invoices/parse-pdf`)
+    .set("Authorization", `Bearer ${token}`)
+    .attach("file", Buffer.from("fake-pdf", "utf8"), {
+      filename: "fatura.pdf",
+      contentType: "application/pdf",
+    });
+
+const resetState = async () => {
+  resetLoginProtectionState();
+  resetImportRateLimiterState();
+  resetWriteRateLimiterState();
+  resetHttpMetricsForTests();
+  mockExtractTextWithRuntime.mockReset();
+  await dbQuery("DELETE FROM credit_card_invoices");
+  await dbQuery("DELETE FROM credit_card_purchases");
+  await dbQuery("DELETE FROM bills");
+  await dbQuery("DELETE FROM credit_cards");
+  await dbQuery("DELETE FROM users");
+};
+
+let goldenFixtures;
+
+describe("credit-card-invoices golden corpus", () => {
+  beforeAll(async () => {
+    await setupTestDb();
+    const fixtureRaw = await fs.readFile(GOLDEN_FIXTURE_PATH, "utf8");
+    goldenFixtures = JSON.parse(fixtureRaw);
+  });
+
+  afterAll(async () => {
+    await clearDbClientForTests();
+  });
+
+  beforeEach(resetState);
+
+  it("corpus v1 respeita politica de anonimizacao minima", () => {
+    expect(goldenFixtures?.version).toBe("1.0.0");
+    expect(goldenFixtures?.anonymizationPolicyVersion).toBe("1.0.0");
+    expect(Array.isArray(goldenFixtures?.cases)).toBe(true);
+
+    for (const fixture of goldenFixtures.cases) {
+      const text = String(fixture?.invoiceText || "");
+      for (const pattern of sensitivePatterns) {
+        expect(pattern.test(text), `fixture ${fixture?.id} viola anonimizacao: ${pattern}`).toBe(false);
+      }
+    }
+  });
+
+  it("corpus v1 valida golden contract de parse e confirmacao", async () => {
+    for (const fixture of goldenFixtures.cases) {
+      const token = await registerAndLogin(`golden-${fixture.id}@test.dev`);
+
+      mockExtractTextWithRuntime.mockResolvedValue(createOcrRuntimeResult(fixture.invoiceText));
+
+      const cardRes = await createCard(token, fixture.card || {});
+      expect(cardRes.status, `createCard failed for ${fixture.id}`).toBe(201);
+      const cardId = cardRes.body.id;
+
+      const parseRes = await uploadInvoice(token, cardId);
+      expect(parseRes.status, `parse invoice failed for ${fixture.id}`).toBe(201);
+
+      expect(parseRes.body.issuer).toBe(fixture.expected.issuer);
+      expect(parseRes.body.parseConfidence).toBe(fixture.expected.parseConfidence);
+      expect(parseRes.body.classificationConfidence).toBe(fixture.expected.classificationConfidence);
+      expect(parseRes.body.classificationAmbiguous).toBe(fixture.expected.classificationAmbiguous);
+      expect(parseRes.body.reasonCode).toBe(fixture.expected.reasonCode);
+      expect(parseRes.body.requiresUserConfirmation).toBe(fixture.expected.requiresUserConfirmation);
+      expect(parseRes.body.totalAmount).toBe(fixture.expected.totalAmount);
+      expect(parseRes.body.dueDate).toBe(fixture.expected.dueDate);
+
+      const billRes = await request(app)
+        .post("/bills")
+        .set("Authorization", `Bearer ${token}`)
+        .send({
+          title: `Golden bill ${fixture.id}`,
+          amount: fixture.expected.totalAmount,
+          dueDate: fixture.expected.dueDate,
+          billType: "credit_card_invoice",
+        });
+      expect(billRes.status, `create bill failed for ${fixture.id}`).toBe(201);
+
+      await dbQuery(
+        `UPDATE bills SET credit_card_id = $1, bill_type = 'credit_card_invoice' WHERE id = $2`,
+        [cardId, billRes.body.id],
+      );
+
+      if (fixture.expected.requiresUserConfirmation) {
+        const blockedRes = await request(app)
+          .post(`/credit-cards/${cardId}/invoices/${parseRes.body.id}/link-bill`)
+          .set("Authorization", `Bearer ${token}`)
+          .send({ billId: billRes.body.id });
+
+        expect(blockedRes.status, `expected block on ambiguous case ${fixture.id}`).toBe(422);
+        expect(blockedRes.body.code).toBe(fixture.expected.blockedCode);
+
+        const confirmedRes = await request(app)
+          .post(`/credit-cards/${cardId}/invoices/${parseRes.body.id}/link-bill`)
+          .set("Authorization", `Bearer ${token}`)
+          .send({ billId: billRes.body.id, confirmAmbiguousClassification: true });
+
+        expect(confirmedRes.status, `expected manual confirmation success for ${fixture.id}`).toBe(200);
+      } else {
+        const linkRes = await request(app)
+          .post(`/credit-cards/${cardId}/invoices/${parseRes.body.id}/link-bill`)
+          .set("Authorization", `Bearer ${token}`)
+          .send({ billId: billRes.body.id });
+
+        expect(linkRes.status, `expected auto accept for ${fixture.id}`).toBe(200);
+      }
+    }
+  });
+});

--- a/apps/api/src/domain/imports/corpus/credit-card-invoices/README.md
+++ b/apps/api/src/domain/imports/corpus/credit-card-invoices/README.md
@@ -1,0 +1,20 @@
+# Credit Card Invoices Golden Corpus (v1)
+
+Este corpus e anonimo e deterministico.
+
+## Regras de anonimizacao
+
+- Nao conter CPF real, e-mail real, telefone real ou numero completo de cartao.
+- Campos de identidade devem usar placeholders neutros.
+- Valores monetarios, datas e padroes documentais necessarios para classificacao/extracao devem ser preservados.
+
+## Politica de atualizacao
+
+- Atualizacoes de expected devem acontecer apenas quando houver mudanca intencional de contrato.
+- Toda mudanca deve ser acompanhada de explicacao no PR sobre impacto de regressao.
+- Evitar ampliar corpus em lote grande nesta fatia; manter recorte pequeno e representativo.
+
+## Execucao
+
+- Local: `npm -w apps/api run test:golden`
+- CI: suite executada pelo job de testes da API.

--- a/apps/api/src/domain/imports/corpus/credit-card-invoices/golden-v1.json
+++ b/apps/api/src/domain/imports/corpus/credit-card-invoices/golden-v1.json
@@ -1,0 +1,45 @@
+{
+  "version": "1.0.0",
+  "anonymizationPolicyVersion": "1.0.0",
+  "cases": [
+    {
+      "id": "itau_high_confidence_auto_accept",
+      "description": "Fluxo de alta confianca segue sem exigir confirmacao explicita.",
+      "invoiceText": "BANCO ITAU S.A.\n**** 1234\nPERIODO DE 08/02/2026 A 07/03/2026\nVENCIMENTO 15/03/2026\nTOTAL DA FATURA R$ 1.247,80\nPAGAMENTO MINIMO R$ 124,78",
+      "card": {
+        "closingDay": 7,
+        "dueDay": 15
+      },
+      "expected": {
+        "issuer": "itau",
+        "parseConfidence": "high",
+        "classificationConfidence": 0.9,
+        "classificationAmbiguous": false,
+        "reasonCode": "not_ambiguous",
+        "requiresUserConfirmation": false,
+        "totalAmount": 1247.8,
+        "dueDate": "2026-03-15"
+      }
+    },
+    {
+      "id": "itau_period_missing_requires_confirmation",
+      "description": "Fluxo ambiguo bloqueia auto-aceite e exige confirmacao explicita.",
+      "invoiceText": "BANCO ITAU S.A.\nVENCIMENTO 15/03/2026\nTOTAL DA FATURA R$ 850,00",
+      "card": {
+        "closingDay": 7,
+        "dueDay": 15
+      },
+      "expected": {
+        "issuer": "itau",
+        "parseConfidence": "low",
+        "classificationConfidence": 0.45,
+        "classificationAmbiguous": true,
+        "reasonCode": "period_inferred_from_closing_day",
+        "requiresUserConfirmation": true,
+        "totalAmount": 850,
+        "dueDate": "2026-03-15",
+        "blockedCode": "AMBIGUOUS_CLASSIFICATION_CONFIRMATION_REQUIRED"
+      }
+    }
+  ]
+}

--- a/docs/roadmaps/aud-009-document-corpus-golden-tests-governance.md
+++ b/docs/roadmaps/aud-009-document-corpus-golden-tests-governance.md
@@ -1,0 +1,35 @@
+# AUD-009 - Corpus real anonimizado e Golden Tests (Governanca de Slice)
+
+Fonte oficial de sequenciamento: docs/roadmaps/audit-backlog-executable-plan-2026-04-03.md.
+
+## Objetivo da fatia
+
+Adicionar corpus de documentos reais anonimizados e suites de golden tests para evitar regressao de extracao/classificacao no fluxo de importacao.
+
+## Contrato herdado (nao regredir)
+
+O contrato de ambiguidade e confirmacao explicita consolidado na AUD-008 permanece valido e fora de rediscussao nesta fatia.
+
+## Escopo que entra
+
+- Fixtures anonimizadas versionadas para cenarios representativos.
+- Golden tests deterministicas para extracao/classificacao.
+- Guardrails de regressao para campos/semantica essenciais.
+- Metricas basicas de regressao por suite (pass/fail) sem labels livres.
+
+## Escopo que nao entra
+
+- Expansao de parser/heuristica em larga escala.
+- UX nova ou fluxos de confirmacao adicionais.
+- Fila/background e mudancas de orquestracao runtime.
+- Reabertura de decisoes semanticas da AUD-007/AUD-008.
+
+## Rollback
+
+- Revert unico da fatia (fixtures e suites) sem migracoes destrutivas.
+
+## Criterios verificaveis minimos
+
+- Pelo menos um conjunto de fixtures anonimizadas por tipo alvo com expected versionado.
+- Suite golden falha quando houver regressao em campos-chave.
+- CI executa a suite e bloqueia regressao funcional no recorte definido.


### PR DESCRIPTION
## Governanca (execucao ativa)
- Fonte oficial: docs/roadmaps/audit-backlog-executable-plan-2026-04-03.md (AUD-009).
- Issue: #466.
- Guardrail de continuidade: nao reabrir semantica de ambiguidade/confirmacao fechada na AUD-008.
- Fora de escopo: parser expansion, UX nova, fila/background, tuning amplo de heuristica.

## Entrega minima implementada
- Corpus anonimizado versionado v1 em JSON com casos representativos (high-confidence e ambiguous-confirmation).
- Expected outputs versionados no proprio corpus para regressao deterministica de contrato.
- Suite golden deterministica (`credit-card-invoices.golden.test.js`) cobrindo:
  - contrato de parse esperado por fixture
  - comportamento de auto-accept vs manual confirmation
  - politica minima de anonimizacao (sem CPF/email/cartao completo)
- Comando unico local/CI para suite: `npm -w apps/api run test:golden`.

## Guardrail de CI nesta fatia
- Regressao real de contrato/fluxo faz a suite golden falhar.
- Nao e expansao documental total; e recorte inicial pequeno e representativo.

## Validacao local
- npm -w apps/api run test:golden
- npm -w apps/api run test -- src/credit-card-invoices.test.js
- npm -w apps/api run lint -- src/credit-card-invoices.golden.test.js

## Rollback
- Revert unico da fatia AUD-009.
