### PR TITLE
fix(billing): use entitlement source to unfreeze forecast for active subscribers

### DIFF
--- a/apps/web/src/components/ForecastCard.tsx
+++ b/apps/web/src/components/ForecastCard.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { forecastService, type Forecast } from "../services/forecast.service";
 import { profileService } from "../services/profile.service";
+import { billingService } from "../services/billing.service";
 import { useMaskedCurrency } from "../context/DiscreetModeContext";
 import { logWidgetFallbackError } from "../utils/widgetFallbackTelemetry";
 import { OperationalSeverityBadge, OperationalStateBlock, type OperationalSeverity } from "./OperationalStateBlock";
@@ -178,7 +179,10 @@ const ForecastCard = ({
     try {
       setError("");
       setHasLoadError(false);
-      const me = await profileService.getMe();
+      const [me, billing] = await Promise.all([
+        profileService.getMe(),
+        billingService.getSubscription(),
+      ]);
 
       const hasProfile =
         me.profile !== null &&
@@ -190,7 +194,13 @@ const ForecastCard = ({
         return;
       }
 
-      const trialEnded = Boolean(me.trialExpired || trialExpired);
+      // Freeze only when entitlement is free with expired trial.
+      // Active subscription (subscription / subscription_grace / prepaid) always unfreezes.
+      const isPaid =
+        billing.entitlementSource === "subscription" ||
+        billing.entitlementSource === "subscription_grace" ||
+        billing.entitlementSource === "prepaid";
+      const trialEnded = !isPaid && Boolean(billing.trialExpired || trialExpired);
       if (trialEnded) {
         setForecast(loadCachedForecast());
         setCardState("frozen");

--- a/apps/web/src/pages/ProfileSettings.tsx
+++ b/apps/web/src/pages/ProfileSettings.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { FormEvent } from "react";
 import { useSearchParams } from "react-router-dom";
 import { profileService, type UserProfile } from "../services/profile.service";
+import { billingService } from "../services/billing.service";
 import { getApiErrorMessage } from "../utils/apiError";
 import { useDiscreetMode } from "../context/DiscreetModeContext";
 
@@ -111,12 +112,19 @@ const ProfileSettings = ({
     setIsLoading(true);
     setLoadError(null);
     try {
-      const me = await profileService.getMe();
+      const [me, billing] = await Promise.all([
+        profileService.getMe(),
+        billingService.getSubscription(),
+      ]);
       setEmail(me.email);
       setHasPassword(me.hasPassword ?? null);
       setLinkedProviders(me.linkedProviders ?? []);
-      setTrialEndsAt(me.trialEndsAt ?? null);
-      setTrialExpired(me.trialExpired ?? false);
+      setTrialEndsAt(billing.trialEndsAt ?? me.trialEndsAt ?? null);
+      const isPaid =
+        billing.entitlementSource === "subscription" ||
+        billing.entitlementSource === "subscription_grace" ||
+        billing.entitlementSource === "prepaid";
+      setTrialExpired(!isPaid && Boolean(billing.trialExpired ?? me.trialExpired));
       const p: UserProfile | null = me.profile;
       setDisplayName(p?.displayName ?? "");
       setSalaryMonthly(


### PR DESCRIPTION
## Summary

- `ForecastCard` and `ProfileSettings` now call `billingService.getSubscription()` in parallel with `profileService.getMe()` to determine subscription status
- Forecast freezes only when `entitlementSource` is `free` with `trialExpired: true` — active subscriptions (`subscription`, `subscription_grace`, `prepaid`) always unfreeze regardless of `/me.trialExpired`
- Fixes bug where Pro subscribers saw "Ativar plano" / frozen forecast because the components were reading `trialExpired` from `/me` which does not reflect active subscription state

## Test plan

- [ ] TypeScript typecheck clean (`tsc --noEmit`)
- [ ] Subscriber with active Pro plan should see forecast unfrozen immediately on page load
- [ ] User with expired trial and no subscription should still see frozen forecast