### PR TITLE
chore(api): add dashboard service to backend typecheck coverage

### DIFF
--- a/apps/api/src/services/dashboard.service.ts
+++ b/apps/api/src/services/dashboard.service.ts
@@ -269,6 +269,7 @@ export const getDashboardSnapshot = async (
 
   const baseSnapshot: DashboardSnapshotBase = {
     bankBalance: toNum(bankRes.rows[0]?.total as NumericLike),
+    semanticSourceMap: DASHBOARD_SEMANTIC_SOURCE_MAP,
     bills: {
       overdueCount: toInt(bills.overdue_count),
       overdueTotal: toNum(bills.overdue_total),

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -16,7 +16,8 @@
     "baseUrl": "."
   },
   "include": [
-    "src/domain/contracts/**/*.ts"
+    "src/domain/contracts/**/*.ts",
+    "src/services/dashboard.service.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Adds dashboard.service.ts to apps/api/tsconfig.json include. Fixes real contract drift: semanticSourceMap was required by DashboardSnapshotBase but missing from baseSnapshot object. Field was already imported and used elsewhere in the service.