### PR TITLE
feat(auth): add mobile bearer-token auth endpoints

### DIFF
--- a/apps/api/src/auth.mobile.test.js
+++ b/apps/api/src/auth.mobile.test.js
@@ -1,0 +1,159 @@
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import app from "./app.js";
+import { clearDbClientForTests, dbQuery } from "./db/index.js";
+import {
+  resetLoginProtectionState,
+} from "./middlewares/login-protection.middleware.js";
+import {
+  resetImportRateLimiterState,
+  resetWriteRateLimiterState,
+} from "./middlewares/rate-limit.middleware.js";
+import { resetHttpMetricsForTests } from "./observability/http-metrics.js";
+import { expectErrorResponseWithRequestId, setupTestDb } from "./test-helpers.js";
+
+const expectNoAuthCookies = (response) => {
+  const cookies = response.headers["set-cookie"] || [];
+  expect(cookies.some((cookie) => cookie.startsWith("cf_access="))).toBe(false);
+  expect(cookies.some((cookie) => cookie.startsWith("cf_refresh="))).toBe(false);
+};
+
+describe("auth mobile", () => {
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  afterAll(async () => {
+    await clearDbClientForTests();
+  });
+
+  beforeEach(async () => {
+    resetLoginProtectionState();
+    resetImportRateLimiterState();
+    resetWriteRateLimiterState();
+    resetHttpMetricsForTests();
+    await dbQuery("DELETE FROM refresh_tokens");
+    await dbQuery("DELETE FROM transactions");
+    await dbQuery("DELETE FROM users");
+  });
+
+  it("POST /auth/mobile/login retorna tokens no body sem setar cookies", async () => {
+    await request(app).post("/auth/register").send({
+      email: "mobile-login@controlfinance.dev",
+      password: "Senha123",
+    });
+
+    const response = await request(app).post("/auth/mobile/login").send({
+      email: "mobile-login@controlfinance.dev",
+      password: "Senha123",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.user).toMatchObject({
+      email: "mobile-login@controlfinance.dev",
+    });
+    expect(response.body.accessToken).toEqual(expect.any(String));
+    expect(response.body.refreshToken).toEqual(expect.any(String));
+    expect(response.body.tokenType).toBe("Bearer");
+    expect(response.body.accessToken.length).toBeGreaterThan(10);
+    expect(response.body.refreshToken.length).toBeGreaterThan(10);
+    expectNoAuthCookies(response);
+  });
+
+  it("POST /auth/mobile/login reutiliza a validacao de credenciais", async () => {
+    const response = await request(app).post("/auth/mobile/login").send({
+      email: "",
+      password: "Senha123",
+    });
+
+    expectErrorResponseWithRequestId(response, 400, "Email e senha sao obrigatorios.");
+  });
+
+  it("POST /auth/mobile/refresh rotaciona refresh token sem setar cookies", async () => {
+    await request(app).post("/auth/register").send({
+      email: "mobile-refresh@controlfinance.dev",
+      password: "Senha123",
+    });
+
+    const loginResponse = await request(app).post("/auth/mobile/login").send({
+      email: "mobile-refresh@controlfinance.dev",
+      password: "Senha123",
+    });
+
+    const refreshResponse = await request(app).post("/auth/mobile/refresh").send({
+      refreshToken: loginResponse.body.refreshToken,
+    });
+
+    expect(refreshResponse.status).toBe(200);
+    expect(refreshResponse.body.user.email).toBe("mobile-refresh@controlfinance.dev");
+    expect(refreshResponse.body.accessToken).toEqual(expect.any(String));
+    expect(refreshResponse.body.refreshToken).toEqual(expect.any(String));
+    expect(refreshResponse.body.tokenType).toBe("Bearer");
+    expect(refreshResponse.body.refreshToken).not.toBe(loginResponse.body.refreshToken);
+    expectNoAuthCookies(refreshResponse);
+  });
+
+  it("POST /auth/mobile/refresh retorna 401 sem refresh token", async () => {
+    const response = await request(app).post("/auth/mobile/refresh").send({});
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe("Sessao expirada.");
+  });
+
+  it("POST /auth/mobile/refresh invalida toda a familia ao reusar token revogado", async () => {
+    await request(app).post("/auth/register").send({
+      email: "mobile-reuse@controlfinance.dev",
+      password: "Senha123",
+    });
+
+    const loginResponse = await request(app).post("/auth/mobile/login").send({
+      email: "mobile-reuse@controlfinance.dev",
+      password: "Senha123",
+    });
+
+    const originalRefreshToken = loginResponse.body.refreshToken;
+
+    const firstRotation = await request(app).post("/auth/mobile/refresh").send({
+      refreshToken: originalRefreshToken,
+    });
+    expect(firstRotation.status).toBe(200);
+
+    const rotatedRefreshToken = firstRotation.body.refreshToken;
+
+    const reuseAttempt = await request(app).post("/auth/mobile/refresh").send({
+      refreshToken: originalRefreshToken,
+    });
+    expect(reuseAttempt.status).toBe(401);
+
+    const familyTokenAttempt = await request(app).post("/auth/mobile/refresh").send({
+      refreshToken: rotatedRefreshToken,
+    });
+    expect(familyTokenAttempt.status).toBe(401);
+  });
+
+  it("POST /auth/mobile/logout revoga refresh token e retorna 204", async () => {
+    await request(app).post("/auth/register").send({
+      email: "mobile-logout@controlfinance.dev",
+      password: "Senha123",
+    });
+
+    const loginResponse = await request(app).post("/auth/mobile/login").send({
+      email: "mobile-logout@controlfinance.dev",
+      password: "Senha123",
+    });
+
+    const logoutResponse = await request(app).post("/auth/mobile/logout").send({
+      refreshToken: loginResponse.body.refreshToken,
+    });
+    expect(logoutResponse.status).toBe(204);
+
+    const refreshAfterLogout = await request(app).post("/auth/mobile/refresh").send({
+      refreshToken: loginResponse.body.refreshToken,
+    });
+    expect(refreshAfterLogout.status).toBe(401);
+  });
+
+  it("POST /auth/mobile/logout retorna 204 mesmo sem refresh token", async () => {
+    const response = await request(app).post("/auth/mobile/logout").send({});
+    expect(response.status).toBe(204);
+  });
+});

--- a/apps/api/src/routes/auth.routes.js
+++ b/apps/api/src/routes/auth.routes.js
@@ -70,15 +70,30 @@ const clearAuthCookies = (res) => {
   res.cookie("cf_refresh", "", { ...buildCookieOptions("/auth"), maxAge: 0 });
 };
 
-const issueSessionCookies = async (res, user, req) => {
+const issueSessionTokens = async (user, req) => {
   const familyId = randomUUID();
   const accessToken = issueAuthToken(user);
   const rawRefreshToken = await issueRefreshToken(user.id, familyId, {
     ipAddress: req.ip,
     userAgent: req.headers["user-agent"],
   });
+  return { accessToken, rawRefreshToken };
+};
+
+const issueSessionCookies = async (res, user, req) => {
+  const { accessToken, rawRefreshToken } = await issueSessionTokens(user, req);
   setAuthCookies(res, accessToken, rawRefreshToken);
 };
+
+const buildMobileAuthPayload = ({ user, accessToken, rawRefreshToken }) => ({
+  user,
+  accessToken,
+  refreshToken: rawRefreshToken,
+  tokenType: "Bearer",
+});
+
+const resolveMobileRefreshToken = (body) =>
+  typeof body?.refreshToken === "string" ? body.refreshToken.trim() : "";
 
 // ─── Routes ───────────────────────────────────────────────────────────────────
 
@@ -102,6 +117,22 @@ router.post("/login", loginRateLimiter, bruteForceLoginGuard, async (req, res, n
     clearLoginFailures(req);
     await issueSessionCookies(res, user, req);
     res.status(200).json({ user });
+  } catch (error) {
+    if (error.status === 401) {
+      registerLoginFailure(req);
+    }
+    next(error);
+  }
+});
+
+router.post("/mobile/login", loginRateLimiter, bruteForceLoginGuard, async (req, res, next) => {
+  req.feature = "auth";
+  req.operation = "mobile_email_password_login";
+  try {
+    const { user } = await loginUser(req.body || {});
+    clearLoginFailures(req);
+    const session = await issueSessionTokens(user, req);
+    res.status(200).json(buildMobileAuthPayload({ user, ...session }));
   } catch (error) {
     if (error.status === 401) {
       registerLoginFailure(req);
@@ -147,6 +178,29 @@ router.post("/refresh", async (req, res, next) => {
   }
 });
 
+router.post("/mobile/refresh", async (req, res, next) => {
+  req.feature = "auth";
+  req.operation = "mobile_refresh_token_rotate";
+  const rawToken = resolveMobileRefreshToken(req.body);
+
+  if (!rawToken) {
+    return res.status(401).json({ message: "Sessao expirada." });
+  }
+
+  try {
+    const { user, rawRefreshToken } = await rotateRefreshToken(rawToken, {
+      ipAddress: req.ip,
+      userAgent: req.headers["user-agent"],
+    });
+    const accessToken = issueAuthToken(user);
+    return res
+      .status(200)
+      .json(buildMobileAuthPayload({ user, accessToken, rawRefreshToken }));
+  } catch (error) {
+    next(error);
+  }
+});
+
 router.delete("/logout", async (req, res) => {
   req.feature = "auth";
   req.operation = "logout";
@@ -161,6 +215,22 @@ router.delete("/logout", async (req, res) => {
   }
 
   clearAuthCookies(res);
+  return res.status(204).send();
+});
+
+router.post("/mobile/logout", async (req, res) => {
+  req.feature = "auth";
+  req.operation = "mobile_logout";
+  const rawToken = resolveMobileRefreshToken(req.body);
+
+  if (rawToken) {
+    try {
+      await revokeRefreshToken(rawToken);
+    } catch {
+      // Best-effort revocation — logout stays idempotent for mobile clients too
+    }
+  }
+
   return res.status(204).send();
 });
 


### PR DESCRIPTION
Adds POST /auth/mobile/login, /mobile/refresh, /mobile/logout returning tokens in body. Web cookie flow unchanged. Reuses existing refresh token rotation, family invalidation, rate limiting and brute force protection. 7 tests covering login, refresh rotation, reuse detection and logout.