### PR TITLE
AUD-019 - politica de retencao e delecao de dados sensiveis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,3 +293,31 @@ jobs:
         with:
           name: async-import-runtime-invoice-log
           path: async-import-runtime-invoice.log
+
+  sensitive_data_retention_aud019:
+    name: sensitive-data-retention-aud019
+    runs-on: ubuntu-latest
+    needs: [api]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Sensitive data retention compliance (AUD-019)
+        run: npm -w apps/api run test:compliance:aud-019 | tee sensitive-data-retention-aud019.log
+
+      - name: Upload retention compliance evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sensitive-data-retention-aud019-log
+          path: sensitive-data-retention-aud019.log

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,6 +18,7 @@
     "test:semantic:dashboard": "vitest run src/dashboard.test.js",
     "test:contracts:dashboard-shared-map": "vitest run src/domain/contracts/dashboard-semantic-source-map.contract.test.ts",
     "test:async-import:invoice": "vitest run src/credit-card-invoice-import-jobs.test.js",
+    "test:compliance:aud-019": "vitest run src/import.test.js --testNamePattern \"COMPLIANCE AUD-019\"",
     "test:hotspot:credit-card-invoices": "vitest run src/services/credit-card-invoice-period-inference.service.test.js src/credit-card-invoices.test.js",
     "test:domain:invoice-classification": "vitest run src/services/credit-card-invoice-classification.service.test.js src/credit-card-invoices.test.js",
     "test:golden": "vitest run src/credit-card-invoices.golden.test.js",

--- a/apps/api/src/import.test.js
+++ b/apps/api/src/import.test.js
@@ -1127,6 +1127,54 @@ describe("transaction imports", () => {
     expect(persistedSessionResult.rows[0].committed_at).toBeTruthy();
   });
 
+  it("COMPLIANCE AUD-019: POST /transactions/import/commit remove normalizedRows do payload persistido", async () => {
+    const token = await registerAndLogin("aud019-retention@controlfinance.dev");
+    await makeProUser("aud019-retention@controlfinance.dev");
+
+    const dryRunCsv = csvFile(
+      [
+        "date,type,value,description,notes,category",
+        "2026-03-01,Entrada,1000,Salario,,",
+        "2026-03-05,Saida,220.5,Mercado,,",
+      ].join("\n"),
+    );
+
+    const dryRunResponse = await request(app)
+      .post("/transactions/import/dry-run")
+      .set("Authorization", `Bearer ${token}`)
+      .attach("file", dryRunCsv.buffer, {
+        filename: dryRunCsv.fileName,
+        contentType: "text/csv",
+      });
+
+    expect(dryRunResponse.status).toBe(200);
+    expect(dryRunResponse.body.summary.validRows).toBe(2);
+
+    const commitResponse = await request(app)
+      .post("/transactions/import/commit")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ importId: dryRunResponse.body.importId });
+
+    expect(commitResponse.status).toBe(200);
+
+    const persistedSessionResult = await dbQuery(
+      `
+        SELECT committed_at, payload_json
+        FROM transaction_import_sessions
+        WHERE id = $1
+      `,
+      [dryRunResponse.body.importId],
+    );
+
+    expect(persistedSessionResult.rows[0].committed_at).toBeTruthy();
+    expect(persistedSessionResult.rows[0].payload_json.summary).toMatchObject({
+      totalRows: 2,
+      validRows: 2,
+      invalidRows: 0,
+    });
+    expect(persistedSessionResult.rows[0].payload_json.normalizedRows).toBeUndefined();
+  });
+
   it("POST /transactions/import/commit retorna 404 para sessao de outro usuario", async () => {
     const ownerToken = await registerAndLogin("import-commit-owner@controlfinance.dev");
     await makeProUser("import-commit-owner@controlfinance.dev");

--- a/apps/api/src/services/transactions-import.service.ts
+++ b/apps/api/src/services/transactions-import.service.ts
@@ -1058,6 +1058,15 @@ const persistImportSession = async (userId: number | string, payload: unknown) =
   };
 };
 
+const stripSensitiveImportPayloadFields = (payload: unknown) => {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return payload;
+  }
+
+  const { normalizedRows, ...retainedPayload } = payload as Record<string, unknown>;
+  return retainedPayload;
+};
+
 const normalizeImportId = (value: unknown): string => {
   if (typeof value === "undefined" || value === null || value === "") {
     throw createError(400, "importId e obrigatorio.");
@@ -1436,14 +1445,19 @@ export const commitTransactionsImportForUser = async (
     const sessionUpdateResult = await transactionClient.query(
       `
         UPDATE transaction_import_sessions
-        SET committed_at = NOW()
+        SET committed_at = NOW(),
+            payload_json = $3::jsonb
         WHERE id = $1
           AND user_id = $2
           AND committed_at IS NULL
           AND expires_at > NOW()
         RETURNING id
       `,
-      [normalizedImportId, userId],
+      [
+        normalizedImportId,
+        userId,
+        JSON.stringify(stripSensitiveImportPayloadFields(payload)),
+      ],
     );
 
     const updatedSessions = Number(sessionUpdateResult.rowCount || 0);

--- a/docs/roadmaps/aud-019-sensitive-data-retention-policy-governance.md
+++ b/docs/roadmaps/aud-019-sensitive-data-retention-policy-governance.md
@@ -1,0 +1,39 @@
+# AUD-019 - Politica de Retencao e Delecao de Dados Sensiveis (Governanca de Slice)
+
+Fonte oficial de sequenciamento: docs/roadmaps/audit-backlog-executable-plan-2026-04-03.md (ordem 19).
+
+## Objetivo da fatia
+
+Executar recorte minimo para aplicar politica verificavel de retencao/delecao de dados sensiveis, preservando contrato publico fora da fronteira escolhida.
+
+## Dependencias e contratos herdados
+
+- AUD-003 fechada (hardening de storage sensivel).
+- AUD-004 fechada (minimizacao de persistencia sensivel).
+- AUD-018 fechada como primeira migracao assincrona minima; qualquer evolucao de runtime de jobs alem do necessario para esta fatia deve nascer em slice propria e referenciar AUD-018.
+
+## Escopo que entra
+
+- Selecionar 1 fronteira unica de lifecycle de dado sensivel para retencao/delecao.
+- Definir regra minima verificavel (retencao, elegibilidade de delecao e evidencia de execucao).
+- Preservar contratos e comportamento publico fora do recorte da fatia.
+- Adicionar teste/check focado de conformidade do lifecycle no recorte.
+
+## Escopo que nao entra
+
+- Politica ampla para todos os tipos de dado sensivel no mesmo PR.
+- Reorganizacao estrutural ampla de storage/runtime.
+- Mudancas transversais de UX/export para multiplos fluxos.
+- Reabertura de AUD-003, AUD-004 ou AUD-018.
+
+## Criterios verificaveis minimos
+
+- Fronteira unica com regra de retencao/delecao aplicada e auditavel.
+- Evidencia de conformidade via teste/check focado.
+- Contrato publico preservado fora da fronteira alterada.
+- Mudanca delimitada a AUD-019 com diff cirurgico.
+
+## Rollback
+
+- Reversao unica da fatia.
+- Caso necessario, restaurar comportamento anterior de lifecycle em um unico revert sem expandir escopo.


### PR DESCRIPTION
## Governanca de slice (execucao minima)
- Fonte oficial: docs/roadmaps/audit-backlog-executable-plan-2026-04-03.md (item 19).
- Regra operacional: 1 issue = 1 PR, branch isolada, escopo minimo.

## Recorte aplicado nesta PR
- Fronteira unica: ciclo de vida do payload persistido em transaction_import_sessions.payload_json apos commit de importacao.
- Regra minima de retencao/delecao: no commit, remover o campo sensivel normalizedRows do payload persistido e manter metadados necessarios (summary, fileName, documentType).

## Mudancas entregues
- apps/api/src/services/transactions-import.service.ts
  - commit da sessao passa a persistir payload sem normalizedRows.
- apps/api/src/import.test.js
  - teste focado: COMPLIANCE AUD-019 garantindo remocao de normalizedRows apos commit.
- apps/api/package.json
  - novo script: test:compliance:aud-019.
- .github/workflows/ci.yml
  - novo job: sensitive-data-retention-aud019.

## Evidencia local
- npm -w apps/api run test:compliance:aud-019
- Resultado: 1 passed, 57 skipped.

## Guardrails mantidos
- Sem politica ampla para todos os dados sensiveis.
- Sem reorganizacao estrutural ampla de storage/runtime.
- Sem mudancas transversais fora da fronteira unica.

Refs #486