### PR TITLE
Docs - fechamento executivo do programa AUD-001..022

### DIFF
--- a/docs/roadmaps/audit-program-closeout-2026-04-05.md
+++ b/docs/roadmaps/audit-program-closeout-2026-04-05.md
@@ -1,0 +1,92 @@
+# Audit Program Closeout (AUD-001 a AUD-022) - 2026-04-05
+
+## Objetivo
+
+Registrar encerramento executivo curto do ciclo de backlog executavel AUD-001..AUD-022, com estado consolidado, riscos residuais e decisao recomendada de proximo passo.
+
+## Escopo deste fechamento
+
+- consolidacao de status remoto por rastreabilidade de issue/PR;
+- sintese do que foi resolvido no ciclo;
+- riscos residuais que permanecem apos o ciclo;
+- decisao recomendada: novo ciclo imediato vs manutencao incremental.
+
+## Estado consolidado por AUD (rastreamento remoto)
+
+Fonte de verificacao: consultas remotas de issue/PR por codigo AUD no titulo (`AUD-001`..`AUD-022`).
+
+### Itens com PR MERGED rastreavel por titulo
+
+- AUD-001: PR #455
+- AUD-002: PR #456
+- AUD-003: PR #458
+- AUD-006: PR #461
+- AUD-007: PR #463
+- AUD-010: PR #469
+- AUD-011: PR #471
+- AUD-012: PR #473
+- AUD-013: PR #475
+- AUD-014: PR #477
+- AUD-015: PR #479
+- AUD-016: PR #481
+- AUD-017: PR #483
+- AUD-018: PR #485
+- AUD-019: PR #487
+- AUD-020: PR #489
+- AUD-021: PR #491
+- AUD-022: PR #493
+
+### Itens com issue CLOSED rastreavel por titulo
+
+- AUD-007: issue #462
+- AUD-008: issue #464
+- AUD-009: issue #466
+- AUD-010: issue #468
+- AUD-011: issue #470
+- AUD-012: issue #472
+- AUD-013: issue #474
+- AUD-014: issue #476
+- AUD-015: issue #478
+- AUD-016: issue #480
+- AUD-017: issue #482
+- AUD-018: issue #484
+- AUD-019: issue #486
+- AUD-020: issue #488
+- AUD-021: issue #490
+- AUD-022: issue #492
+
+### Observacao de rastreabilidade
+
+- AUD-004 e AUD-005 nao retornaram issue/PR dedicadas por titulo exato no levantamento remoto.
+- Isso nao implica automaticamente pendencia funcional, mas representa lacuna de rastreabilidade nominal no historico remoto.
+
+## O que ficou resolvido no ciclo
+
+- trilho operacional 1 issue = 1 PR consolidado para a maior parte das fatias;
+- gates focados em CI adicionados em slices criticas (ex.: AUD-019, AUD-021, AUD-022);
+- recortes minimos preservados sem expansao para politicas globais indevidas;
+- main estabilizada com merges squash e branches de trabalho encerradas por fatia.
+
+## Riscos residuais apos AUD-022
+
+- risco de rastreabilidade historica heterogenea em itens antigos sem nomeacao AUD explicita em issue/PR (principalmente AUD-004 e AUD-005);
+- risco de leitura fora de contexto de baselines e contratos sem referencia ao protocolo/slice de origem;
+- risco de reabertura ampla de escopo em evolucoes futuras (TS/performance/incidentes) se nao manter fronteira unica por fatia.
+
+## Decisao recomendada
+
+Recomendacao: entrar em manutencao incremental orientada a risco, sem abrir novo ciclo grande por inercia.
+
+Criticos para abrir novo ciclo formal:
+
+1. surgimento de risco P1/P2 recorrente nao coberto por fatias anteriores;
+2. evidencia de drift contratual sem cobertura focada;
+3. degradacao sustentada acima das regras de comparacao definidas nas baselines;
+4. mudanca de requisito de produto que exija novo trilho AUD dedicado.
+
+## Plano minimo pos-ciclo
+
+1. manter apenas fatias pequenas de manutencao com fronteira unica e prova focada;
+2. para cada nova fatia, referenciar explicitamente a AUD predecessora do dominio;
+3. padronizar nomenclatura de issue/PR com codigo AUD para eliminar lacunas de rastreabilidade;
+4. revisar este closeout em janela mensal curta para decidir se abre ciclo novo.


### PR DESCRIPTION
## Fechamento executivo do programa AUD-001..022

Esta PR registra um closeout curto do ciclo executável concluído, consolidando:
- estado final por AUD com rastreabilidade remota (issue/PR);
- itens resolvidos no ciclo;
- riscos residuais remanescentes;
- decisão recomendada de continuidade (manutenção incremental orientada a risco).

## Escopo
- apenas documentação de fechamento executivo;
- sem abertura de novo ciclo técnico;
- sem mudanças funcionais em API/Web.

## Artefato
- docs/roadmaps/audit-program-closeout-2026-04-05.md