### PR TITLE
feat(api): file-level dedup for bank import commit

### DIFF
--- a/apps/api/src/db/migrations/114_add_import_files_dedup.sql
+++ b/apps/api/src/db/migrations/114_add_import_files_dedup.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS import_files (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  source_kind TEXT NOT NULL,
+  file_sha256 TEXT NOT NULL,
+  original_filename TEXT,
+  mime_type TEXT,
+  size_bytes BIGINT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT import_files_user_source_hash_key UNIQUE (user_id, source_kind, file_sha256)
+);
+
+CREATE INDEX IF NOT EXISTS idx_import_files_user_id
+  ON import_files (user_id);
+
+CREATE INDEX IF NOT EXISTS idx_import_files_created_at_desc
+  ON import_files (created_at DESC);
+
+ALTER TABLE transaction_import_sessions
+  ADD COLUMN IF NOT EXISTS file_sha256 TEXT;

--- a/apps/api/src/import.test.js
+++ b/apps/api/src/import.test.js
@@ -1419,7 +1419,7 @@ describe("transaction imports", () => {
     expect(Number(transactionCountResult.rows[0].count)).toBe(0);
   });
 
-  it("POST /transactions/import/commit nao insere duplicatas mesmo se sessao foi criada antes do primeiro commit", async () => {
+  it("POST /transactions/import/commit retorna 409 para arquivo duplicado mesmo com sessao criada antes do primeiro commit", async () => {
     const token = await registerAndLogin("import-dedupe-commit@controlfinance.dev");
     await makeProUser("import-dedupe-commit@controlfinance.dev");
 
@@ -1441,20 +1441,45 @@ describe("transaction imports", () => {
       .set("Authorization", `Bearer ${token}`)
       .attach("file", csv.buffer, { filename: csv.fileName, contentType: "text/csv" });
 
+    const sessionHashesResult = await dbQuery(
+      `SELECT id, file_sha256
+       FROM transaction_import_sessions
+       WHERE id IN ($1, $2)
+       ORDER BY id ASC`,
+      [dryA.body.importId, dryB.body.importId],
+    );
+
+    expect(sessionHashesResult.rows).toHaveLength(2);
+    expect(sessionHashesResult.rows[0].file_sha256).toBeTruthy();
+    expect(sessionHashesResult.rows[1].file_sha256).toBeTruthy();
+    expect(sessionHashesResult.rows[0].file_sha256).toBe(sessionHashesResult.rows[1].file_sha256);
+
     // commit A
-    await request(app)
+    const commitA = await request(app)
       .post("/transactions/import/commit")
       .set("Authorization", `Bearer ${token}`)
       .send({ importId: dryA.body.importId });
+    expect(commitA.status).toBe(200);
+    expect(commitA.body.imported).toBe(1);
 
-    // commit B — sessao criada antes do commit A; a linha ja existe agora
+    const importFilesResult = await dbQuery(
+      `SELECT user_id, source_kind, file_sha256
+       FROM import_files
+       ORDER BY id ASC`,
+    );
+
+    expect(importFilesResult.rows).toHaveLength(1);
+    expect(importFilesResult.rows[0].source_kind).toBe("bank_statement");
+    expect(importFilesResult.rows[0].file_sha256).toBe(sessionHashesResult.rows[0].file_sha256);
+
+    // commit B — sessao criada antes do commit A; o mesmo arquivo agora deve ser bloqueado
     const commitB = await request(app)
       .post("/transactions/import/commit")
       .set("Authorization", `Bearer ${token}`)
       .send({ importId: dryB.body.importId });
 
-    expect(commitB.status).toBe(200);
-    expect(commitB.body.imported).toBe(0);
+    expectErrorResponseWithRequestId(commitB, 409, "Arquivo ja importado anteriormente.");
+    expect(commitB.body.code).toBe("DUPLICATE_IMPORT_FILE");
 
     const persisted = await dbQuery(
       `SELECT COUNT(*)::int AS count FROM transactions WHERE user_id = (SELECT id FROM users WHERE email = $1) AND deleted_at IS NULL`,
@@ -1463,6 +1488,13 @@ describe("transaction imports", () => {
 
     expect(Number(persisted.rows[0].count)).toBe(1);
 
+    const secondSessionResult = await dbQuery(
+      `SELECT committed_at FROM transaction_import_sessions WHERE id = $1 LIMIT 1`,
+      [dryB.body.importId],
+    );
+
+    expect(secondSessionResult.rows[0].committed_at).toBeNull();
+
     // proximo dry-run continua detectando o lancamento como duplicado
     const check = await request(app)
       .post("/transactions/import/dry-run")
@@ -1470,6 +1502,47 @@ describe("transaction imports", () => {
       .attach("file", csv.buffer, { filename: csv.fileName, contentType: "text/csv" });
 
     expect(check.body.summary.duplicateRows).toBeGreaterThan(0);
+  });
+
+  it("POST /transactions/import/commit permite mesmo arquivo para usuarios diferentes", async () => {
+    const emailA = "import-dedupe-multi-user-a@controlfinance.dev";
+    const emailB = "import-dedupe-multi-user-b@controlfinance.dev";
+    const tokenA = await registerAndLogin(emailA);
+    const tokenB = await registerAndLogin(emailB);
+    await makeProUser(emailA);
+    await makeProUser(emailB);
+
+    const csv = csvFile(
+      ["date,type,value,description,notes,category", "2026-04-01,Entrada,2000,Freelance,,"].join(
+        "\n",
+      ),
+    );
+
+    const dryRunA = await request(app)
+      .post("/transactions/import/dry-run")
+      .set("Authorization", `Bearer ${tokenA}`)
+      .attach("file", csv.buffer, { filename: csv.fileName, contentType: "text/csv" });
+    expect(dryRunA.status).toBe(200);
+
+    const commitA = await request(app)
+      .post("/transactions/import/commit")
+      .set("Authorization", `Bearer ${tokenA}`)
+      .send({ importId: dryRunA.body.importId });
+    expect(commitA.status).toBe(200);
+    expect(commitA.body.imported).toBe(1);
+
+    const dryRunB = await request(app)
+      .post("/transactions/import/dry-run")
+      .set("Authorization", `Bearer ${tokenB}`)
+      .attach("file", csv.buffer, { filename: csv.fileName, contentType: "text/csv" });
+    expect(dryRunB.status).toBe(200);
+
+    const commitB = await request(app)
+      .post("/transactions/import/commit")
+      .set("Authorization", `Bearer ${tokenB}`)
+      .send({ importId: dryRunB.body.importId });
+    expect(commitB.status).toBe(200);
+    expect(commitB.body.imported).toBe(1);
   });
 
   it("POST /transactions/import/dry-run retorna documentType bank_statement para CSV manual", async () => {

--- a/apps/api/src/services/transactions-import.service.ts
+++ b/apps/api/src/services/transactions-import.service.ts
@@ -28,7 +28,7 @@ import { applySmartClassification } from "../domain/imports/transaction-classifi
 import { normalizeCategoryNameKey } from "./categories-normalization.js";
 import { loadActiveTransactionImportCategoryRulesByUser } from "./transactions-import-rules.service.js";
 
-type ErrorWithStatus = Error & { status: number };
+type ErrorWithStatus = Error & { status: number; publicCode?: string };
 
 type RawCsvRow = {
   date: string;
@@ -322,6 +322,160 @@ const createError = (status: number, message: string): ErrorWithStatus => {
   const error = new Error(message) as ErrorWithStatus;
   error.status = status;
   return error;
+};
+
+const createErrorWithPublicCode = (
+  status: number,
+  message: string,
+  publicCode: string,
+): ErrorWithStatus => {
+  const error = createError(status, message);
+  error.publicCode = publicCode;
+  return error;
+};
+
+const computeImportFileSha256 = (importFile: ImportFile): string | null => {
+  if (!Buffer.isBuffer(importFile?.buffer) || importFile.buffer.length === 0) {
+    return null;
+  }
+
+  return createHash("sha256").update(importFile.buffer).digest("hex");
+};
+
+const normalizeImportSourceKind = (value: unknown): string => {
+  if (typeof value !== "string") {
+    return "bank_statement";
+  }
+
+  const normalizedValue = value.trim().toLowerCase();
+  return normalizedValue || "bank_statement";
+};
+
+const normalizeSha256 = (value: unknown): string | null => {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalizedValue = value.trim().toLowerCase();
+
+  if (!/^[a-f0-9]{64}$/.test(normalizedValue)) {
+    return null;
+  }
+
+  return normalizedValue;
+};
+
+const normalizeOptionalText = (value: unknown): string | null => {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalizedValue = value.trim();
+  return normalizedValue || null;
+};
+
+const normalizeOptionalPositiveInteger = (value: unknown): number | null => {
+  const parsedValue = Number(value);
+
+  if (!Number.isInteger(parsedValue) || parsedValue <= 0) {
+    return null;
+  }
+
+  return parsedValue;
+};
+
+const reserveImportFileFingerprintOrThrow = async (
+  transactionClient: {
+    query: (
+      sql: string,
+      params?: unknown[],
+    ) => Promise<{ rowCount?: number; rows: unknown[] }>;
+  },
+  {
+    userId,
+    sourceKind,
+    fileSha256,
+    originalFileName,
+    mimeType,
+    sizeBytes,
+    hasCandidateRows,
+  }: {
+    userId: number | string;
+    sourceKind: unknown;
+    fileSha256: unknown;
+    originalFileName: unknown;
+    mimeType: unknown;
+    sizeBytes: unknown;
+    hasCandidateRows: boolean;
+  },
+) => {
+  if (!hasCandidateRows) {
+    return;
+  }
+
+  const normalizedFileSha256 = normalizeSha256(fileSha256);
+
+  // Backward compatibility for old sessions created before file_sha256 existed.
+  if (!normalizedFileSha256) {
+    return;
+  }
+
+  const normalizedSourceKind = normalizeImportSourceKind(sourceKind);
+  const duplicateLookupResult = await transactionClient.query(
+    `
+      SELECT id
+      FROM import_files
+      WHERE user_id = $1
+        AND source_kind = $2
+        AND file_sha256 = $3
+      LIMIT 1
+    `,
+    [userId, normalizedSourceKind, normalizedFileSha256],
+  );
+
+  if (Array.isArray(duplicateLookupResult.rows) && duplicateLookupResult.rows.length > 0) {
+    throw createErrorWithPublicCode(
+      409,
+      "Arquivo ja importado anteriormente.",
+      "DUPLICATE_IMPORT_FILE",
+    );
+  }
+
+  try {
+    await transactionClient.query(
+      `
+        INSERT INTO import_files (
+          user_id,
+          source_kind,
+          file_sha256,
+          original_filename,
+          mime_type,
+          size_bytes
+        )
+        VALUES ($1, $2, $3, $4, $5, $6)
+      `,
+      [
+        userId,
+        normalizedSourceKind,
+        normalizedFileSha256,
+        normalizeOptionalText(originalFileName),
+        normalizeOptionalText(mimeType),
+        normalizeOptionalPositiveInteger(sizeBytes),
+      ],
+    );
+  } catch (error) {
+    const errorCode = typeof error?.code === "string" ? error.code : null;
+
+    if (errorCode === "23505") {
+      throw createErrorWithPublicCode(
+        409,
+        "Arquivo ja importado anteriormente.",
+        "DUPLICATE_IMPORT_FILE",
+      );
+    }
+
+    throw error;
+  }
 };
 
 const normalizeHeader = (value: unknown): string => String(value || "").trim().toLowerCase();
@@ -1037,16 +1191,26 @@ const createSummary = (rows = []) => {
   );
 };
 
-const persistImportSession = async (userId: number | string, payload: unknown) => {
+const persistImportSession = async (
+  userId: number | string,
+  payload: unknown,
+  { fileSha256 = null }: { fileSha256?: string | null } = {},
+) => {
   const importId = randomUUID();
   const expiresAtDate = new Date(Date.now() + IMPORT_TTL_MINUTES * 60 * 1000);
   const result = await dbQuery(
     `
-      INSERT INTO transaction_import_sessions (id, user_id, payload_json, expires_at)
-      VALUES ($1, $2, $3::jsonb, $4)
+      INSERT INTO transaction_import_sessions (id, user_id, payload_json, expires_at, file_sha256)
+      VALUES ($1, $2, $3::jsonb, $4, $5)
       RETURNING expires_at
     `,
-    [importId, userId, JSON.stringify(payload), expiresAtDate.toISOString()],
+    [
+      importId,
+      userId,
+      JSON.stringify(payload),
+      expiresAtDate.toISOString(),
+      normalizeSha256(fileSha256),
+    ],
   );
 
   return {
@@ -1088,7 +1252,7 @@ const normalizeImportId = (value: unknown): string => {
 const loadImportSessionById = async (importId: string) => {
   const result = await dbQuery(
     `
-      SELECT id, user_id, payload_json, expires_at, committed_at
+      SELECT id, user_id, payload_json, expires_at, committed_at, file_sha256
       FROM transaction_import_sessions
       WHERE id = $1
       LIMIT 1
@@ -1213,6 +1377,7 @@ export const dryRunTransactionsImportForUser = async (
   });
 
   const summary = createSummary(rows);
+  const fileSha256 = computeImportFileSha256(importFile);
 
   const normalizedRows = rows
     .filter((row) => row.status === "valid" && row.normalized)
@@ -1221,9 +1386,14 @@ export const dryRunTransactionsImportForUser = async (
   const persistedSession = await persistImportSession(userId, {
     normalizedRows,
     summary,
+    fileSha256,
     fileName: importFile?.originalname || null,
+    fileMimeType: importFile?.mimetype || null,
+    fileSizeBytes: Buffer.isBuffer(importFile?.buffer) ? importFile.buffer.length : null,
     documentType,
     utilityBillImportDecision,
+  }, {
+    fileSha256,
   });
 
   return {
@@ -1434,7 +1604,10 @@ export const commitTransactionsImportForUser = async (
       );
   const payloadSummary = payload.summary || {};
   const importFileName = payload.fileName || null;
+  const importFileMimeType = payload.fileMimeType || null;
+  const importFileSizeBytes = payload.fileSizeBytes || null;
   const importDocumentType = payload.documentType || null;
+  const importFileSha256 = importSession.file_sha256 || payload.fileSha256 || null;
   const observabilitySummary = {
     totalRows: normalizeSummaryInteger(payloadSummary.totalRows, normalizedRows.length),
     validRows: normalizeSummaryInteger(payloadSummary.validRows, normalizedRows.length),
@@ -1442,6 +1615,16 @@ export const commitTransactionsImportForUser = async (
   };
 
   const commitOutcome = await withDbTransaction(async (transactionClient) => {
+    await reserveImportFileFingerprintOrThrow(transactionClient, {
+      userId,
+      sourceKind: "bank_statement",
+      fileSha256: importFileSha256,
+      originalFileName: importFileName,
+      mimeType: importFileMimeType,
+      sizeBytes: importFileSizeBytes,
+      hasCandidateRows: normalizedRows.length > 0,
+    });
+
     const sessionUpdateResult = await transactionClient.query(
       `
         UPDATE transaction_import_sessions


### PR DESCRIPTION
## O que faz
Guard de deduplicação por arquivo no caminho de commit de importação bancária.

## Motivação
Previne que o mesmo arquivo CSV seja importado mais de uma vez pelo mesmo usuário.
O dry-run não é afetado — múltiplos previews do mesmo arquivo continuam funcionando.

## Mudanças
- `114_add_import_files_dedup.sql`: tabela `import_files` com unicidade em `(user_id, source_kind, file_sha256)`; coluna `file_sha256` em `transaction_import_sessions`
- `transactions-import.service.ts`: hash computado no dry-run, transportado na sessão, guard com `409 DUPLICATE_IMPORT_FILE` aplicado apenas no commit
- `import.test.js`: cobre dry-run repetido ✓, commit novo ✓, segundo commit mesmo arquivo → 409 ✓, mesmo hash usuário diferente ✓

## Testes
```
1039 passed, 0 failed
```
