### PR TITLE
docs(roadmap): preserve home operational closeout notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,14 @@ v1.31.0 - Central do Leão (IRPF MVP)
 - A trilha fiscal passou a usar um contrato oficial de export no backend, sem side effect implícito de rebuild
 - O produto agora inclui uma frente explícita de preparação do IRPF, com guardrail claro: organiza e prepara, mas não transmite DIRPF
 
+#### Home operacional (A->D) concluída em main (PRs #402-#405)
+
+- `#402` (estrutura) merged em `main`
+- `#403` (protagonismo) merged em `main`
+- `#404` (semântica e severidade) merged em `main`
+- `#405` (ação operacional) merged em `main`, incluindo ajuste incremental no `SalaryWidget` (head `d4a288e`)
+- Pós-merge disciplinado executado: sync de `main`, validação local (`typecheck` + suíte focada da home) e limpeza de branches da trilha
+
 ### Quality
 
 - `npm test` na raiz verde

--- a/docs/roadmaps/sprint-confiabilidade-produto.md
+++ b/docs/roadmaps/sprint-confiabilidade-produto.md
@@ -345,6 +345,37 @@ Essa ordem está certa porque:
 - depois fecha o módulo de cartão
 - por fim faz o polimento narrativo em cima de base já coerente
 
+### Atualização da trilha Home Operacional (A->D)
+
+Leitura consolidada da execução incremental em PRs empilhados:
+
+- `#402`: estrutura da home
+- `#403`: protagonismo dos cards críticos
+- `#404`: semântica e severidade (incluindo `SalaryWidget.tsx`)
+- `#405`: ação operacional por severidade
+
+Ajuste incremental posterior no `#405`:
+
+- commit isolado `d4a288e`
+- mensagem: `polish(web): allow actionable empty state in salary widget`
+- efeito: `SalaryWidget.tsx` passa a aparecer no `#405` por acréscimo controlado, sem contradizer a trilha histórica
+
+Validação local do ajuste incremental:
+
+- typecheck: ok
+- `SalaryWidget.test.tsx`: `35/35`
+
+Status de aterrissagem em `main` (2026-04-01):
+
+- `#402` merged em `main`
+- `#403` merged em `main`
+- `#404` merged em `main`
+- `#405` merged em `main` com head `d4a288e`
+
+Nota operacional:
+
+- Durante o merge train, o `#403` foi fechado automaticamente ao deletar a branch-base do `#402`; a esteira foi recuperada com restauração da base, reabertura do PR e retarget para `main`, sem perda de trilha lógica.
+
 ---
 
 ## 11. Riscos a evitar


### PR DESCRIPTION
## O que muda\nPreserva em documentação oficial as notas de fechamento da trilha Home operacional (A->D), incluindo rastreabilidade dos PRs #402-#405 e nota operacional de merge train.\n\n## Escopo\n- CHANGELOG.md\n- docs/roadmaps/sprint-confiabilidade-produto.md\n\n## Motivo\nEvitar perda de contexto histórico de governança e manter o fechamento formal registrado em main.