### PR TITLE
chore(api): add forecast service to backend typecheck coverage

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -18,7 +18,8 @@
   "include": [
     "src/domain/contracts/**/*.ts",
     "src/services/dashboard.service.ts",
-    "src/services/transactions-import.service.ts"
+    "src/services/transactions-import.service.ts",
+    "src/services/forecast.service.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Adds forecast.service.ts to apps/api/tsconfig.json. No type errors found — file was already clean. Completes backend typecheck coverage for all runtime TypeScript services.