### PR TITLE
AUD-022 - reducao JS+TS por risco

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,3 +349,31 @@ jobs:
         with:
           name: load-latency-baseline-aud021-log
           path: load-latency-baseline-aud021.log
+
+  risk_driven_ts_adoption_aud022:
+    name: risk-driven-ts-adoption-aud022
+    runs-on: ubuntu-latest
+    needs: [web]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Risk-driven TS adoption contract (AUD-022)
+        run: npm -w apps/web run test:risk:aud-022 | tee risk-driven-ts-adoption-aud022.log
+
+      - name: Upload risk-driven TS adoption evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: risk-driven-ts-adoption-aud022-log
+          path: risk-driven-ts-adoption-aud022.log

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
     "typecheck:auth": "tsc -p tsconfig.auth.json --noEmit",
     "preview": "vite preview",
     "test": "vitest",
+    "test:risk:aud-022": "vitest run src/services/api-risk-contract.test.ts src/services/api.test.ts",
     "test:contracts:dashboard-shared-map": "vitest run src/services/dashboard.service.test.ts",
     "test:semantic:dashboard": "vitest run src/services/dashboard.service.test.ts src/components/OperationalSummaryPanel.test.tsx",
     "test:run": "vitest run"

--- a/apps/web/src/services/api-risk-contract.test.ts
+++ b/apps/web/src/services/api-risk-contract.test.ts
@@ -1,30 +1,85 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 import {
   api,
   getApiHealth,
   resolveApiUrl,
-  setUnauthorizedHandler,
   setPaymentRequiredHandler,
+  setUnauthorizedHandler,
+  type PaymentRequiredPayload,
 } from "./api";
 
-var requestInterceptor;
-var responseErrorInterceptor;
+type ApiErrorInput = {
+  response?: {
+    status?: number;
+    data?: {
+      message?: string;
+      code?: string;
+    };
+  };
+  config?: {
+    url?: string;
+    headers?: Record<string, unknown>;
+    _retry?: boolean;
+  };
+};
+
+type RequestConfigInput = {
+  headers?: Record<string, unknown>;
+};
+
+type RequestInterceptor = (config: RequestConfigInput) => RequestConfigInput;
+type ResponseErrorInterceptor = (error: ApiErrorInput) => Promise<unknown>;
+
+type MockAxiosInstance = {
+  get: Mock;
+  post: Mock;
+  request: Mock;
+  interceptors: {
+    request: {
+      use: Mock;
+    };
+    response: {
+      use: Mock;
+    };
+  };
+};
+
+const interceptorState = vi.hoisted(() => ({
+  requestInterceptor: null as RequestInterceptor | null,
+  responseErrorInterceptor: null as ResponseErrorInterceptor | null,
+}));
+
+const requireRequestInterceptor = (): RequestInterceptor => {
+  if (!interceptorState.requestInterceptor) {
+    throw new Error("request interceptor nao inicializado");
+  }
+
+  return interceptorState.requestInterceptor;
+};
+
+const requireResponseErrorInterceptor = (): ResponseErrorInterceptor => {
+  if (!interceptorState.responseErrorInterceptor) {
+    throw new Error("response interceptor nao inicializado");
+  }
+
+  return interceptorState.responseErrorInterceptor;
+};
 
 vi.mock("axios", () => {
-  const instance = {
+  const instance: MockAxiosInstance = {
     get: vi.fn(),
     post: vi.fn(),
     request: vi.fn(),
     interceptors: {
       request: {
-        use: vi.fn((handler) => {
-          requestInterceptor = handler;
+        use: vi.fn((handler: RequestInterceptor) => {
+          interceptorState.requestInterceptor = handler;
           return 0;
         }),
       },
       response: {
-        use: vi.fn((_onSuccess, onError) => {
-          responseErrorInterceptor = onError;
+        use: vi.fn((_onSuccess: unknown, onError: ResponseErrorInterceptor) => {
+          interceptorState.responseErrorInterceptor = onError;
           return 0;
         }),
       },
@@ -38,7 +93,9 @@ vi.mock("axios", () => {
   };
 });
 
-describe("api service", () => {
+const apiMock = api as unknown as Pick<MockAxiosInstance, "get" | "post" | "request">;
+
+describe("api risk contract", () => {
   beforeEach(() => {
     setUnauthorizedHandler(undefined);
     setPaymentRequiredHandler(undefined);
@@ -46,13 +103,13 @@ describe("api service", () => {
   });
 
   it("consulta o healthcheck da API", async () => {
-    api.get.mockResolvedValueOnce({
+    apiMock.get.mockResolvedValueOnce({
       data: { ok: true, version: "1.6.4", commit: "2eb3f64" },
     });
 
     const result = await getApiHealth();
 
-    expect(api.get).toHaveBeenCalledWith("/health");
+    expect(apiMock.get).toHaveBeenCalledWith("/health");
     expect(result).toEqual({ ok: true, version: "1.6.4", commit: "2eb3f64" });
   });
 
@@ -75,31 +132,30 @@ describe("api service", () => {
   });
 
   it("injeta x-request-id em todas as requisicoes", () => {
-    const nextConfig = requestInterceptor({
+    const nextConfig = requireRequestInterceptor()({
       headers: {},
     });
 
-    expect(nextConfig.headers.Authorization).toBeUndefined();
-    expect(typeof nextConfig.headers["x-request-id"]).toBe("string");
-    expect(nextConfig.headers["x-request-id"].length).toBeGreaterThan(0);
+    const headers = (nextConfig.headers || {}) as Record<string, unknown>;
+    expect(headers.Authorization).toBeUndefined();
+    expect(typeof headers["x-request-id"]).toBe("string");
+    expect(String(headers["x-request-id"]).length).toBeGreaterThan(0);
   });
-
-  // ─── 401 / Refresh interceptor ───────────────────────────────────────────────
 
   it("tenta refresh e retenta request quando API retorna 401", async () => {
     const onUnauthorized = vi.fn();
     setUnauthorizedHandler(onUnauthorized);
 
-    api.post.mockResolvedValueOnce({}); // refresh succeeds
-    api.request.mockResolvedValueOnce({ data: "retried" }); // original request retried
+    apiMock.post.mockResolvedValueOnce({});
+    apiMock.request.mockResolvedValueOnce({ data: "retried" });
 
-    const result = await responseErrorInterceptor({
+    const result = await requireResponseErrorInterceptor()({
       response: { status: 401 },
       config: { url: "/transactions", headers: {} },
     });
 
-    expect(api.post).toHaveBeenCalledWith("/auth/refresh");
-    expect(api.request).toHaveBeenCalled();
+    expect(apiMock.post).toHaveBeenCalledWith("/auth/refresh");
+    expect(apiMock.request).toHaveBeenCalled();
     expect(onUnauthorized).not.toHaveBeenCalled();
     expect(result).toEqual({ data: "retried" });
   });
@@ -108,10 +164,10 @@ describe("api service", () => {
     const onUnauthorized = vi.fn();
     setUnauthorizedHandler(onUnauthorized);
 
-    api.post.mockRejectedValueOnce(new Error("refresh failed"));
+    apiMock.post.mockRejectedValueOnce(new Error("refresh failed"));
 
     await expect(
-      responseErrorInterceptor({
+      requireResponseErrorInterceptor()({
         response: { status: 401 },
         config: { url: "/transactions", headers: {} },
       }),
@@ -120,33 +176,33 @@ describe("api service", () => {
     expect(onUnauthorized).toHaveBeenCalledTimes(1);
   });
 
-  it("nao tenta refresh quando 401 vem da rota de refresh (evita loop)", async () => {
+  it("nao tenta refresh quando 401 vem da rota de refresh", async () => {
     const onUnauthorized = vi.fn();
     setUnauthorizedHandler(onUnauthorized);
 
     await expect(
-      responseErrorInterceptor({
+      requireResponseErrorInterceptor()({
         response: { status: 401 },
         config: { url: "/auth/refresh", headers: {} },
       }),
     ).rejects.toBeTruthy();
 
-    expect(api.post).not.toHaveBeenCalled();
+    expect(apiMock.post).not.toHaveBeenCalled();
     expect(onUnauthorized).toHaveBeenCalledTimes(1);
   });
 
-  it("nao tenta refresh quando request ja foi retentado (_retry=true)", async () => {
+  it("nao tenta refresh quando request ja foi retentado", async () => {
     const onUnauthorized = vi.fn();
     setUnauthorizedHandler(onUnauthorized);
 
     await expect(
-      responseErrorInterceptor({
+      requireResponseErrorInterceptor()({
         response: { status: 401 },
         config: { url: "/transactions", headers: {}, _retry: true },
       }),
     ).rejects.toBeTruthy();
 
-    expect(api.post).not.toHaveBeenCalled();
+    expect(apiMock.post).not.toHaveBeenCalled();
     expect(onUnauthorized).toHaveBeenCalledTimes(1);
   });
 
@@ -155,10 +211,10 @@ describe("api service", () => {
     setUnauthorizedHandler(onUnauthorized);
     setUnauthorizedHandler(undefined);
 
-    api.post.mockRejectedValueOnce(new Error("refresh failed"));
+    apiMock.post.mockRejectedValueOnce(new Error("refresh failed"));
 
     await expect(
-      responseErrorInterceptor({
+      requireResponseErrorInterceptor()({
         response: { status: 401 },
         config: { url: "/transactions", headers: {} },
       }),
@@ -167,28 +223,26 @@ describe("api service", () => {
     expect(onUnauthorized).not.toHaveBeenCalled();
   });
 
-  // ─── Concurrent 401 / refresh queue ─────────────────────────────────────────
-
-  it("dois requests 401 simultaneos disparam apenas um refresh e ambos retentam", async () => {
-    api.post.mockResolvedValueOnce({}); // refresh succeeds
-    api.request
+  it("dois requests 401 simultaneos disparam apenas um refresh", async () => {
+    apiMock.post.mockResolvedValueOnce({});
+    apiMock.request
       .mockResolvedValueOnce({ data: "response-1" })
       .mockResolvedValueOnce({ data: "response-2" });
 
     const [r1, r2] = await Promise.all([
-      responseErrorInterceptor({
+      requireResponseErrorInterceptor()({
         response: { status: 401 },
         config: { url: "/summary", headers: {} },
       }),
-      responseErrorInterceptor({
+      requireResponseErrorInterceptor()({
         response: { status: 401 },
         config: { url: "/forecast", headers: {} },
       }),
     ]);
 
-    expect(api.post).toHaveBeenCalledTimes(1);
-    expect(api.post).toHaveBeenCalledWith("/auth/refresh");
-    expect(api.request).toHaveBeenCalledTimes(2);
+    expect(apiMock.post).toHaveBeenCalledTimes(1);
+    expect(apiMock.post).toHaveBeenCalledWith("/auth/refresh");
+    expect(apiMock.request).toHaveBeenCalledTimes(2);
     expect(r1).toEqual({ data: "response-1" });
     expect(r2).toEqual({ data: "response-2" });
   });
@@ -197,34 +251,31 @@ describe("api service", () => {
     const onUnauthorized = vi.fn();
     setUnauthorizedHandler(onUnauthorized);
 
-    api.post.mockRejectedValueOnce(new Error("refresh failed"));
+    apiMock.post.mockRejectedValueOnce(new Error("refresh failed"));
 
     const results = await Promise.allSettled([
-      responseErrorInterceptor({
+      requireResponseErrorInterceptor()({
         response: { status: 401 },
         config: { url: "/summary", headers: {} },
       }),
-      responseErrorInterceptor({
+      requireResponseErrorInterceptor()({
         response: { status: 401 },
         config: { url: "/forecast", headers: {} },
       }),
     ]);
 
-    expect(api.post).toHaveBeenCalledTimes(1);
+    expect(apiMock.post).toHaveBeenCalledTimes(1);
     expect(results[0].status).toBe("rejected");
     expect(results[1].status).toBe("rejected");
-    // unauthorizedHandler fired once — from the first request's catch block only
     expect(onUnauthorized).toHaveBeenCalledTimes(1);
   });
 
-  // ─── 402 handler ─────────────────────────────────────────────────────────────
-
   it("chama paymentRequiredHandler com contexto trial_expired quando code=TRIAL_EXPIRED", async () => {
-    const onPaymentRequired = vi.fn();
+    const onPaymentRequired = vi.fn<(payload: PaymentRequiredPayload) => void>();
     setPaymentRequiredHandler(onPaymentRequired);
 
     await expect(
-      responseErrorInterceptor({
+      requireResponseErrorInterceptor()({
         response: {
           status: 402,
           data: { message: "Periodo de teste encerrado.", code: "TRIAL_EXPIRED" },
@@ -240,11 +291,11 @@ describe("api service", () => {
   });
 
   it("resolve copy explicita para gate de importacao de extrato", async () => {
-    const onPaymentRequired = vi.fn();
+    const onPaymentRequired = vi.fn<(payload: PaymentRequiredPayload) => void>();
     setPaymentRequiredHandler(onPaymentRequired);
 
     await expect(
-      responseErrorInterceptor({
+      requireResponseErrorInterceptor()({
         response: { status: 402, data: { message: "Recurso disponivel apenas no plano Pro." } },
         config: { url: "/transactions/import/dry-run" },
       }),
@@ -258,12 +309,11 @@ describe("api service", () => {
     });
   });
 
-  it("nao falha se paymentRequiredHandler nao estiver definido (status 402)", async () => {
+  it("nao falha se paymentRequiredHandler nao estiver definido", async () => {
     await expect(
-      responseErrorInterceptor({
+      requireResponseErrorInterceptor()({
         response: { status: 402, data: {} },
       }),
     ).rejects.toBeTruthy();
-    // nenhum erro de "is not a function"
   });
 });

--- a/docs/roadmaps/aud-022-risk-driven-ts-adoption-governance.md
+++ b/docs/roadmaps/aud-022-risk-driven-ts-adoption-governance.md
@@ -21,11 +21,21 @@ Executar recorte minimo para reduzir coexistencia JS+TS em superficie de contrat
 
 ## Fronteira selecionada (alvo unico)
 
-- Fronteira unica: superficie de contrato de servicos web em `apps/web/src/services/api.test.js`.
+- Fronteira unica: contrato de risco do cliente HTTP web em `apps/web/src/services/api.ts`, validado por teste dedicado migrado de JS para TS.
+- Risco concreto que a fatia elimina: drift silencioso no contrato de interceptors (request id, retry de 401 e payload de 402) por falta de tipagem explicita no teste de maior cobertura desse fluxo.
+- Artefato minimo de migracao: mover o teste de risco de `apps/web/src/services/api.test.js` para arquivo TypeScript dedicado (`apps/web/src/services/api-risk-contract.test.ts`).
 - Ativo minimo esperado nesta fatia:
   - migracao da fronteira para TypeScript com tipagem explicita;
   - alinhamento do teste/contrato para impedir drift de shape;
   - evidencia de execucao focada no recorte.
+
+## Prova focada de nao regressao
+
+- Check dedicado da fatia executando apenas os testes de contrato de risco da API web.
+- Suficiencia minima da prova:
+  - validar injector de `x-request-id` no interceptor de request;
+  - validar fila/retry de 401 sem loop de refresh;
+  - validar mapeamento de payload 402 (`reason`, `feature`, `context`) sem drift.
 
 ## Escopo que nao entra
 
@@ -43,7 +53,8 @@ Executar recorte minimo para reduzir coexistencia JS+TS em superficie de contrat
 ## Rollback
 
 - Revert unico da fatia.
-- Rollback exato da integracao (a confirmar na execucao minima):
-  - restaurar arquivo JS da fronteira selecionada;
-  - remover adaptacoes TS estritamente introduzidas por esta fatia;
+- Rollback exato da integracao:
+  - restaurar `apps/web/src/services/api.test.js`;
+  - remover `apps/web/src/services/api-risk-contract.test.ts`;
+  - remover script/check dedicado da AUD-022 em `apps/web/package.json` e `.github/workflows/ci.yml`;
   - restaurar governanca ao baseline de kickoff se necessario.

--- a/docs/roadmaps/aud-022-risk-driven-ts-adoption-governance.md
+++ b/docs/roadmaps/aud-022-risk-driven-ts-adoption-governance.md
@@ -1,0 +1,49 @@
+# AUD-022 - Reducao JS+TS por Risco (Governanca de Slice)
+
+Fonte oficial de sequenciamento: docs/roadmaps/audit-backlog-executable-plan-2026-04-03.md (ordem 22).
+
+## Objetivo da fatia
+
+Executar recorte minimo para reduzir coexistencia JS+TS em superficie de contrato de maior risco no web, preservando comportamento funcional e sem migracao ampla do frontend.
+
+## Dependencias e contratos herdados
+
+- AUD-017 fechada (schemas/enums compartilhados como base de contrato tipado).
+- AUD-015 fechada (quebra de hotspots sem regressao funcional).
+- AUD-021 fechada como primeira baseline minima reproduzivel de performance; qualquer ampliacao de politica ampla de performance fica fora desta fatia.
+
+## Escopo que entra
+
+- Selecionar 1 fronteira unica de coexistencia JS+TS em superficie de risco.
+- Aplicar migracao minima para TypeScript no recorte unico.
+- Preservar contratos e comportamento publico fora do recorte.
+- Adicionar prova focada de nao regressao no recorte.
+
+## Fronteira selecionada (alvo unico)
+
+- Fronteira unica: superficie de contrato de servicos web em `apps/web/src/services/api.test.js`.
+- Ativo minimo esperado nesta fatia:
+  - migracao da fronteira para TypeScript com tipagem explicita;
+  - alinhamento do teste/contrato para impedir drift de shape;
+  - evidencia de execucao focada no recorte.
+
+## Escopo que nao entra
+
+- Migracao ampla de multiplos arquivos JS no web no mesmo PR.
+- Politica global de adocao TypeScript para toda a aplicacao.
+- Refactors transversais em runtime de servicos ou componentes.
+- Reabertura de AUD-017, AUD-015 ou AUD-021.
+
+## Criterios verificaveis minimos
+
+- Fronteira unica migrada para TS com contrato explicito.
+- Teste/check focado verde no recorte.
+- Mudanca delimitada a AUD-022 com diff cirurgico.
+
+## Rollback
+
+- Revert unico da fatia.
+- Rollback exato da integracao (a confirmar na execucao minima):
+  - restaurar arquivo JS da fronteira selecionada;
+  - remover adaptacoes TS estritamente introduzidas por esta fatia;
+  - restaurar governanca ao baseline de kickoff se necessario.


### PR DESCRIPTION
## Governanca de slice (execucao minima)
- Fonte oficial: docs/roadmaps/audit-backlog-executable-plan-2026-04-03.md (item 22).
- Regra operacional: 1 issue = 1 PR, branch isolada, escopo minimo.
- Dependencias diretas no plano: AUD-017 e AUD-015.

## Fronteira unica desta PR
- Contrato de risco no cliente HTTP web em `apps/web/src/services/api.ts`, protegido por teste dedicado migrado de JS para TS.
- Recorte cirurgico: migracao de `apps/web/src/services/api.test.js` para `apps/web/src/services/api-risk-contract.test.ts`.

## Risco concreto eliminado
- Antes: maior suite de contrato do cliente HTTP em JS sem tipagem explicita no teste.
- Agora: teste em TypeScript com contratos tipados para interceptor de request, fluxo de retry 401 e payload 402, reduzindo drift silencioso de shape entre contrato e consumo.

## Contrato explicitado no recorte
- request interceptor: injecao obrigatoria de `x-request-id`.
- response 401: retry com refresh, fila concorrente e anti-loop (`/auth/refresh`, `_retry`).
- response 402: shape de payload com `reason`, `feature`, `context` via `PaymentRequiredPayload`.

## Prova focada de nao regressao
- teste dedicado no recorte:
  - `apps/web/src/services/api-risk-contract.test.ts`
- cobertura de contrato mantida para classificacao paywall:
  - `apps/web/src/services/api.test.ts`
- validacao local executada:
  - `npm -w apps/web run lint`
  - `npm -w apps/web run test:risk:aud-022`

## Fora de escopo (mantido)
- sem migracao multi-arquivo ampla de JS+TS
- sem politica global de adocao TS
- sem refactor transversal de servicos/componentes
- sem reabertura de AUD-017, AUD-015 ou AUD-021

## Rollback exato desta fatia
- restaurar `apps/web/src/services/api.test.js`
- remover `apps/web/src/services/api-risk-contract.test.ts`
- restaurar governanca em `docs/roadmaps/aud-022-risk-driven-ts-adoption-governance.md` ao baseline de kickoff

Refs #492