### PR TITLE
AUD-014 - enforcement semantico FE/BE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,3 +143,36 @@ jobs:
         with:
           name: document-financial-observability-log
           path: document-financial-observability.log
+
+  semantic_contract_enforcement_dashboard:
+    name: semantic-contract-enforcement-dashboard
+    runs-on: ubuntu-latest
+    needs: [api, web]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Semantic contract enforcement (dashboard slice)
+        run: |
+          set -o pipefail
+          {
+            npm -w apps/api run test:semantic:dashboard
+            npm -w apps/web run test:semantic:dashboard
+          } 2>&1 | tee semantic-contract-enforcement-dashboard.log
+
+      - name: Upload semantic enforcement evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: semantic-contract-enforcement-dashboard-log
+          path: semantic-contract-enforcement-dashboard.log

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,7 @@
     "db:seed": "node src/db/seed.js",
     "lint": "eslint src --max-warnings 0",
     "test:observability:documents": "vitest run src/document-financial-observability.test.js",
+    "test:semantic:dashboard": "vitest run src/dashboard.test.js",
     "test:golden": "vitest run src/credit-card-invoices.golden.test.js",
     "test:hardening:http": "vitest run src/http-hardening-baseline.test.js",
     "test:smoke:critical": "vitest run src/smoke-critical-finance-journey.test.js",

--- a/apps/api/src/dashboard.test.js
+++ b/apps/api/src/dashboard.test.js
@@ -6,7 +6,10 @@ import { setupTestDb, registerAndLogin } from "./test-helpers.js";
 import { resetLoginProtectionState } from "./middlewares/login-protection.middleware.js";
 import { resetWriteRateLimiterState } from "./middlewares/rate-limit.middleware.js";
 import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
-import { DashboardSnapshotResponseSchema } from "./domain/contracts/dashboard-response.schema.ts";
+import {
+  DASHBOARD_SEMANTIC_SOURCE_MAP,
+  DashboardSnapshotResponseSchema,
+} from "./domain/contracts/dashboard-response.schema.ts";
 
 // ─── Date helpers (UTC-safe) ──────────────────────────────────────────────────
 
@@ -80,6 +83,7 @@ const DASHBOARD_TOP_LEVEL_KEYS = [
   "income",
   "forecast",
   "semanticCore",
+  "semanticSourceMap",
   "consignado",
 ].sort();
 
@@ -100,6 +104,12 @@ const DASHBOARD_CONSIGNADO_KEYS = ["monthlyTotal", "contractsCount", "comprometi
 
 const DASHBOARD_SEMANTIC_CORE_KEYS = [
   "semanticsVersion",
+  "realized",
+  "currentPosition",
+  "projection",
+].sort();
+
+const DASHBOARD_SEMANTIC_SOURCE_MAP_KEYS = [
   "realized",
   "currentPosition",
   "projection",
@@ -463,6 +473,10 @@ describe("dashboard snapshot", () => {
     expect(Object.keys(res.body.income).sort()).toEqual(DASHBOARD_INCOME_KEYS);
     expect(Object.keys(res.body.consignado).sort()).toEqual(DASHBOARD_CONSIGNADO_KEYS);
     expect(Object.keys(res.body.semanticCore).sort()).toEqual(DASHBOARD_SEMANTIC_CORE_KEYS);
+    expect(Object.keys(res.body.semanticSourceMap).sort()).toEqual(
+      DASHBOARD_SEMANTIC_SOURCE_MAP_KEYS,
+    );
+    expect(res.body.semanticSourceMap).toEqual(DASHBOARD_SEMANTIC_SOURCE_MAP);
     expect(Object.keys(res.body.semanticCore.realized).sort()).toEqual(
       DASHBOARD_SEMANTIC_REALIZED_KEYS,
     );
@@ -512,6 +526,11 @@ describe("dashboard snapshot", () => {
           adjustedProjectedBalance: 0,
           expectedInflow: null,
         },
+      },
+      semanticSourceMap: {
+        realized: ["dashboard.income.receivedThisMonth"],
+        currentPosition: ["dashboard.bankBalance"],
+        projection: ["dashboard.income.pendingThisMonth", "dashboard.forecast.projectedBalance"],
       },
       consignado: {
         monthlyTotal: 0,

--- a/apps/api/src/domain/contracts/dashboard-response.schema.ts
+++ b/apps/api/src/domain/contracts/dashboard-response.schema.ts
@@ -32,6 +32,21 @@ const DashboardConsignadoSchema = z.object({
   comprometimentoPct: z.number().nullable(),
 });
 
+export const DashboardSemanticSourceMapSchema = z.object({
+  realized: z.tuple([z.literal("dashboard.income.receivedThisMonth")]),
+  currentPosition: z.tuple([z.literal("dashboard.bankBalance")]),
+  projection: z.tuple([
+    z.literal("dashboard.income.pendingThisMonth"),
+    z.literal("dashboard.forecast.projectedBalance"),
+  ]),
+});
+
+export const DASHBOARD_SEMANTIC_SOURCE_MAP = DashboardSemanticSourceMapSchema.parse({
+  realized: ["dashboard.income.receivedThisMonth"],
+  currentPosition: ["dashboard.bankBalance"],
+  projection: ["dashboard.income.pendingThisMonth", "dashboard.forecast.projectedBalance"],
+});
+
 export const DashboardSnapshotResponseSchema = z.object({
   bankBalance: z.number(),
   bills: DashboardBillsSchema,
@@ -39,7 +54,9 @@ export const DashboardSnapshotResponseSchema = z.object({
   income: DashboardIncomeSchema,
   forecast: DashboardForecastSchema.nullable(),
   semanticCore: CoreFinancialSemanticContractSchema,
+  semanticSourceMap: DashboardSemanticSourceMapSchema,
   consignado: DashboardConsignadoSchema,
 });
 
 export type DashboardSnapshotResponse = z.infer<typeof DashboardSnapshotResponseSchema>;
+export type DashboardSemanticSourceMap = z.infer<typeof DashboardSemanticSourceMapSchema>;

--- a/apps/api/src/services/dashboard.service.ts
+++ b/apps/api/src/services/dashboard.service.ts
@@ -1,4 +1,8 @@
 import { dbQuery } from "../db/index.js";
+import {
+  DASHBOARD_SEMANTIC_SOURCE_MAP,
+  type DashboardSemanticSourceMap,
+} from "../domain/contracts/dashboard-response.schema.ts";
 
 type NumericLike = number | string | null | undefined;
 
@@ -70,6 +74,7 @@ interface DashboardSnapshot {
       expectedInflow: number | null;
     };
   };
+  semanticSourceMap: DashboardSemanticSourceMap;
   consignado: {
     monthlyTotal: number;
     contractsCount: number;
@@ -303,5 +308,6 @@ export const getDashboardSnapshot = async (
   return {
     ...baseSnapshot,
     semanticCore: buildDashboardSemanticCore(baseSnapshot, now),
+    semanticSourceMap: DASHBOARD_SEMANTIC_SOURCE_MAP,
   };
 };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
     "typecheck:auth": "tsc -p tsconfig.auth.json --noEmit",
     "preview": "vite preview",
     "test": "vitest",
+    "test:semantic:dashboard": "vitest run src/services/dashboard.service.test.ts src/components/OperationalSummaryPanel.test.tsx",
     "test:run": "vitest run"
   },
   "dependencies": {

--- a/apps/web/src/components/OperationalSummaryPanel.test.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.test.tsx
@@ -65,6 +65,11 @@ const buildSnapshot = (overrides: Partial<DashboardSnapshot> = {}): DashboardSna
           income.pendingThisMonth > 0 ? income.pendingThisMonth : null,
       },
     },
+    semanticSourceMap: overrides.semanticSourceMap ?? {
+      realized: ["dashboard.income.receivedThisMonth"],
+      currentPosition: ["dashboard.bankBalance"],
+      projection: ["dashboard.income.pendingThisMonth", "dashboard.forecast.projectedBalance"],
+    },
     consignado: {
       monthlyTotal: 0,
       contractsCount: 0,
@@ -364,14 +369,14 @@ describe("OperationalSummaryPanel", () => {
   it("prioriza semanticCore no consumo de saldo e renda", async () => {
     vi.mocked(dashboardService.getSnapshot).mockResolvedValueOnce(
       buildSnapshot({
-        bankBalance: 1000,
+        bankBalance: 850,
         income: {
-          receivedThisMonth: 50,
-          pendingThisMonth: 20,
+          receivedThisMonth: 1200,
+          pendingThisMonth: 350,
           referenceMonth: "2026-04",
         },
         forecast: {
-          projectedBalance: 400,
+          projectedBalance: 200,
           month: "2026-04",
         },
         bills: {
@@ -415,7 +420,43 @@ describe("OperationalSummaryPanel", () => {
     expect(screen.getByText("R$ 1.200,00")).toBeInTheDocument();
     expect(screen.getByText("Previsto no mês: R$ 350,00")).toBeInTheDocument();
     expect(screen.getByText("R$ 200,00")).toBeInTheDocument();
-    expect(screen.queryByText("R$ 50,00")).not.toBeInTheDocument();
-    expect(screen.queryByText("R$ 400,00")).not.toBeInTheDocument();
+  });
+
+  it("usa saldo projetado canônico mesmo quando forecast legado está ausente", async () => {
+    vi.mocked(dashboardService.getSnapshot).mockResolvedValueOnce(
+      buildSnapshot({
+        bankBalance: 640,
+        forecast: null,
+        semanticCore: {
+          semanticsVersion: "v1",
+          realized: {
+            confirmedInflowTotal: 0,
+            settledOutflowTotal: 0,
+            netAmount: 0,
+            referenceMonth: "2026-04",
+          },
+          currentPosition: {
+            bankBalance: 640,
+            technicalBalance: 640,
+            asOf: "2026-04-15T00:00:00.000Z",
+          },
+          projection: {
+            referenceMonth: "2026-04",
+            projectedBalance: 640,
+            adjustedProjectedBalance: 640,
+            expectedInflow: null,
+          },
+        },
+      }),
+    );
+
+    render(<OperationalSummaryPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Fechamento previsto do mês (contrato canônico)")).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText("R$ 640,00").length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText("Sem base para projeção")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/OperationalSummaryPanel.tsx
+++ b/apps/web/src/components/OperationalSummaryPanel.tsx
@@ -162,7 +162,7 @@ const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanel
     );
   }
 
-  const { forecast, consignado, semanticCore } = snapshot;
+  const { consignado, semanticCore } = snapshot;
   const { obligations } = buildDashboardContractView(snapshot);
 
   const nowTimestamp = Date.now();
@@ -317,19 +317,12 @@ const OperationalSummaryPanel = ({ onOpenDueSoonBills }: OperationalSummaryPanel
 
   // ── Tile 5: Forecast ──────────────────────────────────────────────────────
   const projectionBalance = semanticCore.projection.projectedBalance;
-  const forecastTile: TileProps = forecast
-    ? {
-        label: "Saldo projetado",
-        primary: money(projectionBalance),
-        secondary: "Fechamento previsto do mês",
-        accent: projectionBalance < 0 ? "danger" : projectionBalance < 200 ? "warning" : "default",
-      }
-    : {
-        label: "Saldo projetado",
-        primary: "—",
-        secondary: "Sem base para projeção",
-        accent: "muted",
-      };
+  const forecastTile: TileProps = {
+    label: "Saldo projetado",
+    primary: money(projectionBalance),
+    secondary: "Fechamento previsto do mês (contrato canônico)",
+    accent: projectionBalance < 0 ? "danger" : projectionBalance < 200 ? "warning" : "default",
+  };
 
   // ── Tile 6: Consignado ────────────────────────────────────────────────────
   const consignadoAccent: TileProps["accent"] =

--- a/apps/web/src/services/dashboard.service.test.ts
+++ b/apps/web/src/services/dashboard.service.test.ts
@@ -61,6 +61,11 @@ const buildSnapshot = (overrides: Partial<DashboardSnapshot> = {}): DashboardSna
           income.pendingThisMonth > 0 ? income.pendingThisMonth : null,
       },
     },
+    semanticSourceMap: overrides.semanticSourceMap ?? {
+      realized: ["dashboard.income.receivedThisMonth"],
+      currentPosition: ["dashboard.bankBalance"],
+      projection: ["dashboard.income.pendingThisMonth", "dashboard.forecast.projectedBalance"],
+    },
     consignado: {
       monthlyTotal: 0,
       contractsCount: 0,
@@ -77,7 +82,7 @@ describe("dashboardService", () => {
 
   it("normaliza snapshot com agregados de proximas contas", async () => {
     getMock.mockResolvedValueOnce({
-      data: {
+      data: buildSnapshot({
         bankBalance: 1200,
         bills: {
           overdueCount: 1,
@@ -100,12 +105,7 @@ describe("dashboardService", () => {
           projectedBalance: 900,
           month: "2026-04",
         },
-        consignado: {
-          monthlyTotal: 0,
-          contractsCount: 0,
-          comprometimentoPct: null,
-        },
-      },
+      }),
     });
 
     const result = await dashboardService.getSnapshot();
@@ -144,13 +144,17 @@ describe("dashboardService", () => {
     expect(invoiceObligations[0].amount).toBe(780);
   });
 
-  it("buildDashboardContractView prioriza semanticCore para renda e posicao atual", () => {
+  it("buildDashboardContractView consome contrato semantico canonico alinhado", () => {
     const snapshot = buildSnapshot({
-      bankBalance: 1200,
+      bankBalance: 850,
       income: {
-        receivedThisMonth: 10,
-        pendingThisMonth: 20,
-        referenceMonth: "2026-03",
+        receivedThisMonth: 2300,
+        pendingThisMonth: 300,
+        referenceMonth: "2026-04",
+      },
+      forecast: {
+        projectedBalance: 900,
+        month: "2026-04",
       },
       semanticCore: {
         semanticsVersion: "v1",
@@ -191,5 +195,12 @@ describe("dashboardService", () => {
         sourceId: "2026-04",
       }),
     ]);
+  });
+
+  it("falha quando detecta drift entre payload legado e contrato semantico canonico", () => {
+    const snapshot = buildSnapshot();
+    snapshot.semanticCore.currentPosition.bankBalance = snapshot.bankBalance + 1;
+
+    expect(() => buildDashboardContractView(snapshot)).toThrow(/DASHBOARD_SEMANTIC_DRIFT/);
   });
 });

--- a/apps/web/src/services/dashboard.service.ts
+++ b/apps/web/src/services/dashboard.service.ts
@@ -16,6 +16,53 @@ export interface DashboardFinancialContractView {
 }
 
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
+const DRIFT_EPSILON = 0.005;
+
+const DASHBOARD_CANONICAL_SOURCE_MAP: DashboardSnapshot["semanticSourceMap"] = {
+  realized: ["dashboard.income.receivedThisMonth"],
+  currentPosition: ["dashboard.bankBalance"],
+  projection: ["dashboard.income.pendingThisMonth", "dashboard.forecast.projectedBalance"],
+};
+
+const isCloseEnough = (a: number, b: number): boolean => Math.abs(a - b) <= DRIFT_EPSILON;
+
+const assertDashboardSemanticContract = (snapshot: DashboardSnapshot): void => {
+  const semanticCore = snapshot.semanticCore;
+
+  if (semanticCore.semanticsVersion !== "v1") {
+    throw new Error("DASHBOARD_SEMANTIC_DRIFT: unsupported semanticsVersion for dashboard slice");
+  }
+
+  if (
+    JSON.stringify(snapshot.semanticSourceMap) !==
+    JSON.stringify(DASHBOARD_CANONICAL_SOURCE_MAP)
+  ) {
+    throw new Error("DASHBOARD_SEMANTIC_DRIFT: semanticSourceMap does not match canonical dashboard mapping");
+  }
+
+  if (!isCloseEnough(snapshot.bankBalance, semanticCore.currentPosition.bankBalance)) {
+    throw new Error("DASHBOARD_SEMANTIC_DRIFT: dashboard.bankBalance diverges from semanticCore.currentPosition.bankBalance");
+  }
+
+  if (!isCloseEnough(snapshot.income.receivedThisMonth, semanticCore.realized.confirmedInflowTotal)) {
+    throw new Error("DASHBOARD_SEMANTIC_DRIFT: dashboard.income.receivedThisMonth diverges from semanticCore.realized.confirmedInflowTotal");
+  }
+
+  const expectedProjectionInflow =
+    snapshot.income.pendingThisMonth > 0 ? snapshot.income.pendingThisMonth : null;
+
+  if (expectedProjectionInflow !== semanticCore.projection.expectedInflow) {
+    throw new Error("DASHBOARD_SEMANTIC_DRIFT: dashboard.income.pendingThisMonth diverges from semanticCore.projection.expectedInflow");
+  }
+
+  const expectedProjectedBalance = snapshot.forecast
+    ? snapshot.forecast.projectedBalance
+    : snapshot.bankBalance;
+
+  if (!isCloseEnough(expectedProjectedBalance, semanticCore.projection.projectedBalance)) {
+    throw new Error("DASHBOARD_SEMANTIC_DRIFT: dashboard.forecast.projectedBalance diverges from semanticCore.projection.projectedBalance");
+  }
+};
 
 const toAsOfISOString = (
   asOf: CoreFinancialSemanticContract["currentPosition"]["asOf"],
@@ -61,6 +108,8 @@ export const buildDashboardContractView = (
   snapshot: DashboardSnapshot,
   now: Date = new Date(),
 ): DashboardFinancialContractView => {
+  assertDashboardSemanticContract(snapshot);
+
   const semanticCore = snapshot.semanticCore;
   const confirmedInflow = semanticCore.realized.confirmedInflowTotal;
   const expectedInflow = semanticCore.projection.expectedInflow ?? 0;
@@ -142,7 +191,10 @@ export const dashboardService = {
 
     const requestPromise = api
       .get<DashboardSnapshot>("/dashboard/snapshot", withApiRequestContext(context))
-      .then(({ data }) => data)
+      .then(({ data }) => {
+        assertDashboardSemanticContract(data);
+        return data;
+      })
       .finally(() => {
         if (snapshotInFlightRequest === requestPromise) {
           snapshotInFlightRequest = null;

--- a/docs/roadmaps/aud-014-semantic-contract-enforcement-governance.md
+++ b/docs/roadmaps/aud-014-semantic-contract-enforcement-governance.md
@@ -1,39 +1,64 @@
-# AUD-014 - Enforcement semantico FE/BE (Governanca de Slice)
+# AUD-014 - Enforcement semântico FE/BE (Governança de Slice)
 
 Fonte oficial de sequenciamento: docs/roadmaps/audit-backlog-executable-plan-2026-04-03.md (ordem 14).
 
 ## Objetivo da fatia
 
-Fechar formalmente o enforcement do contrato semantico canonico entre API e Web no recorte minimo, impedindo inferencia local fora do payload canonico.
+Fechar formalmente o enforcement do contrato semântico canônico entre API e Web no recorte mínimo, impedindo inferência local fora do payload canônico.
 
-## Dependencias e contratos herdados
+## Dependências e contratos herdados
 
-- AUD-013 fechada como contrato minimo de observabilidade documental/financeira.
+- AUD-013 fechada como contrato mínimo de observabilidade documental/financeira.
 - AUD-010 e AUD-011 fechadas no trilho de contrato/smoke.
 - AUD-012 fechada no trilho de baseline de hardening HTTP.
 
 ## Escopo que entra
 
-- Formalizar contrato semantico canonico consumido por FE e BE no recorte minimo.
-- Eliminar inferencia local fora do payload canonico nos pontos cobertos pela fatia.
-- Adicionar teste(s) de verdade minima para garantir consistencia FE/BE.
-- Adicionar metrica de drift semantico no recorte minimo (se aplicavel sem ampliar escopo).
+- Formalizar contrato semântico canônico consumido por FE e BE no recorte mínimo.
+- Eliminar inferência local fora do payload canônico nos pontos cobertos pela fatia.
+- Adicionar teste(s) de verdade mínima para garantir consistência FE/BE.
+- Adicionar métrica de drift semântico no recorte mínimo (se aplicável sem ampliar escopo).
+
+## Recorte operacional desta fatia
+
+- Endpoint do recorte: `GET /dashboard/snapshot`.
+- Consumo FE do recorte: `OperationalSummaryPanel` + `buildDashboardContractView`.
+- Shape canônico mínimo no recorte:
+	- `semanticCore` (source of truth para renda, posição atual e projeção).
+	- `semanticSourceMap` (mapeamento explícito dos campos canônicos deste endpoint).
+
+- Campos derivados que o FE não pode recalcular fora do contrato:
+	- `saldo projetado` a partir de `forecast` legado sem passar por `semanticCore`.
+	- `renda confirmada/prevista` fora dos grupos `semanticCore.realized` e `semanticCore.projection`.
+- Comportamento de falha no drift:
+	- se `semanticCore` divergir do payload legado mapeado por `semanticSourceMap`, a montagem do contrato no FE falha explicitamente.
 
 ## Escopo que nao entra
 
 - Refactor estrutural amplo de dominio.
 - Reabertura de observabilidade global.
-- Reabertura de labels/pontos de instrumentacao/papel de artifact ja fechados na AUD-013.
-- Expansao de contrato para superficies nao cobertas pela fatia.
+- Reabertura de labels/pontos de instrumentação/papel de artifact já fechados na AUD-013.
+- Expansão de contrato para superfícies não cobertas pela fatia.
 
-## Criterios verificaveis minimos
+## Critérios verificáveis mínimos
 
-- Contrato canonico explicito para o recorte da fatia.
-- FE e BE consumindo o mesmo payload canonico no recorte.
-- Teste de regressao quebra quando houver inferencia local fora do contrato.
-- Evidencia minima de drift/consistencia no CI da fatia.
+- Contrato canônico explícito para o recorte da fatia.
+- FE e BE consumindo o mesmo payload canônico no recorte.
+- Teste de regressão quebra quando houver inferência local fora do contrato.
+- Evidência mínima de drift/consistência no CI da fatia.
+
+## Check dedicado desta fatia
+
+- Check visível: `semantic-contract-enforcement-dashboard`.
+- Gate de sucesso/falha: testes dedicados do recorte (API + Web).
+- Artifact: `semantic-contract-enforcement-dashboard-log` (somente evidência diagnóstica).
 
 ## Rollback
 
-- Reversao unica da fatia, preservando contratos fechados anteriormente.
+- Reversão única da fatia, preservando contratos fechados anteriormente.
 - Fallback temporario somente em staging, conforme plano executavel da AUD-014.
+
+- Rollback exato da integração:
+	- remover script `test:semantic:dashboard` de `apps/api/package.json`.
+	- remover script `test:semantic:dashboard` de `apps/web/package.json`.
+	- remover job `semantic-contract-enforcement-dashboard` de `.github/workflows/ci.yml`.

--- a/docs/roadmaps/aud-014-semantic-contract-enforcement-governance.md
+++ b/docs/roadmaps/aud-014-semantic-contract-enforcement-governance.md
@@ -1,0 +1,39 @@
+# AUD-014 - Enforcement semantico FE/BE (Governanca de Slice)
+
+Fonte oficial de sequenciamento: docs/roadmaps/audit-backlog-executable-plan-2026-04-03.md (ordem 14).
+
+## Objetivo da fatia
+
+Fechar formalmente o enforcement do contrato semantico canonico entre API e Web no recorte minimo, impedindo inferencia local fora do payload canonico.
+
+## Dependencias e contratos herdados
+
+- AUD-013 fechada como contrato minimo de observabilidade documental/financeira.
+- AUD-010 e AUD-011 fechadas no trilho de contrato/smoke.
+- AUD-012 fechada no trilho de baseline de hardening HTTP.
+
+## Escopo que entra
+
+- Formalizar contrato semantico canonico consumido por FE e BE no recorte minimo.
+- Eliminar inferencia local fora do payload canonico nos pontos cobertos pela fatia.
+- Adicionar teste(s) de verdade minima para garantir consistencia FE/BE.
+- Adicionar metrica de drift semantico no recorte minimo (se aplicavel sem ampliar escopo).
+
+## Escopo que nao entra
+
+- Refactor estrutural amplo de dominio.
+- Reabertura de observabilidade global.
+- Reabertura de labels/pontos de instrumentacao/papel de artifact ja fechados na AUD-013.
+- Expansao de contrato para superficies nao cobertas pela fatia.
+
+## Criterios verificaveis minimos
+
+- Contrato canonico explicito para o recorte da fatia.
+- FE e BE consumindo o mesmo payload canonico no recorte.
+- Teste de regressao quebra quando houver inferencia local fora do contrato.
+- Evidencia minima de drift/consistencia no CI da fatia.
+
+## Rollback
+
+- Reversao unica da fatia, preservando contratos fechados anteriormente.
+- Fallback temporario somente em staging, conforme plano executavel da AUD-014.


### PR DESCRIPTION
## Governanca de slice (AUD-014)
- Fonte oficial: docs/roadmaps/audit-backlog-executable-plan-2026-04-03.md (item 14).
- Regra operacional: 1 issue = 1 PR, branch isolada, escopo minimo.
- Escopo desta PR: enforcement semantico FE/BE no recorte de dashboard, sem reabrir AUD-013 e sem refactor estrutural amplo.

## Recorte funcional implementado
- Endpoint do recorte: GET /dashboard/snapshot.
- Consumo FE do recorte: buildDashboardContractView + OperationalSummaryPanel.
- Contrato canônico mínimo do slice:
  - semanticCore (source of truth de renda, posição atual e projeção)
  - semanticSourceMap (mapeamento explícito dos campos canônicos do endpoint)

## Inferencia local removida/bloqueada
- Ponto removido: fallback de exibição do tile de projeção condicionado a forecast legado.
- Comportamento novo: o tile usa semanticCore.projection.projectedBalance como fonte canônica.
- Enforcement explícito: drift entre payload legado mapeado e semanticCore gera falha com DASHBOARD_SEMANTIC_DRIFT.

## Teste de verdade minima
- API: apps/api/src/dashboard.test.js valida shape canônico incluindo semanticSourceMap.
- Web: apps/web/src/services/dashboard.service.test.ts inclui quebra explícita em cenário de drift.
- Web: apps/web/src/components/OperationalSummaryPanel.test.tsx valida consumo canônico sem fallback de forecast legado.

## Check visivel de CI (gate)
- Job/check dedicado: semantic-contract-enforcement-dashboard.
- Gate passa/falha pelos testes dedicados da fatia (API + Web).
- Artifact: semantic-contract-enforcement-dashboard-log (evidência diagnóstica, não critério de sucesso).

## Rollback exato
- Remover script test:semantic:dashboard de apps/api/package.json.
- Remover script test:semantic:dashboard de apps/web/package.json.
- Remover job semantic-contract-enforcement-dashboard de .github/workflows/ci.yml.

Refs #476