### PR TITLE
fix(dashboard): wire settledOutflowTotal from actual expense transactions

### DIFF
--- a/apps/api/src/dashboard.test.js
+++ b/apps/api/src/dashboard.test.js
@@ -35,6 +35,7 @@ const resetState = async () => {
   await dbQuery("DELETE FROM credit_card_purchases");
   await dbQuery("DELETE FROM bills");
   await dbQuery("DELETE FROM credit_cards");
+  await dbQuery("DELETE FROM transactions");
   await dbQuery("DELETE FROM bank_accounts");
   await dbQuery("DELETE FROM users");
 };
@@ -75,6 +76,18 @@ const createIncomeSource = (token) =>
     .post("/income-sources")
     .set("Authorization", `Bearer ${token}`)
     .send({ name: "INSS Aposentadoria", sourceType: "inss_benefit" });
+
+const createTransaction = (token, overrides = {}) =>
+  request(app)
+    .post("/transactions")
+    .set("Authorization", `Bearer ${token}`)
+    .send({
+      description: "Mercado",
+      value: 100,
+      type: "Saída",
+      date: isoDate(0),
+      ...overrides,
+    });
 
 const DASHBOARD_TOP_LEVEL_KEYS = [
   "bankBalance",
@@ -858,5 +871,20 @@ describe("dashboard snapshot", () => {
 
     const parsed = DashboardSnapshotResponseSchema.safeParse(res.body);
     expect(parsed.success).toBe(true);
+  });
+
+  it("settledOutflowTotal reflete transacoes de saida do mes corrente", async () => {
+    const email = "dash-settled-outflow@test.dev";
+    const token = await registerAndLogin(email);
+
+    await createTransaction(token, { description: "Supermercado", value: 350.5, type: "Saida", date: isoDate(0) });
+    await createTransaction(token, { description: "Farmácia", value: 89.9, type: "Saida", date: isoDate(-2) });
+    await createTransaction(token, { description: "Salário", value: 2000, type: "Entrada", date: isoDate(0) });
+
+    const res = await getSnapshot(token);
+
+    expect(res.status).toBe(200);
+    expect(res.body.semanticCore.realized.settledOutflowTotal).toBe(440.4);
+    expect(res.body.semanticCore.realized.confirmedInflowTotal).toBe(0);
   });
 });

--- a/apps/api/src/services/dashboard.service.ts
+++ b/apps/api/src/services/dashboard.service.ts
@@ -123,10 +123,11 @@ const normalizeYearMonth = (value: string | Date | null | undefined): string | n
 
 const buildDashboardSemanticCore = (
   snapshot: DashboardSnapshotBase,
+  spendingToDate: number,
   asOf: Date,
 ): DashboardSnapshot["semanticCore"] => {
   const confirmedInflowTotal = Number(snapshot.income.receivedThisMonth.toFixed(2));
-  const settledOutflowTotal = 0;
+  const settledOutflowTotal = Number(spendingToDate.toFixed(2));
   const netAmount = Number((confirmedInflowTotal - settledOutflowTotal).toFixed(2));
 
   const projectionReferenceMonth = snapshot.forecast?.month ?? snapshot.income.referenceMonth;
@@ -178,6 +179,8 @@ export const getDashboardSnapshot = async (
   const in7Days = toISODate(new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000));
   const currentMonth = toYearMonth(now);
 
+  const monthStart = `${currentMonth}-01`;
+
   const [
     bankRes,
     billsRes,
@@ -186,6 +189,7 @@ export const getDashboardSnapshot = async (
     incomeRes,
     forecastRes,
     consignadoRes,
+    outflowRes,
   ] = await Promise.all([
     // 1. Total bank balance across active accounts
     dbQuery(
@@ -259,6 +263,18 @@ export const getDashboardSnapshot = async (
        GROUP BY sp.gross_salary`,
       [uid],
     ),
+
+    // 7. Settled outflow: confirmed expense transactions this month
+    dbQuery(
+      `SELECT COALESCE(SUM(value), 0) AS total
+       FROM transactions
+       WHERE user_id = $1
+         AND type = 'Saida'
+         AND deleted_at IS NULL
+         AND date >= $2
+         AND date <= $3`,
+      [uid, monthStart, today],
+    ),
   ]);
 
   const bills = (billsRes.rows[0] ?? {}) as BillsRow;
@@ -305,9 +321,11 @@ export const getDashboardSnapshot = async (
     })(),
   };
 
+  const spendingToDate = toNum(outflowRes.rows[0]?.total as NumericLike);
+
   return {
     ...baseSnapshot,
-    semanticCore: buildDashboardSemanticCore(baseSnapshot, now),
+    semanticCore: buildDashboardSemanticCore(baseSnapshot, spendingToDate, now),
     semanticSourceMap: DASHBOARD_SEMANTIC_SOURCE_MAP,
   };
 };


### PR DESCRIPTION
## Summary
- `semanticCore.realized.settledOutflowTotal` was hardcoded to `0` in `dashboard.service.ts`
- Added query #7 to `Promise.all`: sums `type = 'Saida'` transactions for the current month (month-start to today), excluding soft-deleted rows
- Passes result as `spendingToDate` parameter to `buildDashboardSemanticCore`
- Adds regression test `settledOutflowTotal reflete transacoes de saida do mes corrente` (25/25 green)

## Test plan
- [ ] All 25 dashboard tests pass
- [ ] New test asserts `settledOutflowTotal = 440.4` for two Saida transactions (350.5 + 89.9) and ignores Entrada
- [ ] Empty-state test still passes (no transactions → 0)