### PR TITLE
AUD-016 - domínio explícito de regras críticas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,3 +204,31 @@ jobs:
         with:
           name: hotspot-credit-card-invoices-log
           path: hotspot-credit-card-invoices.log
+
+  domain_invoice_classification:
+    name: domain-invoice-classification
+    runs-on: ubuntu-latest
+    needs: [api]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Domain invariant (invoice classification)
+        run: npm -w apps/api run test:domain:invoice-classification | tee domain-invoice-classification.log
+
+      - name: Upload domain invariant evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: domain-invoice-classification-log
+          path: domain-invoice-classification.log

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,6 +17,7 @@
     "test:observability:documents": "vitest run src/document-financial-observability.test.js",
     "test:semantic:dashboard": "vitest run src/dashboard.test.js",
     "test:hotspot:credit-card-invoices": "vitest run src/services/credit-card-invoice-period-inference.service.test.js src/credit-card-invoices.test.js",
+    "test:domain:invoice-classification": "vitest run src/services/credit-card-invoice-classification.service.test.js src/credit-card-invoices.test.js",
     "test:golden": "vitest run src/credit-card-invoices.golden.test.js",
     "test:hardening:http": "vitest run src/http-hardening-baseline.test.js",
     "test:smoke:critical": "vitest run src/smoke-critical-finance-journey.test.js",

--- a/apps/api/src/services/credit-card-invoice-classification.service.js
+++ b/apps/api/src/services/credit-card-invoice-classification.service.js
@@ -1,0 +1,47 @@
+const HIGH_CONFIDENCE_SCORE = 0.9;
+const LOW_CONFIDENCE_SCORE = 0.45;
+
+const normalizeJsonObject = (value) => {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed;
+      }
+    } catch {
+      return {};
+    }
+  }
+
+  return {};
+};
+
+export const resolveInvoiceClassificationSignals = ({ parseConfidence, parseMetadata }) => {
+  const normalizedParseConfidence = String(parseConfidence || "").trim().toLowerCase() === "high" ? "high" : "low";
+  const normalizedParseMetadata = normalizeJsonObject(parseMetadata);
+  const reviewContext = normalizeJsonObject(normalizedParseMetadata.reviewContext);
+  const reasonCodes = Array.isArray(reviewContext.reasonCodes)
+    ? reviewContext.reasonCodes
+      .map((value) => String(value || "").trim().toLowerCase())
+      .filter(Boolean)
+    : [];
+
+  const classificationAmbiguous =
+    reviewContext.needsReview === true || normalizedParseConfidence !== "high" || reasonCodes.length > 0;
+
+  const reasonCode = classificationAmbiguous
+    ? reasonCodes[0] || (normalizedParseConfidence === "low" ? "parse_confidence_low" : "manual_review_required")
+    : "not_ambiguous";
+
+  return {
+    classificationConfidence: normalizedParseConfidence === "high" ? HIGH_CONFIDENCE_SCORE : LOW_CONFIDENCE_SCORE,
+    classificationAmbiguous,
+    reasonCode,
+    requiresUserConfirmation: classificationAmbiguous,
+    parseMetadata: normalizedParseMetadata,
+  };
+};

--- a/apps/api/src/services/credit-card-invoice-classification.service.test.js
+++ b/apps/api/src/services/credit-card-invoice-classification.service.test.js
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { resolveInvoiceClassificationSignals } from "./credit-card-invoice-classification.service.js";
+
+describe("credit-card-invoice classification service", () => {
+  it("returns non-ambiguous classification for high confidence without review signals", () => {
+    const result = resolveInvoiceClassificationSignals({
+      parseConfidence: "high",
+      parseMetadata: {
+        reviewContext: {
+          needsReview: false,
+          reasonCodes: [],
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      classificationConfidence: 0.9,
+      classificationAmbiguous: false,
+      reasonCode: "not_ambiguous",
+      requiresUserConfirmation: false,
+      parseMetadata: {
+        reviewContext: {
+          needsReview: false,
+          reasonCodes: [],
+        },
+      },
+    });
+  });
+
+  it("keeps low confidence fallback reason when no explicit review reason exists", () => {
+    const result = resolveInvoiceClassificationSignals({
+      parseConfidence: "LOW",
+      parseMetadata: {
+        reviewContext: {
+          needsReview: false,
+          reasonCodes: [],
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      classificationConfidence: 0.45,
+      classificationAmbiguous: true,
+      reasonCode: "parse_confidence_low",
+      requiresUserConfirmation: true,
+    });
+  });
+
+  it("prioritizes normalized review reason codes over fallback reason", () => {
+    const result = resolveInvoiceClassificationSignals({
+      parseConfidence: "high",
+      parseMetadata: JSON.stringify({
+        reviewContext: {
+          needsReview: false,
+          reasonCodes: [" Period_Inferred_From_Closing_Day ", ""],
+        },
+      }),
+    });
+
+    expect(result).toMatchObject({
+      classificationConfidence: 0.9,
+      classificationAmbiguous: true,
+      reasonCode: "period_inferred_from_closing_day",
+      requiresUserConfirmation: true,
+    });
+  });
+
+  it("falls back to empty metadata for invalid serialized payload", () => {
+    const result = resolveInvoiceClassificationSignals({
+      parseConfidence: "high",
+      parseMetadata: "{invalid-json",
+    });
+
+    expect(result).toEqual({
+      classificationConfidence: 0.9,
+      classificationAmbiguous: false,
+      reasonCode: "not_ambiguous",
+      requiresUserConfirmation: false,
+      parseMetadata: {},
+    });
+  });
+});

--- a/apps/api/src/services/credit-card-invoices.service.js
+++ b/apps/api/src/services/credit-card-invoices.service.js
@@ -2,14 +2,13 @@ import { dbQuery } from "../db/index.js";
 import { extractTextFromPdfWithOcrRuntime } from "../domain/imports/pdf-ocr.js";
 import { parseBRL, parseDMY, parseItauInvoice } from "../domain/imports/itau-invoice.parser.js";
 import { trackDomainFlowError, trackDomainFlowSuccess } from "../observability/domain-metrics.js";
+import { resolveInvoiceClassificationSignals } from "./credit-card-invoice-classification.service.js";
 import { resolveCreditCardInvoicePeriod } from "./credit-card-invoice-period-inference.service.js";
 
 const CREDIT_CARD_INVOICE_BILL_TYPE = "credit_card_invoice";
 const CREDIT_CARD_INVOICE_PARSE_FLOW = "credit_card_invoice_parse";
 const CREDIT_CARD_INVOICE_OCR_RUNTIME_FLOW = "credit_card_invoice_ocr_runtime";
 const CREDIT_CARD_INVOICE_CLASSIFICATION_CONFIRMATION_FLOW = "credit_card_invoice_classification_confirmation";
-const HIGH_CONFIDENCE_SCORE = 0.9;
-const LOW_CONFIDENCE_SCORE = 0.45;
 const KNOWN_INVOICE_ISSUER_METRIC_KEYS = new Set([
   "itau",
   "nubank",
@@ -29,25 +28,6 @@ const createError = (status, message, extra = {}) => {
   error.status = status;
   Object.assign(error, extra);
   return error;
-};
-
-const normalizeJsonObject = (value) => {
-  if (value && typeof value === "object" && !Array.isArray(value)) {
-    return value;
-  }
-
-  if (typeof value === "string") {
-    try {
-      const parsed = JSON.parse(value);
-      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-        return parsed;
-      }
-    } catch {
-      return {};
-    }
-  }
-
-  return {};
 };
 
 const normalizeUserId = (value) => {
@@ -131,32 +111,6 @@ const resolveParseErrorFromOcrRuntime = (ocrRuntimeMetadata) => {
   }
 
   return null;
-};
-
-const resolveInvoiceClassificationSignals = ({ parseConfidence, parseMetadata }) => {
-  const normalizedParseConfidence = String(parseConfidence || "").trim().toLowerCase() === "high" ? "high" : "low";
-  const normalizedParseMetadata = normalizeJsonObject(parseMetadata);
-  const reviewContext = normalizeJsonObject(normalizedParseMetadata.reviewContext);
-  const reasonCodes = Array.isArray(reviewContext.reasonCodes)
-    ? reviewContext.reasonCodes
-      .map((value) => String(value || "").trim().toLowerCase())
-      .filter(Boolean)
-    : [];
-
-  const classificationAmbiguous =
-    reviewContext.needsReview === true || normalizedParseConfidence !== "high" || reasonCodes.length > 0;
-
-  const reasonCode = classificationAmbiguous
-    ? reasonCodes[0] || (normalizedParseConfidence === "low" ? "parse_confidence_low" : "manual_review_required")
-    : "not_ambiguous";
-
-  return {
-    classificationConfidence: normalizedParseConfidence === "high" ? HIGH_CONFIDENCE_SCORE : LOW_CONFIDENCE_SCORE,
-    classificationAmbiguous,
-    reasonCode,
-    requiresUserConfirmation: classificationAmbiguous,
-    parseMetadata: normalizedParseMetadata,
-  };
 };
 
 const detectInvoiceIssuer = (rawText) => {

--- a/docs/roadmaps/aud-016-financial-domain-consolidation-governance.md
+++ b/docs/roadmaps/aud-016-financial-domain-consolidation-governance.md
@@ -1,0 +1,40 @@
+# AUD-016 - Domínio Explícito de Regras Críticas (Governança de Slice)
+
+Fonte oficial de sequenciamento: docs/roadmaps/audit-backlog-executable-plan-2026-04-03.md (ordem 16).
+
+## Objetivo da fatia
+
+Consolidar, em recorte mínimo, regras financeiras críticas em módulo de domínio canônico, preservando contratos públicos e sem alteração funcional externa.
+
+## Dependências e contratos herdados
+
+- AUD-015 fechada como primeira quebra cirúrgica de hotspot único.
+- AUD-014 fechada no recorte mínimo de enforcement semântico de dashboard.
+- AUD-011/AUD-012/AUD-009 permanecem fechadas e fora de reabertura nesta fatia.
+
+## Escopo que entra
+
+- Selecionar 1 fronteira de regra crítica para consolidação explícita no domínio.
+- Extrair lógica para módulo canônico interno com responsabilidade clara.
+- Preservar contratos públicos, payloads e semântica observável.
+- Adicionar teste(s) de invariantes/regressão focados no recorte.
+
+## Escopo que não entra
+
+- Refactor estrutural amplo do domínio inteiro.
+- Múltiplas frentes de consolidação na mesma PR.
+- Mudanças de contrato público FE/BE.
+- Reabertura de dashboard semantics (AUD-014) ou modularização ampla de hotspots (AUD-015).
+- Reabertura de smoke/corpus/hardening já encerrados.
+
+## Critérios verificáveis mínimos
+
+- Regra crítica selecionada consolidada em módulo explícito e testável.
+- Contrato público preservado sem mudança de comportamento externo.
+- Testes focados verdes no recorte alterado.
+- Mudança delimitada à AUD-016.
+
+## Rollback
+
+- Reversão única da fatia.
+- Caso necessário, restaurar implementação anterior da regra consolidada em um único revert.

--- a/docs/roadmaps/aud-016-financial-domain-consolidation-governance.md
+++ b/docs/roadmaps/aud-016-financial-domain-consolidation-governance.md
@@ -19,6 +19,14 @@ Consolidar, em recorte mínimo, regras financeiras críticas em módulo de domí
 - Preservar contratos públicos, payloads e semântica observável.
 - Adicionar teste(s) de invariantes/regressão focados no recorte.
 
+## Fronteira crítica selecionada (alvo único)
+
+- Arquivo alvo: `apps/api/src/services/credit-card-invoices.service.js`.
+- Critério operacional de escolha: regra financeira crítica usada em dois pontos sensíveis do fluxo (shape de resposta de fatura e bloqueio de confirmação no link de pendência), com risco direto de inconsistência sem fronteira canônica.
+- Fronteira consolidada nesta fatia: resolução de sinais de classificação ambígua (`classificationAmbiguous`, `reasonCode`, `requiresUserConfirmation`, `classificationConfidence`) em módulo interno dedicado (`credit-card-invoice-classification.service.js`).
+- Contrato público que deve permanecer intocado: rotas de `credit-cards invoices` e shape de resposta retornado pelo parse/list/link.
+- Métrica simples de melhora desta fatia: regra única de classificação removida do serviço principal e isolada em módulo testável próprio, sem alteração de API.
+
 ## Escopo que não entra
 
 - Refactor estrutural amplo do domínio inteiro.
@@ -34,7 +42,20 @@ Consolidar, em recorte mínimo, regras financeiras críticas em módulo de domí
 - Testes focados verdes no recorte alterado.
 - Mudança delimitada à AUD-016.
 
+## Prova de preservação de contrato
+
+- Teste regressivo focado no comportamento público do endpoint:
+	- `apps/api/src/credit-card-invoices.test.js`
+- Teste dedicado da fronteira interna consolidada:
+	- `apps/api/src/services/credit-card-invoice-classification.service.test.js`
+- Check visível da fatia:
+	- `domain-invoice-classification` (CI)
+
 ## Rollback
 
 - Reversão única da fatia.
 - Caso necessário, restaurar implementação anterior da regra consolidada em um único revert.
+- Rollback exato da integração:
+	- remover script `test:domain:invoice-classification` de `apps/api/package.json`.
+	- remover job `domain-invoice-classification` de `.github/workflows/ci.yml`.
+	- reverter extração do módulo `apps/api/src/services/credit-card-invoice-classification.service.js`.


### PR DESCRIPTION
## Governança de slice (execução mínima)
- Fonte oficial: docs/roadmaps/audit-backlog-executable-plan-2026-04-03.md (item 16).
- Regra operacional mantida: 1 issue = 1 PR, branch isolada, escopo único e mínimo.
- Dependência direta: AUD-015.

## Fronteira crítica única consolidada
- Alvo: apps/api/src/services/credit-card-invoices.service.js
- Regra consolidada: resolução de sinais de classificação ambígua de fatura (`classificationAmbiguous`, `reasonCode`, `requiresUserConfirmation`, `classificationConfidence`).
- Módulo canônico interno extraído: apps/api/src/services/credit-card-invoice-classification.service.js

## Preservação de contrato público
- Sem mudança de rotas/payloads no fluxo `credit-cards invoices` (parse/list/link).
- Serviço público continua consumindo a mesma regra, agora via módulo dedicado.

## Prova de invariantes e regressão
- Invariante dedicado da fronteira extraída:
  - apps/api/src/services/credit-card-invoice-classification.service.test.js
- Regressão pública do endpoint:
  - apps/api/src/credit-card-invoices.test.js
- Execução local desta fatia:
  - `npm -w apps/api run test:domain:invoice-classification` (23 testes verdes)

## Evidência de CI da fatia
- Script dedicado:
  - apps/api/package.json -> `test:domain:invoice-classification`
- Job dedicado:
  - .github/workflows/ci.yml -> `domain-invoice-classification`

## Rollback exato
- Reverter este commit da fatia; ou, manualmente:
  - remover script `test:domain:invoice-classification` de apps/api/package.json;
  - remover job `domain-invoice-classification` de .github/workflows/ci.yml;
  - reverter extração de apps/api/src/services/credit-card-invoice-classification.service.js.

## Fora de escopo preservado
- Refactor estrutural amplo do domínio.
- Múltiplas frentes de consolidação na mesma PR.
- Mudança de contrato público FE/BE.
- Reabertura de AUD-014/AUD-015.

Refs #480
