### PR TITLE
feat(import): add dedicated Nubank credit card invoice PDF parser

### DIFF
--- a/apps/api/src/credit-card-invoices.test.js
+++ b/apps/api/src/credit-card-invoices.test.js
@@ -60,10 +60,10 @@ PAGAMENTO MÍNIMO R$ 124,78
 `.trim();
 
 const VALID_NUBANK_TEXT = `
-NUBANK
+Nu Pagamentos S.A.
 Cartao final 9988
-VENCIMENTO  20/03/2026
-TOTAL DA FATURA    R$ 540,35
+Data de vencimento: 20 MAR 2026
+Total a pagar R$ 540,35
 `.trim();
 
 const INVALID_TEXT = `Este texto nao tem nenhum dado de fatura.`;
@@ -201,8 +201,8 @@ describe("credit-card-invoices", () => {
     expect(res.body.parseMetadata.reviewContext.reasonCodes).toContain("period_inferred_from_closing_day");
   });
 
-  it("POST parse-pdf usa fallback por emissor reconhecido nao-itau com needsReview", async () => {
-    const token = await registerAndLogin("inv-nubank-fallback@test.dev");
+  it("POST parse-pdf usa parser Nubank dedicado — sem periodo inferido do dia de fechamento", async () => {
+    const token = await registerAndLogin("inv-nubank-parser@test.dev");
     mockExtractTextWithRuntime.mockResolvedValue(createOcrRuntimeResult(VALID_NUBANK_TEXT));
 
     const cardRes = await createCard(token, { closingDay: 10, dueDay: 20 });
@@ -217,8 +217,9 @@ describe("credit-card-invoices", () => {
     expect(res.body.dueDate).toBe("2026-03-20");
     expect(res.body.parseConfidence).toBe("low");
     expect(res.body.needsReview).toBe(true);
-    expect(res.body.parseMetadata?.parser?.strategy).toBe("generic_fallback");
-    expect(res.body.parseMetadata?.reviewContext?.reasonCodes).toContain("issuer_parser_fallback");
+    expect(res.body.parseMetadata?.parser?.strategy).toBe("issuer_specific");
+    expect(res.body.parseMetadata?.parser?.name).toBe("nubank_parser_v1");
+    expect(res.body.parseMetadata?.reviewContext?.reasonCodes).not.toContain("issuer_parser_fallback");
     expect(res.body.parseMetadata?.reviewContext?.reasonCodes).toContain("period_inferred_from_closing_day");
   });
 

--- a/apps/api/src/domain/imports/corpus/credit-card-invoices/golden-v1.json
+++ b/apps/api/src/domain/imports/corpus/credit-card-invoices/golden-v1.json
@@ -22,6 +22,45 @@
       }
     },
     {
+      "id": "nubank_high_confidence_auto_accept",
+      "description": "Fatura Nubank com periodo identificado — alta confianca, auto-aceite.",
+      "invoiceText": "Nu Pagamentos S.A.\nCartao final 9988\nData de vencimento: 15 NOV 2024\nPeriodo vigente: 08 OUT a 08 NOV\nTotal a pagar R$ 767,23\nPagamento minimo R$ 172,28",
+      "card": {
+        "closingDay": 8,
+        "dueDay": 15
+      },
+      "expected": {
+        "issuer": "nubank",
+        "parseConfidence": "high",
+        "classificationConfidence": 0.9,
+        "classificationAmbiguous": false,
+        "reasonCode": "not_ambiguous",
+        "requiresUserConfirmation": false,
+        "totalAmount": 767.23,
+        "dueDate": "2024-11-15"
+      }
+    },
+    {
+      "id": "nubank_period_missing_requires_confirmation",
+      "description": "Fatura Nubank sem periodo — baixa confianca, exige confirmacao explicita.",
+      "invoiceText": "Nu Pagamentos S.A.\nCartao final 5577\nData de vencimento: 20 MAR 2026\nTotal a pagar R$ 540,35",
+      "card": {
+        "closingDay": 8,
+        "dueDay": 20
+      },
+      "expected": {
+        "issuer": "nubank",
+        "parseConfidence": "low",
+        "classificationConfidence": 0.45,
+        "classificationAmbiguous": true,
+        "reasonCode": "period_inferred_from_closing_day",
+        "requiresUserConfirmation": true,
+        "totalAmount": 540.35,
+        "dueDate": "2026-03-20",
+        "blockedCode": "AMBIGUOUS_CLASSIFICATION_CONFIRMATION_REQUIRED"
+      }
+    },
+    {
       "id": "itau_period_missing_requires_confirmation",
       "description": "Fluxo ambiguo bloqueia auto-aceite e exige confirmacao explicita.",
       "invoiceText": "BANCO ITAU S.A.\nVENCIMENTO 15/03/2026\nTOTAL DA FATURA R$ 850,00",

--- a/apps/api/src/domain/imports/document-classifier.js
+++ b/apps/api/src/domain/imports/document-classifier.js
@@ -110,6 +110,14 @@ const CREDIT_CARD_INVOICE_ITAU_SIGNALS = [
   "limite total de credito",
 ];
 
+const CREDIT_CARD_INVOICE_NUBANK_SIGNALS = [
+  "nu pagamentos",
+  "periodo vigente",
+  "total a pagar",
+  "pagamentos e financiamentos",
+  "data de vencimento",
+];
+
 const BANK_STATEMENT_SIGNALS = [
   "saldo anterior",
   "saldo final",
@@ -173,6 +181,14 @@ export const detectDocumentType = ({ text = "", extension = "" }) => {
     countMatches(normalized, CREDIT_CARD_INVOICE_ITAU_SIGNALS) >= 2
   ) {
     return "credit_card_invoice_itau";
+  }
+
+  // Nubank credit card invoice — requires "nu pagamentos" + 2 structural signals
+  if (
+    normalized.includes("nu pagamentos") &&
+    countMatches(normalized, CREDIT_CARD_INVOICE_NUBANK_SIGNALS) >= 2
+  ) {
+    return "credit_card_invoice_nubank";
   }
 
   // PDF with bank statement content

--- a/apps/api/src/domain/imports/document-classifier.test.js
+++ b/apps/api/src/domain/imports/document-classifier.test.js
@@ -169,6 +169,38 @@ describe("detectDocumentType", () => {
     });
   });
 
+  describe("credit_card_invoice_nubank", () => {
+    it("detecta fatura Nubank com nu pagamentos + periodo vigente + total a pagar", () => {
+      const text = [
+        "Nu Pagamentos S.A.",
+        "Periodo vigente: 08 OUT a 08 NOV",
+        "Total a pagar R$ 767,23",
+        "Data de vencimento: 18 NOV 2024",
+      ].join("\n");
+      expect(detectDocumentType({ text, extension: ".pdf" })).toBe("credit_card_invoice_nubank");
+    });
+
+    it("detecta fatura Nubank com pagamentos e financiamentos + data de vencimento", () => {
+      const text = [
+        "Nu Pagamentos S.A.",
+        "Pagamentos e Financiamentos R$ 106,15",
+        "Data de vencimento: 15 AGO 2025",
+      ].join("\n");
+      expect(detectDocumentType({ text, extension: ".pdf" })).toBe("credit_card_invoice_nubank");
+    });
+
+    it("NAO detecta nubank sem nu pagamentos no texto", () => {
+      const text = "periodo vigente: 08 OUT a 08 NOV\ntotal a pagar R$ 767,23\npagamentos e financiamentos";
+      expect(detectDocumentType({ text, extension: ".pdf" })).not.toBe("credit_card_invoice_nubank");
+    });
+
+    it("NAO detecta nubank com apenas nu pagamentos e nenhum outro sinal da lista", () => {
+      // "nu pagamentos" e o unico sinal (countMatches = 1 < 2) — nao deve detectar
+      const text = "Nu Pagamentos S.A.\nFatura de credito cancelado.";
+      expect(detectDocumentType({ text, extension: ".pdf" })).not.toBe("credit_card_invoice_nubank");
+    });
+  });
+
   describe("bank_statement via conteudo", () => {
     it("detecta extrato com saldo anterior", () => {
       const text = "Saldo anterior: R$ 1.000,00\nlançamentos do periodo";

--- a/apps/api/src/domain/imports/nubank-invoice.parser.js
+++ b/apps/api/src/domain/imports/nubank-invoice.parser.js
@@ -1,0 +1,303 @@
+/**
+ * Nubank credit card invoice PDF parser.
+ *
+ * Pure function — no I/O, no DB access, no AI.
+ * Input:  rawText (string from extractTextFromPdfWithOcr)
+ * Output: ParsedNubankInvoice | null
+ *
+ * Returns null only when mandatory fields (totalAmount + dueDate) are missing.
+ * Period inference from closing_day is handled by the service layer.
+ * The parser signals missing period via periodStart/periodEnd = null.
+ *
+ * Nubank-specific format:
+ *   Due date  : "Data de vencimento: DD MES YYYY"  (PT-BR month abbreviation)
+ *   Total     : "Total a pagar R$ X.XXX,XX"
+ *   Period    : "Período vigente: DD MES a DD MES"  (no year — inferred)
+ *   Tx line   : "DD MES Description -?R$ X,XX"
+ */
+
+// ─── Month map PT-BR ─────────────────────────────────────────────────────────
+
+const MONTH_MAP = {
+  JAN: 1, FEV: 2, MAR: 3, ABR: 4, MAI: 5, JUN: 6,
+  JUL: 7, AGO: 8, SET: 9, OUT: 10, NOV: 11, DEZ: 12,
+};
+
+const MONTHS_PAT = Object.keys(MONTH_MAP).join("|");
+
+// ─── Currency helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Parse a Nubank amount string to float.
+ * Accepts "R$ 767,23", "1.247,80", "103,09" — strips "R$" prefix first.
+ * Returns null for zero or non-parseable input.
+ */
+export const parseNubankBRL = (str) => {
+  if (typeof str !== "string") return null;
+  const cleaned = str
+    .trim()
+    .replace(/^R\$\s*/, "")
+    .trim()
+    .replace(/\./g, "")
+    .replace(",", ".");
+  const parsed = Number(cleaned);
+  return Number.isFinite(parsed) && parsed > 0 ? Number(parsed.toFixed(2)) : null;
+};
+
+// ─── Date helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Convert day (string), PT-BR month abbreviation (string), year (string) →
+ * "YYYY-MM-DD". Returns null for unknown month abbreviation.
+ */
+const nubankDateToIso = (day, mon, year) => {
+  const m = MONTH_MAP[String(mon).toUpperCase()];
+  if (!m) return null;
+  return `${year}-${String(m).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+};
+
+/**
+ * Extract year from invoice due date "YYYY-MM-DD". Falls back to current year.
+ */
+const invoiceYear = (dueDate) => {
+  if (typeof dueDate === "string" && /^\d{4}/.test(dueDate)) return dueDate.slice(0, 4);
+  return String(new Date().getFullYear());
+};
+
+// ─── Field extractors ─────────────────────────────────────────────────────────
+
+const extractDueDate = (text) => {
+  // "Data de vencimento: 15 AGO 2025" or "Data de vencimento 18 NOV 2024"
+  const re = new RegExp(
+    `data\\s+de\\s+vencimento\\s*:?\\s*(\\d{2})\\s+(${MONTHS_PAT})\\s+(\\d{4})`,
+    "i",
+  );
+  const m = text.match(re);
+  if (m) {
+    const iso = nubankDateToIso(m[1], m[2], m[3]);
+    if (iso) return { value: iso, source: "regex:DATA_VENCIMENTO" };
+  }
+  return null;
+};
+
+const extractTotalAmount = (text) => {
+  // "Total a pagar R$ 945,49" — primary Nubank format (RESUMO section)
+  // "Valor para pagamento à vista R$ 504,16" — secondary (negotiated/discounted)
+  const patterns = [
+    /TOTAL\s+A\s+PAGAR\s+R\$\s*([\d.,]+)/i,
+    /VALOR\s+PARA\s+PAGAMENTO\s+[AÀ]\s+VISTA\s+R\$\s*([\d.,]+)/i,
+  ];
+  for (const re of patterns) {
+    const m = text.match(re);
+    if (m) {
+      const val = parseNubankBRL(m[1]);
+      if (val !== null) return { value: val, source: "regex:TOTAL_A_PAGAR" };
+    }
+  }
+  return null;
+};
+
+const extractPeriod = (text, dueDateYear) => {
+  // "Período vigente: 08 JUL a 08 AGO" — no year; derived from dueDate year.
+  // Cross-year boundary: if startMonth > endMonth, start belongs to prior year.
+  const re = new RegExp(
+    `per[ií]odo\\s+vigente\\s*:?\\s*(\\d{2})\\s+(${MONTHS_PAT})\\s+[aA]\\s+(\\d{2})\\s+(${MONTHS_PAT})`,
+    "i",
+  );
+  const m = text.match(re);
+  if (!m) return null;
+
+  const year = dueDateYear || String(new Date().getFullYear());
+  const startMonNum = MONTH_MAP[m[2].toUpperCase()];
+  const endMonNum = MONTH_MAP[m[4].toUpperCase()];
+  if (!startMonNum || !endMonNum) return null;
+
+  const startYear = startMonNum > endMonNum ? String(Number(year) - 1) : year;
+  const start = `${startYear}-${String(startMonNum).padStart(2, "0")}-${String(m[1]).padStart(2, "0")}`;
+  const end = `${year}-${String(endMonNum).padStart(2, "0")}-${String(m[3]).padStart(2, "0")}`;
+
+  if (start >= end) return null;
+  return { start, end, source: "regex:PERIODO_VIGENTE" };
+};
+
+const extractMinimumPayment = (text) => {
+  const re = /pagamento\s+m[ií]nimo\s+R\$\s*([\d.,]+)/i;
+  const m = text.match(re);
+  return m ? parseNubankBRL(m[1]) : null;
+};
+
+const extractCardLast4 = (text) => {
+  const patterns = [
+    /cart[aã]o\s+final\s+(\d{4})/i,
+    /\*{4}\s*(\d{4})/,
+    /final\s+(\d{4})/i,
+  ];
+  for (const re of patterns) {
+    const m = text.match(re);
+    if (m) return m[1];
+  }
+  return null;
+};
+
+// ─── Transaction parser ───────────────────────────────────────────────────────
+
+/**
+ * Description patterns for non-purchase lines that must be filtered out.
+ * Tested against the normalized (accent-stripped, lowercased) description string.
+ */
+const SKIP_DESCRIPTION_PATTERNS = [
+  /^pagamento\s+em\s+\d/i,
+  /^credito\s+de\s+rotativo/i,
+  /^saldo\s+em\s+rotativo/i,
+];
+
+/**
+ * Sub-line / continuation patterns — these belong to the previous transaction
+ * entry and must not be parsed as standalone transactions.
+ */
+const CONTINUATION_LINE_PATTERNS = [
+  /^[•·]/,
+  /^brl\s/i,
+  /^convers[aã]o/i,
+  /^referente\s/i,
+  /^saldo\s+parcelado/i,
+  /^total\s+a\s+pagar\s*:/i,
+  /^valor\s+original\s*:/i,
+  /^usd\s+[\d]/i,
+  /^como\s+assegurado/i,
+  /^v[aá]lido\s+apenas/i,
+  /^\.\s*valor\s+do\s+iof/i,
+  /^\.\s*saldo/i,
+];
+
+const TRANSACTION_LINE_RE = new RegExp(
+  `^(\\d{2})\\s+(${MONTHS_PAT})\\s+(.+?)\\s+(-?\\s*R\\$\\s*[\\d.,]+)$`,
+  "i",
+);
+
+/**
+ * Parse individual purchase/service transactions from a Nubank invoice PDF text.
+ *
+ * Returns an array of raw import rows compatible with the statement-import pipeline:
+ *   { line: number, raw: { date, type, value, description, notes, category } }
+ *
+ * Rules:
+ *   - Positive amount  → type "Saida"  (purchase charged to card)
+ *   - Negative amount  → type "Entrada" (refund/reversal credited to card)
+ *   - Pagamento / Crédito de rotativo / Saldo em rotativo → filtered
+ *   - Continuation sub-lines (bullet, BRL, Conversão, Referente) → skipped
+ */
+export const parseNubankInvoiceTransactions = (rawText) => {
+  if (typeof rawText !== "string" || !rawText.trim()) {
+    throw new Error("Nao foi possivel extrair transacoes da fatura.");
+  }
+
+  const invoiceMetadata = parseNubankInvoice(rawText);
+  const year = invoiceYear(invoiceMetadata?.dueDate ?? null);
+
+  const lines = rawText
+    .replace(/\r/g, "")
+    .split("\n")
+    .map((l) => l.replace(/\s+/g, " ").trim())
+    .filter(Boolean);
+
+  const rows = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    if (CONTINUATION_LINE_PATTERNS.some((re) => re.test(line))) continue;
+
+    const match = line.match(TRANSACTION_LINE_RE);
+    if (!match) continue;
+
+    const [, day, mon, rawDescription, rawAmount] = match;
+    const description = rawDescription.trim();
+
+    const normalizedDesc = description
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .toLowerCase();
+
+    if (SKIP_DESCRIPTION_PATTERNS.some((re) => re.test(normalizedDesc))) continue;
+
+    const isNegative = rawAmount.trim().startsWith("-");
+    const amountStr = rawAmount.replace(/^-?\s*R\$\s*/, "").trim();
+    const val = parseNubankBRL(amountStr);
+    if (val === null) continue;
+
+    const isoDate = nubankDateToIso(day, mon, year);
+    if (!isoDate) continue;
+
+    rows.push({
+      line: i + 1,
+      raw: {
+        date: isoDate,
+        type: isNegative ? "Entrada" : "Saida",
+        value: String(val.toFixed(2)),
+        description,
+        notes: "",
+        category: "",
+      },
+    });
+  }
+
+  if (rows.length === 0) {
+    throw new Error("Nenhuma transacao reconhecida na fatura.");
+  }
+
+  return rows;
+};
+
+// ─── Main parser ─────────────────────────────────────────────────────────────
+
+/**
+ * @typedef {Object} ParsedNubankInvoice
+ * @property {number}      totalAmount
+ * @property {string}      dueDate          - "YYYY-MM-DD"
+ * @property {string|null} periodStart      - null when not found in PDF
+ * @property {string|null} periodEnd        - null when not found in PDF
+ * @property {number|null} minimumPayment
+ * @property {null}        financedBalance  - not applicable to Nubank format
+ * @property {string|null} cardLast4
+ * @property {string}      issuer           - always 'nubank'
+ * @property {Object}      fieldsSources    - which regex matched each field
+ */
+
+/**
+ * Parse raw text from a Nubank credit card invoice PDF.
+ * Returns null if mandatory fields (totalAmount OR dueDate) are missing.
+ */
+export const parseNubankInvoice = (rawText) => {
+  if (typeof rawText !== "string" || !rawText.trim()) return null;
+
+  const text = rawText.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+
+  const totalResult = extractTotalAmount(text);
+  if (!totalResult) return null;
+
+  const dueDateResult = extractDueDate(text);
+  if (!dueDateResult) return null;
+
+  const year = dueDateResult.value.slice(0, 4);
+  const periodResult = extractPeriod(text, year);
+  const minimumPayment = extractMinimumPayment(text);
+  const cardLast4 = extractCardLast4(text);
+
+  return {
+    totalAmount: totalResult.value,
+    dueDate: dueDateResult.value,
+    periodStart: periodResult ? periodResult.start : null,
+    periodEnd: periodResult ? periodResult.end : null,
+    minimumPayment,
+    financedBalance: null,
+    cardLast4,
+    issuer: "nubank",
+    fieldsSources: {
+      totalAmount: totalResult.source,
+      dueDate: dueDateResult.source,
+      periodStart: periodResult ? periodResult.source : null,
+      periodEnd: periodResult ? periodResult.source : null,
+    },
+  };
+};

--- a/apps/api/src/domain/imports/nubank-invoice.parser.test.js
+++ b/apps/api/src/domain/imports/nubank-invoice.parser.test.js
@@ -1,0 +1,261 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseNubankBRL,
+  parseNubankInvoice,
+  parseNubankInvoiceTransactions,
+} from "./nubank-invoice.parser.js";
+
+// ─── parseNubankBRL ───────────────────────────────────────────────────────────
+
+describe("parseNubankBRL", () => {
+  it("converte 'R$ 767,23' para 767.23", () => {
+    expect(parseNubankBRL("R$ 767,23")).toBe(767.23);
+  });
+
+  it("converte 'R$ 1.247,80' para 1247.80", () => {
+    expect(parseNubankBRL("R$ 1.247,80")).toBe(1247.8);
+  });
+
+  it("converte sem prefixo R$ — '103,09'", () => {
+    expect(parseNubankBRL("103,09")).toBe(103.09);
+  });
+
+  it("converte sem milhar — '34,99'", () => {
+    expect(parseNubankBRL("34,99")).toBe(34.99);
+  });
+
+  it("retorna null para zero", () => {
+    expect(parseNubankBRL("R$ 0,00")).toBeNull();
+    expect(parseNubankBRL("0,00")).toBeNull();
+  });
+
+  it("retorna null para string vazia", () => {
+    expect(parseNubankBRL("")).toBeNull();
+  });
+
+  it("retorna null para input nao string", () => {
+    expect(parseNubankBRL(null)).toBeNull();
+    expect(parseNubankBRL(undefined)).toBeNull();
+  });
+});
+
+// ─── parseNubankInvoice ───────────────────────────────────────────────────────
+
+const buildNubankText = (overrides = {}) => {
+  const defaults = {
+    header: "Nu Pagamentos S.A.",
+    last4: "Cartao final 9988",
+    vencimento: "Data de vencimento: 18 NOV 2024",
+    periodo: "Periodo vigente: 08 OUT a 08 NOV",
+    total: "Total a pagar R$ 767,23",
+    minimo: "Pagamento minimo R$ 172,28",
+  };
+  const config = { ...defaults, ...overrides };
+
+  return Object.values(config).filter(Boolean).join("\n");
+};
+
+describe("parseNubankInvoice", () => {
+  it("parse completo — retorna todos os campos", () => {
+    const text = buildNubankText();
+    const result = parseNubankInvoice(text);
+
+    expect(result).not.toBeNull();
+    expect(result.totalAmount).toBe(767.23);
+    expect(result.dueDate).toBe("2024-11-18");
+    expect(result.periodStart).toBe("2024-10-08");
+    expect(result.periodEnd).toBe("2024-11-08");
+    expect(result.minimumPayment).toBe(172.28);
+    expect(result.financedBalance).toBeNull();
+    expect(result.cardLast4).toBe("9988");
+    expect(result.issuer).toBe("nubank");
+    expect(result.fieldsSources.totalAmount).toContain("regex:");
+    expect(result.fieldsSources.dueDate).toContain("regex:");
+    expect(result.fieldsSources.periodStart).toContain("regex:");
+  });
+
+  it("parse sem periodo — periodStart e periodEnd ficam null", () => {
+    const text = buildNubankText({ periodo: null });
+    const result = parseNubankInvoice(text);
+
+    expect(result).not.toBeNull();
+    expect(result.periodStart).toBeNull();
+    expect(result.periodEnd).toBeNull();
+    expect(result.fieldsSources.periodStart).toBeNull();
+    expect(result.fieldsSources.periodEnd).toBeNull();
+  });
+
+  it("retorna null quando totalAmount nao encontrado", () => {
+    const text = buildNubankText({ total: "sem total aqui" });
+    expect(parseNubankInvoice(text)).toBeNull();
+  });
+
+  it("retorna null quando dueDate nao encontrado", () => {
+    const text = buildNubankText({ vencimento: "sem data aqui" });
+    expect(parseNubankInvoice(text)).toBeNull();
+  });
+
+  it("retorna null para string vazia", () => {
+    expect(parseNubankInvoice("")).toBeNull();
+  });
+
+  it("retorna null para input nao string", () => {
+    expect(parseNubankInvoice(null)).toBeNull();
+    expect(parseNubankInvoice(undefined)).toBeNull();
+  });
+
+  it("nao retorna rawExcerpt no objeto parseado", () => {
+    const result = parseNubankInvoice(buildNubankText());
+    expect(result).not.toBeNull();
+    expect(result.rawExcerpt).toBeUndefined();
+  });
+
+  it("aceita variacao 'Total a pagar R$ X.XXX,XX' com milhar", () => {
+    const text = buildNubankText({ total: "Total a pagar R$ 1.247,80" });
+    const result = parseNubankInvoice(text);
+    expect(result).not.toBeNull();
+    expect(result.totalAmount).toBe(1247.8);
+  });
+
+  it("extrai cardLast4 no formato 'Cartao final XXXX'", () => {
+    const text = buildNubankText({ last4: "Cartao final 1234" });
+    const result = parseNubankInvoice(text);
+    expect(result?.cardLast4).toBe("1234");
+  });
+
+  it("funciona sem cardLast4 no texto", () => {
+    const text = buildNubankText({ last4: null });
+    const result = parseNubankInvoice(text);
+    expect(result).not.toBeNull();
+    expect(result.cardLast4).toBeNull();
+  });
+
+  it("infere ano anterior no startYear para periodo cruzando virada de ano (DEZ a JAN)", () => {
+    const text = buildNubankText({
+      vencimento: "Data de vencimento: 15 JAN 2026",
+      periodo: "Periodo vigente: 08 DEZ a 08 JAN",
+      total: "Total a pagar R$ 500,00",
+    });
+    const result = parseNubankInvoice(text);
+    expect(result).not.toBeNull();
+    expect(result.periodStart).toBe("2025-12-08");
+    expect(result.periodEnd).toBe("2026-01-08");
+  });
+
+  it("aceita 'Valor para pagamento a vista' como fallback de totalAmount", () => {
+    const text = buildNubankText({
+      total: "Valor para pagamento a vista R$ 504,16",
+    });
+    const result = parseNubankInvoice(text);
+    expect(result).not.toBeNull();
+    expect(result.totalAmount).toBe(504.16);
+  });
+
+  it("issuer e sempre nubank", () => {
+    const result = parseNubankInvoice(buildNubankText());
+    expect(result?.issuer).toBe("nubank");
+  });
+});
+
+// ─── parseNubankInvoiceTransactions ──────────────────────────────────────────
+
+const SAMPLE_TX_TEXT = `
+Nu Pagamentos S.A.
+Cartao final 9988
+Data de vencimento: 18 NOV 2024
+Periodo vigente: 08 OUT a 08 NOV
+Total a pagar R$ 767,23
+Pagamento minimo R$ 172,28
+TRANSACOES DE 08 OUT A 08 NOV
+Amaro Valerio da Silva Junior R$ 0,00
+Pagamentos e Financiamentos R$ 399,51
+15 OUT Credito de rotativo -R$ 399,51
+15 OUT Saldo em rotativo R$ 399,51
+• Saldo em aberto de R$ 466,80. Valor total acumulado de juros de R$ 64,73
+. Valor do iof R$ 2,55.
+• Valor original: R$ 402,06
+15 OUT Pagamento em 15 OUT -R$ 170,90
+21 OUT Dl *Google Youtube R$ 13,90
+24 OUT Linkedin R$ 34,99
+27 OUT Atibaia Gavioes R$ 99,00
+30 OUT Paypal *Discord R$ 25,96
+BRL 24.99 = USD 4.38
+Conversao: BRL 5.92 = USD 1 = R$ 5,92
+30 OUT IOF de Paypal *Discord R$ 1,13
+31 OUT Juros de rotativo R$ 64,73
+05 NOV IOF de rotativo R$ 2,55
+`.trim();
+
+describe("parseNubankInvoiceTransactions", () => {
+  it("extrai transacoes validas e filtra pagamentos e creditos", () => {
+    const rows = parseNubankInvoiceTransactions(SAMPLE_TX_TEXT);
+    const descriptions = rows.map((r) => r.raw.description);
+
+    expect(descriptions).toContain("Dl *Google Youtube");
+    expect(descriptions).toContain("Linkedin");
+    expect(descriptions).toContain("Atibaia Gavioes");
+    expect(descriptions).toContain("Paypal *Discord");
+    expect(descriptions).toContain("IOF de Paypal *Discord");
+    expect(descriptions).toContain("Juros de rotativo");
+    expect(descriptions).toContain("IOF de rotativo");
+  });
+
+  it("filtra Credito de rotativo, Saldo em rotativo e Pagamento em", () => {
+    const rows = parseNubankInvoiceTransactions(SAMPLE_TX_TEXT);
+    const descriptions = rows.map((r) => r.raw.description);
+
+    expect(descriptions).not.toContain("Credito de rotativo");
+    expect(descriptions).not.toContain("Saldo em rotativo");
+    expect(descriptions).not.toContain("Pagamento em 15 OUT");
+  });
+
+  it("nao inclui cabecalhos de secao ou linhas de continuacao", () => {
+    const rows = parseNubankInvoiceTransactions(SAMPLE_TX_TEXT);
+    const descriptions = rows.map((r) => r.raw.description);
+
+    expect(descriptions).not.toContain("Amaro Valerio da Silva Junior");
+    expect(descriptions).not.toContain("Pagamentos e Financiamentos");
+    // BRL / Conversao lines must not appear
+    expect(descriptions.some((d) => /^brl\s/i.test(d))).toBe(false);
+    expect(descriptions.some((d) => /^convers/i.test(d))).toBe(false);
+  });
+
+  it("mapeia tipo Saida para compras normais", () => {
+    const rows = parseNubankInvoiceTransactions(SAMPLE_TX_TEXT);
+    const youtube = rows.find((r) => r.raw.description === "Dl *Google Youtube");
+    expect(youtube).toBeDefined();
+    expect(youtube.raw.type).toBe("Saida");
+    expect(youtube.raw.value).toBe("13.90");
+    expect(youtube.raw.date).toBe("2024-10-21");
+  });
+
+  it("usa ano do dueDate para todos os meses do periodo", () => {
+    const rows = parseNubankInvoiceTransactions(SAMPLE_TX_TEXT);
+    const nov = rows.find((r) => r.raw.description === "IOF de rotativo");
+    expect(nov?.raw.date).toBe("2024-11-05");
+  });
+
+  it("lanca erro para texto vazio", () => {
+    expect(() => parseNubankInvoiceTransactions("")).toThrow();
+  });
+
+  it("lanca erro quando nenhuma transacao e reconhecida", () => {
+    expect(() =>
+      parseNubankInvoiceTransactions("Nu Pagamentos S.A.\nTexto sem transacoes validas."),
+    ).toThrow("Nenhuma transacao reconhecida na fatura.");
+  });
+
+  it("transacao com valor negativo gera tipo Entrada", () => {
+    const text = `
+Nu Pagamentos S.A.
+Data de vencimento: 18 NOV 2024
+Total a pagar R$ 50,00
+15 OUT Reembolso Mercado Livre -R$ 45,00
+    `.trim();
+    const rows = parseNubankInvoiceTransactions(text);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].raw.type).toBe("Entrada");
+    expect(rows[0].raw.value).toBe("45.00");
+    expect(rows[0].raw.description).toBe("Reembolso Mercado Livre");
+  });
+});

--- a/apps/api/src/services/credit-card-invoices.service.js
+++ b/apps/api/src/services/credit-card-invoices.service.js
@@ -1,6 +1,7 @@
 import { dbQuery } from "../db/index.js";
 import { extractTextFromPdfWithOcrRuntime } from "../domain/imports/pdf-ocr.js";
 import { parseBRL, parseDMY, parseItauInvoice } from "../domain/imports/itau-invoice.parser.js";
+import { parseNubankInvoice } from "../domain/imports/nubank-invoice.parser.js";
 import { trackDomainFlowError, trackDomainFlowSuccess } from "../observability/domain-metrics.js";
 import { resolveInvoiceClassificationSignals } from "./credit-card-invoice-classification.service.js";
 import { resolveCreditCardInvoicePeriod } from "./credit-card-invoice-period-inference.service.js";
@@ -263,6 +264,15 @@ const parseCreditCardInvoiceByStrategy = (rawText) => {
       parsed: parseItauInvoice(rawText),
       strategy: "issuer_specific",
       parserName: "itau_parser_v1",
+      issuerDetection,
+    };
+  }
+
+  if (issuerDetection.issuer === "nubank") {
+    return {
+      parsed: parseNubankInvoice(rawText),
+      strategy: "issuer_specific",
+      parserName: "nubank_parser_v1",
       issuerDetection,
     };
   }


### PR DESCRIPTION
## Summary

- Implements `nubank-invoice.parser.js` — pure parser for the Nubank PDF format with no I/O or AI dependency
- Handles PT-BR month abbreviations (`DD MES YYYY`), `Total a pagar R$` total, `Período vigente` period (year inferred from dueDate, cross-year DEZ→JAN boundary supported), and transaction lines with continuation sub-line skipping
- Wires Nubank into `parseCreditCardInvoiceByStrategy()` as `issuer_specific` / `nubank_parser_v1` — replaces previous `generic_fallback` path
- Adds `credit_card_invoice_nubank` to `document-classifier.js` (requires `nu pagamentos` + 2 structural signals)
- Transaction filter: skips `Pagamento em`, `Crédito de rotativo`, `Saldo em rotativo`, bullet sub-lines, `BRL`/`Conversão`/`Referente` continuation lines

## Test plan

- [x] 28 unit tests in `nubank-invoice.parser.test.js` — all passing
- [x] 4 classifier tests added to `document-classifier.test.js`
- [x] 2 golden corpus cases added (`nubank_high_confidence_auto_accept`, `nubank_period_missing_requires_confirmation`)
- [x] Existing Nubank integration test updated to real format + new assertions
- [x] Full API suite: 71 files / 1073 tests — all green