### PR TITLE
fix(import): prioritize bank_statement over telecom and guard INSS classifier

### DIFF
--- a/apps/api/src/domain/imports/document-classifier.js
+++ b/apps/api/src/domain/imports/document-classifier.js
@@ -128,6 +128,8 @@ const BANK_STATEMENT_SIGNALS = [
   "stmttrn",
   "fitid",
   "trnamt",
+  "extrato conta",
+  "periodo de visualizacao",
 ];
 
 const countMatches = (normalized, signals) =>
@@ -141,8 +143,10 @@ export const detectDocumentType = ({ text = "", extension = "" }) => {
   if (!normalized) return "unknown";
 
   // INSS — requires "instituto nacional" + at least one more signal
+  // Guard: "historico de emprestimo consignado" is a loan history report, not an income statement
   if (
     normalized.includes("instituto nacional do seguro social") &&
+    !normalized.includes("historico de emprestimo consignado") &&
     countMatches(normalized, INSS_SIGNALS) >= 2
   ) {
     return "income_statement_inss";
@@ -153,6 +157,13 @@ export const detectDocumentType = ({ text = "", extension = "" }) => {
     countMatches(normalized, [...PAYROLL_PRIMARY_SIGNALS, ...PAYROLL_SECONDARY_SIGNALS]) >= 3
   ) {
     return "income_statement_payroll";
+  }
+
+  // Bank statement with strong evidence takes priority over utility bill misclassification.
+  // Extrato Itaú contains carrier names (Claro, TIM) as transaction descriptions which
+  // would otherwise match TELECOM_SIGNALS. Promote bank_statement when ≥2 strong signals.
+  if (countMatches(normalized, BANK_STATEMENT_SIGNALS) >= 2) {
+    return "bank_statement";
   }
 
   // Energy bill — 2+ signals
@@ -191,7 +202,7 @@ export const detectDocumentType = ({ text = "", extension = "" }) => {
     return "credit_card_invoice_nubank";
   }
 
-  // PDF with bank statement content
+  // PDF with bank statement content — single signal fallback
   if (countMatches(normalized, BANK_STATEMENT_SIGNALS) >= 1) {
     return "bank_statement";
   }

--- a/apps/api/src/domain/imports/document-classifier.test.js
+++ b/apps/api/src/domain/imports/document-classifier.test.js
@@ -211,6 +211,35 @@ describe("detectDocumentType", () => {
       const text = "<STMTTRN>\n<FITID>20260101001\n<TRNAMT>-150.00";
       expect(detectDocumentType({ text, extension: ".pdf" })).toBe("bank_statement");
     });
+
+    it("extrato Itau com transacoes CLARO/TIM nao e classificado como utility_bill_telecom", () => {
+      // Reproduz extrato_itau_032026.pdf: tem SALDO DO DIA, lançamentos, periodo de visualizacao
+      // e transacoes como PIX QRS CLARO e PAY TIM — nao deve virar telecom bill
+      const text = [
+        "extrato conta / lancamentos",
+        "periodo de visualizacao: 09/03/2026 ate 08/04/2026",
+        "SALDO DO DIA 447,64",
+        "PIX QRS CLARO07/04 -44,83",
+        "PAY TIM 07/04 -89,90",
+        "PGTO INSS 01776829899 2.803,52",
+        "SALDO DO DIA 497,64",
+      ].join("\n");
+      expect(detectDocumentType({ text, extension: ".pdf" })).toBe("bank_statement");
+    });
+  });
+
+  describe("income_statement_inss guard", () => {
+    it("historico de emprestimo consignado NAO e classificado como income_statement_inss", () => {
+      const text = [
+        "Instituto Nacional do Seguro Social",
+        "HISTÓRICO DE EMPRÉSTIMO CONSIGNADO",
+        "MARIA EDLEUSA MONSAO DA SILVA",
+        "Benefício NB: 177.682.989-9",
+        "SITUAÇÃO: ATIVO",
+        "competência início desconto fim desconto",
+      ].join("\n");
+      expect(detectDocumentType({ text, extension: ".pdf" })).not.toBe("income_statement_inss");
+    });
   });
 
   describe("unknown", () => {


### PR DESCRIPTION
## Summary

- Promotes `bank_statement` classification when ≥2 strong signals are present, before utility bill checks — prevents extrato Itaú from being misclassified as `utility_bill_telecom` due to carrier names (Claro, TIM) appearing as transaction descriptions
- Adds `extrato conta` and `periodo de visualizacao` to `BANK_STATEMENT_SIGNALS` for stronger anchoring on Itaú account statements
- Adds guard in INSS classifier: `!normalized.includes("historico de emprestimo consignado")` — prevents INSS loan history PDFs from being classified as `income_statement_inss`

## Test plan

- [ ] 2 new regression tests: extrato Itaú with CLARO/TIM transactions → `bank_statement`; INSS loan history → not `income_statement_inss`
- [ ] 38/38 classifier tests passing
- [ ] 1075/1075 full API suite passing