### PR TITLE
[codex] fix billing recovery and import guidance

### DIFF
--- a/apps/api/src/import-utility-dry-run.test.js
+++ b/apps/api/src/import-utility-dry-run.test.js
@@ -234,4 +234,30 @@ describe("transaction imports utility bills dry-run", () => {
     expect(metrics.import_dry_run_utility_gate_blocked_total).toBe(1);
     expect(metrics.import_dry_run_utility_gate_supported_total).toBe(0);
   });
+
+  it("POST /transactions/import/dry-run explica quando o PDF e historico de emprestimo consignado do INSS", async () => {
+    const token = await registerAndLogin("import-consignado-inss@controlfinance.dev");
+    await makeProUser("import-consignado-inss@controlfinance.dev");
+
+    vi.mocked(extractTextFromPdfBuffer).mockResolvedValue([
+      "Instituto Nacional do Seguro Social",
+      "HISTORICO DE EMPRESTIMO CONSIGNADO",
+      "Beneficio NB: 177.682.989-9",
+      "Situacao: Ativo",
+    ].join("\n"));
+
+    const response = await request(app)
+      .post("/transactions/import/dry-run")
+      .set("Authorization", `Bearer ${token}`)
+      .attach("file", Buffer.from("%PDF-1.4 consignado"), {
+        filename: "consignado.pdf",
+        contentType: "application/pdf",
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe(
+      "Este PDF e um historico de emprestimo consignado do INSS. Para importar renda, envie o Historico de Creditos do beneficio.",
+    );
+    expect(vi.mocked(detectDocumentType)).not.toHaveBeenCalled();
+  });
 });

--- a/apps/api/src/services/stripe-webhook.service.js
+++ b/apps/api/src/services/stripe-webhook.service.js
@@ -399,6 +399,19 @@ export const handleInvoicePaymentFailed = async (invoice) => {
   );
 };
 
+export const handleInvoicePaid = async (invoice) => {
+  const stripeSubscriptionId = invoice?.subscription ?? null;
+  if (!stripeSubscriptionId) return;
+
+  await dbQuery(
+    `UPDATE subscriptions SET
+      status = 'active',
+      updated_at = NOW()
+     WHERE stripe_subscription_id = $1`,
+    [stripeSubscriptionId],
+  );
+};
+
 const markStripeEventProcessed = async (stripeEventId, eventType) => {
   if (!stripeEventId) return false;
 
@@ -436,6 +449,9 @@ export const processStripeEvent = async (event) => {
       return handleSubscriptionUpserted(event.data?.object);
     case "customer.subscription.deleted":
       return handleSubscriptionDeleted(event.data?.object);
+    case "invoice.paid":
+    case "invoice.payment_succeeded":
+      return handleInvoicePaid(event.data?.object);
     case "invoice.payment_failed":
       return handleInvoicePaymentFailed(event.data?.object);
     default:

--- a/apps/api/src/services/transactions-import.service.ts
+++ b/apps/api/src/services/transactions-import.service.ts
@@ -111,6 +111,7 @@ const UTILITY_BILL_DOCUMENT_TYPES = new Set([
   "utility_bill_gas",
   "utility_bill_telecom",
 ]);
+const collapseWhitespace = (value: unknown) => String(value || "").replace(/\s+/g, " ").trim();
 
 const resolveUtilityBillImportDecision = (documentType: unknown): UtilityBillImportDecision | null => {
   const normalizedDocumentType =
@@ -874,6 +875,21 @@ const parseImportFileRows = async (importFile: ImportFile) => {
     const guidanceError = getPdfImportGuidanceError(text);
     if (guidanceError) {
       throw createError(400, guidanceError);
+    }
+
+    const normalizedPdfText = collapseWhitespace(text)
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .toLowerCase();
+
+    if (
+      normalizedPdfText.includes("instituto nacional do seguro social") &&
+      normalizedPdfText.includes("historico de emprestimo consignado")
+    ) {
+      throw createError(
+        400,
+        "Este PDF e um historico de emprestimo consignado do INSS. Para importar renda, envie o Historico de Creditos do beneficio.",
+      );
     }
 
     const documentType = detectDocumentType({ text, extension });

--- a/apps/api/src/stripe-webhooks.test.js
+++ b/apps/api/src/stripe-webhooks.test.js
@@ -394,6 +394,63 @@ describe("stripe webhooks", () => {
     expect(sub.status).toBe("past_due");
   });
 
+  it("invoice.payment_succeeded reativa subscription apos past_due", async () => {
+    await registerAndLogin("webhook-payment-recovered@controlfinance.dev");
+    const userId = await getUserIdByEmail("webhook-payment-recovered@controlfinance.dev");
+    const token = extractAccessToken(
+      await request(app)
+        .post("/auth/login")
+        .send({ email: "webhook-payment-recovered@controlfinance.dev", password: "Senha123" }),
+    );
+
+    await stripePost({
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          customer: "cus_test_010",
+          subscription: "sub_test_010",
+          metadata: { userId: String(userId) },
+        },
+      },
+    });
+
+    await stripePost({
+      type: "invoice.payment_failed",
+      data: {
+        object: {
+          subscription: "sub_test_010",
+          customer: "cus_test_010",
+        },
+      },
+    });
+
+    let sub = await getSubscription(userId);
+    expect(sub.status).toBe("past_due");
+
+    const response = await stripePost({
+      type: "invoice.payment_succeeded",
+      data: {
+        object: {
+          subscription: "sub_test_010",
+          customer: "cus_test_010",
+          status: "paid",
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+
+    sub = await getSubscription(userId);
+    expect(sub.status).toBe("active");
+
+    const summaryResponse = await request(app)
+      .get("/billing/subscription")
+      .set("Authorization", `Bearer ${token}`);
+    expect(summaryResponse.status).toBe(200);
+    expect(summaryResponse.body.plan).toBe("pro");
+    expect(summaryResponse.body.entitlementSource).toBe("subscription");
+  });
+
   it("apos subscription.deleted, entitlement retorna ao plano free", async () => {
     await registerAndLogin("webhook-entitlement-fallback@controlfinance.dev");
     const userId = await getUserIdByEmail("webhook-entitlement-fallback@controlfinance.dev");

--- a/apps/web/src/components/ForecastCard.test.tsx
+++ b/apps/web/src/components/ForecastCard.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import ForecastCard, { FORECAST_CACHE_KEY } from "./ForecastCard";
 import { DiscreetModeProvider } from "../context/DiscreetModeContext";
+import { billingService } from "../services/billing.service";
 import type { Forecast } from "../services/forecast.service";
 
 vi.mock("../services/forecast.service", () => ({
@@ -14,6 +15,18 @@ vi.mock("../services/forecast.service", () => ({
 vi.mock("../services/profile.service", () => ({
   profileService: {
     getMe: vi.fn(),
+  },
+}));
+
+vi.mock("../services/billing.service", () => ({
+  billingService: {
+    getSubscription: vi.fn(() => Promise.resolve({
+      entitlementSource: "subscription",
+      trialExpired: false,
+      trialEndsAt: null,
+      subscription: { currentPeriodEnd: "2026-04-25", cancelAtPeriodEnd: false },
+      proExpiresAt: null,
+    })),
   },
 }));
 
@@ -171,6 +184,13 @@ describe("ForecastCard", () => {
     vi.mocked(profileService.getMe).mockResolvedValue({
       ...buildMe(),
       trialExpired: true,
+    });
+    vi.mocked(billingService.getSubscription).mockResolvedValueOnce({
+      entitlementSource: "free",
+      trialExpired: true,
+      trialEndsAt: null,
+      subscription: null,
+      proExpiresAt: null,
     });
 
     render(

--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -1,3 +1,14 @@
+vi.mock("../services/billing.service", () => ({
+  billingService: {
+    getSubscription: vi.fn(() => Promise.resolve({
+      entitlementSource: "free",
+      trialExpired: false,
+      trialEndsAt: null,
+      subscription: null,
+      proExpiresAt: null,
+    })),
+  },
+}));
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/apps/web/src/pages/ProfileSettings.test.tsx
+++ b/apps/web/src/pages/ProfileSettings.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import ProfileSettings from "./ProfileSettings";
+import { billingService } from "../services/billing.service";
 import { profileService } from "../services/profile.service";
 import { DiscreetModeProvider } from "../context/DiscreetModeContext";
 
@@ -10,6 +11,18 @@ vi.mock("../services/profile.service", () => ({
   profileService: {
     getMe: vi.fn(),
     updateProfile: vi.fn(),
+  },
+}));
+
+vi.mock("../services/billing.service", () => ({
+  billingService: {
+    getSubscription: vi.fn(() => Promise.resolve({
+      entitlementSource: "subscription",
+      trialExpired: false,
+      trialEndsAt: null,
+      subscription: { currentPeriodEnd: "2026-04-25", cancelAtPeriodEnd: false },
+      proExpiresAt: null,
+    })),
   },
 }));
 
@@ -318,6 +331,13 @@ describe("ProfileSettings — Assinatura", () => {
     vi.mocked(profileService.getMe).mockResolvedValue(
       buildMe({ trialEndsAt: pastDate, trialExpired: true }),
     );
+    vi.mocked(billingService.getSubscription).mockResolvedValueOnce({
+      entitlementSource: "free",
+      trialExpired: true,
+      trialEndsAt: null,
+      subscription: null,
+      proExpiresAt: null,
+    });
     const onOpenBilling = vi.fn();
     renderPage({ onOpenBilling });
     await waitFor(() => expect(screen.getByText("Trial expirado")).toBeInTheDocument());
@@ -332,6 +352,13 @@ describe("ProfileSettings — Assinatura", () => {
     vi.mocked(profileService.getMe).mockResolvedValue(
       buildMe({ trialEndsAt: pastDate, trialExpired: true }),
     );
+    vi.mocked(billingService.getSubscription).mockResolvedValueOnce({
+      entitlementSource: "free",
+      trialExpired: true,
+      trialEndsAt: null,
+      subscription: null,
+      proExpiresAt: null,
+    });
     renderPage();
     await waitFor(() => expect(screen.getByText("Trial expirado")).toBeInTheDocument());
     expect(screen.queryByRole("button", { name: "Fazer upgrade" })).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary
- restore billing entitlement when Stripe sends `invoice.payment_succeeded` or `invoice.paid` after a `past_due` transition
- return a specific dry-run guidance message when the uploaded INSS PDF is a loan history (`historico de emprestimo consignado`) instead of a benefit credit history
- mock `billingService` in web tests that now depend on subscription state, with targeted expired-trial overrides for the frozen/trial-expired cases

## Root cause
- the billing webhook flow handled `invoice.payment_failed` but not the recovery path, so subscription state could remain stale after payment recovery
- the import flow rejected consignado PDFs generically instead of telling the user which INSS document is required
- billing-aware UI components introduced an additional service dependency that existing tests were not mocking

## Validation
- `cd apps/api && npx vitest run`  
  1077 passed
- `cd apps/web && npx vitest run`  
  424 passed
