### PR TITLE
AUD-017 - schemas/enums compartilhados

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,3 +232,36 @@ jobs:
         with:
           name: domain-invoice-classification-log
           path: domain-invoice-classification.log
+
+  shared_contract_schemas_dashboard_map:
+    name: shared-contract-schemas-dashboard-map
+    runs-on: ubuntu-latest
+    needs: [api, web]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Shared contract anti-drift (dashboard source map)
+        run: |
+          set -o pipefail
+          {
+            npm -w apps/api run test:contracts:dashboard-shared-map
+            npm -w apps/web run test:contracts:dashboard-shared-map
+          } 2>&1 | tee shared-contract-schemas-dashboard-map.log
+
+      - name: Upload shared contract evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: shared-contract-schemas-dashboard-map-log
+          path: shared-contract-schemas-dashboard-map.log

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,6 +16,7 @@
     "lint": "eslint src --max-warnings 0",
     "test:observability:documents": "vitest run src/document-financial-observability.test.js",
     "test:semantic:dashboard": "vitest run src/dashboard.test.js",
+    "test:contracts:dashboard-shared-map": "vitest run src/domain/contracts/dashboard-semantic-source-map.contract.test.ts",
     "test:hotspot:credit-card-invoices": "vitest run src/services/credit-card-invoice-period-inference.service.test.js src/credit-card-invoices.test.js",
     "test:domain:invoice-classification": "vitest run src/services/credit-card-invoice-classification.service.test.js src/credit-card-invoices.test.js",
     "test:golden": "vitest run src/credit-card-invoices.golden.test.js",

--- a/apps/api/src/domain/contracts/dashboard-response.schema.ts
+++ b/apps/api/src/domain/contracts/dashboard-response.schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { CoreFinancialSemanticContractSchema } from "./core-financial-semantic-contract.schema";
+import { DASHBOARD_SEMANTIC_SOURCE_MAP as DASHBOARD_CANONICAL_SEMANTIC_SOURCE_MAP } from "./dashboard-semantic-source-map.contract";
 
 const DashboardBillsSchema = z.object({
   overdueCount: z.number().int().nonnegative(),
@@ -33,19 +34,17 @@ const DashboardConsignadoSchema = z.object({
 });
 
 export const DashboardSemanticSourceMapSchema = z.object({
-  realized: z.tuple([z.literal("dashboard.income.receivedThisMonth")]),
-  currentPosition: z.tuple([z.literal("dashboard.bankBalance")]),
+  realized: z.tuple([z.literal(DASHBOARD_CANONICAL_SEMANTIC_SOURCE_MAP.realized[0])]),
+  currentPosition: z.tuple([z.literal(DASHBOARD_CANONICAL_SEMANTIC_SOURCE_MAP.currentPosition[0])]),
   projection: z.tuple([
-    z.literal("dashboard.income.pendingThisMonth"),
-    z.literal("dashboard.forecast.projectedBalance"),
+    z.literal(DASHBOARD_CANONICAL_SEMANTIC_SOURCE_MAP.projection[0]),
+    z.literal(DASHBOARD_CANONICAL_SEMANTIC_SOURCE_MAP.projection[1]),
   ]),
 });
 
-export const DASHBOARD_SEMANTIC_SOURCE_MAP = DashboardSemanticSourceMapSchema.parse({
-  realized: ["dashboard.income.receivedThisMonth"],
-  currentPosition: ["dashboard.bankBalance"],
-  projection: ["dashboard.income.pendingThisMonth", "dashboard.forecast.projectedBalance"],
-});
+export const DASHBOARD_SEMANTIC_SOURCE_MAP = DashboardSemanticSourceMapSchema.parse(
+  DASHBOARD_CANONICAL_SEMANTIC_SOURCE_MAP,
+);
 
 export const DashboardSnapshotResponseSchema = z.object({
   bankBalance: z.number(),

--- a/apps/api/src/domain/contracts/dashboard-semantic-source-map.contract.test.ts
+++ b/apps/api/src/domain/contracts/dashboard-semantic-source-map.contract.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { DashboardSemanticSourceMapSchema } from "./dashboard-response.schema";
+import { DASHBOARD_SEMANTIC_SOURCE_MAP } from "./dashboard-semantic-source-map.contract";
+
+describe("dashboard semantic source map shared contract", () => {
+  it("keeps canonical source map compatible with dashboard public schema", () => {
+    const parsed = DashboardSemanticSourceMapSchema.parse(DASHBOARD_SEMANTIC_SOURCE_MAP);
+
+    expect(parsed).toEqual(DASHBOARD_SEMANTIC_SOURCE_MAP);
+  });
+});

--- a/apps/api/src/domain/contracts/dashboard-semantic-source-map.contract.ts
+++ b/apps/api/src/domain/contracts/dashboard-semantic-source-map.contract.ts
@@ -1,0 +1,7 @@
+export const DASHBOARD_SEMANTIC_SOURCE_MAP = {
+  realized: ["dashboard.income.receivedThisMonth"],
+  currentPosition: ["dashboard.bankBalance"],
+  projection: ["dashboard.income.pendingThisMonth", "dashboard.forecast.projectedBalance"],
+} as const;
+
+export type DashboardSemanticSourceMapContract = typeof DASHBOARD_SEMANTIC_SOURCE_MAP;

--- a/apps/api/src/domain/contracts/types.ts
+++ b/apps/api/src/domain/contracts/types.ts
@@ -73,3 +73,7 @@ export type {
   TaxDocumentPreviewSourceType,
   TaxDocumentPreviewTextSource,
 } from "./tax-document-preview-response.schema";
+
+export {
+  DASHBOARD_SEMANTIC_SOURCE_MAP,
+} from "./dashboard-semantic-source-map.contract";

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
     "typecheck:auth": "tsc -p tsconfig.auth.json --noEmit",
     "preview": "vite preview",
     "test": "vitest",
+    "test:contracts:dashboard-shared-map": "vitest run src/services/dashboard.service.test.ts",
     "test:semantic:dashboard": "vitest run src/services/dashboard.service.test.ts src/components/OperationalSummaryPanel.test.tsx",
     "test:run": "vitest run"
   },

--- a/apps/web/src/services/dashboard.service.test.ts
+++ b/apps/web/src/services/dashboard.service.test.ts
@@ -203,4 +203,14 @@ describe("dashboardService", () => {
 
     expect(() => buildDashboardContractView(snapshot)).toThrow(/DASHBOARD_SEMANTIC_DRIFT/);
   });
+
+  it("falha quando semanticSourceMap diverge da fonte canonica compartilhada", () => {
+    const snapshot = buildSnapshot();
+    snapshot.semanticSourceMap = {
+      ...snapshot.semanticSourceMap,
+      projection: [...snapshot.semanticSourceMap.projection].reverse(),
+    } as unknown as DashboardSnapshot["semanticSourceMap"];
+
+    expect(() => buildDashboardContractView(snapshot)).toThrow(/DASHBOARD_SEMANTIC_DRIFT/);
+  });
 });

--- a/apps/web/src/services/dashboard.service.ts
+++ b/apps/web/src/services/dashboard.service.ts
@@ -1,4 +1,5 @@
 import { api, withApiRequestContext, type ApiRequestContext } from "./api";
+import { DASHBOARD_SEMANTIC_SOURCE_MAP } from "@control/contracts";
 import type {
   BalanceSnapshot,
   CoreFinancialSemanticContract,
@@ -18,12 +19,6 @@ export interface DashboardFinancialContractView {
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
 const DRIFT_EPSILON = 0.005;
 
-const DASHBOARD_CANONICAL_SOURCE_MAP: DashboardSnapshot["semanticSourceMap"] = {
-  realized: ["dashboard.income.receivedThisMonth"],
-  currentPosition: ["dashboard.bankBalance"],
-  projection: ["dashboard.income.pendingThisMonth", "dashboard.forecast.projectedBalance"],
-};
-
 const isCloseEnough = (a: number, b: number): boolean => Math.abs(a - b) <= DRIFT_EPSILON;
 
 const assertDashboardSemanticContract = (snapshot: DashboardSnapshot): void => {
@@ -35,7 +30,7 @@ const assertDashboardSemanticContract = (snapshot: DashboardSnapshot): void => {
 
   if (
     JSON.stringify(snapshot.semanticSourceMap) !==
-    JSON.stringify(DASHBOARD_CANONICAL_SOURCE_MAP)
+    JSON.stringify(DASHBOARD_SEMANTIC_SOURCE_MAP)
   ) {
     throw new Error("DASHBOARD_SEMANTIC_DRIFT: semanticSourceMap does not match canonical dashboard mapping");
   }

--- a/docs/roadmaps/aud-017-shared-contract-schemas-governance.md
+++ b/docs/roadmaps/aud-017-shared-contract-schemas-governance.md
@@ -1,0 +1,38 @@
+# AUD-017 - Schemas/Enums Compartilhados (Governanca de Slice)
+
+Fonte oficial de sequenciamento: docs/roadmaps/audit-backlog-executable-plan-2026-04-03.md (ordem 17).
+
+## Objetivo da fatia
+
+Consolidar fonte unica de contrato para schemas e enums compartilhados entre API e Web, em recorte minimo, sem alterar semantica publica vigente.
+
+## Dependencias e contratos herdados
+
+- AUD-014 fechada no recorte minimo de enforcement semantico FE/BE.
+- AUD-016 fechada como consolidacao da primeira fronteira critica de classificacao (base historica obrigatoria para futuras extracoes relacionadas).
+
+## Escopo que entra
+
+- Selecionar recorte minimo de contrato compartilhado para eliminar drift entre API e Web.
+- Definir fonte canonica unica para schema/enums do recorte escolhido.
+- Preservar payloads e comportamento publico observavel.
+- Adicionar testes/checks focados para impedir regressao de contrato.
+
+## Escopo que nao entra
+
+- Reorganizacao ampla de dominio.
+- Multipla consolidacao de superficies nao relacionadas no mesmo PR.
+- Reabertura de AUD-014 ou AUD-016.
+- Migracao estrutural ampla FE/BE fora da fronteira da fatia.
+
+## Criterios verificaveis minimos
+
+- Contrato compartilhado unico definido para a fronteira selecionada.
+- API e Web consumindo o mesmo schema/enums no recorte.
+- Teste/check focado detectando drift no recorte alterado.
+- Mudanca delimitada a AUD-017 com diff cirurgico.
+
+## Rollback
+
+- Reversao unica da fatia.
+- Caso necessario, restaurar contrato anterior em um unico revert mantendo comportamento publico.

--- a/docs/roadmaps/aud-017-shared-contract-schemas-governance.md
+++ b/docs/roadmaps/aud-017-shared-contract-schemas-governance.md
@@ -18,6 +18,14 @@ Consolidar fonte unica de contrato para schemas e enums compartilhados entre API
 - Preservar payloads e comportamento publico observavel.
 - Adicionar testes/checks focados para impedir regressao de contrato.
 
+## Fronteira selecionada (alvo unico)
+
+- Tipo de recorte: schema de payload (semanticSourceMap do dashboard).
+- Duplicidade atual atacada: mapa canonico repetido em API (`dashboard-response.schema.ts`) e Web (`dashboard.service.ts`).
+- Fonte canonica unica nesta fatia: `apps/api/src/domain/contracts/dashboard-semantic-source-map.contract.ts`.
+- Contrato publico preservado: shape de `semanticSourceMap` no endpoint `GET /dashboard/snapshot` permanece equivalente.
+- Criterio operacional de conclusao: API e Web consomem a mesma constante canonica no recorte escolhido.
+
 ## Escopo que nao entra
 
 - Reorganizacao ampla de dominio.
@@ -32,7 +40,22 @@ Consolidar fonte unica de contrato para schemas e enums compartilhados entre API
 - Teste/check focado detectando drift no recorte alterado.
 - Mudanca delimitada a AUD-017 com diff cirurgico.
 
+## Prova de equivalencia e anti-drift
+
+- Teste dedicado da fronteira canonica no API:
+	- `apps/api/src/domain/contracts/dashboard-semantic-source-map.contract.test.ts`
+- Teste de anti-drift no Web consumindo a fonte compartilhada:
+	- `apps/web/src/services/dashboard.service.test.ts`
+- Check visivel da fatia:
+	- `shared-contract-schemas-dashboard-map` (CI)
+
 ## Rollback
 
 - Reversao unica da fatia.
 - Caso necessario, restaurar contrato anterior em um unico revert mantendo comportamento publico.
+- Rollback exato da integracao:
+	- remover `apps/api/src/domain/contracts/dashboard-semantic-source-map.contract.ts`.
+	- remover script `test:contracts:dashboard-shared-map` de `apps/api/package.json`.
+	- remover script `test:contracts:dashboard-shared-map` de `apps/web/package.json`.
+	- remover job `shared-contract-schemas-dashboard-map` de `.github/workflows/ci.yml`.
+	- restaurar mapa local anterior em `apps/web/src/services/dashboard.service.ts` e em `apps/api/src/domain/contracts/dashboard-response.schema.ts`.


### PR DESCRIPTION
## Governanca de slice (execucao minima)
- Fonte oficial: docs/roadmaps/audit-backlog-executable-plan-2026-04-03.md (item 17).
- Regra operacional mantida: 1 issue = 1 PR, branch isolada, escopo unico e minimo.
- Dependencias diretas: AUD-014 e AUD-016.

## Fronteira unica consolidada
- Tipo de recorte: schema de payload (`semanticSourceMap` do dashboard).
- Duplicidade eliminada: mapa canonico repetido em API (`dashboard-response.schema.ts`) e Web (`dashboard.service.ts`).
- Fonte canonica unica nesta fatia:
  - `apps/api/src/domain/contracts/dashboard-semantic-source-map.contract.ts`

## Preservacao de contrato publico
- Shape de `semanticSourceMap` no endpoint `GET /dashboard/snapshot` foi preservado.
- Sem mudanca de semantica publica observavel no fluxo de dashboard.

## Prova de equivalencia e anti-drift
- API (compatibilidade schema publico com fonte canonica):
  - `apps/api/src/domain/contracts/dashboard-semantic-source-map.contract.test.ts`
- Web (detecao de drift consumindo fonte compartilhada):
  - `apps/web/src/services/dashboard.service.test.ts`
- Check dedicado da fatia:
  - `.github/workflows/ci.yml` -> `shared-contract-schemas-dashboard-map`

## Validacao local executada
- `npm -w apps/api run test:contracts:dashboard-shared-map`
- `npm -w apps/web run test:contracts:dashboard-shared-map`
- `npm -w apps/web run typecheck`
- `npm -w apps/api run lint`
- `npm -w apps/web run lint`

## Fora de escopo preservado
- Pacote amplo de contratos/tipagem geral do projeto.
- Multiplas consolidacoes na mesma PR.
- Reorganizacao estrutural ampla FE/BE.
- Reabertura de AUD-014 ou AUD-016.

## Rollback exato
- Reverter este commit da fatia; ou, manualmente:
  - remover `apps/api/src/domain/contracts/dashboard-semantic-source-map.contract.ts`;
  - remover `apps/api/src/domain/contracts/dashboard-semantic-source-map.contract.test.ts`;
  - remover script `test:contracts:dashboard-shared-map` de `apps/api/package.json`;
  - remover script `test:contracts:dashboard-shared-map` de `apps/web/package.json`;
  - remover job `shared-contract-schemas-dashboard-map` de `.github/workflows/ci.yml`;
  - restaurar mapa local anterior em `apps/web/src/services/dashboard.service.ts` e `apps/api/src/domain/contracts/dashboard-response.schema.ts`.

Refs #482
