### PR TITLE
feat(mobile): add auth session layer with SecureStore, AuthContext and LoginScreen

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,8 +1,10 @@
 import { StatusBar } from "expo-status-bar";
 import { SafeAreaView, ScrollView, StyleSheet, Text, View } from "react-native";
+import { AuthProvider } from "./src/context/AuthContext";
 
 export default function App() {
   return (
+    <AuthProvider>
     <SafeAreaView style={styles.safeArea}>
       <StatusBar style="dark" />
       <ScrollView contentContainerStyle={styles.content}>
@@ -36,6 +38,7 @@ export default function App() {
         </View>
       </ScrollView>
     </SafeAreaView>
+    </AuthProvider>
   );
 }
 

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,103 +1,54 @@
 import { StatusBar } from "expo-status-bar";
-import { SafeAreaView, ScrollView, StyleSheet, Text, View } from "react-native";
-import { AuthProvider } from "./src/context/AuthContext";
+import { ActivityIndicator, SafeAreaView, StyleSheet, Text, View } from "react-native";
+import { AuthProvider, useAuth } from "./src/context/AuthContext";
+import LoginScreen from "./src/screens/LoginScreen";
+
+function RootNavigator() {
+  const { isInitializing, isAuthenticated } = useAuth();
+
+  if (isInitializing) {
+    return (
+      <View style={styles.splash}>
+        <ActivityIndicator size="large" color="#6741d9" />
+      </View>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <LoginScreen />;
+  }
+
+  return (
+    <SafeAreaView style={styles.dashboard}>
+      <StatusBar style="light" />
+      <Text style={styles.dashboardText}>Dashboard — em breve</Text>
+    </SafeAreaView>
+  );
+}
 
 export default function App() {
   return (
     <AuthProvider>
-    <SafeAreaView style={styles.safeArea}>
-      <StatusBar style="dark" />
-      <ScrollView contentContainerStyle={styles.content}>
-        <View style={styles.hero}>
-          <Text style={styles.eyebrow}>Control Finance Mobile</Text>
-          <Text style={styles.title}>MVP mobile do monorepo pronto para evoluir.</Text>
-          <Text style={styles.subtitle}>
-            A base inicial esta preparada para iOS e Android com Expo managed, EAS e espaco
-            reservado para a sessao mobile via bearer token.
-          </Text>
-        </View>
-
-        <View style={styles.card}>
-          <Text style={styles.cardTitle}>Escopo do primeiro corte</Text>
-          <Text style={styles.cardText}>Login, dashboard, transacoes, cartoes, contas e perfil.</Text>
-        </View>
-
-        <View style={styles.card}>
-          <Text style={styles.cardTitle}>Monorepo preservado</Text>
-          <Text style={styles.cardText}>
-            `apps/mobile` entra ao lado de `apps/web` e `apps/api`, sem quebrar a estrutura atual.
-          </Text>
-        </View>
-
-        <View style={styles.card}>
-          <Text style={styles.cardTitle}>Proximo passo tecnico</Text>
-          <Text style={styles.cardText}>
-            Adicionar endpoints de auth mobile que retornem tokens no body e guardar o refresh com
-            armazenamento seguro no dispositivo.
-          </Text>
-        </View>
-      </ScrollView>
-    </SafeAreaView>
+      <RootNavigator />
     </AuthProvider>
   );
 }
 
 const styles = StyleSheet.create({
-  safeArea: {
+  splash: {
     flex: 1,
-    backgroundColor: "#f5efe3",
+    backgroundColor: "#0f172a",
+    alignItems: "center",
+    justifyContent: "center",
   },
-  content: {
-    gap: 16,
-    paddingHorizontal: 20,
-    paddingVertical: 24,
+  dashboard: {
+    flex: 1,
+    backgroundColor: "#0f172a",
+    alignItems: "center",
+    justifyContent: "center",
   },
-  hero: {
-    backgroundColor: "#102820",
-    borderRadius: 28,
-    gap: 12,
-    paddingHorizontal: 20,
-    paddingVertical: 24,
-    shadowColor: "#102820",
-    shadowOffset: { width: 0, height: 10 },
-    shadowOpacity: 0.12,
-    shadowRadius: 24,
-  },
-  eyebrow: {
-    color: "#d7c18a",
-    fontSize: 13,
-    fontWeight: "700",
-    letterSpacing: 1.1,
-    textTransform: "uppercase",
-  },
-  title: {
-    color: "#f8f4ea",
-    fontSize: 30,
-    fontWeight: "800",
-    lineHeight: 36,
-  },
-  subtitle: {
-    color: "#dfe7df",
+  dashboardText: {
+    color: "#94a3b8",
     fontSize: 16,
-    lineHeight: 24,
-  },
-  card: {
-    backgroundColor: "#fffaf0",
-    borderColor: "#e1d6bf",
-    borderRadius: 22,
-    borderWidth: 1,
-    gap: 8,
-    paddingHorizontal: 18,
-    paddingVertical: 18,
-  },
-  cardTitle: {
-    color: "#1f2a24",
-    fontSize: 18,
-    fontWeight: "700",
-  },
-  cardText: {
-    color: "#4b5a51",
-    fontSize: 15,
-    lineHeight: 22,
   },
 });

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -11,7 +11,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "axios": "^1.15.1",
     "expo": "~54.0.33",
+    "expo-secure-store": "^55.0.13",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
     "react-native": "0.81.5"

--- a/apps/mobile/src/context/AuthContext.tsx
+++ b/apps/mobile/src/context/AuthContext.tsx
@@ -1,0 +1,65 @@
+import React, { createContext, useContext, useEffect, useRef, useState } from "react";
+import * as authService from "../services/auth.service";
+import type { AuthUser, LoginPayload } from "../services/auth.service";
+
+interface AuthContextValue {
+  user: AuthUser | null;
+  isAuthenticated: boolean;
+  isInitializing: boolean;
+  login: (payload: LoginPayload) => Promise<void>;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [isInitializing, setIsInitializing] = useState(true);
+  const bootstrapped = useRef(false);
+
+  useEffect(() => {
+    if (bootstrapped.current) return;
+    bootstrapped.current = true;
+
+    authService.refresh()
+      .then((tokens) => {
+        if (tokens) setUser(tokens.user);
+      })
+      .catch(() => {
+        // no valid session — stay logged out
+      })
+      .finally(() => {
+        setIsInitializing(false);
+      });
+  }, []);
+
+  async function login(payload: LoginPayload) {
+    const tokens = await authService.login(payload);
+    setUser(tokens.user);
+  }
+
+  async function logout() {
+    await authService.logout();
+    setUser(null);
+  }
+
+  return (
+    <AuthContext.Provider
+      value={{
+        user,
+        isAuthenticated: !isInitializing && user !== null,
+        isInitializing,
+        login,
+        logout,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
+  return ctx;
+}

--- a/apps/mobile/src/screens/LoginScreen.tsx
+++ b/apps/mobile/src/screens/LoginScreen.tsx
@@ -1,0 +1,136 @@
+import React, { useState } from "react";
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { useAuth } from "../context/AuthContext";
+
+export default function LoginScreen() {
+  const { login } = useAuth();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleLogin() {
+    if (!email.trim() || !password) return;
+    setError(null);
+    setIsLoading(true);
+    try {
+      await login({ email: email.trim(), password });
+    } catch {
+      setError("E-mail ou senha inválidos.");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+    >
+      <View style={styles.card}>
+        <Text style={styles.title}>Control Finance</Text>
+        <Text style={styles.subtitle}>Entre na sua conta</Text>
+
+        <TextInput
+          style={styles.input}
+          placeholder="E-mail"
+          placeholderTextColor="#8a9a91"
+          value={email}
+          onChangeText={setEmail}
+          autoCapitalize="none"
+          keyboardType="email-address"
+          autoComplete="email"
+          editable={!isLoading}
+        />
+
+        <TextInput
+          style={styles.input}
+          placeholder="Senha"
+          placeholderTextColor="#8a9a91"
+          value={password}
+          onChangeText={setPassword}
+          secureTextEntry
+          autoComplete="password"
+          editable={!isLoading}
+        />
+
+        {error ? <Text style={styles.error}>{error}</Text> : null}
+
+        <Pressable
+          style={[styles.button, isLoading && styles.buttonDisabled]}
+          onPress={handleLogin}
+          disabled={isLoading}
+        >
+          {isLoading ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <Text style={styles.buttonText}>Entrar</Text>
+          )}
+        </Pressable>
+      </View>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#0f172a",
+    justifyContent: "center",
+    paddingHorizontal: 24,
+  },
+  card: {
+    backgroundColor: "#1e293b",
+    borderRadius: 20,
+    padding: 28,
+    gap: 16,
+  },
+  title: {
+    color: "#f1f5f9",
+    fontSize: 26,
+    fontWeight: "800",
+  },
+  subtitle: {
+    color: "#94a3b8",
+    fontSize: 15,
+    marginBottom: 4,
+  },
+  input: {
+    backgroundColor: "#0f172a",
+    borderColor: "#334155",
+    borderRadius: 12,
+    borderWidth: 1,
+    color: "#f1f5f9",
+    fontSize: 15,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+  },
+  error: {
+    color: "#f87171",
+    fontSize: 14,
+  },
+  button: {
+    alignItems: "center",
+    backgroundColor: "#6741d9",
+    borderRadius: 12,
+    paddingVertical: 15,
+    marginTop: 4,
+  },
+  buttonDisabled: {
+    opacity: 0.6,
+  },
+  buttonText: {
+    color: "#fff",
+    fontSize: 16,
+    fontWeight: "700",
+  },
+});

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -1,0 +1,86 @@
+import axios from "axios";
+import * as SecureStore from "expo-secure-store";
+
+const REFRESH_TOKEN_KEY = "cf_refresh_token";
+const BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? "http://10.0.2.2:3001";
+
+export const apiClient = axios.create({
+  baseURL: BASE_URL,
+  headers: { "Content-Type": "application/json" },
+  timeout: 15000,
+});
+
+export const getStoredRefreshToken = () => SecureStore.getItemAsync(REFRESH_TOKEN_KEY);
+export const setStoredRefreshToken = (token: string) => SecureStore.setItemAsync(REFRESH_TOKEN_KEY, token);
+export const deleteStoredRefreshToken = () => SecureStore.deleteItemAsync(REFRESH_TOKEN_KEY);
+
+let accessToken: string | null = null;
+export const setAccessToken = (token: string | null) => { accessToken = token; };
+export const getAccessToken = () => accessToken;
+
+apiClient.interceptors.request.use((config) => {
+  if (accessToken) {
+    config.headers.Authorization = `Bearer ${accessToken}`;
+  }
+  return config;
+});
+
+let isRefreshing = false;
+let pendingQueue: Array<{ resolve: (token: string) => void; reject: (err: unknown) => void }> = [];
+
+const flushQueue = (token: string | null, error: unknown = null) => {
+  pendingQueue.forEach(({ resolve, reject }) => {
+    if (token) resolve(token);
+    else reject(error);
+  });
+  pendingQueue = [];
+};
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const original = error.config;
+
+    if (error.response?.status !== 401 || original._retry) {
+      return Promise.reject(error);
+    }
+
+    if (isRefreshing) {
+      return new Promise((resolve, reject) => {
+        pendingQueue.push({
+          resolve: (token) => {
+            original.headers.Authorization = `Bearer ${token}`;
+            resolve(apiClient(original));
+          },
+          reject,
+        });
+      });
+    }
+
+    original._retry = true;
+    isRefreshing = true;
+
+    try {
+      const refreshToken = await getStoredRefreshToken();
+      if (!refreshToken) throw new Error("no_refresh_token");
+
+      const { data } = await axios.post(`${BASE_URL}/auth/mobile/refresh`, { refreshToken });
+      const newAccess: string = data.accessToken;
+      const newRefresh: string = data.refreshToken;
+
+      setAccessToken(newAccess);
+      await setStoredRefreshToken(newRefresh);
+
+      flushQueue(newAccess);
+      original.headers.Authorization = `Bearer ${newAccess}`;
+      return apiClient(original);
+    } catch (err) {
+      flushQueue(null, err);
+      setAccessToken(null);
+      await deleteStoredRefreshToken();
+      return Promise.reject(err);
+    } finally {
+      isRefreshing = false;
+    }
+  }
+);

--- a/apps/mobile/src/services/auth.service.ts
+++ b/apps/mobile/src/services/auth.service.ts
@@ -1,0 +1,44 @@
+import { apiClient, setAccessToken, setStoredRefreshToken, deleteStoredRefreshToken, getStoredRefreshToken } from "./api";
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  name?: string;
+}
+
+export interface LoginPayload {
+  email: string;
+  password: string;
+}
+
+export interface AuthTokens {
+  accessToken: string;
+  refreshToken: string;
+  user: AuthUser;
+}
+
+export async function login(payload: LoginPayload): Promise<AuthTokens> {
+  const { data } = await apiClient.post<AuthTokens>("/auth/mobile/login", payload);
+  setAccessToken(data.accessToken);
+  await setStoredRefreshToken(data.refreshToken);
+  return data;
+}
+
+export async function refresh(): Promise<AuthTokens | null> {
+  const refreshToken = await getStoredRefreshToken();
+  if (!refreshToken) return null;
+
+  const { data } = await apiClient.post<AuthTokens>("/auth/mobile/refresh", { refreshToken });
+  setAccessToken(data.accessToken);
+  await setStoredRefreshToken(data.refreshToken);
+  return data;
+}
+
+export async function logout(): Promise<void> {
+  try {
+    await apiClient.post("/auth/mobile/logout", { refreshToken: await getStoredRefreshToken() });
+  } finally {
+    setAccessToken(null);
+    await deleteStoredRefreshToken();
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,9 @@
       "name": "@control-finance/mobile",
       "version": "1.29.0",
       "dependencies": {
+        "axios": "^1.15.1",
         "expo": "~54.0.33",
+        "expo-secure-store": "^55.0.13",
         "expo-status-bar": "~3.0.9",
         "react": "19.1.0",
         "react-native": "0.81.5"
@@ -229,6 +231,15 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "apps/mobile/node_modules/expo-secure-store": {
+      "version": "55.0.13",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-55.0.13.tgz",
+      "integrity": "sha512-I6r0JNO1Fd4o0Gu7Ixiic7s89lqgdUHq17uBH9y1f/AntoyKn71TdtYJH82RgfsBbu5qNVzrwImmvlANyOlITQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "apps/mobile/node_modules/expo-status-bar": {
@@ -5995,12 +6006,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -11853,8 +11866,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",


### PR DESCRIPTION
Implements the mobile auth session on top of the bearer token endpoints added in #546.

- axios client with Bearer token injection and automatic 401 refresh with pending queue
- SecureStore persistence for refresh token
- AuthContext with session bootstrap on mount (useRef guard for StrictMode)
- LoginScreen with email/password form, loading state and error handling
- RootNavigator with three states: initializing splash, login, authenticated dashboard placeholder

No navigation library added yet — conditional routing in App.tsx is sufficient for the current scope. react-navigation enters when there are more than 2 screens to manage.