### PR TITLE
AUD-012 - baseline hardening HTTP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,31 @@ jobs:
         with:
           name: smoke-critical-finance-journey-log
           path: smoke-critical-finance-journey.log
+
+  http_hardening_baseline:
+    name: http-hardening-baseline
+    runs-on: ubuntu-latest
+    needs: [api]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Hardening baseline contract
+        run: npm -w apps/api run test:hardening:http | tee http-hardening-baseline.log
+
+      - name: Upload hardening evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: http-hardening-baseline-log
+          path: http-hardening-baseline.log

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,7 @@
     "db:seed": "node src/db/seed.js",
     "lint": "eslint src --max-warnings 0",
     "test:golden": "vitest run src/credit-card-invoices.golden.test.js",
+    "test:hardening:http": "vitest run src/http-hardening-baseline.test.js",
     "test:smoke:critical": "vitest run src/smoke-critical-finance-journey.test.js",
     "test": "vitest run",
     "test:run": "vitest run"

--- a/apps/api/src/http-hardening-baseline.test.js
+++ b/apps/api/src/http-hardening-baseline.test.js
@@ -1,0 +1,89 @@
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import app from "./app.js";
+import { clearDbClientForTests, dbQuery } from "./db/index.js";
+import { resetLoginProtectionState } from "./middlewares/login-protection.middleware.js";
+import {
+  resetImportRateLimiterState,
+  resetWriteRateLimiterState,
+} from "./middlewares/rate-limit.middleware.js";
+import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
+
+const ALLOWED_ORIGIN = "http://localhost:5173";
+
+describe("http hardening baseline", () => {
+  beforeAll(async () => {
+    const { setupTestDb } = await import("./test-helpers.js");
+    await setupTestDb();
+  });
+
+  afterAll(async () => {
+    await clearDbClientForTests();
+  });
+
+  beforeEach(async () => {
+    resetLoginProtectionState();
+    resetImportRateLimiterState();
+    resetWriteRateLimiterState();
+    resetHttpMetricsForTests();
+    await dbQuery("DELETE FROM refresh_tokens");
+    await dbQuery("DELETE FROM subscriptions");
+    await dbQuery("DELETE FROM users");
+  });
+
+  it("applies baseline security headers on sensitive route", async () => {
+    const response = await request(app).get("/health").set("Origin", ALLOWED_ORIGIN);
+
+    expect(response.status).toBe(200);
+    expect(response.headers["cross-origin-opener-policy"]).toBe("same-origin");
+    expect(response.headers["cross-origin-embedder-policy"]).toBe("require-corp");
+    expect(response.headers["x-content-type-options"]).toBe("nosniff");
+    expect(response.headers["x-frame-options"]).toBe("SAMEORIGIN");
+    expect(response.headers["referrer-policy"]).toBe("strict-origin-when-cross-origin");
+    expect(response.headers["x-permitted-cross-domain-policies"]).toBe("none");
+    expect(response.headers["permissions-policy"]).toBe("camera=(), microphone=(), geolocation=()");
+  });
+
+  it("keeps OAuth popup compatibility on auth routes", async () => {
+    const response = await request(app).get("/auth/me");
+
+    expect(response.status).toBe(401);
+    expect(response.headers["cross-origin-opener-policy"]).toBe("same-origin-allow-popups");
+  });
+
+  it("enforces minimal CORS contract for allowed origin", async () => {
+    const response = await request(app).get("/health").set("Origin", ALLOWED_ORIGIN);
+
+    expect(response.status).toBe(200);
+    expect(response.headers["access-control-allow-origin"]).toBe(ALLOWED_ORIGIN);
+    expect(response.headers["access-control-allow-credentials"]).toBe("true");
+  });
+
+  it("blocks disallowed CORS origin with 403", async () => {
+    const response = await request(app)
+      .get("/health")
+      .set("Origin", "https://malicious.example");
+
+    expect(response.status).toBe(403);
+    expect(response.body.message).toBe("CORS origin not allowed.");
+  });
+
+  it("issues auth cookies with baseline httpOnly and sameSite flags", async () => {
+    const response = await request(app).post("/auth/register").send({
+      email: "http-hardening-baseline@test.dev",
+      password: "Senha123",
+    });
+
+    expect(response.status).toBe(201);
+    const cookies = response.headers["set-cookie"] || [];
+    const accessCookie = cookies.find((cookie) => cookie.startsWith("cf_access="));
+    const refreshCookie = cookies.find((cookie) => cookie.startsWith("cf_refresh="));
+
+    expect(accessCookie).toBeTruthy();
+    expect(refreshCookie).toBeTruthy();
+    expect(accessCookie).toContain("HttpOnly");
+    expect(refreshCookie).toContain("HttpOnly");
+    expect(accessCookie).toContain("SameSite=Lax");
+    expect(refreshCookie).toContain("SameSite=Lax");
+  });
+});

--- a/apps/api/src/http-hardening-baseline.test.js
+++ b/apps/api/src/http-hardening-baseline.test.js
@@ -11,6 +11,20 @@ import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
 
 const ALLOWED_ORIGIN = "http://localhost:5173";
 
+const getExpectedSameSiteCookieAttribute = () => {
+  const rawValue = (process.env.COOKIE_SAME_SITE || "lax").toLowerCase().trim();
+
+  if (rawValue === "none") {
+    return "SameSite=None";
+  }
+
+  if (rawValue === "strict") {
+    return "SameSite=Strict";
+  }
+
+  return "SameSite=Lax";
+};
+
 describe("http hardening baseline", () => {
   beforeAll(async () => {
     const { setupTestDb } = await import("./test-helpers.js");
@@ -59,6 +73,26 @@ describe("http hardening baseline", () => {
     expect(response.headers["access-control-allow-credentials"]).toBe("true");
   });
 
+  it("keeps same-origin requests without Origin header working", async () => {
+    const response = await request(app).get("/health");
+
+    expect(response.status).toBe(200);
+    expect(response.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("accepts legitimate preflight for allowed frontend origin", async () => {
+    const response = await request(app)
+      .options("/health")
+      .set("Origin", ALLOWED_ORIGIN)
+      .set("Access-Control-Request-Method", "GET")
+      .set("Access-Control-Request-Headers", "content-type");
+
+    expect(response.status).toBe(204);
+    expect(response.headers["access-control-allow-origin"]).toBe(ALLOWED_ORIGIN);
+    expect(response.headers["access-control-allow-credentials"]).toBe("true");
+    expect(response.headers["access-control-allow-methods"]).toContain("GET");
+  });
+
   it("blocks disallowed CORS origin with 403", async () => {
     const response = await request(app)
       .get("/health")
@@ -78,12 +112,13 @@ describe("http hardening baseline", () => {
     const cookies = response.headers["set-cookie"] || [];
     const accessCookie = cookies.find((cookie) => cookie.startsWith("cf_access="));
     const refreshCookie = cookies.find((cookie) => cookie.startsWith("cf_refresh="));
+    const expectedSameSite = getExpectedSameSiteCookieAttribute();
 
     expect(accessCookie).toBeTruthy();
     expect(refreshCookie).toBeTruthy();
     expect(accessCookie).toContain("HttpOnly");
     expect(refreshCookie).toContain("HttpOnly");
-    expect(accessCookie).toContain("SameSite=Lax");
-    expect(refreshCookie).toContain("SameSite=Lax");
+    expect(accessCookie).toContain(expectedSameSite);
+    expect(refreshCookie).toContain(expectedSameSite);
   });
 });

--- a/apps/api/src/middlewares/security-headers.middleware.js
+++ b/apps/api/src/middlewares/security-headers.middleware.js
@@ -11,6 +11,15 @@
  */
 
 export const securityHeadersMiddleware = (req, res, next) => {
+  const baselineHeaders = {
+    "Cross-Origin-Embedder-Policy": "require-corp",
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "SAMEORIGIN",
+    "Referrer-Policy": "strict-origin-when-cross-origin",
+    "X-Permitted-Cross-Domain-Policies": "none",
+    "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
+  };
+
   // Default COOP policy: restrict popup communication for general security
   let coopPolicy = "same-origin";
 
@@ -23,8 +32,9 @@ export const securityHeadersMiddleware = (req, res, next) => {
   // Set COOP header
   res.setHeader("Cross-Origin-Opener-Policy", coopPolicy);
 
-  // Set COEP header: require CORS headers on cross-origin resources
-  res.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+  Object.entries(baselineHeaders).forEach(([name, value]) => {
+    res.setHeader(name, value);
+  });
 
   next();
 };

--- a/docs/roadmaps/aud-012-http-hardening-baseline-governance.md
+++ b/docs/roadmaps/aud-012-http-hardening-baseline-governance.md
@@ -22,6 +22,28 @@ Estabelecer baseline minimo de hardening HTTP para workloads sensiveis, com cont
 - Adicionar teste(s) de contrato para impedir regressao do baseline no CI.
 - Produzir metrica basica de violacao de policy no recorte validado.
 
+## Baseline minimo explicito do recorte
+
+- Headers obrigatorios no recorte sensivel:
+	- `Cross-Origin-Opener-Policy` (default `same-origin`, excecao auth `same-origin-allow-popups`)
+	- `Cross-Origin-Embedder-Policy: require-corp`
+	- `X-Content-Type-Options: nosniff`
+	- `X-Frame-Options: SAMEORIGIN`
+	- `Referrer-Policy: strict-origin-when-cross-origin`
+	- `X-Permitted-Cross-Domain-Policies: none`
+	- `Permissions-Policy: camera=(), microphone=(), geolocation=()`
+- CORS minimo:
+	- origem permitida do recorte deve receber `Access-Control-Allow-Origin` e `Access-Control-Allow-Credentials: true`
+	- origem nao permitida deve falhar com 403
+- Cookies (contrato de flags):
+	- cookies de autenticacao com `HttpOnly` e `SameSite` coerente com politica atual do ambiente
+
+## Regressao bloqueante nesta fatia
+
+- Ausencia/alteracao indevida de qualquer item do baseline minimo acima no recorte testado.
+- CORS aceitando origem fora da allowlist do recorte.
+- Emissao de cookie de autenticacao sem flags minimas de contrato.
+
 ## Escopo que nao entra
 
 - Reestruturacao ampla de middlewares/roteamento.
@@ -33,6 +55,10 @@ Estabelecer baseline minimo de hardening HTTP para workloads sensiveis, com cont
 
 - Reversao unica da fatia.
 - Fallback por profile de headers por ambiente, conforme plano executavel.
+- Rollback exato da integracao:
+	- remover script `test:hardening:http` de `apps/api/package.json`
+	- remover job `http-hardening-baseline` de `.github/workflows/ci.yml`
+	- remover teste de contrato do recorte em `apps/api/src/http-hardening-baseline.test.js`
 
 ## Criterios verificaveis minimos
 

--- a/docs/roadmaps/aud-012-http-hardening-baseline-governance.md
+++ b/docs/roadmaps/aud-012-http-hardening-baseline-governance.md
@@ -1,0 +1,42 @@
+# AUD-012 - Baseline hardening HTTP (Governanca de Slice)
+
+Fonte oficial de sequenciamento: docs/roadmaps/audit-backlog-executable-plan-2026-04-03.md.
+
+## Objetivo da fatia
+
+Estabelecer baseline minimo de hardening HTTP para workloads sensiveis, com contrato objetivo de headers/cors/cookies e validacao automatizada contra regressao.
+
+## Dependencia recomendada
+
+- AUD-002 (hard fail de JWT) como base de seguranca para o recorte de hardening.
+
+## Contrato herdado (nao regredir)
+
+- AUD-007, AUD-008 e AUD-009: sem reabertura de parser/OCR/ambiguidade/corpus.
+- AUD-011: primeiro gate integrado de jornada critica ja entregue; esta fatia nao expande smoke amplo/e2e.
+
+## Escopo que entra
+
+- Definir baseline minima de headers de seguranca para respostas HTTP sensiveis.
+- Definir regra minima de CORS/cookies no recorte atual.
+- Adicionar teste(s) de contrato para impedir regressao do baseline no CI.
+- Produzir metrica basica de violacao de policy no recorte validado.
+
+## Escopo que nao entra
+
+- Reestruturacao ampla de middlewares/roteamento.
+- Mudanca de semantica funcional de endpoints de negocio.
+- Expansao para auditoria completa de todo trafego HTTP fora do recorte minimo.
+- Reabertura de temas das fatias AUD-007/008/009/011.
+
+## Rollback
+
+- Reversao unica da fatia.
+- Fallback por profile de headers por ambiente, conforme plano executavel.
+
+## Criterios verificaveis minimos
+
+- Contrato explicito de headers/cors/cookies para o recorte sensivel definido.
+- Teste automatizado falha quando houver regressao do baseline.
+- CI sinaliza a validacao de hardening no recorte minimo.
+- Mudancas restritas a AUD-012, sem acoplamento indevido com outras fatias.


### PR DESCRIPTION
## Governanca de slice (inicio)
- Fonte oficial de sequenciamento: docs/roadmaps/audit-backlog-executable-plan-2026-04-03.md (item 12).
- Regra operacional: 1 issue = 1 PR, branch isolada, escopo minimo.
- Dependencia recomendada: AUD-002.
- Fora de escopo: hardening global do app, refactor amplo, mudancas de negocio, e reabertura de parser/OCR/ambiguidade/corpus.

Refs #472

## Entrega minima funcional desta PR
- Baseline minimo explicito do recorte HTTP sensivel:
  - headers: COOP/COEP + X-Content-Type-Options + X-Frame-Options + Referrer-Policy + X-Permitted-Cross-Domain-Policies + Permissions-Policy;
  - CORS: origem permitida recebe allow-origin/credentials; origem nao permitida recebe 403;
  - cookies: contrato minimo de flags (HttpOnly + SameSite) para cookies de auth.
- Teste de contrato de regressao:
  - apps/api/src/http-hardening-baseline.test.js
- Gate visivel no CI para o recorte:
  - job/check: http-hardening-baseline
- Evidencia operacional no CI:
  - log do step;
  - artifact: http-hardening-baseline-log.

## Regressao bloqueante no recorte
- alteracao indevida/ausencia de item do baseline;
- CORS aceitando origem fora da allowlist;
- emissao de cookie de auth sem flags minimas de contrato.

## Rollback exato
- remover script test:hardening:http em apps/api/package.json
- remover job http-hardening-baseline em .github/workflows/ci.yml
- remover teste apps/api/src/http-hardening-baseline.test.js