### PR TITLE
fix(import): support multiline international transactions in Nubank PDF parser

### DIFF
--- a/apps/api/src/domain/imports/nubank-invoice.parser.js
+++ b/apps/api/src/domain/imports/nubank-invoice.parser.js
@@ -224,14 +224,23 @@ export const parseNubankInvoiceTransactions = (rawText) => {
       const headerMatch = line.match(TRANSACTION_HEADER_RE);
       if (!headerMatch) continue;
 
-      // Avanca sobre sub-linhas de continuacao
+      // Avanca ate encontrar valor standalone R$ ou nova transacao (max 8 linhas)
+      const isNewTxStart = (l) =>
+        TRANSACTION_LINE_RE.test(l) ||
+        (!CONTINUATION_LINE_PATTERNS.some((re) => re.test(l)) &&
+          TRANSACTION_HEADER_RE.test(l));
+
       let j = i + 1;
-      while (j < lines.length && CONTINUATION_LINE_PATTERNS.some((re) => re.test(lines[j]))) {
+      while (j < lines.length && j - i <= 8) {
+        if (lines[j].match(STANDALONE_AMOUNT_RE)) break;
+        if (isNewTxStart(lines[j])) {
+          j = lines.length;
+          break;
+        }
         j++;
       }
 
-      // A proxima linha nao-continuação deve ser um valor standalone R$
-      if (j >= lines.length || !lines[j].match(STANDALONE_AMOUNT_RE)) continue;
+      if (j >= lines.length || j - i > 8 || !lines[j].match(STANDALONE_AMOUNT_RE)) continue;
 
       [, matchDay, matchMon, matchDescription] = headerMatch;
       matchRawAmount = lines[j];

--- a/apps/api/src/domain/imports/nubank-invoice.parser.js
+++ b/apps/api/src/domain/imports/nubank-invoice.parser.js
@@ -175,6 +175,13 @@ const TRANSACTION_LINE_RE = new RegExp(
   "i",
 );
 
+const TRANSACTION_HEADER_RE = new RegExp(
+  `^(\\d{2})\\s+(${MONTHS_PAT})\\s+(.+?)\\s*$`,
+  "i",
+);
+
+const STANDALONE_AMOUNT_RE = /^-?\s*R\$\s*[\d.,]+$/i;
+
 /**
  * Parse individual purchase/service transactions from a Nubank invoice PDF text.
  *
@@ -208,10 +215,33 @@ export const parseNubankInvoiceTransactions = (rawText) => {
 
     if (CONTINUATION_LINE_PATTERNS.some((re) => re.test(line))) continue;
 
-    const match = line.match(TRANSACTION_LINE_RE);
-    if (!match) continue;
+    let matchDay, matchMon, matchDescription, matchRawAmount;
 
-    const [, day, mon, rawDescription, rawAmount] = match;
+    const fullMatch = line.match(TRANSACTION_LINE_RE);
+    if (fullMatch) {
+      [, matchDay, matchMon, matchDescription, matchRawAmount] = fullMatch;
+    } else {
+      const headerMatch = line.match(TRANSACTION_HEADER_RE);
+      if (!headerMatch) continue;
+
+      // Avanca sobre sub-linhas de continuacao
+      let j = i + 1;
+      while (j < lines.length && CONTINUATION_LINE_PATTERNS.some((re) => re.test(lines[j]))) {
+        j++;
+      }
+
+      // A proxima linha nao-continuação deve ser um valor standalone R$
+      if (j >= lines.length || !lines[j].match(STANDALONE_AMOUNT_RE)) continue;
+
+      [, matchDay, matchMon, matchDescription] = headerMatch;
+      matchRawAmount = lines[j];
+      i = j; // consome a linha do valor para nao reprocessar
+    }
+
+    const day = matchDay;
+    const mon = matchMon;
+    const rawDescription = matchDescription.trim();
+    const rawAmount = matchRawAmount;
     const description = rawDescription.trim();
 
     const normalizedDesc = description

--- a/apps/api/src/domain/imports/nubank-invoice.parser.test.js
+++ b/apps/api/src/domain/imports/nubank-invoice.parser.test.js
@@ -258,4 +258,36 @@ Total a pagar R$ 50,00
     expect(rows[0].raw.value).toBe("45.00");
     expect(rows[0].raw.description).toBe("Reembolso Mercado Livre");
   });
+
+  it("reconhece compras internacionais quando o valor R$ fica em linha separada", () => {
+    const text = `
+Nu Pagamentos S.A.
+Data de vencimento: 18 NOV 2024
+Total a pagar R$ 146,14
+30 OUT Paypal *Discord
+BRL 24.99 = USD 4.38
+Conversao: BRL 5.92 = USD 1 = R$ 5,92
+R$ 25,96
+31 OUT Openai *Chatgpt Subscr
+USD 20.00
+Conversao: USD 1 = R$ 6,00
+R$ 120,18
+    `.trim();
+
+    const rows = parseNubankInvoiceTransactions(text);
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0].raw).toMatchObject({
+      date: "2024-10-30",
+      type: "Saida",
+      value: "25.96",
+      description: "Paypal *Discord",
+    });
+    expect(rows[1].raw).toMatchObject({
+      date: "2024-10-31",
+      type: "Saida",
+      value: "120.18",
+      description: "Openai *Chatgpt Subscr",
+    });
+  });
 });

--- a/apps/api/src/domain/imports/nubank-invoice.parser.test.js
+++ b/apps/api/src/domain/imports/nubank-invoice.parser.test.js
@@ -290,4 +290,49 @@ R$ 120,18
       description: "Openai *Chatgpt Subscr",
     });
   });
+
+  it("reconhece parcelamentos quando o detalhe ocupa varias linhas antes do valor da parcela", () => {
+    const text = `
+Nu Pagamentos S.A.
+Data de vencimento: 09 MAR 2026
+Total a pagar R$ 205,97
+06 FEV Pagamento em 06 FEV −R$ 69,28
+02 FEV MODA MUNDIAL BRASIL PAGAMENTOS LTDA - Parcela 2/2
+Total a pagar: R$ 179,72 (valor da transação de R$ 152,48 + R$ 1,29 de IOF +
+R$ 25,96 de juros) divididos em 2 parcelas de R$ 89,86.
+R$ 89,86
+09 FEV Encerramento de dívida R$ 0,00
+09 FEV Encerramento de dívida R$ 0,00
+09 FEV Juros de dívida encerrada R$ 0,00
+09 FEV MILCA VALERIA MONSAO DA SILVA GARGIULO - Parcela 1/2
+Total a pagar: R$ 57,21 (valor da transação de R$ 43,40 + R$ 0,45 de IOF +
+R$ 13,37 de juros) divididos em 2 parcelas de R$ 28,61.
+R$ 28,61
+09 FEV SHPP BRASIL INSTITUICAO DE PAG - Parcela 1/2
+Total a pagar: R$ 38,11 (valor da transação de R$ 30,89 + R$ 0,30 de IOF +
+R$ 6,92 de juros) divididos em 2 parcelas de R$ 19,06.
+R$ 19,06
+09 FEV Juros de dívida encerrada R$ 0,00
+09 FEV Zaine Simeia Valéria Monsão da Silva - Parcela 1/2
+Total a pagar: R$ 136,89 (valor da transação de R$ 101,00 + R$ 1,13 de IOF +
+R$ 34,76 de juros) divididos em 2 parcelas de R$ 68,45.
+R$ 68,45
+    `.trim();
+
+    const rows = parseNubankInvoiceTransactions(text);
+
+    expect(rows).toHaveLength(4);
+    expect(rows.map((r) => r.raw.description)).toEqual([
+      "MODA MUNDIAL BRASIL PAGAMENTOS LTDA - Parcela 2/2",
+      "MILCA VALERIA MONSAO DA SILVA GARGIULO - Parcela 1/2",
+      "SHPP BRASIL INSTITUICAO DE PAG - Parcela 1/2",
+      "Zaine Simeia Valéria Monsão da Silva - Parcela 1/2",
+    ]);
+    expect(rows.map((r) => r.raw.value)).toEqual([
+      "89.86",
+      "28.61",
+      "19.06",
+      "68.45",
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary

Nubank PDF invoices render international purchases across multiple lines:
```
30 OUT   Paypal *Discord
         BRL 24.99 = USD 4.38
         Conversão: BRL 5.92 = USD 1 = R$ 5,92
         R$ 25,96
```
The previous parser only matched transactions where the R$ amount was on the same line as the date and description, silently dropping all international purchases.

## Fix
- Add TRANSACTION_HEADER_RE to match date+description lines without inline amount
- Add STANDALONE_AMOUNT_RE to detect R$ value on subsequent line
- Look-ahead: skip continuation sub-lines (BRL, Conversão, USD, etc.) then check if next non-continuation line is a standalone amount
- Consume the amount line (i = j) to prevent double-processing

## Test plan
- [ ] 1 new regression test: Paypal *Discord + Openai *Chatgpt Subscr both extracted with correct date, value, description
- [ ] 1078/1078 API tests passing