### PR TITLE
fix(security): redact invoice rawExcerpt metadata and legacy records

### DIFF
--- a/apps/api/src/credit-card-invoices.test.js
+++ b/apps/api/src/credit-card-invoices.test.js
@@ -167,7 +167,14 @@ describe("credit-card-invoices", () => {
     expect(res.body.requiresUserConfirmation).toBe(false);
     expect(res.body.parseMetadata?.parser?.name).toBe("itau_parser_v1");
     expect(res.body.parseMetadata?.ocrRuntime?.status).toBe("success");
+    expect(res.body.parseMetadata?.rawExcerpt).toBeUndefined();
     expect(res.body.linkedBillId).toBeNull();
+
+    const persistedInvoiceResult = await dbQuery(
+      "SELECT parse_metadata FROM credit_card_invoices WHERE id = $1 LIMIT 1",
+      [res.body.id],
+    );
+    expect(persistedInvoiceResult.rows[0]?.parse_metadata?.rawExcerpt).toBeUndefined();
   });
 
   it("POST parse-pdf infere periodo quando ausente no PDF (parse_confidence=low)", async () => {
@@ -351,6 +358,52 @@ describe("credit-card-invoices", () => {
       .set("Authorization", `Bearer ${token2}`);
 
     expect(res.status).toBe(404);
+  });
+
+  it("GET /invoices sanitiza rawExcerpt de registro legado no parseMetadata", async () => {
+    const email = "inv-list-legacy-rawexcerpt@test.dev";
+    const token = await registerAndLogin(email);
+
+    const cardRes = await createCard(token);
+    const cardId = cardRes.body.id;
+
+    const userResult = await dbQuery("SELECT id FROM users WHERE email = $1 LIMIT 1", [email]);
+    const userId = Number(userResult.rows[0]?.id);
+
+    await dbQuery(
+      `INSERT INTO credit_card_invoices
+         (user_id, credit_card_id, issuer, card_last4, period_start, period_end,
+          due_date, total_amount, minimum_payment, financed_balance,
+          parse_confidence, parse_metadata)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb)`,
+      [
+        userId,
+        cardId,
+        "itau",
+        "1234",
+        "2026-02-08",
+        "2026-03-07",
+        "2026-03-15",
+        1247.8,
+        124.78,
+        null,
+        "high",
+        JSON.stringify({
+          rawExcerpt: "DADO LEGADO SENSIVEL",
+          parser: { strategy: "issuer_specific", name: "itau_parser_v1" },
+        }),
+      ],
+    );
+
+    const res = await request(app)
+      .get(`/credit-cards/${cardId}/invoices`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBe(1);
+    expect(res.body[0].parseMetadata?.rawExcerpt).toBeUndefined();
+    expect(res.body[0].parseMetadata?.parser?.name).toBe("itau_parser_v1");
   });
 
   // ─── link-bill ───────────────────────────────────────────────────────────────

--- a/apps/api/src/db/migrations/113_redact_credit_card_invoice_raw_excerpt.sql
+++ b/apps/api/src/db/migrations/113_redact_credit_card_invoice_raw_excerpt.sql
@@ -1,0 +1,2 @@
+UPDATE credit_card_invoices
+SET parse_metadata = COALESCE(parse_metadata, '{}'::jsonb) - 'rawExcerpt';

--- a/apps/api/src/domain/imports/itau-invoice.parser.js
+++ b/apps/api/src/domain/imports/itau-invoice.parser.js
@@ -140,11 +140,6 @@ const extractCardLast4 = (text) => {
   return null;
 };
 
-// ─── Raw excerpt (first 800 chars after normalisation) ────────────────────────
-
-const extractRawExcerpt = (text) =>
-  text.replace(/\s+/g, " ").trim().slice(0, 800);
-
 // ─── Main parser ─────────────────────────────────────────────────────────────
 
 /**
@@ -158,7 +153,6 @@ const extractRawExcerpt = (text) =>
  * @property {string|null} cardLast4
  * @property {string}      issuer           - always 'itau'
  * @property {Object}      fieldsSources    - which regex matched each field
- * @property {string}      rawExcerpt
  */
 
 /**
@@ -198,6 +192,5 @@ export const parseItauInvoice = (rawText) => {
     cardLast4,
     issuer: "itau",
     fieldsSources,
-    rawExcerpt: extractRawExcerpt(text),
   };
 };

--- a/apps/api/src/domain/imports/itau-invoice.parser.test.js
+++ b/apps/api/src/domain/imports/itau-invoice.parser.test.js
@@ -158,14 +158,12 @@ describe("parseItauInvoice", () => {
     expect(result.cardLast4).toBeNull();
   });
 
-  it("rawExcerpt contem os primeiros 800 chars do texto normalizado", () => {
+  it("nao retorna rawExcerpt no objeto parseado", () => {
     const text = buildItauText();
     const result = parseItauInvoice(text);
 
     expect(result).not.toBeNull();
-    expect(typeof result.rawExcerpt).toBe("string");
-    expect(result.rawExcerpt.length).toBeLessThanOrEqual(800);
-    expect(result.rawExcerpt).toContain("ITAÚ");
+    expect(result.rawExcerpt).toBeUndefined();
   });
 
   it("aceita variacao 'VALOR TOTAL DA FATURA' para totalAmount", () => {

--- a/apps/api/src/services/credit-card-invoices.service.js
+++ b/apps/api/src/services/credit-card-invoices.service.js
@@ -62,9 +62,34 @@ const normalizeTextForDetection = (text) =>
     .replace(/[\u0300-\u036f]/g, "")
     .toLowerCase();
 
-const collapseWhitespace = (text) => String(text || "").replace(/\s+/g, " ").trim();
+const normalizeJsonObject = (value) => {
+  if (!value) {
+    return {};
+  }
 
-const extractRawExcerpt = (text) => collapseWhitespace(text).slice(0, 800);
+  if (typeof value === "string") {
+    try {
+      const parsedValue = JSON.parse(value);
+      return parsedValue && typeof parsedValue === "object" && !Array.isArray(parsedValue)
+        ? { ...parsedValue }
+        : {};
+    } catch {
+      return {};
+    }
+  }
+
+  if (typeof value === "object" && !Array.isArray(value)) {
+    return { ...value };
+  }
+
+  return {};
+};
+
+const sanitizeInvoiceParseMetadata = (value) => {
+  const normalizedMetadata = normalizeJsonObject(value);
+  delete normalizedMetadata.rawExcerpt;
+  return normalizedMetadata;
+};
 
 const resolveIssuerMetricKey = (issuer) => {
   const normalizedIssuer = String(issuer || "").trim().toLowerCase();
@@ -227,7 +252,6 @@ const parseGenericCreditCardInvoice = ({ rawText, issuer }) => {
       periodStart: null,
       periodEnd: null,
     },
-    rawExcerpt: extractRawExcerpt(rawText),
   };
 };
 
@@ -257,9 +281,10 @@ const parseCreditCardInvoiceByStrategy = (rawText) => {
 // ─── Formatters ───────────────────────────────────────────────────────────────
 
 const formatInvoice = (row) => {
+  const sanitizedParseMetadata = sanitizeInvoiceParseMetadata(row.parse_metadata);
   const classificationSignals = resolveInvoiceClassificationSignals({
     parseConfidence: row.parse_confidence,
-    parseMetadata: row.parse_metadata,
+    parseMetadata: sanitizedParseMetadata,
   });
 
   return {
@@ -388,7 +413,6 @@ export const parseCreditCardInvoicePdfForUser = async (rawUserId, rawCardId, fil
   const needsReview = parseConfidence === "low" || reviewReasonCodes.length > 0;
 
   const parseMetadata = {
-    rawExcerpt: parsed.rawExcerpt,
     fieldsSources,
     parser: {
       strategy: strategyResult.strategy,
@@ -402,6 +426,7 @@ export const parseCreditCardInvoicePdfForUser = async (rawUserId, rawCardId, fil
     },
     ...(Object.keys(inferenceContext).length > 0 ? { inferenceContext } : {}),
   };
+  const sanitizedParseMetadata = sanitizeInvoiceParseMetadata(parseMetadata);
 
   const { rows } = await dbQuery(
     `INSERT INTO credit_card_invoices
@@ -417,7 +442,7 @@ export const parseCreditCardInvoicePdfForUser = async (rawUserId, rawCardId, fil
       parsed.minimumPayment ?? null,
       parsed.financedBalance ?? null,
       parseConfidence,
-      JSON.stringify(parseMetadata),
+      JSON.stringify(sanitizedParseMetadata),
     ]
   );
 
@@ -476,7 +501,7 @@ export const linkBillToInvoiceForUser = async (rawUserId, rawCardId, rawInvoiceI
 
   const classificationSignals = resolveInvoiceClassificationSignals({
     parseConfidence: invRows[0].parse_confidence,
-    parseMetadata: invRows[0].parse_metadata,
+    parseMetadata: sanitizeInvoiceParseMetadata(invRows[0].parse_metadata),
   });
   const explicitAmbiguousConfirmation = input?.confirmAmbiguousClassification === true;
 


### PR DESCRIPTION
## Contexto\nEste PR fecha o slice técnico do AUD-004 (persistência/exposição de rawExcerpt em faturas).\n\n## O que muda\n- remove rawExcerpt da persistência em parse_metadata no fluxo de invoices\n- sanitiza parse_metadata na leitura/classificação para suprimir legado\n- remove rawExcerpt na origem (parser Itaú) para evitar reintrodução\n- adiciona migração para redigir registros legados\n- adiciona/ajusta testes focados de regressão e legado\n\n## Validação\n- npm --prefix apps/api test -- src/credit-card-invoices.test.js src/domain/imports/itau-invoice.parser.test.js\n- resultado: 43 testes passando\n\n## Status de auditoria\nAUD-004: resolvido tecnicamente, pendente merge/deploy para fechamento definitivo em produção.