### PR TITLE
feat(observability): export import domain metrics to Prometheus

### DIFF
--- a/apps/api/src/document-financial-observability.test.js
+++ b/apps/api/src/document-financial-observability.test.js
@@ -8,6 +8,7 @@ import {
   resetWriteRateLimiterState,
 } from "./middlewares/rate-limit.middleware.js";
 import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
+import { resetImportObservabilityForTests } from "./observability/import-observability.js";
 import { csvFile, makeProUser, registerAndLogin, setupTestDb } from "./test-helpers.js";
 
 const getObservabilityCounterValue = (metricsText, { source, signal, reasonClass }) => {
@@ -15,6 +16,22 @@ const getObservabilityCounterValue = (metricsText, { source, signal, reasonClass
     `document_financial_observability_events_total\\{[^}]*source="${source}"[^}]*signal="${signal}"[^}]*reason_class="${reasonClass}"[^}]*\\}\\s+([0-9.]+)`,
   );
 
+  const match = metricsText.match(expression);
+
+  if (!match) {
+    return 0;
+  }
+
+  return Number(match[1] || 0);
+};
+
+const getImportMetricValue = (metricsText, metricName, labels = {}) => {
+  const labelSegments = Object.entries(labels).map(
+    ([labelName, labelValue]) => `(?=[^}]*${labelName}="${labelValue}")`,
+  );
+  const labelsPattern =
+    labelSegments.length > 0 ? `\\{${labelSegments.join("")}[^}]*\\}` : "";
+  const expression = new RegExp(`${metricName}${labelsPattern}\\s+([0-9.]+)`);
   const match = metricsText.match(expression);
 
   if (!match) {
@@ -38,6 +55,7 @@ describe("document financial observability", () => {
     resetImportRateLimiterState();
     resetWriteRateLimiterState();
     resetHttpMetricsForTests();
+    resetImportObservabilityForTests();
     await dbQuery("DELETE FROM transactions");
     await dbQuery("DELETE FROM transaction_import_sessions");
     await dbQuery("DELETE FROM subscriptions");
@@ -111,5 +129,14 @@ describe("document financial observability", () => {
         reasonClass: "none",
       }),
     ).toBeGreaterThanOrEqual(1);
+    expect(metricsResponse.text).toContain("# HELP import_dry_run_total");
+    expect(metricsResponse.text).toContain("# HELP import_commit_total");
+    expect(getImportMetricValue(metricsResponse.text, "import_dry_run_total")).toBe(1);
+    expect(getImportMetricValue(metricsResponse.text, "import_commit_total")).toBe(1);
+    expect(getImportMetricValue(metricsResponse.text, "import_commit_success_total")).toBe(1);
+    expect(getImportMetricValue(metricsResponse.text, "import_rows_total", { operation: "dry_run" })).toBe(1);
+    expect(getImportMetricValue(metricsResponse.text, "import_rows_total", { operation: "commit" })).toBe(1);
+    expect(getImportMetricValue(metricsResponse.text, "import_rows_samples_total", { operation: "dry_run" })).toBe(1);
+    expect(getImportMetricValue(metricsResponse.text, "import_rows_samples_total", { operation: "commit" })).toBe(1);
   });
 });

--- a/apps/api/src/import-utility-dry-run.test.js
+++ b/apps/api/src/import-utility-dry-run.test.js
@@ -47,6 +47,22 @@ import {
   setupTestDb,
 } from "./test-helpers.js";
 
+const getImportMetricValue = (metricsText, metricName, labels = {}) => {
+  const labelSegments = Object.entries(labels).map(
+    ([labelName, labelValue]) => `(?=[^}]*${labelName}="${labelValue}")`,
+  );
+  const labelsPattern =
+    labelSegments.length > 0 ? `\\{${labelSegments.join("")}[^}]*\\}` : "";
+  const expression = new RegExp(`${metricName}${labelsPattern}\\s+([0-9.]+)`);
+  const match = metricsText.match(expression);
+
+  if (!match) {
+    return 0;
+  }
+
+  return Number(match[1] || 0);
+};
+
 describe("transaction imports utility bills dry-run", () => {
   beforeAll(async () => {
     await setupTestDb();
@@ -94,8 +110,10 @@ describe("transaction imports utility bills dry-run", () => {
         filename: "telecom.pdf",
         contentType: "application/pdf",
       });
+    const metricsResponse = await request(app).get("/metrics");
 
     expect(response.status).toBe(200);
+    expect(metricsResponse.status).toBe(200);
     expect(response.body.documentType).toBe("utility_bill_telecom");
     expect(response.body.utilityBillImportDecision).toEqual({
       scope: "generic_boleto",
@@ -131,6 +149,9 @@ describe("transaction imports utility bills dry-run", () => {
     expect(metrics.import_dry_run_semantic_drift_total).toBe(0);
     expect(metrics.import_dry_run_utility_gate_blocked_total).toBe(1);
     expect(metrics.import_dry_run_utility_gate_supported_total).toBe(0);
+    expect(getImportMetricValue(metricsResponse.text, "import_dry_run_total")).toBe(1);
+    expect(getImportMetricValue(metricsResponse.text, "import_dry_run_utility_gate_blocked_total")).toBe(1);
+    expect(getImportMetricValue(metricsResponse.text, "import_rows_samples_total", { operation: "dry_run" })).toBe(1);
   });
 
   it("POST /transactions/import/dry-run retorna documentType e suggestion para utility_bill_gas", async () => {
@@ -216,8 +237,10 @@ describe("transaction imports utility bills dry-run", () => {
         filename: "gas-drift.pdf",
         contentType: "application/pdf",
       });
+    const metricsResponse = await request(app).get("/metrics");
 
     expect(response.status).toBe(200);
+    expect(metricsResponse.status).toBe(200);
     expect(response.body.documentType).toBe("utility_bill_gas");
     expect(response.body.utilityBillImportDecision).toEqual({
       scope: "generic_boleto",
@@ -233,6 +256,7 @@ describe("transaction imports utility bills dry-run", () => {
     expect(metrics.import_dry_run_semantic_drift_total).toBe(1);
     expect(metrics.import_dry_run_utility_gate_blocked_total).toBe(1);
     expect(metrics.import_dry_run_utility_gate_supported_total).toBe(0);
+    expect(getImportMetricValue(metricsResponse.text, "import_dry_run_semantic_drift_total")).toBe(1);
   });
 
   it("POST /transactions/import/dry-run explica quando o PDF e historico de emprestimo consignado do INSS", async () => {

--- a/apps/api/src/import.test.js
+++ b/apps/api/src/import.test.js
@@ -10,6 +10,7 @@ import {
   resetWriteRateLimiterState,
 } from "./middlewares/rate-limit.middleware.js";
 import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
+import { resetImportObservabilityForTests } from "./observability/import-observability.js";
 import {
   csvFile,
   expectErrorResponseWithRequestId,
@@ -18,6 +19,17 @@ import {
   registerAndLogin,
   setupTestDb,
 } from "./test-helpers.js";
+
+const getImportMetricValue = (metricsText, metricName) => {
+  const expression = new RegExp(`${metricName}\\s+([0-9.]+)`);
+  const match = metricsText.match(expression);
+
+  if (!match) {
+    return 0;
+  }
+
+  return Number(match[1] || 0);
+};
 
 describe("transaction imports", () => {
   beforeAll(async () => {
@@ -33,6 +45,7 @@ describe("transaction imports", () => {
     resetImportRateLimiterState();
     resetWriteRateLimiterState();
     resetHttpMetricsForTests();
+    resetImportObservabilityForTests();
     await dbQuery("DELETE FROM transactions");
     await dbQuery("DELETE FROM subscriptions");
     await dbQuery("DELETE FROM users");
@@ -1029,8 +1042,12 @@ describe("transaction imports", () => {
       .post("/transactions/import/commit")
       .set("Authorization", `Bearer ${token}`)
       .send({});
+    const metricsResponse = await request(app).get("/metrics");
 
     expectErrorResponseWithRequestId(response, 400, "importId e obrigatorio.");
+    expect(metricsResponse.status).toBe(200);
+    expect(getImportMetricValue(metricsResponse.text, "import_commit_total")).toBe(1);
+    expect(getImportMetricValue(metricsResponse.text, "import_commit_fail_total")).toBe(1);
   });
 
   it("POST /transactions/import/commit retorna 400 com importId invalido", async () => {

--- a/apps/api/src/observability/import-observability.js
+++ b/apps/api/src/observability/import-observability.js
@@ -1,3 +1,5 @@
+import { Counter } from "prom-client";
+import { metricsRegistry } from "./http-metrics.js";
 import { logError, logInfo } from "./logger.js";
 
 const METRIC_NAMES = {
@@ -24,6 +26,74 @@ const importMetricsState = {
   [METRIC_NAMES.rowsSamples]: 0,
 };
 
+const importDryRunTotalCounter = new Counter({
+  name: "import_dry_run_total",
+  help: "Total de dry-runs de importacao executados.",
+  registers: [metricsRegistry],
+});
+
+const importDryRunSemanticDriftTotalCounter = new Counter({
+  name: "import_dry_run_semantic_drift_total",
+  help: "Total de dry-runs com drift semantico detectado na importacao.",
+  registers: [metricsRegistry],
+});
+
+const importDryRunUtilityGateBlockedTotalCounter = new Counter({
+  name: "import_dry_run_utility_gate_blocked_total",
+  help: "Total de dry-runs bloqueados pelo gate de contas utilitarias.",
+  registers: [metricsRegistry],
+});
+
+const importDryRunUtilityGateSupportedTotalCounter = new Counter({
+  name: "import_dry_run_utility_gate_supported_total",
+  help: "Total de dry-runs suportados pelo gate de contas utilitarias.",
+  registers: [metricsRegistry],
+});
+
+const importCommitTotalCounter = new Counter({
+  name: "import_commit_total",
+  help: "Total de tentativas de commit de importacao.",
+  registers: [metricsRegistry],
+});
+
+const importCommitSuccessTotalCounter = new Counter({
+  name: "import_commit_success_total",
+  help: "Total de commits de importacao concluidos com sucesso.",
+  registers: [metricsRegistry],
+});
+
+const importCommitFailTotalCounter = new Counter({
+  name: "import_commit_fail_total",
+  help: "Total de commits de importacao que falharam.",
+  registers: [metricsRegistry],
+});
+
+const importRowsTotalCounter = new Counter({
+  name: "import_rows_total",
+  help: "Total de linhas observadas nos fluxos de importacao por operacao.",
+  labelNames: ["operation"],
+  registers: [metricsRegistry],
+});
+
+const importRowsSamplesTotalCounter = new Counter({
+  name: "import_rows_samples_total",
+  help: "Total de amostras de linhas observadas nos fluxos de importacao por operacao.",
+  labelNames: ["operation"],
+  registers: [metricsRegistry],
+});
+
+const prometheusImportMetrics = [
+  importDryRunTotalCounter,
+  importDryRunSemanticDriftTotalCounter,
+  importDryRunUtilityGateBlockedTotalCounter,
+  importDryRunUtilityGateSupportedTotalCounter,
+  importCommitTotalCounter,
+  importCommitSuccessTotalCounter,
+  importCommitFailTotalCounter,
+  importRowsTotalCounter,
+  importRowsSamplesTotalCounter,
+];
+
 const toNonNegativeInteger = (value, fallbackValue = 0) => {
   const parsedValue = Number(value);
 
@@ -38,11 +108,14 @@ const incrementMetric = (metricName, incrementValue = 1) => {
   importMetricsState[metricName] += toNonNegativeInteger(incrementValue, 0);
 };
 
-const observeRows = (rowsCount) => {
+const observeRows = (rowsCount, operation) => {
   const normalizedRowsCount = toNonNegativeInteger(rowsCount, 0);
+  const normalizedOperation = String(operation || "unknown").trim().toLowerCase() || "unknown";
 
   incrementMetric(METRIC_NAMES.rowsTotal, normalizedRowsCount);
   incrementMetric(METRIC_NAMES.rowsSamples, 1);
+  importRowsTotalCounter.inc({ operation: normalizedOperation }, normalizedRowsCount);
+  importRowsSamplesTotalCounter.inc({ operation: normalizedOperation }, 1);
 };
 
 const shouldEmitImportLogs = () => {
@@ -85,7 +158,8 @@ export const createElapsedTimer = () => {
 
 export const trackDryRunMetrics = ({ rowsTotal = 0 } = {}) => {
   incrementMetric(METRIC_NAMES.dryRunTotal);
-  observeRows(rowsTotal);
+  importDryRunTotalCounter.inc();
+  observeRows(rowsTotal, "dry_run");
 };
 
 export const trackDryRunSemanticDriftMetrics = ({ driftDetected = false } = {}) => {
@@ -94,30 +168,36 @@ export const trackDryRunSemanticDriftMetrics = ({ driftDetected = false } = {}) 
   }
 
   incrementMetric(METRIC_NAMES.dryRunSemanticDriftTotal);
+  importDryRunSemanticDriftTotalCounter.inc();
 };
 
 export const trackDryRunUtilityGateDecisionMetrics = ({ decision = null } = {}) => {
   if (decision === "blocked") {
     incrementMetric(METRIC_NAMES.dryRunUtilityGateBlockedTotal);
+    importDryRunUtilityGateBlockedTotalCounter.inc();
     return;
   }
 
   if (decision === "supported") {
     incrementMetric(METRIC_NAMES.dryRunUtilityGateSupportedTotal);
+    importDryRunUtilityGateSupportedTotalCounter.inc();
   }
 };
 
 export const trackCommitAttemptMetrics = () => {
   incrementMetric(METRIC_NAMES.commitTotal);
+  importCommitTotalCounter.inc();
 };
 
 export const trackCommitSuccessMetrics = ({ rowsImported = 0 } = {}) => {
   incrementMetric(METRIC_NAMES.commitSuccessTotal);
-  observeRows(rowsImported);
+  importCommitSuccessTotalCounter.inc();
+  observeRows(rowsImported, "commit");
 };
 
 export const trackCommitFailMetrics = () => {
   incrementMetric(METRIC_NAMES.commitFailTotal);
+  importCommitFailTotalCounter.inc();
 };
 
 export const logImportEvent = (eventName, payload = {}) => {
@@ -144,5 +224,9 @@ export const logImportEvent = (eventName, payload = {}) => {
 export const resetImportObservabilityForTests = () => {
   Object.keys(importMetricsState).forEach((metricName) => {
     importMetricsState[metricName] = 0;
+  });
+
+  prometheusImportMetrics.forEach((metric) => {
+    metric.reset();
   });
 };


### PR DESCRIPTION
Registers import counters (dry-run, commit, utility gate, semantic drift, rows) in the shared Prometheus registry. Preserves existing in-memory snapshot for backward compatibility. Adds /metrics proof in 3 test files.