### PR TITLE
build(ci): add api typecheck target and gate backend TS in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Lint (api)
         run: npm -w apps/api run lint
 
+      - name: Typecheck (api)
+        run: npm -w apps/api run typecheck
+
       - name: Test (api)
         run: npm -w apps/api run test
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,6 +10,7 @@
     "dev": "node --import tsx/esm --watch src/server.js",
     "start": "node --import tsx/esm src/server.js",
     "build": "node -e \"console.log('api build: no-op')\"",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "db:migrate": "node src/db/migrate.js",
     "db:backfill:categories-normalized": "node src/db/backfill-categories-normalized.js",
     "db:seed": "node src/db/seed.js",

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "allowJs": false,
+    "checkJs": false,
+    "strict": false,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+    "baseUrl": "."
+  },
+  "include": [
+    "src/domain/contracts/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/*.test.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "check:js-boundaries": "node scripts/check-js-boundaries.mjs",
     "lint": "npm run check:js-boundaries && npm -w apps/web run lint && npm -w apps/api run lint",
     "typecheck:web": "npm -w apps/web run typecheck",
-    "typecheck": "npm run typecheck:web",
+    "typecheck": "npm run typecheck:web && npm -w apps/api run typecheck",
     "test": "npm -w apps/web run test:run && npm -w apps/api run test:run",
     "test:run": "npm run test",
     "build": "npm -w apps/web run build && npm -w apps/api run build",


### PR DESCRIPTION
Adds apps/api/tsconfig.json (contracts-only, strict: false) and typecheck:api script. Gates the CI api job on backend TS — contracts fail fast before tests run. Services (dashboard, transactions-import) excluded for dedicated follow-up PRs due to existing type debt.