### PR TITLE
fix(api): keep API up when tax storage is misconfigured

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -3,10 +3,11 @@ import cors from "cors";
 import cookieParser from "cookie-parser";
 import dotenv from "dotenv";
 import { assertJwtEnvironmentConsistency } from "./config/jwt-env-guard.js";
-import { assertTaxStorageEnvironmentConsistency } from "./config/tax-storage-env-guard.js";
+import { resolveTaxStorageModuleAvailability } from "./config/tax-storage-env-guard.js";
 import healthRoutes from "./routes/health.routes.js";
 import metricsRoutes from "./routes/metrics.routes.js";
 import authRoutes from "./routes/auth.routes.js";
+import { logWarn } from "./observability/logger.js";
 import { securityHeadersMiddleware } from "./middlewares/security-headers.middleware.js";
 import categoriesRoutes from "./routes/categories.routes.js";
 import budgetsRoutes from "./routes/budgets.routes.js";
@@ -33,7 +34,7 @@ import { httpMetricsMiddleware } from "./observability/http-metrics.js";
 
 dotenv.config();
 assertJwtEnvironmentConsistency();
-assertTaxStorageEnvironmentConsistency();
+const taxStorageModuleAvailability = resolveTaxStorageModuleAvailability();
 
 const app = express();
 
@@ -116,7 +117,25 @@ app.use("/bills", billsRoutes);
 app.use("/credit-cards", creditCardsRoutes);
 app.use("/income-sources", incomeSourcesRoutes);
 app.use("/salary", salaryRoutes);
-app.use("/tax", taxRoutes);
+if (taxStorageModuleAvailability.enabled) {
+  app.use("/tax", taxRoutes);
+} else {
+  logWarn({
+    event: "tax.module.disabled",
+    code: taxStorageModuleAvailability.code,
+    reason: taxStorageModuleAvailability.reason,
+  });
+
+  app.use("/tax", (_req, _res, next) => {
+    const error = new Error(
+      "Modulo fiscal temporariamente indisponivel. Contate o suporte e tente novamente.",
+    );
+    error.status = 503;
+    error.publicCode = "TAX_MODULE_DISABLED";
+    error.internalMessage = taxStorageModuleAvailability.reason;
+    next(error);
+  });
+}
 app.use("/ops", opsRoutes);
 app.use("/ai", aiRoutes);
 app.use("/goals", goalsRoutes);

--- a/apps/api/src/config/tax-storage-env-guard.js
+++ b/apps/api/src/config/tax-storage-env-guard.js
@@ -15,11 +15,7 @@ const createTaxStorageEnvError = (message, code = "TAX_STORAGE_ENV_INVALID") => 
   return error;
 };
 
-export const assertTaxStorageEnvironmentConsistency = (env = process.env) => {
-  if (!isProductionEnvironment(env)) {
-    return;
-  }
-
+const validateProductionTaxStorageEnvironment = (env = process.env) => {
   const adapterName = resolveTaxDocumentStorageAdapterName(env);
 
   if (adapterName !== TAX_DOCUMENT_STORAGE_ADAPTER_REMOTE_S3) {
@@ -37,4 +33,40 @@ export const assertTaxStorageEnvironmentConsistency = (env = process.env) => {
       "TAX_STORAGE_LEGACY_LOCAL_DIR_REQUIRED",
     );
   }
+};
+
+export const resolveTaxStorageModuleAvailability = (env = process.env) => {
+  if (!isProductionEnvironment(env)) {
+    return {
+      enabled: true,
+      code: null,
+      reason: null,
+    };
+  }
+
+  try {
+    validateProductionTaxStorageEnvironment(env);
+    return {
+      enabled: true,
+      code: null,
+      reason: null,
+    };
+  } catch (error) {
+    return {
+      enabled: false,
+      code: typeof error?.code === "string" && error.code.trim() ? error.code.trim() : "TAX_STORAGE_ENV_INVALID",
+      reason:
+        typeof error?.message === "string" && error.message.trim()
+          ? error.message.trim()
+          : "Invalid tax storage environment.",
+    };
+  }
+};
+
+export const assertTaxStorageEnvironmentConsistency = (env = process.env) => {
+  if (!isProductionEnvironment(env)) {
+    return;
+  }
+
+  validateProductionTaxStorageEnvironment(env);
 };

--- a/apps/api/src/config/tax-storage-env-guard.test.js
+++ b/apps/api/src/config/tax-storage-env-guard.test.js
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { assertTaxStorageEnvironmentConsistency } from "./tax-storage-env-guard.js";
+import {
+  assertTaxStorageEnvironmentConsistency,
+  resolveTaxStorageModuleAvailability,
+} from "./tax-storage-env-guard.js";
 
 const baseEnv = {
   NODE_ENV: "test",
@@ -55,5 +58,28 @@ describe("tax-storage-env-guard", () => {
         TAX_DOCUMENTS_REMOTE_REGION: "us-east-1",
       }),
     ).not.toThrow();
+  });
+
+  it("resolve availability desabilita modulo fiscal em producao quando adapter nao e s3", () => {
+    expect(
+      resolveTaxStorageModuleAvailability({
+        ...baseEnv,
+        NODE_ENV: "production",
+        TAX_DOCUMENTS_STORAGE_ADAPTER: "local",
+      }),
+    ).toEqual({
+      enabled: false,
+      code: "TAX_STORAGE_ADAPTER_REQUIRED",
+      reason:
+        "Invalid tax storage environment: NODE_ENV=production requires TAX_DOCUMENTS_STORAGE_ADAPTER=s3.",
+    });
+  });
+
+  it("resolve availability mantem modulo habilitado fora de producao", () => {
+    expect(resolveTaxStorageModuleAvailability(baseEnv)).toEqual({
+      enabled: true,
+      code: null,
+      reason: null,
+    });
   });
 });


### PR DESCRIPTION
## Contexto
Corrige incidente de disponibilidade: a API inteira estava falhando no boot em producao quando o modulo fiscal estava sem configuracao S3 valida.

## Mudancas
- Introduz resolveTaxStorageModuleAvailability para avaliar disponibilidade do modulo fiscal sem derrubar o processo
- Mantem assert estrito reutilizavel para cenarios que precisam hard-fail
- App passa a:
  - montar /tax normalmente quando configuracao fiscal esta valida
  - montar fallback /tax com 503 e code=TAX_MODULE_DISABLED quando configuracao fiscal esta invalida
  - registrar warning estruturado com motivo da desabilitacao
- Testes do guard atualizados para cobrir o modo de disponibilidade

## Resultado
- API continua disponivel para os demais modulos mesmo com misconfig do storage fiscal
- Rotas /tax respondem erro explicito e estavel (503 + TAX_MODULE_DISABLED)

## Testes
- npm -w apps/api run test:run -- src/config/tax-storage-env-guard.test.js src/security-headers.test.js
- 12 passed, 0 failed
