### PR TITLE
fix(api): expose IMPORT_PDF_OCR_DISABLED in dry-run response

### DIFF
--- a/apps/api/src/import-utility-dry-run.test.js
+++ b/apps/api/src/import-utility-dry-run.test.js
@@ -88,6 +88,31 @@ describe("transaction imports utility bills dry-run", () => {
     vi.mocked(extractTextFromPdfBuffer).mockResolvedValue("mocked pdf text");
   });
 
+  it("POST /transactions/import/dry-run retorna codigo explicito quando OCR de PDF esta desativado", async () => {
+    const token = await registerAndLogin("import-pdf-ocr-disabled@controlfinance.dev");
+    await makeProUser("import-pdf-ocr-disabled@controlfinance.dev");
+
+    vi.mocked(getPdfImportGuidanceError).mockReturnValue(
+      "PDF sem texto reconhecivel. Tente OFX ou CSV.",
+    );
+
+    const response = await request(app)
+      .post("/transactions/import/dry-run")
+      .set("Authorization", `Bearer ${token}`)
+      .attach("file", Buffer.from("%PDF-1.4 scanned"), {
+        filename: "extrato-escaneado.pdf",
+        contentType: "application/pdf",
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      message: "PDF sem texto reconhecivel. Tente OFX ou CSV.",
+      code: "IMPORT_PDF_OCR_DISABLED",
+    });
+    expect(typeof response.body.requestId).toBe("string");
+    expect(response.body.requestId).not.toHaveLength(0);
+  });
+
   it("POST /transactions/import/dry-run retorna documentType e suggestion para utility_bill_telecom", async () => {
     const token = await registerAndLogin("import-doctype-telecom@controlfinance.dev");
     await makeProUser("import-doctype-telecom@controlfinance.dev");

--- a/apps/api/src/services/transactions-import.service.ts
+++ b/apps/api/src/services/transactions-import.service.ts
@@ -1120,7 +1120,7 @@ const parseImportFileRows = async (importFile: ImportFile) => {
 
     const guidanceError = getPdfImportGuidanceError(text);
     if (guidanceError) {
-      throw createError(400, guidanceError);
+      throw createErrorWithPublicCode(400, guidanceError, "IMPORT_PDF_OCR_DISABLED");
     }
 
     const normalizedPdfText = collapseWhitespace(text)


### PR DESCRIPTION
## Summary
- follow up on the OCR-disabled dry-run flow already delivered in #418
- expose `IMPORT_PDF_OCR_DISABLED` from the backend dry-run response instead of relying only on the message text
- add API regression coverage for scanned PDF imports when OCR is unavailable

## Notes
- this does not reopen the UX scope from #418; the visual feedback is already in place
- no incompatible behavior change: the existing message is preserved and the response now also includes a stable semantic code
- diff kept intentionally small and limited to the dry-run contract

## Validation
- `npm run test -w apps/api -- import-utility-dry-run.test.js`
- `npm run test -w apps/web -- ImportCsvModal.test.jsx`
- `npm run typecheck`