### PR TITLE
fix(dashboard): remove double-counting of credit_card_invoice in pendingObligationsTotal

### DIFF
--- a/apps/api/src/dashboard.test.js
+++ b/apps/api/src/dashboard.test.js
@@ -622,6 +622,33 @@ describe("dashboard snapshot", () => {
     expect(parsed.success).toBe(true);
   });
 
+  it("nao duplica credit_card_invoice no adjustedProjectedBalance do semanticCore", async () => {
+    const email = "dash-no-double-count-invoice@test.dev";
+    const token = await registerAndLogin(email);
+
+    await createBankAccount(token, { balance: 1234.56 });
+    await createBill(token, { dueDate: isoDate(-2), amount: 400.15 });
+    await createBill(token, { dueDate: isoDate(4), amount: 99.85 });
+
+    const cardRes = await createCreditCard(token, { name: "Nubank" });
+    const cardId = cardRes.body.id;
+    await createPurchase(token, cardId, { amount: 310.4 });
+
+    const userId = await getUserIdByEmail(email);
+    await dbQuery(
+      `INSERT INTO bills (user_id, title, amount, due_date, bill_type, credit_card_id)
+       VALUES ($1, 'Fatura Nubank', 789.9, $2, 'credit_card_invoice', $3)`,
+      [userId, isoDate(6), cardId],
+    );
+
+    const res = await getSnapshot(token);
+
+    expect(res.status).toBe(200);
+    expect(res.body.cards.pendingInvoicesTotal).toBe(789.9);
+    expect(res.body.semanticCore.projection.projectedBalance).toBe(1234.56);
+    expect(res.body.semanticCore.projection.adjustedProjectedBalance).toBe(-365.74);
+  });
+
   // ─── Truth table regression ─────────────────────────────────────────────
 
   it.each([

--- a/apps/api/src/services/dashboard.service.ts
+++ b/apps/api/src/services/dashboard.service.ts
@@ -135,8 +135,7 @@ const buildDashboardSemanticCore = (
     snapshot.bills.overdueTotal +
     snapshot.bills.dueSoonTotal +
     snapshot.bills.upcomingTotal +
-    snapshot.cards.openPurchasesTotal +
-    snapshot.cards.pendingInvoicesTotal;
+    snapshot.cards.openPurchasesTotal;
   const expectedInflow =
     snapshot.income.pendingThisMonth > 0 ? snapshot.income.pendingThisMonth : null;
   const adjustedProjectedBalance = Number(


### PR DESCRIPTION
## O que muda
Remove `snapshot.cards.pendingInvoicesTotal` da soma de
`pendingObligationsTotal` em `buildDashboardSemanticCore()`.

## Por que
A query principal de bills (`dashboard.service.ts:200`) já retorna
todas as rows com `status = 'pending'`, incluindo `bill_type =
'credit_card_invoice'`. O campo `pendingInvoicesTotal` é uma subset
query do mesmo universo. Somar os dois é double-counting.

## Impacto
Usuários com faturas de cartão pendentes viam `adjustedProjectedBalance`
mais negativo que a realidade.

## Teste de regressão
`dashboard.test.js`: "nao duplica credit_card_invoice no
adjustedProjectedBalance do semanticCore"

## Checklist
- [x] fix em uma linha, sem migração
- [x] teste de regressão adicionado
- [x] typecheck passando
- [x] 23 testes passando no dashboard.test.js
