### PR TITLE
fix(tests): complete SubscriptionSummary shape in billing mocks

### DIFF
--- a/apps/web/src/components/ForecastCard.test.tsx
+++ b/apps/web/src/components/ForecastCard.test.tsx
@@ -21,6 +21,9 @@ vi.mock("../services/profile.service", () => ({
 vi.mock("../services/billing.service", () => ({
   billingService: {
     getSubscription: vi.fn(() => Promise.resolve({
+      plan: "pro",
+      displayName: "Control Finance PRO",
+      features: {},
       entitlementSource: "subscription",
       trialExpired: false,
       trialEndsAt: null,
@@ -186,6 +189,9 @@ describe("ForecastCard", () => {
       trialExpired: true,
     });
     vi.mocked(billingService.getSubscription).mockResolvedValueOnce({
+      plan: "free",
+      displayName: "Plano Gratuito",
+      features: {},
       entitlementSource: "free",
       trialExpired: true,
       trialEndsAt: null,

--- a/apps/web/src/pages/App.test.jsx
+++ b/apps/web/src/pages/App.test.jsx
@@ -1,6 +1,9 @@
 vi.mock("../services/billing.service", () => ({
   billingService: {
     getSubscription: vi.fn(() => Promise.resolve({
+      plan: "free",
+      displayName: "Plano Gratuito",
+      features: {},
       entitlementSource: "free",
       trialExpired: false,
       trialEndsAt: null,

--- a/apps/web/src/pages/ProfileSettings.test.tsx
+++ b/apps/web/src/pages/ProfileSettings.test.tsx
@@ -17,6 +17,9 @@ vi.mock("../services/profile.service", () => ({
 vi.mock("../services/billing.service", () => ({
   billingService: {
     getSubscription: vi.fn(() => Promise.resolve({
+      plan: "pro",
+      displayName: "Control Finance PRO",
+      features: {},
       entitlementSource: "subscription",
       trialExpired: false,
       trialEndsAt: null,
@@ -332,6 +335,9 @@ describe("ProfileSettings — Assinatura", () => {
       buildMe({ trialEndsAt: pastDate, trialExpired: true }),
     );
     vi.mocked(billingService.getSubscription).mockResolvedValueOnce({
+      plan: "free",
+      displayName: "Plano Gratuito",
+      features: {},
       entitlementSource: "free",
       trialExpired: true,
       trialEndsAt: null,
@@ -353,6 +359,9 @@ describe("ProfileSettings — Assinatura", () => {
       buildMe({ trialEndsAt: pastDate, trialExpired: true }),
     );
     vi.mocked(billingService.getSubscription).mockResolvedValueOnce({
+      plan: "free",
+      displayName: "Plano Gratuito",
+      features: {},
       entitlementSource: "free",
       trialExpired: true,
       trialEndsAt: null,


### PR DESCRIPTION
Adds missing plan, displayName and features fields to all billingService.getSubscription mocks to satisfy the SubscriptionSummary TypeScript type. Fixes CI typecheck failure introduced when billing mocks were added without the full type shape.